### PR TITLE
Add a feature to add only unique shares

### DIFF
--- a/app/Models/Configuration.php
+++ b/app/Models/Configuration.php
@@ -212,6 +212,7 @@ class FreshRSS_Configuration {
 	}
 	public function _sharing ($values) {
 		$this->data['sharing'] = array();
+		$unique = array();
 		foreach ($values as $value) {
 			if (!is_array($value)) {
 				continue;
@@ -237,7 +238,11 @@ class FreshRSS_Configuration {
 				$value['name'] = $value['type'];
 			}
 
-			$this->data['sharing'][] = $value;
+			$json_value = json_encode($value);
+			if (!in_array($json_value, $unique)) {
+				$unique[] = $json_value;
+				$this->data['sharing'][] = $value;
+			}
 		}
 	}
 	public function _queries ($values) {


### PR DESCRIPTION
Before, it was possible to have different shares of the same type with the same information.
Now, even if you try to input identical shares, only the first one is kept. Of course, the verification is simple, so for instance if you input two shares to the same shaarli instance with different names, they are kept.

See #614
