### PR TITLE
Change article observer

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -606,7 +606,7 @@ function init_shortcuts() {
 }
 
 function init_stream(divStream) {
-	divStream.on('click', '.flux_header,.flux_content > .bottom', function (e) {	//flux_header_toggle, flux_footer_toggle
+	divStream.on('click', '.flux_header,.flux_content', function (e) {	//flux_toggle
 		if ($(e.target).closest('.item.website, .item.link').length > 0) {
 			return;
 		}


### PR DESCRIPTION
Instead of observe only the bottom of the article to collapse the article, the whole article is observed.
Now if you want to close an article in the middle of your reading, you can.
