### PR TITLE
Utilise par défaut des adresses relatives

### DIFF
--- a/lib/minz/Url.php
+++ b/lib/minz/Url.php
@@ -16,25 +16,21 @@ class Url {
 	 * @param $encodage pour indiquer comment encoder les & (& ou &amp; pour html)
 	 * @return l'url formatée
 	 */
-	public static function display ($url = array (), $encodage = 'html') {
+	public static function display ($url = array (), $encodage = 'html', $absolute = false) {
 		$url = self::checkUrl ($url);
 		
 		$url_string = '';
 		
-		if (is_array ($url) && isset ($url['protocol'])) {
-			$protocol = $url['protocol'];
-		} else {
-			if(isset($_SERVER['HTTPS']) && $_SERVER["HTTPS"] == 'on') {
-				$protocol = 'https';
-			} else {
-				$protocol = 'http';
-			}
+		if ($absolute) {
+			$protocol = (is_array ($url) && isset ($url['protocol'])) ? ($url['protocol'] . ':') : '';	//Empty protocol will use automatic http or https
+			$url_string = $protocol
+			            . '//'
+			            . Request::getDomainName ()
+			            . Request::getBaseUrl ();
 		}
-		$url_string .= $protocol . '://';
-		
-		$url_string .= Request::getDomainName ();
-		
-		$url_string .= Request::getBaseUrl ();
+		else {
+			$url_string = '.';
+		}
 		
 		if (is_array ($url)) {
 			$router = new Router ();


### PR DESCRIPTION
Sur ma page d'accueil, l'adresse absolue de FreshRSS est écrite 1300 fois, ce qui représente 15% de la taille de cette page (542Ko -> 460Ko).
Ce patch utilise une adresse relative par défaut, beaucoup plus courte (un simple '.').
De plus, dans le cas d'une adresse absolue, le protocole relatif "//" est maintenant utilisé pour sélectionner automatiquement "http://" ou "https://".

Pas testé avec url_rewriting.
