### PR TITLE
Ajoute URL dans message FeedException

### DIFF
--- a/app/models/Feed.php
+++ b/app/models/Feed.php
@@ -205,7 +205,7 @@ class Feed extends Model {
 				$feed->init ();
 
 				if ($feed->error ()) {
-					throw new FeedException ($feed->error);
+					throw new FeedException ($feed->error . ' [' . $url . ']');
 				}
 
 				// si on a utilisé l'auto-discover, notre url va avoir changé


### PR DESCRIPTION
Ajoute l'adresse du flux dans la description de l'erreur lorsqu'une exception est générée.
![logs](https://f.cloud.github.com/assets/1008324/1385012/00cc0588-3b58-11e3-991a-679f1d3df965.png)
