### PR TITLE
Fix Screwdriver theme

### DIFF
--- a/p/themes/Screwdriver/template.css
+++ b/p/themes/Screwdriver/template.css
@@ -309,6 +309,9 @@ a.btn {
 	list-style: none;
 	margin: 0;
 }
+.state_unread li:not(.active)[data-unread="0"] {
+	display: none;
+}
 .category {
 	display: block;
 	overflow: hidden;


### PR DESCRIPTION
Before, it wasn't possible to hide categories when they had no articles to read.
I applied the same rule than the one described in here (https://github.com/marienfressinaud/FreshRSS/commit/d19824b919289ad63743f27da7861f2422da5baa).
Now, the categories are hidden when they have no articles to read.

See #594
