### PR TITLE
Add a confirmation when using shortcuts

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -499,7 +499,13 @@ function init_shortcuts() {
 	shortcut.add("shift+" + shortcuts.mark_read, function () {
 		// on marque tout comme lu
 		var url = $(".nav_menu a.read_all").attr("href");
-		redirect(url, false);
+		if ($(".nav_menu a.read_all").hasClass('confirm')) {
+			if (confirm(str_confirmation)) {
+				redirect(url, false);
+			}
+		} else {
+			redirect(url, false);
+		}
 	}, {
 		'disable_in_input': true
 	});


### PR DESCRIPTION
Before, it was possible to mark everything as read with no confirmation using shortcut even if the configuration introduced in a previous commit asked for a confirmation.
Now, depending of the configuration, a confirm dialog box is displayed when requested in the configuration.
