### PR TITLE
URL absolue pour token

### DIFF
--- a/app/views/configure/display.phtml
+++ b/app/views/configure/display.phtml
@@ -56,7 +56,7 @@
 			<?php $token = $this->conf->token (); ?>
 			<div class="group-controls">
 				<input type="text" id="token" name="token" value="<?php echo $token; ?>"  placeholder="<?php echo Translate::t ('blank_to_disable'); ?>"/>
-				<i class="icon i_help"></i> <?php echo Translate::t('explain_token', Url::display(), $token); ?>
+				<i class="icon i_help"></i> <?php echo Translate::t('explain_token', Url::display(null, 'html', true), $token); ?>
 			</div>
 		</div>
 	

--- a/lib/minz/Url.php
+++ b/lib/minz/Url.php
@@ -22,11 +22,14 @@ class Url {
 		$url_string = '';
 		
 		if ($absolute) {
-			$protocol = (is_array ($url) && isset ($url['protocol'])) ? ($url['protocol'] . ':') : '';	//Empty protocol will use automatic http or https
-			$url_string = $protocol
-			            . '//'
-			            . Request::getDomainName ()
-			            . Request::getBaseUrl ();
+			if (is_array ($url) && isset ($url['protocol'])) {
+				$protocol = $url['protocol'];
+			} elseif (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') {
+				$protocol = 'https:';
+			} else {
+				$protocol = 'http:';
+			}
+			$url_string = $protocol . '//' . Request::getDomainName () . Request::getBaseUrl ();
 		}
 		else {
 			$url_string = '.';


### PR DESCRIPTION
Corrige https://github.com/marienfressinaud/FreshRSS/issues/213
Abandonne le protocole relatif "//" et repasse à des "http://" ou "https://" explicites
