### PR TITLE
Correction du theme foncé

### DIFF
--- a/p/themes/default_dark/freshrss.css
+++ b/p/themes/default_dark/freshrss.css
@@ -419,7 +419,7 @@
 	top: 10px; bottom: 10px;
 	left: 100px; right: 100px;
 	overflow: auto;
-	background: #fff;
+	background: #1c1c1c;
 	border: 1px solid #95a5a6;
 	border-radius: 5px;
 }


### PR DESCRIPTION
En vue globale, l'arrière plan de la popup était blanc et risquait de rendre les
utilisateurs aveugles. Je l'ai remplacé par la même couleur que le reste du thème.
