### PR TITLE
Title: Unread in category/feed vs. global

### DIFF
--- a/app/controllers/indexController.php
+++ b/app/controllers/indexController.php
@@ -29,10 +29,9 @@ class indexController extends ActionController {
 
 		$nb_not_read = $this->view->nb_not_read;
 		if($nb_not_read > 0) {
-			View::prependTitle (' (' . $nb_not_read . ') - ');
-		} else {
-			View::prependTitle (' - ');
+			View::appendTitle (' (' . $nb_not_read . ')');
 		}
+		View::prependTitle (' - ');
 
 		$entryDAO = new EntryDAO ();
 		$feedDAO = new FeedDAO ();
@@ -132,7 +131,8 @@ class indexController extends ActionController {
 			$catDAO = new CategoryDAO ();
 			$cat = $catDAO->searchById ($type['id']);
 			if ($cat) {
-				View::prependTitle ($cat->name ());
+				$nbnr = $cat->nbNotRead ();
+				View::prependTitle ($cat->name () . ($nbnr > 0 ? ' (' . $nbnr . ')' : ''));
 				$this->view->get_c = $type['id'];
 				return false;
 			} else {
@@ -142,7 +142,8 @@ class indexController extends ActionController {
 			$feedDAO = new FeedDAO ();
 			$feed = $feedDAO->searchById ($type['id']);
 			if ($feed) {
-				View::prependTitle ($feed->name ());
+				$nbnr = $feed->nbNotRead ();
+				View::prependTitle ($feed->name () . ($nbnr > 0 ? ' (' . $nbnr . ')' : ''));
 				$this->view->get_f = $type['id'];
 				$this->view->get_c = $feed->category ();
 				return false;

--- a/app/controllers/indexController.php
+++ b/app/controllers/indexController.php
@@ -3,7 +3,7 @@
 class indexController extends ActionController {
 	private $get = false;
 	private $nb_not_read = 0;
-	private $mode = 'all';
+	private $mode = 'all';	//TODO: Is this used?
 
 	public function indexAction () {
 		$output = Request::param ('output');
@@ -40,6 +40,7 @@ class indexController extends ActionController {
 		$this->view->cat_aside = $catDAO->listCategories ();
 		$this->view->nb_favorites = $entryDAO->countFavorites ();
 		$this->view->nb_total = $entryDAO->count ();
+		$this->view->currentName = '';
 
 		$this->view->get_c = '';
 		$this->view->get_f = '';
@@ -116,23 +117,27 @@ class indexController extends ActionController {
 	 */
 	private function checkAndProcessType ($type) {
 		if ($type['type'] == 'all') {
-			View::prependTitle (Translate::t ('your_rss_feeds'));
+			$this->view->currentName = Translate::t ('your_rss_feeds');
+			View::prependTitle ($this->view->currentName);
 			$this->view->get_c = $type['type'];
 			return false;
 		} elseif ($type['type'] == 'favoris') {
-			View::prependTitle (Translate::t ('your_favorites'));
+			$this->view->currentName = Translate::t ('your_favorites');
+			View::prependTitle ($this->view->currentName);
 			$this->view->get_c = $type['type'];
 			return false;
 		} elseif ($type['type'] == 'public') {
-			View::prependTitle (Translate::t ('public'));
+			$this->view->currentName = Translate::t ('public');
+			View::prependTitle ($this->view->currentName);
 			$this->view->get_c = $type['type'];
 			return false;
 		} elseif ($type['type'] == 'c') {
 			$catDAO = new CategoryDAO ();
 			$cat = $catDAO->searchById ($type['id']);
 			if ($cat) {
+				$this->view->currentName = $cat->name ();
 				$nbnr = $cat->nbNotRead ();
-				View::prependTitle ($cat->name () . ($nbnr > 0 ? ' (' . $nbnr . ')' : ''));
+				View::prependTitle ($this->view->currentName . ($nbnr > 0 ? ' (' . $nbnr . ')' : ''));
 				$this->view->get_c = $type['id'];
 				return false;
 			} else {
@@ -142,8 +147,9 @@ class indexController extends ActionController {
 			$feedDAO = new FeedDAO ();
 			$feed = $feedDAO->searchById ($type['id']);
 			if ($feed) {
+				$this->view->currentName = $feed->name ();
 				$nbnr = $feed->nbNotRead ();
-				View::prependTitle ($feed->name () . ($nbnr > 0 ? ' (' . $nbnr . ')' : ''));
+				View::prependTitle ($this->view->currentName . ($nbnr > 0 ? ' (' . $nbnr . ')' : ''));
 				$this->view->get_f = $type['id'];
 				$this->view->get_c = $feed->category ();
 				return false;

--- a/app/views/helpers/view/normal_view.phtml
+++ b/app/views/helpers/view/normal_view.phtml
@@ -16,13 +16,13 @@ if (isset ($this->entryPaginator) && !$this->entryPaginator->isEmpty ()) {
 	<?php foreach ($items as $item) { ?>
 
 	<?php if ($display_today && $item->isDay (Days::TODAY)) { ?>
-	<div class="day"><?php echo Translate::t ('today'); ?> - <?php echo timestamptodate (time (), false); ?></div>
+	<div class="day"><?php echo Translate::t ('today'); ?> - <?php echo timestamptodate (time (), false); ?> : <em><?php echo $this->currentName; ?></em></div>
 	<?php $display_today = false; } ?>
 	<?php if ($display_yesterday && $item->isDay (Days::YESTERDAY)) { ?>
-	<div class="day"><?php echo Translate::t ('yesterday'); ?> - <?php echo timestamptodate (time () - 86400, false); ?></div>
+	<div class="day"><?php echo Translate::t ('yesterday'); ?> - <?php echo timestamptodate (time () - 86400, false); ?> : <em><?php echo $this->currentName; ?></em></div>
 	<?php $display_yesterday = false; } ?>
 	<?php if ($display_others && $item->isDay (Days::BEFORE_YESTERDAY)) { ?>
-	<div class="day"><?php echo Translate::t ('before_yesterday'); ?></div>
+	<div class="day"><?php echo Translate::t ('before_yesterday'); ?> : <em><?php echo $this->currentName; ?></em></div>
 	<?php $display_others = false; } ?>
 
 	<div class="flux<?php echo !$item->isRead () ? ' not_read' : ''; ?><?php echo $item->isFavorite () ? ' favorite' : ''; ?>" id="flux_<?php echo $item->id (); ?>">

--- a/public/themes/default/freshrss.css
+++ b/public/themes/default/freshrss.css
@@ -180,6 +180,18 @@
 	.day:first-child {
 		border-top: none;
 	}
+	.day em {
+		color:#AAB;
+		font-size:2em;
+		height:1.5em;
+		opacity:.4;
+		overflow:hidden;
+		padding:0 .2em 0 0;
+		position:absolute;
+		right:0;
+		text-align:right;
+		width:75%
+	}
 
 .flux {
 	border-left: 3px solid #aaa;

--- a/public/themes/flat-design/freshrss.css
+++ b/public/themes/flat-design/freshrss.css
@@ -179,6 +179,18 @@ body {
 	background: #ecf0f1;
 	border-radius: 0 20px 20px 0;
 }
+	.day em {
+		color:#AAB;
+		font-size:2em;
+		height:1.5em;
+		opacity:.4;
+		overflow:hidden;
+		padding:0 .2em 0 0;
+		position:absolute;
+		right:0;
+		text-align:right;
+		width:75%;
+	}
 
 .flux {
 }


### PR DESCRIPTION
Distinguish in the title of the page between the number of unread articles in the category/feed displayed vs. the total number of unread articles.
Before, it was confusing when showing the total number of unread articles next to the name of the category/feed.

![tmp_screenshot_2013-09-13-21-51-432063654071](https://f.cloud.github.com/assets/1008324/1141183/f8ee2c64-1cae-11e3-9c32-077013d97012.png)
