### PR TITLE
Add a feed selector in repartition statistics.

### DIFF
--- a/app/Controllers/statsController.php
+++ b/app/Controllers/statsController.php
@@ -58,9 +58,11 @@ class FreshRSS_stats_Controller extends Minz_ActionController {
 
 	public function repartitionAction() {
 		$statsDAO = FreshRSS_Factory::createStatsDAO();
+		$categoryDAO = new FreshRSS_CategoryDAO();
 		$feedDAO = FreshRSS_Factory::createFeedDao();
 		Minz_View::appendScript(Minz_Url::display('/scripts/flotr2.min.js?' . @filemtime(PUBLIC_PATH . '/scripts/flotr2.min.js')));
 		$id = Minz_Request::param ('id', null);
+		$this->view->categories = $categoryDAO->listCategories ();
 		$this->view->feed = $feedDAO->searchById($id);
 		$this->view->days = $statsDAO->getDays();
 		$this->view->months = $statsDAO->getMonths();

--- a/app/views/stats/repartition.phtml
+++ b/app/views/stats/repartition.phtml
@@ -2,23 +2,38 @@
 
 <div class="post content">
 	<a href="<?php echo _url('index', 'index'); ?>"><?php echo _t('back_to_rss_feeds'); ?></a>
-	
+
+	<h1><?php echo _t('stats_repartition'); ?></h1>
+
+	<select id="feed_select">
+		<option data-url="<?php echo _url ('stats', 'repartition')?>"></option>
+	<?php foreach ($this->categories as $category) {
+		$feeds = $category->feeds ();
+		if (!empty ($feeds)) {
+			echo '<optgroup label=', $category->name(), '>';
+			foreach ($feeds as $feed) {
+				if ($this->feed && $feed->id() == $this->feed->id()){
+					echo '<option value ="', $feed->id(), '" selected data-url="', _url ('stats', 'repartition', 'id', $feed->id()), '">', $feed->name(), '</option>';
+				} else {
+					echo '<option value ="', $feed->id(), '" data-url="', _url ('stats', 'repartition', 'id', $feed->id()), '">', $feed->name(), '</option>';
+				}
+			}
+			echo '</optgroup>';
+		}
+	}?>
+	</select>
+
 	<?php if ($this->feed) {?>
-		<h1>
-			<?php echo _t('stats_repartition'), " - "; ?>
-			<a href="<?php echo _url('configure', 'feed', 'id', $this->feed->id()); ?>">
-				<?php echo $this->feed->name(); ?>
-			</a>
-		</h1>
-	<?php } else {?>
-		<h1><?php echo _t('stats_repartition'); ?></h1>
+		<a href="<?php echo _url('configure', 'feed', 'id', $this->feed->id()); ?>">
+			<?php echo _t('administration'); ?>
+		</a>
 	<?php }?>
-	
+
 	<div class="stat">
 		<h2><?php echo _t('stats_entry_per_hour'); ?></h2>
 		<div id="statsEntryPerHour" style="height: 300px"></div>
 	</div>
-	
+
 	<div class="stat">
 		<h2><?php echo _t('stats_entry_per_day_of_week'); ?></h2>
 		<div id="statsEntryPerDayOfWeek" style="height: 300px"></div>
@@ -93,7 +108,7 @@ function initStats() {
 			yaxis: {min: 0},
 			mouse: {relative: true, track: true, trackDecimals: 0, trackFormatter: function(obj) {return numberFormat(obj.y);}}
 		});
-	
+
 }
 initStats();
 </script>

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1063,6 +1063,12 @@ function init_share_observers() {
 	});
 }
 
+function init_stats_observers() {
+	$('#feed_select').on('change', function(e) {
+		redirect($(this).find(':selected').data('url'));
+	});
+}
+
 function init_remove_observers() {
 	$('.post').on('click', 'a.remove', function(e) {
 		var remove_what = $(this).attr('data-remove');
@@ -1177,6 +1183,7 @@ function init_all() {
 		init_remove_observers();
 		init_feed_observers();
 		init_password_observers();
+		init_stats_observers();
 	}
 
 	if (window.console) {


### PR DESCRIPTION
Before we could choose the feed in the statistics only from the feed options in the main view. Now with the new drop-down list, it is possible to choose it from the statistics page.
The rendering needs to be polished to be nicer.

See #547
