### PR TITLE
Add a default URL value

### DIFF
--- a/app/Models/Share.php
+++ b/app/Models/Share.php
@@ -3,6 +3,9 @@
 class FreshRSS_Share {
 
 	static public function generateUrl($options, $selected, $link, $title) {
+		if (!array_key_exists('url', $selected)) {
+			$selected['url'] = '';
+		}
 		$share = $options[$selected['type']];
 		$matches = array(
 			'~URL~',


### PR DESCRIPTION
Add a default URL value for share types that do not have one.
I could not test that properly since no notice was raised on my machine.
See #442
