### PR TITLE
Issue283: Améliorer fonctionnement raccourci pour refermer un article

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -1,6 +1,19 @@
 "use strict";
 var $stream = null;
 
+// Create a new object to store FreshRSS methods and variables.
+// It will prevent over-riding other libraries methods and variables.
+var FreshRSS = {};
+FreshRSS.isCollapsed = true;
+
+FreshRSS.Entry = {};
+
+// Toggle the collapse flag
+FreshRSS.Entry.toggleCollapse = function() {
+	FreshRSS.isCollapsed = !FreshRSS.isCollapsed;
+	$(".flux.current").toggleClass("active");
+};
+
 function is_normal_mode() {
 	return $stream.hasClass('normal');
 }
@@ -143,9 +156,12 @@ function toggleContent(new_active, old_active) {
 		});
 	}
 
-	old_active.removeClass("active");
+	old_active.removeClass("active").removeClass("current");
 	if (old_active[0] !== new_active[0]) {
-		new_active.addClass("active");
+		if (FreshRSS.isCollapsed) {
+			new_active.addClass("active");
+		};
+		new_active.addClass("current");
 	}
 
 	var box_to_move = "html,body",
@@ -185,7 +201,7 @@ function toggleContent(new_active, old_active) {
 }
 
 function prev_entry() {
-	var old_active = $(".flux.active"),
+	var old_active = $(".flux.current"),
 		last_active = $(".flux:last"),
 		new_active = old_active.prevAll(".flux:first");
 
@@ -197,7 +213,7 @@ function prev_entry() {
 }
 
 function next_entry() {
-	var old_active = $(".flux.active"),
+	var old_active = $(".flux.current"),
 		first_active = $(".flux:first"),
 		last_active = $(".flux:last"),
 		new_active = old_active.nextAll(".flux:first");
@@ -211,10 +227,6 @@ function next_entry() {
 	if ((!auto_load_more) && (last_active.attr("id") === new_active.attr("id"))) {
 		load_more_posts();
 	}
-}
-
-function collapse_entry() {
-	$(".flux.active").removeClass("active");
 }
 
 function inMarkViewport(flux, box_to_follow, relative_follow) {
@@ -303,7 +315,7 @@ function init_shortcuts() {
 	// Touches de manipulation
 	shortcut.add(shortcuts.mark_read, function () {
 		// on marque comme lu ou non lu
-		var active = $(".flux.active");
+		var active = $(".flux.current");
 		mark_read(active, false);
 	}, {
 		'disable_in_input': true
@@ -317,13 +329,13 @@ function init_shortcuts() {
 	});
 	shortcut.add(shortcuts.mark_favorite, function () {
 		// on marque comme favori ou non favori
-		var active = $(".flux.active");
+		var active = $(".flux.current");
 		mark_favorite(active);
 	}, {
 		'disable_in_input': true
 	});
 	shortcut.add(shortcuts.collapse_entry, function () {
-		collapse_entry();
+		FreshRSS.Entry.toggleCollapse();
 	}, {
 		'disable_in_input': true
 	});
@@ -333,7 +345,7 @@ function init_shortcuts() {
 		'disable_in_input': true
 	});
 	shortcut.add("shift+" + shortcuts.prev_entry, function () {
-		var old_active = $(".flux.active"),
+		var old_active = $(".flux.current"),
 			first = $(".flux:first");
 
 		if (first.hasClass("flux")) {
@@ -346,7 +358,7 @@ function init_shortcuts() {
 		'disable_in_input': true
 	});
 	shortcut.add("shift+" + shortcuts.next_entry, function () {
-		var old_active = $(".flux.active"),
+		var old_active = $(".flux.current"),
 			last = $(".flux:last");
 
 		if (last.hasClass("flux")) {
@@ -359,7 +371,7 @@ function init_shortcuts() {
 		var url_website = $(".flux.active .link a").attr("href");
 
 		if (auto_mark_site) {
-			$(".flux.active").each(function () {
+			$(".flux.current").each(function () {
 				mark_read($(this), true);
 			});
 		}
@@ -372,7 +384,7 @@ function init_shortcuts() {
 
 function init_stream_delegates(divStream) {
 	divStream.on('click', '.flux_header>.item.title, .flux_header>.item.date', function (e) {	//flux_header_toggle
-		var old_active = $(".flux.active"),
+		var old_active = $(".flux.current"),
 			new_active = $(this).parent().parent();
 		if (e.target.tagName.toUpperCase() === 'A') {	//Leave real links alone
 			if (auto_mark_article) {
@@ -427,7 +439,7 @@ function init_nav_entries() {
 		return false;
 	});
 	$nav_entries.find('.up').click(function () {
-		var active_item = $(".flux.active"),
+		var active_item = $(".flux.current"),
 			windowTop = $(window).scrollTop(),
 			item_top = active_item.position().top;
 

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -1,18 +1,7 @@
 "use strict";
 var $stream = null;
 
-// Create a new object to store FreshRSS methods and variables.
-// It will prevent over-riding other libraries methods and variables.
-var FreshRSS = {};
-FreshRSS.isCollapsed = true;
-
-FreshRSS.Entry = {};
-
-// Toggle the collapse flag
-FreshRSS.Entry.toggleCollapse = function() {
-	FreshRSS.isCollapsed = !FreshRSS.isCollapsed;
-	$(".flux.current").toggleClass("active");
-};
+var isCollapsed = true;
 
 function is_normal_mode() {
 	return $stream.hasClass('normal');
@@ -158,7 +147,7 @@ function toggleContent(new_active, old_active) {
 
 	old_active.removeClass("active").removeClass("current");
 	if (old_active[0] !== new_active[0]) {
-		if (FreshRSS.isCollapsed) {
+		if (isCollapsed) {
 			new_active.addClass("active");
 		};
 		new_active.addClass("current");
@@ -228,6 +217,11 @@ function next_entry() {
 		load_more_posts();
 	}
 }
+
+function collapse_entry() {
+	isCollapsed = !isCollapsed;
+	$(".flux.current").toggleClass("active");
+};
 
 function inMarkViewport(flux, box_to_follow, relative_follow) {
 	var top = flux.position().top;
@@ -343,7 +337,7 @@ function init_shortcuts() {
 		'disable_in_input': true
 	});
 	shortcut.add(shortcuts.collapse_entry, function () {
-		FreshRSS.Entry.toggleCollapse();
+		collapse_entry();
 	}, {
 		'disable_in_input': true
 	});

--- a/public/themes/default/freshrss.css
+++ b/public/themes/default/freshrss.css
@@ -280,6 +280,9 @@
 				color: #000;
 				outline: none;
 			}
+			.flux.current .item.title a {
+				text-decoration: underline;
+			}
 			.flux.not_read .flux_header .item.title {
 				font-weight: bold;
 			}

--- a/public/themes/flat-design/freshrss.css
+++ b/public/themes/flat-design/freshrss.css
@@ -259,6 +259,9 @@ body {
 				color: #333;
 				outline: none;
 			}
+			.flux.current .item.title a {
+				text-decoration: underline;
+			}
 			.flux.not_read .flux_header .item.title {
 				font-weight: bold;
 			}


### PR DESCRIPTION
J'ai ajouté un mécanisme pour se souvenir de l'état ouvert ou fermé de l'article.
La position courante est conservée et notée par le titre souligné.

Le code JavaScript est une proposition de qu'il serait possible de faire pour l'ensemble du JavaScript de l'application. Je ne l'ai appliqué qu'à cette portion de code pour ne pas faire trop de changements. Cependant, je suis prêt à continuer la conversion du reste du code si besoin est ou à convertir le code que j'ai écrit au standard utilisé ailleurs
