### PR TITLE
Change event handling for confirmation dialog

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -973,7 +973,7 @@ function init_persona() {
 //</persona>
 
 function init_confirm_action() {
-	$('.confirm').click(function () {
+	$('body').on('click', '.confirm', function () {
 		return confirm(str_confirmation);
 	});
 }


### PR DESCRIPTION
See #567
Before, when content was loaded dynamically, the confirmation was not poping.
Now, the confirmation pops by changing event handling.
