### PR TITLE
Optimisation SQL, deuxième vague

### DIFF
--- a/app/models/Category.php
+++ b/app/models/Category.php
@@ -11,7 +11,7 @@ class Category extends Model {
 	public function __construct ($name = '', $color = '#0062BE', $feeds = null) {
 		$this->_name ($name);
 		$this->_color ($color);
-		if (!empty($feeds)) {
+		if (isset ($feeds)) {
 			$this->_feeds ($feeds);
 			$this->nbFeed = 0;
 			$this->nbNotRead = 0;
@@ -177,10 +177,13 @@ class CategoryDAO extends Model_pdo {
 
 	public function listCategories ($prePopulateFeeds = true) {	//TODO: Search code-base for places where $prePopulateFeeds should be false
 		if ($prePopulateFeeds) {
-			$sql = 'SELECT c.id as c_id, c.name as c_name, c.color as c_color, count(e.id) as nbNotRead, f.* '
+			$sql = 'SELECT c.id AS c_id, c.name AS c_name, c.color AS c_color, '
+			     . 'COUNT(CASE WHEN e.is_read = 0 THEN 1 END) AS nbNotRead, '
+			     . 'COUNT(e.id) AS nbEntries, '
+			     . 'f.* '
 			     . 'FROM  ' . $this->prefix . 'category c '
 			     . 'LEFT OUTER JOIN ' . $this->prefix . 'feed f ON f.category = c.id '
-			     . 'LEFT OUTER JOIN  ' . $this->prefix . 'entry e ON e.id_feed = f.id AND e.is_read = 0 '
+			     . 'LEFT OUTER JOIN ' . $this->prefix . 'entry e ON e.id_feed = f.id '
 			     . 'GROUP BY f.id '
 			     . 'ORDER BY c.name, f.name';
 			$stm = $this->bd->prepare ($sql);

--- a/app/models/Feed.php
+++ b/app/models/Feed.php
@@ -145,10 +145,7 @@ class Feed extends Model {
 		$this->lastUpdate = $value;
 	}
 	public function _priority ($value) {
-		if (!is_int (intval ($value))) {
-			$value = 10;
-		}
-		$this->priority = $value;
+		$this->priority = is_numeric ($value) ? intval ($value) : 10;
 	}
 	public function _pathEntries ($value) {
 		$this->pathEntries = $value;
@@ -173,11 +170,10 @@ class Feed extends Model {
 		$this->keep_history = $value;
 	}
 	public function _nbNotRead ($value) {
-		if (!is_int ($value)) {
-			$value = -1;
+		$this->nbNotRead = is_numeric ($value) ? intval ($value) : -1;
 		}
-
-		$this->nbNotRead = intval ($value);
+	public function _nbEntries ($value) {
+		$this->nbEntries = is_numeric ($value) ? intval ($value) : -1;
 	}
 
 	public function load () {
@@ -472,7 +468,7 @@ class FeedDAO extends Model_pdo {
 		return HelperFeed::daoToFeed ($stm->fetchAll (PDO::FETCH_ASSOC));
 	}
 
-	public function count () {
+	public function count () {	//Is this used?
 		$sql = 'SELECT COUNT(*) AS count FROM ' . $this->prefix . 'feed';
 		$stm = $this->bd->prepare ($sql);
 		$stm->execute ();
@@ -490,7 +486,7 @@ class FeedDAO extends Model_pdo {
 
 		return $res[0]['count'];
 	}
-	public function countNotRead ($id) {
+	public function countNotRead ($id) {	//Is this used?
 		$sql = 'SELECT COUNT(*) AS count FROM ' . $this->prefix . 'entry WHERE is_read=0 AND id_feed=?';
 		$stm = $this->bd->prepare ($sql);
 		$values = array ($id);
@@ -530,6 +526,9 @@ class HelperFeed {
 			$list[$key]->_keepHistory ($dao['keep_history']);
 			if (isset ($dao['nbNotRead'])) {
 				$list[$key]->_nbNotRead ($dao['nbNotRead']);
+			}
+			if (isset ($dao['nbEntries'])) {
+				$list[$key]->_nbEntries ($dao['nbEntries']);
 			}
 			if (isset ($dao['id'])) {
 				$list[$key]->_id ($dao['id']);

--- a/lib/minz/dao/Model_pdo.php
+++ b/lib/minz/dao/Model_pdo.php
@@ -9,6 +9,14 @@
  * Seul la connexion MySQL est prise en charge pour le moment
  */
 class Model_pdo {
+
+	/**
+	 * Partage la connexion à la base de données entre toutes les instances.
+	 */
+	public static $useSharedBd = true;
+	private static $sharedBd = null;
+	private static $sharedPrefix;
+
 	/**
 	 * $bd variable représentant la base de données
 	 */
@@ -21,6 +29,12 @@ class Model_pdo {
 	 * HOST, BASE, USER et PASS définies dans le fichier de configuration
 	 */
 	public function __construct () {
+		if (self::$useSharedBd && self::$sharedBd != null) {
+			$this->bd = self::$sharedBd;
+			$this->prefix = self::$sharedPrefix;
+			return;
+		}
+
 		$db = Configuration::dataBase ();
 		$driver_options = null;
 
@@ -46,8 +60,10 @@ class Model_pdo {
 				$db['password'],
 				$driver_options
 			);
+			self::$sharedBd = $this->bd;
 
 			$this->prefix = $db['prefix'];
+			self::$sharedPrefix = $this->prefix;
 		} catch (Exception $e) {
 			throw new PDOConnectionException (
 				$string,


### PR DESCRIPTION
Réduction du nombre de requêtes SQL.

Corrige le problème de performance de https://github.com/marienfressinaud/FreshRSS/commit/b0809fcf5eec9d19f335bbed57102beadefba276#commitcomment-4316586

Utilisation d'une seule connexion SQL plutôt que 3 précédemment, en partageant la connexion entre les plusieurs classes DAO (de toute manière, les requêtes sont faites en série et pas en parallèle).

Il reste encore deux ou trois requêtes COUNT(*) superflues (dont une en cache), mais l'essentiel est fait.

Voilà les requêtes nécessaires au chargement de la page d'accueil (contre une par flux auparavant plus quelques autres, ainsi que deux connexions inutiles) : 

```
131013  0:08:22 87521 Connect   root@localhost on freshrss
                87521 Query     SET NAMES utf8
                87521 Query     SELECT is_read, COUNT(*) AS count FROM freshrss_entry e INNER JOIN freshrss_feed f ON e.id_feed = f.id WHERE priority > 0 GROUP BY is_read
                87521 Query     SELECT c.id AS c_id, c.name AS c_name, c.color AS c_color,
                                COUNT(CASE WHEN e.is_read = 0 THEN 1 END) AS nbNotRead, COUNT(e.id) AS nbEntries, f.*
                                FROM freshrss_category c LEFT OUTER JOIN freshrss_feed f ON f.category = c.id LEFT OUTER JOIN freshrss_entry e ON e.id_feed = f.id
                                GROUP BY f.id ORDER BY c.name, f.name
                87521 Query     SELECT is_read, COUNT(*) AS count FROM freshrss_entry WHERE is_favorite=1 GROUP BY is_read
                87521 Query     SELECT is_read, COUNT(*) AS count FROM freshrss_entry e INNER JOIN freshrss_feed f ON e.id_feed = f.id WHERE priority > 0 GROUP BY is_read
                87521 Query     SELECT e.* FROM freshrss_entry e INNER JOIN  freshrss_feed f ON e.id_feed = f.id WHERE priority > 0 AND is_read = 0 ORDER BY e.date DESC, e.id DESC LIMIT 50
                87521 Quit
```
