### PR TITLE
Change category modifier for shortcuts

### DIFF
--- a/app/i18n/en.php
+++ b/app/i18n/en.php
@@ -80,7 +80,7 @@ return array (
 	'shortcuts_updated'		=> 'Shortcuts have been updated',
 	'shortcuts_management'		=> 'Shortcuts management',
 	'shortcuts_navigation'		=> 'Navigation',
-	'shortcuts_navigation_help'	=> 'With the "Shift" modifier, navigation shortcuts apply on feeds.<br/>With the "Ctrl" modifier, navigation shortcuts apply on categories.',
+	'shortcuts_navigation_help'	=> 'With the "Shift" modifier, navigation shortcuts apply on feeds.<br/>With the "Alt" modifier, navigation shortcuts apply on categories.',
 	'shortcuts_article_action'	=> 'Article actions',
 	'shortcuts_other_action'	=> 'Other actions',
 	'feeds_marked_read'		=> 'Feeds have been marked as read',

--- a/app/i18n/fr.php
+++ b/app/i18n/fr.php
@@ -80,7 +80,7 @@ return array (
 	'shortcuts_updated'		=> 'Les raccourcis ont été mis à jour',
 	'shortcuts_management'		=> 'Gestion des raccourcis',
 	'shortcuts_navigation'		=> 'Navigation',
-	'shortcuts_navigation_help'	=> 'Avec le modificateur "Shift", les raccourcis de navigation s’appliquent aux flux.<br/>Avec le modificateur "Ctrl", les raccourcis de navigation s’appliquent aux catégories.',
+	'shortcuts_navigation_help'	=> 'Avec le modificateur "Shift", les raccourcis de navigation s’appliquent aux flux.<br/>Avec le modificateur "Alt", les raccourcis de navigation s’appliquent aux catégories.',
 	'shortcuts_article_action'	=> 'Actions associées à l’article courant',
 	'shortcuts_other_action'	=> 'Autres actions',
 	'feeds_marked_read'		=> 'Les flux ont été marqués comme lus',

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -286,10 +286,7 @@ function next_entry() {
 function prev_feed() {
 	var active_feed = $("#aside_flux .feeds li.active");
 	if (active_feed.length > 0) {
-		var prev_feed = active_feed.prev().find('a.feed');
-		if (prev_feed.length > 0) {
-			prev_feed[0].click();
-		}
+		active_feed.prev().find('a.feed').each(function(){this.click();});
 	} else {
 		last_feed();
 	}
@@ -298,10 +295,7 @@ function prev_feed() {
 function next_feed() {
 	var active_feed = $("#aside_flux .feeds li.active");
 	if (active_feed.length > 0) {
-		var next_feed = active_feed.next().find('a.feed');
-		if (next_feed.length > 0) {
-			next_feed[0].click();
-		}
+		active_feed.next().find('a.feed').each(function(){this.click();});
 	} else {
 		first_feed();
 	}

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -322,10 +322,10 @@ function last_feed() {
 }
 
 function prev_category() {
-	var active_cat = $("#aside_flux .category.active");
+	var active_cat = $("#aside_flux .category.stick.active");
 
 	if (active_cat.length > 0) {
-		var prev_cat = active_cat.parent('li').prev().find('.category a.btn');
+		var prev_cat = active_cat.parent('li').prev().find('.category.stick a.btn');
 		if (prev_cat.length > 0) {
 			prev_cat[0].click();
 		}
@@ -336,10 +336,10 @@ function prev_category() {
 }
 
 function next_category() {
-	var active_cat = $("#aside_flux .category.active");
+	var active_cat = $("#aside_flux .category.stick.active");
 
 	if (active_cat.length > 0) {
-		var next_cat = active_cat.parent('li').next().find('.category a.btn');
+		var next_cat = active_cat.parent('li').next().find('.category.stick a.btn');
 		if (next_cat.length > 0) {
 			next_cat[0].click();
 		}
@@ -350,14 +350,14 @@ function next_category() {
 }
 
 function first_category() {
-	var cat = $("#aside_flux .category:first");
+	var cat = $("#aside_flux .category.stick:first");
 	if (cat.length > 0) {
 		cat.find('a.btn')[0].click();
 	}
 }
 
 function last_category() {
-	var cat = $("#aside_flux .category:last");
+	var cat = $("#aside_flux .category.stick:last");
 	if (cat.length > 0) {
 		cat.find('a.btn')[0].click();
 	}
@@ -577,16 +577,16 @@ function init_shortcuts() {
 		'disable_in_input': true
 	});
 	// Touches de navigation pour les categories
-	shortcut.add("ctrl+" + shortcuts.prev_entry, prev_category, {
+	shortcut.add("alt+" + shortcuts.prev_entry, prev_category, {
 		'disable_in_input': true
 	});
-	shortcut.add("ctrl+" + shortcuts.next_entry, next_category, {
+	shortcut.add("alt+" + shortcuts.next_entry, next_category, {
 		'disable_in_input': true
 	});
-	shortcut.add("ctrl+" + shortcuts.first_entry, first_category, {
+	shortcut.add("alt+" + shortcuts.first_entry, first_category, {
 		'disable_in_input': true
 	});
-	shortcut.add("ctrl+" + shortcuts.last_entry, last_category, {
+	shortcut.add("alt+" + shortcuts.last_entry, last_category, {
 		'disable_in_input': true
 	});
 


### PR DESCRIPTION
The modifier to change the focus of categories was Ctrl. It was changed to avoid
interference with browser shortcuts.
See #256

It fixes also category shorcuts.
