### PR TITLE
Avoid preg_replace() for simple cases

### DIFF
--- a/app/models/Feed.php
+++ b/app/models/Feed.php
@@ -172,7 +172,7 @@ class Feed extends Model {
 				);
 			} else {
 				$feed = new SimplePie ();
-				$url = preg_replace ('/&amp;/', '&', $this->url);
+				$url = str_replace ('&amp;', '&', $this->url);
 				if ($this->httpAuth != '') {
 					$url = preg_replace ('#((.+)://)(.+)#', '${1}' . $this->httpAuth . '@${3}', $url);
 				}

--- a/app/views/entry/bookmark.phtml
+++ b/app/views/entry/bookmark.phtml
@@ -12,4 +12,4 @@ $url = Url::display (array (
 	'params' => Request::params (),
 ));
 
-echo json_encode (array ('url' => preg_replace ('#&amp;#i', '&', $url)));
+echo json_encode (array ('url' => str_ireplace ('&amp;', '&', $url)));

--- a/app/views/entry/read.phtml
+++ b/app/views/entry/read.phtml
@@ -12,4 +12,4 @@ $url = Url::display (array (
 	'params' => Request::params (),
 ));
 
-echo json_encode (array ('url' => preg_replace ('#&amp;#i', '&', $url)));
+echo json_encode (array ('url' => str_ireplace ('&amp;', '&', $url)));


### PR DESCRIPTION
Use the faster str_replace() and str_ireplace() instead.
From http://www.php.net/manual/function.str-replace.php : "If you don't need fancy replacing rules (like regular expressions), you should always use this function instead of preg_replace(). "
