### PR TITLE
SimplePie : Corrige le cas des </body> et </html>

### DIFF
--- a/lib/SimplePie/SimplePie/Sanitize.php
+++ b/lib/SimplePie/SimplePie/Sanitize.php
@@ -379,6 +379,7 @@ class SimplePie_Sanitize
 	protected function preprocess($html, $type)
 	{
 		$ret = '';
+		$html = preg_replace('%</?(?:html|body)[^>]*?'.'>%is', '', $html);
 		if ($type & ~SIMPLEPIE_CONSTRUCT_XHTML)
 		{
 			// Atom XHTML constructs are wrapped with a div by default


### PR DESCRIPTION
Corrige #159
Les balises fermantes /body et /html n'étaient pas nettoyées par SimplePie.
À tester un moment puis proposer en amont à SimplePie.
