### PR TITLE
Username regexp is too strict

### DIFF
--- a/p/i/install.php
+++ b/p/i/install.php
@@ -913,7 +913,7 @@ function printStep3 () {
 		<div class="form-group">
 			<label class="group-name" for="user"><?php echo _t ('username'); ?></label>
 			<div class="group-controls">
-				<input type="text" id="user" name="user" maxlength="16" pattern="[0-9A-Za-z_]{1,16}" value="<?php echo isset ($_SESSION['bd_user']) ? $_SESSION['bd_user'] : ''; ?>" />
+				<input type="text" id="user" name="user" maxlength="16" pattern="[0-9A-Za-z_.-]{1,16}" value="<?php echo isset ($_SESSION['bd_user']) ? $_SESSION['bd_user'] : ''; ?>" />
 			</div>
 		</div>
 


### PR DESCRIPTION
Username can contains more characters that the regexp allows. For example, on a raspberry pi, the default user for web server is 'www-data'.
