### PR TITLE
Refactor code for strict unread message display

### DIFF
--- a/app/Models/Configuration.php
+++ b/app/Models/Configuration.php
@@ -147,7 +147,7 @@ class FreshRSS_Configuration {
 			// left blank on purpose
 		case FreshRSS_Entry::STATE_NOT_READ:
 			// left blank on purpose
-		case FreshRSS_Entry::STATE_NOT_READ_STRICT:
+		case FreshRSS_Entry::STATE_STRICT + FreshRSS_Entry::STATE_NOT_READ:
 			$this->data['default_view'] = $value;
 			break;
 		default:

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -6,8 +6,7 @@ class FreshRSS_Entry extends Minz_Model {
 	const STATE_NOT_READ = 2;
 	const STATE_FAVORITE = 4;
 	const STATE_NOT_FAVORITE = 8;
-	const STATE_READ_STRICT = 16;
-	const STATE_NOT_READ_STRICT = 32;
+	const STATE_STRICT = 16;
 
 	private $id = 0;
 	private $guid;

--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -333,13 +333,12 @@ class FreshRSS_EntryDAO extends Minz_ModelPdo {
 		if ($state & FreshRSS_Entry::STATE_NOT_READ) {
 			if (!($state & FreshRSS_Entry::STATE_READ)) {
 				$where .= 'AND e1.is_read=0 ';
+			} elseif ($state & FreshRSS_Entry::STATE_STRICT) {
+				$where .= 'AND e1.is_read=0 ';
 			}
 		}
 		elseif ($state & FreshRSS_Entry::STATE_READ) {
 			$where .= 'AND e1.is_read=1 ';
-		}
-		elseif ($state & FreshRSS_Entry::STATE_NOT_READ_STRICT) {
-			$where .= 'AND e1.is_read=0 ';
 		}
 		if ($state & FreshRSS_Entry::STATE_FAVORITE) {
 			if (!($state & FreshRSS_Entry::STATE_NOT_FAVORITE)) {

--- a/app/i18n/en.php
+++ b/app/i18n/en.php
@@ -281,7 +281,7 @@ return array (
 	'auto_load_more'		=> 'Load next articles at the page bottom',
 	'display_articles_unfolded'	=> 'Show articles unfolded by default',
 	'display_categories_unfolded'	=> 'Show categories folded by default',
-	'hide_read_feeds'		=> 'Hide categories &amp; feeds with no unread article (only in “unread articles” display mode)',
+	'hide_read_feeds'		=> 'Hide categories &amp; feeds with no unread article (does not work with “Show all articles” configuration)',
 	'after_onread'			=> 'After “mark all as read”,',
 	'jump_next'			=> 'jump to next unread sibling (feed or category)',
 	'article_icons'			=> 'Article icons',

--- a/app/i18n/fr.php
+++ b/app/i18n/fr.php
@@ -281,7 +281,7 @@ return array (
 	'auto_load_more'		=> 'Charger les articles suivants en bas de page',
 	'display_articles_unfolded'	=> 'Afficher les articles dépliés par défaut',
 	'display_categories_unfolded'	=> 'Afficher les catégories pliées par défaut',
-	'hide_read_feeds'		=> 'Cacher les catégories &amp; flux sans article non-lu (uniquement en affichage “articles non lus”)',
+	'hide_read_feeds'		=> 'Cacher les catégories &amp; flux sans article non-lu (ne fonctionne pas avec la configuration “Afficher tous les articles”)',
 	'after_onread'			=> 'Après “marquer tout comme lu”,',
 	'jump_next'			=> 'sauter au prochain voisin non lu (flux ou catégorie)',
 	'article_icons'			=> 'Icônes d’article',

--- a/app/views/configure/reading.phtml
+++ b/app/views/configure/reading.phtml
@@ -43,7 +43,7 @@
 				<select name="default_view" id="default_view">
 					<option value="<?php echo FreshRSS_Entry::STATE_NOT_READ; ?>"<?php echo $this->conf->default_view === FreshRSS_Entry::STATE_NOT_READ ? ' selected="selected"' : ''; ?>><?php echo _t('show_adaptive'); ?></option>
 					<option value="<?php echo FreshRSS_Entry::STATE_ALL; ?>"<?php echo $this->conf->default_view === FreshRSS_Entry::STATE_ALL ? ' selected="selected"' : ''; ?>><?php echo _t('show_all_articles'); ?></option>
-					<option value="<?php echo FreshRSS_Entry::STATE_NOT_READ_STRICT; ?>"<?php echo $this->conf->default_view === FreshRSS_Entry::STATE_NOT_READ_STRICT ? ' selected="selected"' : ''; ?>><?php echo _t('show_not_reads'); ?></option>
+					<option value="<?php echo FreshRSS_Entry::STATE_STRICT + FreshRSS_Entry::STATE_NOT_READ; ?>"<?php echo $this->conf->default_view === FreshRSS_Entry::STATE_STRICT + FreshRSS_Entry::STATE_NOT_READ ? ' selected="selected"' : ''; ?>><?php echo _t('show_not_reads'); ?></option>
 				</select>
 			</div>
 		</div>


### PR DESCRIPTION
Before, when you choose the show unread message option and the hide categories and feeds options, the categories and feeds weren't hidden. Now it is working properly.
Before, the unread filter icon was not selected with the previous way of using the constants. Now, the filter is highlighted when selected in strict mode.

See #619
