### PR TITLE
UTF-8 encoding bug on PHP older than 5.4

### DIFF
--- a/app/controllers/configureController.php
+++ b/app/controllers/configureController.php
@@ -143,6 +143,7 @@ class configureController extends ActionController {
 			$mode = Request::param ('view_mode', 'normal');
 			$view = Request::param ('default_view', 'all');
 			$display = Request::param ('display_posts', 'no');
+			$onread_jump_next = Request::param ('onread_jump_next', 'yes');
 			$lazyload = Request::param ('lazyload', 'yes');
 			$sort = Request::param ('sort_order', 'low_to_high');
 			$old = Request::param ('old_entries', 3);
@@ -157,6 +158,7 @@ class configureController extends ActionController {
 			$this->view->conf->_viewMode ($mode);
 			$this->view->conf->_defaultView ($view);
 			$this->view->conf->_displayPosts ($display);
+			$this->view->conf->_onread_jump_next ($onread_jump_next);
 			$this->view->conf->_lazyload ($lazyload);
 			$this->view->conf->_sortOrder ($sort);
 			$this->view->conf->_oldEntries ($old);
@@ -174,6 +176,7 @@ class configureController extends ActionController {
 				'view_mode' => $this->view->conf->viewMode (),
 				'default_view' => $this->view->conf->defaultView (),
 				'display_posts' => $this->view->conf->displayPosts (),
+				'onread_jump_next' => $this->view->conf->onread_jump_next (),
 				'lazyload' => $this->view->conf->lazyload (),
 				'sort_order' => $this->view->conf->sortOrder (),
 				'old_entries' => $this->view->conf->oldEntries (),

--- a/app/controllers/entryController.php
+++ b/app/controllers/entryController.php
@@ -35,13 +35,10 @@ class entryController extends ActionController {
 		$id = Request::param ('id');
 		$is_read = Request::param ('is_read');
 		$get = Request::param ('get');
+		$nextGet = Request::param ('nextGet', $get);
 		$dateMax = Request::param ('dateMax', time ());
 
-		if ($is_read) {
-			$is_read = true;
-		} else {
-			$is_read = false;
-		}
+		$is_read = !!$is_read;
 
 		$entryDAO = new EntryDAO ();
 		if ($id == false) {
@@ -53,10 +50,10 @@ class entryController extends ActionController {
 
 				if ($typeGet == 'c') {
 					$entryDAO->markReadCat ($get, $is_read, $dateMax);
-					$this->params = array ('get' => 'c_' . $get);
+					$this->params = array ('get' => $nextGet);
 				} elseif ($typeGet == 'f') {
 					$entryDAO->markReadFeed ($get, $is_read, $dateMax);
-					$this->params = array ('get' => 'f_' . $get);
+					$this->params = array ('get' => $nextGet);
 				}
 			}
 

--- a/app/i18n/en.php
+++ b/app/i18n/en.php
@@ -149,6 +149,7 @@ return array (
 	'default_view'			=> 'Default view',
 	'sort_order'			=> 'Sort order',
 	'display_articles_unfolded'	=> 'Show articles unfolded by default',
+	'onread_jump_next'		=> 'On marked as read jump to next unread sibling',
 	'img_with_lazyload'		=> 'Use "lazy load" mode to load pictures',
 	'auto_read_when'		=> 'Mark automatically as read when',
 	'article_selected'		=> 'Article is selected',

--- a/app/i18n/fr.php
+++ b/app/i18n/fr.php
@@ -149,6 +149,7 @@ return array (
 	'default_view'			=> 'Vue par défaut',
 	'sort_order'			=> 'Ordre de tri',
 	'display_articles_unfolded'	=> 'Afficher les articles dépliés par défaut',
+	'onread_jump_next'		=> 'Après marqué comme lu, sauter au voisin non lu',
 	'img_with_lazyload'		=> 'Utiliser le mode "lazy load" pour charger les images',
 	'auto_read_when'		=> 'Marquer automatiquement comme lu lorsque',
 	'article_selected'		=> 'L\'article est sélectionné',

--- a/app/layout/aside_flux.phtml
+++ b/app/layout/aside_flux.phtml
@@ -53,7 +53,7 @@
 				<a class="btn<?php echo $c_active ? ' active' : ''; ?>" href="<?php echo _url ('index', 'index', 'get', 'c_' . $cat->id ()); ?>">
 					<?php echo $cat->name (); ?>
 					<?php if ($catNotRead > 0) { ?>
-					<span class="notRead"><?php echo $catNotRead > 1 ? Translate::t ('not_reads', $catNotRead) : Translate::t ('not_read', $catNotRead); ?></span>
+					<span class="notRead" title="<?php echo $catNotRead > 1 ? Translate::t ('not_reads', $catNotRead) : Translate::t ('not_read', $catNotRead); ?>"><?php echo $catNotRead ; ?></span>
 					<?php } ?>
 				</a>
 			</div>

--- a/app/layout/nav_menu.phtml
+++ b/app/layout/nav_menu.phtml
@@ -17,10 +17,46 @@
 			$get = 'c_' . $this->get_c;
 			$string_mark = Translate::t ('mark_cat_read');
 		}
+		$nextGet = $get;
+		if (($this->conf->onread_jump_next () === 'yes') && (strlen ($get) > 2)) {
+			$anotherUnreadId = '';
+			$foundCurrent = false;
+			switch ($get[0]) {
+				case 'c':
+					foreach ($this->cat_aside as $cat) {
+						if ($cat->id () === $this->get_c) {
+							$foundCurrent = true;
+							continue;
+						}
+						if ($cat->nbNotRead () <= 0) continue;
+						$anotherUnreadId = $cat->id ();
+						if ($foundCurrent) break;
+					}
+					$nextGet = strlen ($anotherUnreadId) > 1 ? 'c_' . $anotherUnreadId : 'all';
+					break;
+				case 'f':
+					foreach ($this->cat_aside as $cat) {
+						if ($cat->id () === $this->get_c) {
+							foreach ($cat->feeds () as $feed) {
+								if ($feed->id () === $this->get_f) {
+									$foundCurrent = true;
+									continue;
+								}
+								if ($feed->nbNotRead () <= 0) continue;
+								$anotherUnreadId = $feed->id ();
+								if ($foundCurrent) break;
+							}
+							break;
+						}
+					}
+					$nextGet = strlen ($anotherUnreadId) > 1 ? 'f_' . $anotherUnreadId : 'c_' . $this->get_c;
+					break;
+			}
+		}
 	?>
 
 	<div class="stick">
-		<a class="read_all btn" href="<?php echo _url ('entry', 'read', 'is_read', 1, 'get', $get); ?>"><?php echo Translate::t ('mark_read'); ?></a>
+		<a class="read_all btn" href="<?php echo _url ('entry', 'read', 'is_read', 1, 'get', $get, 'nextGet', $nextGet); ?>"><?php echo Translate::t ('mark_read'); ?></a>
 		<div class="dropdown">
 			<div id="dropdown-read" class="dropdown-target"></div>
 
@@ -28,7 +64,7 @@
 			<ul class="dropdown-menu">
 				<li class="dropdown-close"><a href="#close"><i class="icon i_close"></i></a></li>
 
-				<li class="item"><a href="<?php echo _url ('entry', 'read', 'is_read', 1, 'get', $get); ?>"><?php echo $string_mark; ?></a></li>
+				<li class="item"><a href="<?php echo _url ('entry', 'read', 'is_read', 1, 'get', $get, 'nextGet', $nextGet); ?>"><?php echo $string_mark; ?></a></li>
 				<li class="separator"></li>
 <?php
 	$date = getdate ();

--- a/app/models/RSSConfiguration.php
+++ b/app/models/RSSConfiguration.php
@@ -10,6 +10,7 @@ class RSSConfiguration extends Model {
 	private $view_mode;
 	private $default_view;
 	private $display_posts;
+	private $onread_jump_next;
 	private $lazyload;
 	private $sort_order;
 	private $old_entries;
@@ -25,6 +26,7 @@ class RSSConfiguration extends Model {
 		$this->_viewMode ($confDAO->view_mode);
 		$this->_defaultView ($confDAO->default_view);
 		$this->_displayPosts ($confDAO->display_posts);
+		$this->_onread_jump_next ($confDAO->onread_jump_next);
 		$this->_lazyload ($confDAO->lazyload);
 		$this->_sortOrder ($confDAO->sort_order);
 		$this->_oldEntries ($confDAO->old_entries);
@@ -51,6 +53,9 @@ class RSSConfiguration extends Model {
 	}
 	public function displayPosts () {
 		return $this->display_posts;
+	}
+	public function onread_jump_next () {
+		return $this->onread_jump_next;
 	}
 	public function lazyload () {
 		return $this->lazyload;
@@ -117,6 +122,13 @@ class RSSConfiguration extends Model {
 			$this->display_posts = 'no';
 		}
 	}
+	public function _onread_jump_next ($value) {
+		if ($value == 'no') {
+			$this->onread_jump_next = 'no';
+		} else {
+			$this->onread_jump_next = 'yes';
+		}
+	}
 	public function _lazyload ($value) {
 		if ($value == 'no') {
 			$this->lazyload = 'no';
@@ -179,6 +191,7 @@ class RSSConfigurationDAO extends Model_array {
 	public $view_mode = 'normal';
 	public $default_view = 'not_read';
 	public $display_posts = 'no';
+	public $onread_jump_next = 'yes';
 	public $lazyload = 'yes';
 	public $sort_order = 'low_to_high';
 	public $old_entries = 3;
@@ -216,6 +229,9 @@ class RSSConfigurationDAO extends Model_array {
 		}
 		if (isset ($this->array['display_posts'])) {
 			$this->display_posts = $this->array['display_posts'];
+		}
+		if (isset ($this->array['onread_jump_next'])) {
+			$this->onread_jump_next = $this->array['onread_jump_next'];
 		}
 		if (isset ($this->array['lazyload'])) {
 			$this->lazyload = $this->array['lazyload'];

--- a/app/views/configure/display.phtml
+++ b/app/views/configure/display.phtml
@@ -73,6 +73,20 @@
 		</div>
 
 		<div class="form-group">
+			<label class="group-name"><?php echo Translate::t ('onread_jump_next'); ?></label>
+			<div class="group-controls">
+				<label class="radio" for="onread_jump_next_yes">
+					<input type="radio" name="onread_jump_next" id="onread_jump_next_yes" value="yes"<?php echo $this->conf->onread_jump_next () == 'yes' ? ' checked="checked"' : ''; ?> />
+					<?php echo Translate::t ('yes'); ?><noscript> - <b><?php echo Translate::t ('javascript_should_be_activated'); ?></b></noscript>
+				</label>
+				<label class="radio" for="onread_jump_next_no">
+					<input type="radio" name="onread_jump_next" id="onread_jump_next_no" value="no"<?php echo $this->conf->onread_jump_next () == 'no' ? ' checked="checked"' : ''; ?> />
+					<?php echo Translate::t ('no'); ?>
+				</label>
+			</div>
+		</div>
+
+		<div class="form-group">
 			<label class="group-name"><?php echo Translate::t ('img_with_lazyload'); ?></label>
 			<div class="group-controls">
 				<label class="radio" for="lazyload_yes">

--- a/app/views/helpers/pagination.phtml
+++ b/app/views/helpers/pagination.phtml
@@ -10,7 +10,11 @@
 	<?php $params[$getteur] = $this->next; ?>
 	<a id="load_more" href="<?php echo Url::display (array ('c' => $c, 'a' => $a, 'params' => $params)); ?>"><?php echo Translate::t ('load_more'); ?></a>
 	<?php } else { ?>
-	<?php echo Translate::t ('nothing_to_load'); ?>
+	<div class="bigMarkAsRead">
+		<p><?php echo Translate::t ('nothing_to_load'); ?></p>
+		<p class="bigTick">✔</p>
+		<p><?php echo Translate::t ('mark_all_read'); ?></p>
+	</div>
 	<?php } ?>
 	</li>
 </ul>

--- a/app/views/helpers/rss_view.phtml
+++ b/app/views/helpers/rss_view.phtml
@@ -12,7 +12,7 @@ $items = $this->entryPaginator->items ();
 foreach ($items as $item) {
 ?>
 		<item>
-			<title><?php echo htmlspecialchars(html_entity_decode($item->title ())); ?></title>
+			<title><?php echo htmlspecialchars(html_entity_decode($item->title (), ENT_NOQUOTES, 'UTF-8'), ENT_NOQUOTES, 'UTF-8'); ?></title>
 			<link><?php echo $item->link (); ?></link>
 			<?php $author = $item->author (); ?>
 			<?php if ($author != '') { ?>

--- a/app/views/javascript/main.phtml
+++ b/app/views/javascript/main.phtml
@@ -324,6 +324,14 @@ function init_nav_entries() {
 	});
 }
 
+function init_bigMarkAsRead() {
+	$('.bigMarkAsRead').click(function() {
+		url = $(".nav_menu a.read_all").attr ("href");
+		redirect (url, false);
+		return false;
+	});
+}
+
 $(document).ready (function () {
 	if(is_reader_mode()) {
 		hide_posts = false;
@@ -332,4 +340,5 @@ $(document).ready (function () {
 	init_column_categories ();
 	init_shortcuts ();
 	init_nav_entries();
+	init_bigMarkAsRead();
 });

--- a/public/theme/freshrss.css
+++ b/public/theme/freshrss.css
@@ -437,6 +437,21 @@
 	font-size: 0;
 }
 
+.bigMarkAsRead {
+	background:#CCC;
+	color:#FFF;
+	cursor:pointer;
+	height:32em;
+	text-shadow: 0 -1px 0 #AAA;
+}
+.bigMarkAsRead:hover {
+	background:#06C;
+}
+.bigTick {
+	font-size:72pt;
+	margin:32px 0 8px 0;
+}
+
 /*** NOTIFICATION ***/
 .notification {
 	position: fixed;


### PR DESCRIPTION
In PHP older than 5.4.0, the default charset for htmlspecialchars() and html_entity_decode() was ISO-8859-1, which created erroneous UTF-8 characters
