### PR TITLE
Ajout d'un timeout pour la notification HTML5

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -157,6 +157,7 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 			$this->view->conf->_bottomline_tags(Minz_Request::param('bottomline_tags', false));
 			$this->view->conf->_bottomline_date(Minz_Request::param('bottomline_date', false));
 			$this->view->conf->_bottomline_link(Minz_Request::param('bottomline_link', false));
+			$this->view->conf->_html5_notif_timeout(Minz_Request::param('html5_notif_timeout', 0));
 			$this->view->conf->save();
 
 			Minz_Session::_param('language', $this->view->conf->language);

--- a/app/Models/Configuration.php
+++ b/app/Models/Configuration.php
@@ -60,6 +60,7 @@ class FreshRSS_Configuration {
 		'bottomline_link' => true,
 		'sharing' => array(),
 		'queries' => array(),
+		'html5_notif_timeout' => 0,
 	);
 
 	private $available_languages = array(
@@ -269,6 +270,12 @@ class FreshRSS_Configuration {
 			$this->data['content_width'] = 'thin';
 		}
 	}
+	
+	public function _html5_notif_timeout ($value) {
+		$value = intval($value);
+		$this->data['html5_notif_timeout'] = $value >= 0 ? $value : 0;
+	}
+	
 	public function _token($value) {
 		$this->data['token'] = $value;
 	}

