### PR TITLE
Do not perform double HTML-encoding

### DIFF
--- a/app/models/Feed.php
+++ b/app/models/Feed.php
@@ -216,7 +216,7 @@ class Feed extends Model {
 		foreach ($feed->get_items () as $item) {
 			$title = $item->get_title ();
 			$title = preg_replace('#<a(.+)>(.+)</a>#', '\\2', $title);
-			$title = htmlentities($title);
+			//$title = htmlentities($title, ENT_NOQUOTES, 'UTF-8');  //Do not do double html-encoding (debug needed)
 			$author = $item->get_author ();
 			$link = $item->get_permalink ();
 			$date = strtotime ($item->get_date ());


### PR DESCRIPTION
The content seems to be already HTML safe, e.g. for some feeds in UTF-8 with HTML special characters encoded, for some other feeds with all eligible characters HTML-encoded.
This problem was introduced in /dev when trying to address https://github.com/marienfressinaud/FreshRSS/issues/129
I think the patches for the UTF-8 bugs need to be applied first https://github.com/marienfressinaud/FreshRSS/pull/140
Tested with several feeds containing special characters, and seems fine.
