### PR TITLE
Allow native control-click of article titles

### DIFF
--- a/app/views/helpers/view/normal_view.phtml
+++ b/app/views/helpers/view/normal_view.phtml
@@ -44,7 +44,7 @@ if (isset ($this->entryPaginator) && !$this->entryPaginator->isEmpty ()) {
 			<?php } ?>
 			<?php $feed = $item->feed (true); ?>
 			<li class="item website"><a href="<?php echo _url ('index', 'index', 'get', 'f_' . $feed->id ()); ?>"><img class="favicon" src="<?php echo $feed->favicon (); ?>" alt="" /> <span><?php echo $feed->name (); ?></span></a></li>
-			<li class="item title"><?php echo $item->title (); ?></li>
+			<li class="item title"><a target="_blank" href="<?php echo $item->link (); ?>"><?php echo $item->title (); ?></a></li>
 			<li class="item date"><?php echo $item->date (); ?></li>
 			<li class="item link"><a target="_blank" href="<?php echo $item->link (); ?>">&nbsp;</a></li>
 		</ul>

--- a/app/views/javascript/main.phtml
+++ b/app/views/javascript/main.phtml
@@ -196,10 +196,15 @@ function init_posts () {
 
 	var flux_header_toggle = $(".flux_header .item.title, .flux_header .item.date");
 	flux_header_toggle.unbind('click'); // évite d'associer 2 fois le toggle
-	flux_header_toggle.click (function () {
+	flux_header_toggle.click (function (e) {
 		old_active = $(".flux.active");
 		new_active = $(this).parent ().parent ();
-
+		if (e.target.tagName.toUpperCase() === 'A') {	//Leave real links alone
+			<?php if ($mark['article'] == 'yes') { ?>
+			mark_read(new_active, true);
+			<?php } ?>
+			return true;
+		}
 		toggleContent (new_active, old_active);
 	});
 
@@ -219,6 +224,12 @@ function init_posts () {
 
 	$(".flux .content a").click (function () {
 		$(this).attr ('target', '_blank');
+	});
+
+	$(".item.title>a").click (function (e) {
+		if (e.ctrlKey) return true;	//Allow default control-click behaviour such as open in backround-tab
+		$(this).parent ().click ();	//Will perform toggle flux_content
+		return false;
 	});
 
 	<?php if ($mark['site'] == 'yes') { ?>


### PR DESCRIPTION
Provide better access to the link of the article, and allow control-click on the title to e.g. open in a background tab, without having to reach the little link icon on the far right.
Link style may have to be improved in the CSS.
