### PR TITLE
Fix unexpected behavior during navigation

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -227,6 +227,8 @@ function toggleContent(new_active, old_active) {
 			new_active.addClass("active");
 		}
 		new_active.addClass("current");
+	} else {
+		new_active.toggleClass("current");
 	}
 
 	var box_to_move = "html,body",


### PR DESCRIPTION
When the navigation is done with the mouse and shortcuts, the focus on the current article is lost when
the article is collapsed with the mouse. So when navigating with the shortcut does not open the intended
article.

See #473 and #478
