### PR TITLE
LazyLoad manuel pour les articles repliés

### DIFF
--- a/app/App_FrontController.php
+++ b/app/App_FrontController.php
@@ -62,7 +62,7 @@ class App_FrontController extends FrontController {
 			View::appendScript ('https://login.persona.org/include.js');
 		}
 		View::appendScript (Url::display ('/scripts/jquery.min.js'));
-		if ($this->conf->displayPosts () === 'yes' && $this->conf->lazyload () === 'yes') {
+		if ($this->conf->lazyload () === 'yes' && ($this->conf->displayPosts () === 'yes' || Request::param ('output') === 'reader')) {
 			View::appendScript (Url::display ('/scripts/jquery.lazyload.min.js'));
 		}
 		View::appendScript (Url::display ('/scripts/notification.js'));

--- a/app/App_FrontController.php
+++ b/app/App_FrontController.php
@@ -62,7 +62,7 @@ class App_FrontController extends FrontController {
 			View::appendScript ('https://login.persona.org/include.js');
 		}
 		View::appendScript (Url::display ('/scripts/jquery.min.js'));
-		if ($this->conf->lazyload () === 'yes') {
+		if ($this->conf->displayPosts () === 'yes' && $this->conf->lazyload () === 'yes') {
 			View::appendScript (Url::display ('/scripts/jquery.lazyload.min.js'));
 		}
 		View::appendScript (Url::display ('/scripts/notification.js'));

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -24,6 +24,13 @@ function redirect (url, new_tab) {
 }
 
 function toggleContent (new_active, old_active) {
+	if (does_lazyload) {
+		new_active.find('img[data-original]').each(function() {
+			this.setAttribute('src', this.getAttribute('data-original'));
+			this.removeAttribute('data-original');
+		});
+	}
+
 	old_active.removeClass ("active");
 	if (old_active[0] != new_active[0]) {
 		new_active.addClass ("active");
@@ -60,10 +67,6 @@ function toggleContent (new_active, old_active) {
 		}
 
 		new_scroll = $(box_to_move).scrollTop (new_pos).scrollTop ();
-	}
-
-	if ((new_scroll === old_scroll) && $.fn.lazyload) {
-		$(window).trigger ("scroll");	//When no scroll was done, generate fake scroll event for LazyLoad to load images
 	}
 
 	if (auto_mark_article) {
@@ -182,7 +185,7 @@ function inMarkViewport(flux, box_to_follow, relative_follow) {
 
 function init_posts () {
 	init_img ();
-	if (does_lazyload) {
+	if ($.fn.lazyload) {
 		if (is_global_mode()) {
 			$(".flux .content img").lazyload({
 				container: $("#panel")


### PR DESCRIPTION
LazyLoad.js utilise énormément de CPU et ralentit considérablement le défilement de page, en particulier lorsque le nombre d'articles augmente.
Dans le cas des articles repliés, il n'y a en fait pas besoin du mécanisme complexe de LazyLoad.js basé sur les événements scroll, car il suffit de charger les images lors du dépliage des articles, et cela allège énormément l'expérience.
