### PR TITLE
Propose un .htaccess par défaut

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -14,14 +14,14 @@ AddDefaultCharset	UTF-8
 
 <IfModule mod_expires.c>
 	ExpiresActive	on
-	ExpiresByType	application/font-woff	access plus 1 year
-	ExpiresByType	application/javascript	access plus 1 week
-	ExpiresByType	image/gif	access plus 1 month
-	ExpiresByType	image/png	access plus 1 month
-	ExpiresByType	image/svg+xml	access plus 1 month
-	ExpiresByType	image/x-icon	access plus 1 year
-	ExpiresByType	text/css	access plus 1 week
-	ExpiresByType	text/javascript	access plus 1 week
+	ExpiresByType	application/font-woff	"access plus 1 year"
+	ExpiresByType	application/javascript	"access plus 1 week"
+	ExpiresByType	image/gif	"access plus 1 month"
+	ExpiresByType	image/png	"access plus 1 month"
+	ExpiresByType	image/svg+xml	"access plus 1 month"
+	ExpiresByType	image/x-icon	"access plus 1 year"
+	ExpiresByType	text/css	"access plus 1 week"
+	ExpiresByType	text/javascript	"access plus 1 week"
 	<FilesMatch "\.php$">
 		ExpiresActive	Off
 	</FilesMatch>

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -14,7 +14,7 @@ AddDefaultCharset	UTF-8
 
 <IfModule mod_expires.c>
 	ExpiresActive	on
-	ExpiresByType	application/font-woff	"access plus 1 year"
+	ExpiresByType	application/font-woff	"access plus 1 month"
 	ExpiresByType	application/javascript	"access plus 1 week"
 	ExpiresByType	image/gif	"access plus 1 month"
 	ExpiresByType	image/png	"access plus 1 month"

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,40 @@
+<IfModule mod_dir.c>
+	DirectoryIndex	index.php index.html
+</IfModule>
+
+FileETag	None
+AddDefaultCharset	UTF-8
+
+<IfModule mod_mime.c>
+	AddCharset	UTF-8	.css
+	AddCharset	UTF-8	.js
+	AddCharset	UTF-8	.svg
+	AddType application/font-woff .woff
+</IfModule>
+
+<IfModule mod_expires.c>
+	ExpiresActive	on
+	ExpiresByType	application/font-woff	access plus 1 year
+	ExpiresByType	application/javascript	access plus 1 week
+	ExpiresByType	image/gif	access plus 1 month
+	ExpiresByType	image/png	access plus 1 month
+	ExpiresByType	image/svg+xml	access plus 1 month
+	ExpiresByType	image/x-icon	access plus 1 year
+	ExpiresByType	text/css	access plus 1 week
+	ExpiresByType	text/javascript	access plus 1 week
+	<FilesMatch "\.php$">
+		ExpiresActive	Off
+	</FilesMatch>
+</IfModule>
+
+<IfModule mod_headers.c>
+	<FilesMatch "\.(css|ico|gif|png|woff)$">
+		Header	merge Cache-Control "public"
+	</FilesMatch>
+</IfModule>
+
+<Files "favicon.ico">
+	Order	Deny,Allow
+	Allow	from all
+	Satisfy	Any
+</Files>


### PR DESCRIPTION
Une bonne amélioration des performances est possible en utilisant le
cache HTTP.
Ce patch propose un .htaccess par défaut (pour Apache).

L'accès "Satisfy Any" pour favicon.ico est pour le cas où le répertoire
FreshRSS serait protégé par un mot de passe, ce qui pose problèmes pour
certaines utilisations de favicon (y compris dans Firefox).
Le "Cache-Control public" est surtout utile pour la mise en cache dans
le cas de HTTPS.
