### PR TITLE
Fix read all shortcut

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -538,14 +538,7 @@ function init_shortcuts() {
 	});
 	shortcut.add("shift+" + shortcuts.mark_read, function () {
 		// on marque tout comme lu
-		var btn = $(".nav_menu .read_all");
-		if (btn.hasClass('confirm')) {
-			if (confirm(str_confirmation)) {
-				btn.click();
-			}
-		} else {
-			btn.click();
-		}
+		$(".nav_menu .read_all").click();
 	}, {
 		'disable_in_input': true
 	});


### PR DESCRIPTION
Before, the read all shortcut raised a javascript exception when we use the confirmation option. The confirmation was not even displayed. The code was failling since there was a missing variable.
Now, the shortcut ask for confirmation when the option is selected in the reading configuration page.

The definition of the shortcut was buggy since the confirmation was handled properly in an other location. I simplified the code by removing the confirmation code in the shortcut.
