### PR TITLE
Add category reading option

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -184,6 +184,7 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 			$this->view->conf->_default_view((int)Minz_Request::param('default_view', FreshRSS_Entry::STATE_ALL));
 			$this->view->conf->_auto_load_more(Minz_Request::param('auto_load_more', false));
 			$this->view->conf->_display_posts(Minz_Request::param('display_posts', false));
+			$this->view->conf->_display_categories(Minz_Request::param('display_categories', false));
 			$this->view->conf->_hide_read_feeds(Minz_Request::param('hide_read_feeds', false));
 			$this->view->conf->_onread_jump_next(Minz_Request::param('onread_jump_next', false));
 			$this->view->conf->_lazyload(Minz_Request::param('lazyload', false));

--- a/app/Models/Configuration.php
+++ b/app/Models/Configuration.php
@@ -17,6 +17,7 @@ class FreshRSS_Configuration {
 		'default_view' => FreshRSS_Entry::STATE_NOT_READ,
 		'auto_load_more' => true,
 		'display_posts' => false,
+		'display_categories' => false,
 		'hide_read_feeds' => true,
 		'onread_jump_next' => true,
 		'lazyload' => true,
@@ -141,6 +142,9 @@ class FreshRSS_Configuration {
 	}
 	public function _display_posts ($value) {
 		$this->data['display_posts'] = ((bool)$value) && $value !== 'no';
+	}
+	public function _display_categories ($value) {
+		$this->data['display_categories'] = ((bool)$value) && $value !== 'no';
 	}
 	public function _hide_read_feeds($value) {
 		$this->data['hide_read_feeds'] = (bool)$value;

--- a/app/i18n/en.php
+++ b/app/i18n/en.php
@@ -267,6 +267,7 @@ return array (
 	'sort_order'			=> 'Sort order',
 	'auto_load_more'		=> 'Load next articles at the page bottom',
 	'display_articles_unfolded'	=> 'Show articles unfolded by default',
+	'display_categories_unfolded'	=> 'Show categories folded by default',
 	'hide_read_feeds'		=> 'Hide categories &amp; feeds with no unread article (only in “unread articles” display mode)',
 	'after_onread'			=> 'After “mark all as read”,',
 	'jump_next'			=> 'jump to next unread sibling (feed or category)',

--- a/app/i18n/fr.php
+++ b/app/i18n/fr.php
@@ -267,6 +267,7 @@ return array (
 	'sort_order'			=> 'Ordre de tri',
 	'auto_load_more'		=> 'Charger les articles suivants en bas de page',
 	'display_articles_unfolded'	=> 'Afficher les articles dépliés par défaut',
+	'display_categories_unfolded'	=> 'Afficher les catégories pliées par défaut',
 	'hide_read_feeds'		=> 'Cacher les catégories &amp; flux sans article non-lu (uniquement en affichage “articles non lus”)',
 	'after_onread'			=> 'Après “marquer tout comme lu”,',
 	'jump_next'			=> 'sauter au prochain voisin non lu (flux ou catégorie)',

--- a/app/layout/aside_flux.phtml
+++ b/app/layout/aside_flux.phtml
@@ -42,8 +42,14 @@
 			$feeds = $cat->feeds ();
 			if (!empty ($feeds)) {
 				$c_active = false;
-				if ($this->get_c == $cat->id ()) {
-					$c_active = true;
+				if ($this->conf->display_categories) {
+					if ($this->get_c == $cat->id () && $this->get_f) {
+						$c_active = true;
+					}
+				} else {
+					if ($this->get_c == $cat->id ()) {
+						$c_active = true;
+					}
 				}
 				?><li data-unread="<?php echo $cat->nbNotRead(); ?>"<?php if ($c_active) echo ' class="active"'; ?>><?php
 				?><div class="category stick<?php echo $c_active ? ' active' : ''; ?>"><?php

--- a/app/views/configure/reading.phtml
+++ b/app/views/configure/reading.phtml
@@ -63,6 +63,16 @@
 
 		<div class="form-group">
 			<div class="group-controls">
+				<label class="checkbox" for="display_categories">
+					<input type="checkbox" name="display_categories" id="display_categories" value="1"<?php echo $this->conf->display_categories ? ' checked="checked"' : ''; ?> />
+					<?php echo Minz_Translate::t ('display_categories_unfolded'); ?>
+					<noscript> — <strong><?php echo Minz_Translate::t ('javascript_should_be_activated'); ?></strong></noscript>
+				</label>
+			</div>
+		</div>
+
+		<div class="form-group">
+			<div class="group-controls">
 				<label class="checkbox" for="sticky_post">
 					<input type="checkbox" name="sticky_post" id="sticky_post" value="1"<?php echo $this->conf->sticky_post ? ' checked="checked"' : ''; ?> />
 					<?php echo Minz_Translate::t ('sticky_post'); ?>


### PR DESCRIPTION
Before, when a category was selected, it was expanded to show the feeds in that category.
Now, there is a parameter that allows the user to choose either if he wants the old behaviour or if he wants to expand only when needed (when selecting a feed or when clicking the appropriate button)
