### PR TITLE
Change behavior when selecting an article

### DIFF
--- a/app/i18n/en.php
+++ b/app/i18n/en.php
@@ -256,7 +256,7 @@ return array (
 	'img_with_lazyload'		=> 'Use "lazy load" mode to load pictures',
 	'sticky_post'			=> 'Stick the article to the top when opened',
 	'auto_read_when'		=> 'Mark article as read…',
-	'article_selected'		=> 'when article is selected',
+	'article_viewed'		=> 'when article is view',
 	'article_open_on_website'	=> 'when article is opened on its original website',
 	'scroll'			=> 'during page scrolls',
 	'upon_reception'		=> 'upon reception of the article',

--- a/app/i18n/fr.php
+++ b/app/i18n/fr.php
@@ -256,7 +256,7 @@ return array (
 	'img_with_lazyload'		=> 'Utiliser le mode “chargement différé” pour les images',
 	'sticky_post'			=> 'Aligner l’article en haut quand il est ouvert',
 	'auto_read_when'		=> 'Marquer un article comme lu…',
-	'article_selected'		=> 'lorsque l’article est sélectionné',
+	'article_viewed'		=> 'lorsque l’article est affiché',
 	'article_open_on_website'	=> 'lorsque l’article est ouvert sur le site d’origine',
 	'scroll'			=> 'au défilement de la page',
 	'upon_reception'		=> 'dès la réception du nouvel article',

--- a/app/views/configure/reading.phtml
+++ b/app/views/configure/reading.phtml
@@ -87,7 +87,7 @@
 			<div class="group-controls">
 				<label class="checkbox" for="check_open_article">
 					<input type="checkbox" name="mark_open_article" id="check_open_article" value="1"<?php echo $this->conf->mark_when['article'] ? ' checked="checked"' : ''; ?> />
-					<?php echo Minz_Translate::t ('article_selected'); ?>
+					<?php echo Minz_Translate::t ('article_viewed'); ?>
 				</label>
 				<label class="checkbox" for="check_open_site">
 					<input type="checkbox" name="mark_open_site" id="check_open_site" value="1"<?php echo $this->conf->mark_when['site'] ? ' checked="checked"' : ''; ?> />

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -258,7 +258,7 @@ function toggleContent(new_active, old_active) {
 		}
 	}
 
-	if (auto_mark_article) {
+	if (auto_mark_article && new_active.hasClass('active')) {
 		mark_read(new_active, true);
 	}
 }


### PR DESCRIPTION
See #524
Before, when the configuration was set so the article is marked as read when selected, if you mark it as unread while it is open and then close it, it is marked again as read. This behavior was not straightforward.
Now, the article is not marked again as read.
