### PR TITLE
Ajout du tag sur la notification HTML5

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -860,7 +860,8 @@ function notifs_html5_show(nb) {
 
 	var notification = new window.Notification(str_notif_title_articles, {
 		icon: "../themes/icons/favicon-256.png",
-		body: str_notif_body_articles.replace("\d", nb)
+		body: str_notif_body_articles.replace("\d", nb),
+		tag: "freshRssNewArticles"
 	});
 
 	notification.onclick = function() {


### PR DESCRIPTION
Permet de remplacer le contenu d'une notification HTML5 non fermée par un nouveau message.
