### PR TITLE
Fix collapse shortcut behavior

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -373,7 +373,7 @@ function collapse_entry() {
 
 	var flux_current = $(".flux.current");
 	flux_current.toggleClass("active");
-	if (isCollapsed) {
+	if (isCollapsed && auto_mark_article) {
 		mark_read(flux_current, true);
 	}
 }


### PR DESCRIPTION
Before, the collapse shortcut was marking all articles as read when used. No matter what configuration you use.
Now, the collapse shortcut marks articles only if the appropriate configuration is used (when article is viewed).

See #602 
