### PR TITLE
Corrige doublons autochargement avec navigation clavier

### DIFF
--- a/app/views/javascript/main.phtml
+++ b/app/views/javascript/main.phtml
@@ -143,16 +143,18 @@ function next_entry() {
 	last_active = $(".flux:last");
 	new_active = old_active.nextAll (".flux:first");
 
-	if(last_active.attr("id") == new_active.attr("id")) {
-		load_more_posts ();
-	}
-
 	if (new_active.hasClass("flux")) {
 		toggleContent (new_active, old_active);
 	} else if (old_active[0] === undefined &&
 	           new_active[0] === undefined) {
 		toggleContent (first_active, old_active);
 	}
+
+	<?php if ($auto_load_more !== 'yes') { ?>
+	if(last_active.attr("id") == new_active.attr("id")) {
+		load_more_posts ();
+	}
+	<?php } ?>
 }
 
 function init_img () {


### PR DESCRIPTION
1) Lors de la navigation clavier, si le chargement automatique en bas de page est activé, il ne faut pas manuellement charger les nouveaux articles, sinon il y a des doublons.

2) Il faut d'abord changer d'article avant d'en charger des nouveaux.

Vite fait, et vite testé, mais semble marcher et corriger les bugs de doublons que je constatais en navigation clavier (les articles non-lus que je venais de lire se rechargeaient une 2ème fois).
