### PR TITLE
Corrige images qui ne se chargent pas avec LazyLoad

### DIFF
--- a/app/views/javascript/main.phtml
+++ b/app/views/javascript/main.phtml
@@ -48,12 +48,12 @@ function toggleContent (new_active, old_active) {
 		relative_move = true;
 	}
 
-	var new_pos = new_active.position ().top,
-		old_scroll = $(box_to_move).scrollTop (),
+	var old_scroll = $(box_to_move).scrollTop (),
 		new_scroll = old_scroll;
 	if (hide_posts) {
 		old_active.children (".flux_content").toggle (0);
 
+		var new_pos = new_active.position ().top;
 		if(relative_move) {
 			new_pos += old_scroll;
 		}
@@ -64,7 +64,7 @@ function toggleContent (new_active, old_active) {
 			});
 		}
 	} else {
-		new_scroll = $(box_to_move).scrollTop (new_pos).scrollTop ();
+		new_scroll = $(box_to_move).scrollTop (new_active.position ().top).scrollTop ();
 	}
 
 	if ((new_scroll === old_scroll) && $.fn.lazyload) {

--- a/app/views/javascript/main.phtml
+++ b/app/views/javascript/main.phtml
@@ -48,21 +48,27 @@ function toggleContent (new_active, old_active) {
 		relative_move = true;
 	}
 
+	var new_pos = new_active.position ().top,
+		old_scroll = $(box_to_move).scrollTop (),
+		new_scroll = old_scroll;
 	if (hide_posts) {
 		old_active.children (".flux_content").toggle (0);
 
-		var new_pos = new_active.position ().top;
 		if(relative_move) {
-			new_pos += $(box_to_move).scrollTop();
+			new_pos += old_scroll;
 		}
 
 		if (old_active[0] != new_active[0]) {
 			new_active.children (".flux_content").toggle (0, function () {
-				$(box_to_move).scrollTop (new_pos);
+				new_scroll = $(box_to_move).scrollTop (new_pos).scrollTop ();
 			});
 		}
 	} else {
-		$(box_to_move).scrollTop (new_active.position ().top);
+		new_scroll = $(box_to_move).scrollTop (new_pos).scrollTop ();
+	}
+
+	if ((new_scroll === old_scroll) && $.fn.lazyload) {
+		$(window).trigger ("scroll");	//When no scroll was done, generate fake scroll event for LazyLoad to load images
 	}
 
 	<?php if ($mark['article'] == 'yes') { ?>


### PR DESCRIPTION
Tel qu'utilisé, LazyLoad charge les nouvelles images lors d'un scroll. Hors dans certains cas (navigation clavier ou clic souris sur un article pour l'ouvrir), aucun scroll n'est généré et du coup les images ne sont pas chargées.
Ce patch ajoute un événement scroll artificiel dans ces cas là.

Exemple de cas sans scroll: bas de liste d'articles (ex: non lus), avec des articles plus petits que la taille verticale de la fenêtre, il n'y a pas de matière pour scroller plus haut.
