### PR TITLE
Fix error when displaying favorite count

### DIFF
--- a/app/i18n/en.php
+++ b/app/i18n/en.php
@@ -27,7 +27,7 @@ return array (
 	'subscription_management'	=> 'Subscriptions management',
 	'main_stream'			=> 'Main stream',
 	'all_feeds'			=> 'All feeds',
-	'favorite_feeds'		=> 'Favourites (%d)',
+	'favorite_feeds'		=> 'Favourites (%s)',
 	'not_read'			=> '%d unread',
 	'not_reads'			=> '%d unread',
 

--- a/app/i18n/fr.php
+++ b/app/i18n/fr.php
@@ -27,7 +27,7 @@ return array (
 	'subscription_management'	=> 'Gestion des abonnements',
 	'main_stream'			=> 'Flux principal',
 	'all_feeds'			=> 'Tous les flux',
-	'favorite_feeds'		=> 'Favoris (%d)',
+	'favorite_feeds'		=> 'Favoris (%s)',
 	'not_read'			=> '%d non lu',
 	'not_reads'			=> '%d non lus',
 


### PR DESCRIPTION
This bug appears because we where trying to display a string as a number.
The function to translate was cutting the parameter to the first non numeric character (the space)

See #487
