### PR TITLE
Clean removed SQL columns in PHP

### DIFF
--- a/app/controllers/entryController.php
+++ b/app/controllers/entryController.php
@@ -90,7 +90,6 @@ class entryController extends ActionController {
 			if ($entry != false) {
 				$values = array (
 					'is_favorite' => $is_fav,
-					'lastUpdate' => time ()
 				);
 
 				$entryDAO->updateEntry ($entry->id (), $values);


### PR DESCRIPTION
A "lastUpdate" field was forgotten, and it was not possible anymore to mark entries as favourites.
Bug was introduced by https://github.com/marienfressinaud/FreshRSS/issues/118
