### PR TITLE
Correction du bug de vue globale.

### DIFF
--- a/app/layout/aside_flux.phtml
+++ b/app/layout/aside_flux.phtml
@@ -13,9 +13,15 @@
 		<li><a href="<?php echo _url ('index', 'about'); ?>"><?php echo Minz_Translate::t ('about_freshrss'); ?></a></li>
 		<?php } ?>
 
+		<?php 
+			$output = array();
+			if ($this->conf->view_mode !== Minz_Request::param('output', 'normal')) {
+				$output = array('output', 'normal');
+			}
+		?>
 		<li>
 			<div class="category all">
-				<a data-unread="<?php echo $this->nb_not_read; ?>" class="btn<?php echo $this->get_c == 'a' ? ' active' : ''; ?>" href="<?php echo _url ('index', 'index'); ?>">
+				<a data-unread="<?php echo $this->nb_not_read; ?>" class="btn<?php echo $this->get_c == 'a' ? ' active' : ''; ?>" href="<?php echo call_user_func_array('_url', array_merge(array('index', 'index'), $output)); ?>">
 					<?php echo FreshRSS_Themes::icon('all'); ?>
 					<?php echo Minz_Translate::t ('all_feeds'); ?>
 				</a>
@@ -24,7 +30,7 @@
 
 		<li>
 			<div class="category favorites">
-				<a data-unread="<?php echo $this->nb_favorites['unread']; ?>" class="btn<?php echo $this->get_c == 's' ? ' active' : ''; ?>" href="<?php echo _url ('index', 'index', 'get', 's'); ?>">
+				<a data-unread="<?php echo $this->nb_favorites['unread']; ?>" class="btn<?php echo $this->get_c == 's' ? ' active' : ''; ?>" href="<?php echo call_user_func_array('_url', array_merge(array('index', 'index', 'get', 's'), $output)); ?>">
 					<?php echo FreshRSS_Themes::icon('bookmark'); ?>
 					<?php echo Minz_Translate::t ('favorite_feeds', $this->nb_favorites['all']); ?>
 				</a>
@@ -37,7 +43,7 @@
 		<li>
 			<?php $c_active = false; if ($this->get_c == $cat->id ()) { $c_active = true; } ?>
 			<div class="category stick<?php echo $c_active ? ' active' : ''; ?>">
-				<a data-unread="<?php echo $cat->nbNotRead (); ?>" class="btn<?php echo $c_active ? ' active' : ''; ?>" href="<?php echo _url ('index', 'index', 'get', 'c_' . $cat->id ()); ?>"><?php echo $cat->name (); ?></a>
+				<a data-unread="<?php echo $cat->nbNotRead (); ?>" class="btn<?php echo $c_active ? ' active' : ''; ?>" href="<?php echo call_user_func_array('_url', array_merge(array('index', 'index', 'get', 'c_' . $cat->id ()), $output)); ?>"><?php echo $cat->name (); ?></a>
 				<a class="btn dropdown-toggle" href="#"><?php echo FreshRSS_Themes::icon($c_active ? 'up' : 'down'); ?></a>
 			</div>
 
@@ -53,7 +59,7 @@
 <?php /* feed_config_template */ ?>
 					</div>
 					<img class="favicon" src="<?php echo $feed->favicon (); ?>" alt="✇" />
-					<a class="feed" data-unread="<?php echo $feed->nbNotRead (); ?>" data-priority="<?php echo $feed->priority (); ?>" href="<?php echo _url ('index', 'index', 'get', 'f_' . $feed_id); ?>"><?php echo $feed->name(); ?></a>
+					<a class="feed" data-unread="<?php echo $feed->nbNotRead (); ?>" data-priority="<?php echo $feed->priority (); ?>" href="<?php echo call_user_func_array('_url', array_merge(array('index', 'index', 'get', 'f_' . $feed_id), $output)); ?>"><?php echo $feed->name(); ?></a>
 				</li>
 				<?php } ?>
 			</ul>


### PR DESCRIPTION
Lorsque la vue globale est la vue par défaut et que la vue normale est sélectionnée,
la navigation continue en vue globale. C'est également vrai pour la vue lecture.
Le comportement est modifié pour conserver la vue sélectionnée lors de la navigation.

Voir https://github.com/marienfressinaud/FreshRSS/issues/346
