### PR TITLE
Add a confirmation dialog when clicking on the big tick

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -185,8 +185,9 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 			$this->view->conf->_auto_load_more(Minz_Request::param('auto_load_more', false));
 			$this->view->conf->_display_posts(Minz_Request::param('display_posts', false));
 			$this->view->conf->_onread_jump_next(Minz_Request::param('onread_jump_next', false));
-			$this->view->conf->_lazyload(Minz_Request::param('lazyload', false));
-			$this->view->conf->_sticky_post(Minz_Request::param('sticky_post', false));
+			$this->view->conf->_lazyload (Minz_Request::param('lazyload', false));
+			$this->view->conf->_sticky_post (Minz_Request::param('sticky_post', false));
+			$this->view->conf->_reading_confirm (Minz_Request::param('reading_confirm', false));
 			$this->view->conf->_sort_order(Minz_Request::param('sort_order', 'DESC'));
 			$this->view->conf->_mark_when(array(
 				'article' => Minz_Request::param('mark_open_article', false),

--- a/app/Models/Configuration.php
+++ b/app/Models/Configuration.php
@@ -20,6 +20,7 @@ class FreshRSS_Configuration {
 		'onread_jump_next' => true,
 		'lazyload' => true,
 		'sticky_post' => true,
+		'reading_confirm' => false,
 		'sort_order' => 'DESC',
 		'anon_access' => false,
 		'mark_when' => array(
@@ -148,6 +149,9 @@ class FreshRSS_Configuration {
 	}
 	public function _sticky_post($value) {
 		$this->data['sticky_post'] = ((bool)$value) && $value !== 'no';
+	}
+	public function _reading_confirm($value) {
+		$this->data['reading_confirm'] = ((bool)$value) && $value !== 'no';
 	}
 	public function _sort_order ($value) {
 		$this->data['sort_order'] = $value === 'ASC' ? 'ASC' : 'DESC';

--- a/app/i18n/en.php
+++ b/app/i18n/en.php
@@ -264,6 +264,7 @@ return array (
 	'bottom_line'			=> 'Bottom line',
 	'img_with_lazyload'		=> 'Use "lazy load" mode to load pictures',
 	'sticky_post'			=> 'Stick the article to the top when opened',
+	'reading_confirm'		=> 'Display a confirmation dialog on “mark all as read” actions',
 	'auto_read_when'		=> 'Mark article as read…',
 	'article_viewed'		=> 'when article is viewed',
 	'article_open_on_website'	=> 'when article is opened on its original website',

--- a/app/i18n/fr.php
+++ b/app/i18n/fr.php
@@ -264,6 +264,7 @@ return array (
 	'bottom_line'			=> 'Ligne du bas',
 	'img_with_lazyload'		=> 'Utiliser le mode “chargement différé” pour les images',
 	'sticky_post'			=> 'Aligner l’article en haut quand il est ouvert',
+	'reading_confirm'		=> 'Afficher une confirmation lors des actions “marquer tout comme lu”',
 	'auto_read_when'		=> 'Marquer un article comme lu…',
 	'article_viewed'		=> 'lorsque l’article est affiché',
 	'article_open_on_website'	=> 'lorsque l’article est ouvert sur le site d’origine',

--- a/app/layout/nav_menu.phtml
+++ b/app/layout/nav_menu.phtml
@@ -181,7 +181,7 @@
 	?>
 
 	<div class="stick" id="nav_menu_read_all">
-		<a class="read_all btn confirm" href="<?php echo $markReadUrl; ?>"><?php echo Minz_Translate::t ('mark_read'); ?></a>
+		<a class="read_all btn<?php if ($this->conf->reading_confirm) {echo ' confirm';} ?>" href="<?php echo $markReadUrl; ?>"><?php echo Minz_Translate::t ('mark_read'); ?></a>
 		<div class="dropdown">
 			<div id="dropdown-read" class="dropdown-target"></div>
 

--- a/app/layout/nav_menu.phtml
+++ b/app/layout/nav_menu.phtml
@@ -181,7 +181,7 @@
 	?>
 
 	<div class="stick" id="nav_menu_read_all">
-		<a class="read_all btn" href="<?php echo $markReadUrl; ?>"><?php echo Minz_Translate::t ('mark_read'); ?></a>
+		<a class="read_all btn confirm" href="<?php echo $markReadUrl; ?>"><?php echo Minz_Translate::t ('mark_read'); ?></a>
 		<div class="dropdown">
 			<div id="dropdown-read" class="dropdown-target"></div>
 

--- a/app/views/configure/reading.phtml
+++ b/app/views/configure/reading.phtml
@@ -83,6 +83,16 @@
 		</div>
 
 		<div class="form-group">
+			<div class="group-controls">
+				<label class="checkbox" for="reading_confirm">
+					<input type="checkbox" name="reading_confirm" id="reading_confirm" value="1"<?php echo $this->conf->reading_confirm ? ' checked="checked"' : ''; ?> />
+					<?php echo Minz_Translate::t ('reading_confirm'); ?>
+					<noscript> — <strong><?php echo Minz_Translate::t ('javascript_should_be_activated'); ?></strong></noscript>
+				</label>
+			</div>
+		</div>
+
+		<div class="form-group">
 			<label class="group-name"><?php echo Minz_Translate::t ('auto_read_when'); ?></label>
 			<div class="group-controls">
 				<label class="checkbox" for="check_open_article">

--- a/app/views/helpers/pagination.phtml
+++ b/app/views/helpers/pagination.phtml
@@ -12,7 +12,7 @@
 	<?php $params['next'] = $this->nextId; ?>
 	<a id="load_more" href="<?php echo Minz_Url::display (array ('c' => $c, 'a' => $a, 'params' => $params)); ?>"><?php echo Minz_Translate::t ('load_more'); ?></a>
 	<?php } elseif ($markReadUrl) { ?>
-	<a id="bigMarkAsRead" href="<?php echo $markReadUrl; ?>">
+	<a id="bigMarkAsRead" href="<?php echo $markReadUrl; ?>" class="confirm">
 		<?php echo Minz_Translate::t ('nothing_to_load'); ?><br />
 		<span class="bigTick">✔</span><br />
 		<?php echo Minz_Translate::t ('mark_all_read'); ?>

--- a/app/views/helpers/pagination.phtml
+++ b/app/views/helpers/pagination.phtml
@@ -12,7 +12,7 @@
 	<?php $params['next'] = $this->nextId; ?>
 	<a id="load_more" href="<?php echo Minz_Url::display (array ('c' => $c, 'a' => $a, 'params' => $params)); ?>"><?php echo Minz_Translate::t ('load_more'); ?></a>
 	<?php } elseif ($markReadUrl) { ?>
-	<a id="bigMarkAsRead" href="<?php echo $markReadUrl; ?>" class="confirm">
+	<a id="bigMarkAsRead" href="<?php echo $markReadUrl; ?>"<?php if ($this->conf->reading_confirm) { echo ' class="confirm"';} ?>>
 		<?php echo Minz_Translate::t ('nothing_to_load'); ?><br />
 		<span class="bigTick">✔</span><br />
 		<?php echo Minz_Translate::t ('mark_all_read'); ?>


### PR DESCRIPTION
See #519
Before, when clicking on the big tick to mark all articles as read, it triggers directly the action.
Now, it asks for a confirmation to block unwanted user clicks.
