### PR TITLE
UTF-8 encoding bug on PHP older than 5.4

### DIFF
--- a/app/models/Feed.php
+++ b/app/models/Feed.php
@@ -216,7 +216,7 @@ class Feed extends Model {
 		foreach ($feed->get_items () as $item) {
 			$title = $item->get_title ();
 			$title = preg_replace('#<a(.+)>(.+)</a>#', '\\2', $title);
-			$title = htmlentities($title);
+			$title = htmlentities($title, ENT_NOQUOTES, 'UTF-8');
 			$author = $item->get_author ();
 			$link = $item->get_permalink ();
 			$date = strtotime ($item->get_date ());

--- a/app/views/helpers/view/rss_view.phtml
+++ b/app/views/helpers/view/rss_view.phtml
@@ -12,7 +12,7 @@ $items = $this->entryPaginator->items ();
 foreach ($items as $item) {
 ?>
 		<item>
-			<title><?php echo htmlspecialchars(html_entity_decode($item->title ())); ?></title>
+			<title><?php echo htmlspecialchars(html_entity_decode($item->title (), ENT_NOQUOTES, 'UTF-8'), ENT_NOQUOTES, 'UTF-8'); ?></title>
 			<link><?php echo $item->link (); ?></link>
 			<?php $author = $item->author (); ?>
 			<?php if ($author != '') { ?>

--- a/lib/SimplePie/SimplePie/Misc.php
+++ b/lib/SimplePie/SimplePie/Misc.php
@@ -138,7 +138,7 @@ class SimplePie_Misc
 		foreach ($element['attribs'] as $key => $value)
 		{
 			$key = strtolower($key);
-			$full .= " $key=\"" . htmlspecialchars($value['data']) . '"';
+			$full .= " $key=\"" . htmlspecialchars($value['data'], ENT_COMPAT, 'UTF-8') . '"';
 		}
 		if ($element['self_closing'])
 		{

--- a/lib/lib_phpQuery.php
+++ b/lib/lib_phpQuery.php
@@ -3365,7 +3365,7 @@ class phpQueryObject
 	 */
 	public function text($text = null, $callback1 = null, $callback2 = null, $callback3 = null) {
 		if (isset($text))
-			return $this->html(htmlspecialchars($text));
+			return $this->html(htmlspecialchars($text), ENT_NOQUOTES, 'UTF-8');
 		$args = func_get_args();
 		$args = array_slice($args, 1);
 		$return = '';

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -48,7 +48,7 @@ function opml_export ($cats) {
 		$txt .= '<outline text="' . $cat['name'] . '">' . "\n";
 		
 		foreach ($cat['feeds'] as $feed) {
-			$txt .= "\t" . '<outline text="' . cleanText ($feed->name ()) . '" type="rss" xmlUrl="' . htmlentities ($feed->url ()) . '" htmlUrl="' . htmlentities ($feed->website ()) . '" />' . "\n";
+			$txt .= "\t" . '<outline text="' . cleanText ($feed->name ()) . '" type="rss" xmlUrl="' . htmlentities ($feed->url (), ENT_COMPAT, 'UTF-8') . '" htmlUrl="' . htmlentities ($feed->website (), ENT_COMPAT, 'UTF-8') . '" />' . "\n";
 		}
 		
 		$txt .= '</outline>' . "\n";

--- a/lib/minz/Request.php
+++ b/lib/minz/Request.php
@@ -35,9 +35,9 @@ class Request {
 			if(is_object($p) || $specialchars) {
 				return $p;
 			} elseif(is_array($p)) {
-				return array_map('htmlspecialchars', $p);
+				return array_map('htmlspecialchars', $p, ENT_NOQUOTES, 'UTF-8');
 			} else {
-				return htmlspecialchars($p);
+				return htmlspecialchars($p, ENT_NOQUOTES, 'UTF-8');
 			}
 		} else {
 			return $default;

--- a/lib/minz/Request.php
+++ b/lib/minz/Request.php
@@ -35,7 +35,7 @@ class Request {
 			if(is_object($p) || $specialchars) {
 				return $p;
 			} elseif(is_array($p)) {
-				return array_map('htmlspecialchars', $p, ENT_NOQUOTES, 'UTF-8');
+				return array_map('htmlspecialchars', $p);	//TODO: Should use explicit UTF-8
 			} else {
 				return htmlspecialchars($p, ENT_NOQUOTES, 'UTF-8');
 			}

--- a/lib/minz/dao/Model_pdo.php
+++ b/lib/minz/dao/Model_pdo.php
@@ -22,23 +22,29 @@ class Model_pdo {
 	 */
 	public function __construct () {
 		$db = Configuration::dataBase ();
+		$driver_options = null;
 
 		try {
 			$type = $db['type'];
 			if($type == 'mysql') {
 				$string = $type
 				        . ':host=' . $db['host']
-				        . ';dbname=' . $db['base'];
+				        . ';dbname=' . $db['base']
+				        . ';charset=utf8';
+				$driver_options = array(
+					PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8'
+					);
 			} elseif($type == 'sqlite') {
 				$string = $type
 				        . ':/' . PUBLIC_PATH
-				        . '/data/' . $db['base'] . '.sqlite';
+				        . '/data/' . $db['base'] . '.sqlite';	//TODO: DEBUG UTF-8 http://www.siteduzero.com/forum/sujet/sqlite-connexion-utf-8-18797
 			}
 
 			$this->bd = new PDO (
 				$string,
 				$db['user'],
-				$db['password']
+				$db['password'],
+				$driver_options
 			);
 
 			$this->prefix = $db['prefix'];

--- a/public/install.php
+++ b/public/install.php
@@ -309,8 +309,12 @@ function checkBD () {
 
 	try {
 		$str = '';
+		$driver_options = null;
 		if($_SESSION['bd_type'] == 'mysql') {
 			$str = 'mysql:host=' . $_SESSION['bd_host'] . ';dbname=' . $_SESSION['bd_name'];
+			$driver_options = array(
+				PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8'
+				);
 		} elseif($_SESSION['bd_type'] == 'sqlite') {
 			$str = 'sqlite:' . PUBLIC_PATH
 			     . '/data/' . $_SESSION['bd_name'] . '.sqlite';
@@ -318,7 +322,8 @@ function checkBD () {
 
 		$c = new PDO ($str,
 			      $_SESSION['bd_user'],
-			      $_SESSION['bd_pass']);
+			      $_SESSION['bd_pass'],
+			      $driver_options);
 
 		$sql = sprintf (SQL_REQ_CAT, $_SESSION['bd_prefix']);
 		$res = $c->query ($sql);


### PR DESCRIPTION
In PHP older than 5.4.0, the default charset for html_entity_decode(), htmlentities(), and htmlspecialchars() (less important) was ISO-8859-1, which creates erroneous UTF-8 characters.
Add explicit UTF-8 for these functions, as well as for PDO MySQL conexions.
