### PR TITLE
start with admin only if exists

### DIFF
--- a/app/actualize_script.php
+++ b/app/actualize_script.php
@@ -11,8 +11,11 @@ Minz_Configuration::init();
 
 $users = listUsers();
 shuffle($users);	//Process users in random order
-array_unshift($users, Minz_Configuration::defaultUser());	//But always start with admin
-$users = array_unique($users);
+
+if (Minz_Configuration::defaultUser() !== ''){
+	array_unshift($users, Minz_Configuration::defaultUser());	//But always start with admin
+	$users = array_unique($users);
+}
 
 foreach ($users as $myUser) {
 	syslog(LOG_INFO, 'FreshRSS actualize ' . $myUser);


### PR DESCRIPTION
Salut,
J'ai fait une mini évolution dans le script d'actualisation des fluxs.
Dans le cas où aucun admin ne soit configuré, le script se plantait.
C'est quelque chose que je voulais faire dans le cadre du package yunohost et j'ai eu une demande dans ce sens là.

Il y a aucune influence dans le cas où l'appli est configurée correctement mais ça évite le plantage en cas de mauvaise configuration où dans le cas du package.

Merci.