--- a/app/i18n/de.php
+++ b/app/i18n/de.php
@@ -212,7 +212,7 @@ return array (
 	'reading_icons'			=> 'Lese Symbol',
 	'top_line'			=> 'Kopfzeile',
 	'bottom_line'			=> 'Fusszeile',
-	'html5_notif_timeout'	=> 'HTML5 notification timeout',
+	'html5_notif_timeout'		=> 'HTML5 notification timeout',
 	'seconds_(0_means_no_timeout)'	=> 'seconds (0 means no timeout)',
 	'img_with_lazyload'		=> 'Verwende die "tr&auml;ge laden" Methode zum laden von Bildern',
 	'auto_read_when'		=> 'Artikel als gelesen markieren…',

--- a/app/i18n/de.php
+++ b/app/i18n/de.php
@@ -212,6 +212,8 @@ return array (
 	'reading_icons'			=> 'Lese Symbol',
 	'top_line'			=> 'Kopfzeile',
 	'bottom_line'			=> 'Fusszeile',
+	'html5_notif_timeout'	=> 'HTML5 notification timeout',
+	'seconds_(0_means_no_timeout)'	=> 'seconds (0 means no timeout)',
 	'img_with_lazyload'		=> 'Verwende die "tr&auml;ge laden" Methode zum laden von Bildern',
 	'auto_read_when'		=> 'Artikel als gelesen markieren…',
 	'article_selected'		=> 'wenn der Artikel ausgew&auml;hlt ist',

--- a/app/i18n/en.php
+++ b/app/i18n/en.php
@@ -280,7 +280,7 @@ return array (
 	'article_icons'			=> 'Article icons',
 	'top_line'			=> 'Top line',
 	'bottom_line'			=> 'Bottom line',
-	'html5_notif_timeout'	=> 'HTML5 notification timeout',
+	'html5_notif_timeout'		=> 'HTML5 notification timeout',
 	'seconds_(0_means_no_timeout)'	=> 'seconds (0 means no timeout)',
 	'img_with_lazyload'		=> 'Use "lazy load" mode to load pictures',
 	'sticky_post'			=> 'Stick the article to the top when opened',

--- a/app/i18n/en.php
+++ b/app/i18n/en.php
@@ -280,6 +280,8 @@ return array (
 	'article_icons'			=> 'Article icons',
 	'top_line'			=> 'Top line',
 	'bottom_line'			=> 'Bottom line',
+	'html5_notif_timeout'	=> 'HTML5 notification timeout',
+	'seconds_(0_means_no_timeout)'	=> 'seconds (0 means no timeout)',
 	'img_with_lazyload'		=> 'Use "lazy load" mode to load pictures',
 	'sticky_post'			=> 'Stick the article to the top when opened',
 	'reading_confirm'		=> 'Display a confirmation dialog on “mark all as read” actions',

--- a/app/i18n/fr.php
+++ b/app/i18n/fr.php
@@ -280,7 +280,7 @@ return array (
 	'article_icons'			=> 'Icônes d’article',
 	'top_line'			=> 'Ligne du haut',
 	'bottom_line'			=> 'Ligne du bas',
-	'html5_notif_timeout'	=> 'Temps d\'affichage de la notification HTML5',
+	'html5_notif_timeout'		=> 'Temps d\'affichage de la notification HTML5',
 	'seconds_(0_means_no_timeout)'	=> 'secondes (0 signifie aucun timeout ) ',
 	'img_with_lazyload'		=> 'Utiliser le mode “chargement différé” pour les images',
 	'sticky_post'			=> 'Aligner l’article en haut quand il est ouvert',

--- a/app/i18n/fr.php
+++ b/app/i18n/fr.php
@@ -280,6 +280,8 @@ return array (
 	'article_icons'			=> 'Icônes d’article',
 	'top_line'			=> 'Ligne du haut',
 	'bottom_line'			=> 'Ligne du bas',
+	'html5_notif_timeout'	=> 'Temps d\'affichage de la notification HTML5',
+	'seconds_(0_means_no_timeout)'	=> 'secondes (0 signifie aucun timeout ) ',
 	'img_with_lazyload'		=> 'Utiliser le mode “chargement différé” pour les images',
 	'sticky_post'			=> 'Aligner l’article en haut quand il est ouvert',
 	'reading_confirm'		=> 'Afficher une confirmation lors des actions “marquer tout comme lu”',

--- a/app/views/configure/display.phtml
+++ b/app/views/configure/display.phtml
@@ -91,6 +91,13 @@
 				</tbody>
 			</table><br />
 		</div>
+		
+		<div class="form-group">
+			<label class="group-name" for="posts_per_page"><?php echo Minz_Translate::t ('html5_notif_timeout'); ?></label>
+			<div class="group-controls">
+				<input type="number" id="html5_notif_timeout" name="html5_notif_timeout" value="<?php echo $this->conf->html5_notif_timeout; ?>" /> <?php echo Minz_Translate::t ('seconds_(0_means_no_timeout)'); ?>
+			</div>
+		</div>
 
 		<div class="form-group form-actions">
 			<div class="group-controls">

--- a/app/views/helpers/javascript_vars.phtml
+++ b/app/views/helpers/javascript_vars.phtml
@@ -54,6 +54,8 @@ echo 'authType="', $authType, '",',
 echo 'str_confirmation="', Minz_Translate::t('confirm_action'), '"', ",\n";
 echo 'str_notif_title_articles="', Minz_Translate::t('notif_title_new_articles'), '"', ",\n";
 echo 'str_notif_body_articles="', Minz_Translate::t('notif_body_new_articles'), '"', ",\n";
+echo 'html5_notif_timeout=', $this->conf->html5_notif_timeout,",\n";
+
 
 $autoActualise = Minz_Session::param('actualize_feeds', false);
 echo 'auto_actualize_feeds=', $autoActualise ? 'true' : 'false', ";\n";

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -866,6 +866,12 @@ function notifs_html5_show(nb) {
 	notification.onclick = function() {
 		window.location.reload();
 	}
+
+	if (html5_notif_timeout !== 0){
+		setTimeout(function() {
+					notification.close();
+				}, html5_notif_timeout * 1000);
+	}
 }
 
 function init_notifs_html5() {


### PR DESCRIPTION
Salut,
J'aime bien le principe de la notification HTML5 mais quand on laisse trop longtemps la fenêtre sans surveillance, on se retrouve avec 15 notifications empilées.

J'ai juste ajouté une option utilisateur dans la section "Affichage" pour pouvoir enregistrer en seconde le temps d'affichage de la notification.

J'ai mis à jour les fichiers de langue anglais et français mais j'ai préférer ne pas faire de google trad pour l'allemand.

Merci.
