### PR TITLE
UTF-8 encoding bug on PHP older than 5.4

### DIFF
--- a/app/views/helpers/rss_view.phtml
+++ b/app/views/helpers/rss_view.phtml
@@ -12,7 +12,7 @@ $items = $this->entryPaginator->items ();
 foreach ($items as $item) {
 ?>
 		<item>
-			<title><?php echo htmlspecialchars(html_entity_decode($item->title ())); ?></title>
+			<title><?php echo htmlspecialchars(html_entity_decode($item->title (), ENT_NOQUOTES, 'UTF-8'), ENT_NOQUOTES, 'UTF-8'); ?></title>
 			<link><?php echo $item->link (); ?></link>
 			<?php $author = $item->author (); ?>
 			<?php if ($author != '') { ?>


### PR DESCRIPTION
In PHP older than 5.4.0, the default charset for htmlspecialchars() and html_entity_decode() was ISO-8859-1, which created erroneous UTF-8 characters
