### PR TITLE
Change click behavior on articles

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -604,6 +604,9 @@ function init_shortcuts() {
 
 function init_stream(divStream) {
 	divStream.on('click', '.flux_header,.flux_content', function (e) {	//flux_toggle
+		if ($(e.target).parents('.content').length > 0) {
+			return;
+		}
 		if ($(e.target).closest('.item.website, .item.link').length > 0) {
 			return;
 		}


### PR DESCRIPTION
Before, when the user click on an article it closes even if he want to select text.
This behavior was not acceptable, so I changed it to close the article when cliking
on the article footer or in the article margins.

See #473
