### PR TITLE
Add a feature to hide articles when they are read

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -89,6 +89,7 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 	 *   - image lazy loading
 	 *   - stick open articles to the top
 	 *   - display a confirmation when reading all articles
+	 *   - auto remove article after reading
 	 *   - article order (default: DESC)
 	 *   - mark articles as read when:
 	 *       - displayed
@@ -110,6 +111,7 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 			FreshRSS_Context::$conf->_lazyload(Minz_Request::param('lazyload', false));
 			FreshRSS_Context::$conf->_sticky_post(Minz_Request::param('sticky_post', false));
 			FreshRSS_Context::$conf->_reading_confirm(Minz_Request::param('reading_confirm', false));
+			FreshRSS_Context::$conf->_auto_remove_article(Minz_Request::param('auto_remove_article', false));
 			FreshRSS_Context::$conf->_sort_order(Minz_Request::param('sort_order', 'DESC'));
 			FreshRSS_Context::$conf->_mark_when(array(
 				'article' => Minz_Request::param('mark_open_article', false),

--- a/app/Models/Configuration.php
+++ b/app/Models/Configuration.php
@@ -24,6 +24,7 @@ class FreshRSS_Configuration {
 		'lazyload' => true,
 		'sticky_post' => true,
 		'reading_confirm' => false,
+		'auto_remove_article' => false,
 		'sort_order' => 'DESC',
 		'anon_access' => false,
 		'mark_when' => array(
@@ -190,6 +191,9 @@ class FreshRSS_Configuration {
 	}
 	public function _reading_confirm($value) {
 		$this->data['reading_confirm'] = ((bool)$value) && $value !== 'no';
+	}
+	public function _auto_remove_article($value) {
+		$this->data['auto_remove_article'] = ((bool)$value) && $value !== 'no';
 	}
 	public function _sort_order($value) {
 		$this->data['sort_order'] = $value === 'ASC' ? 'ASC' : 'DESC';

--- a/app/Models/Context.php
+++ b/app/Models/Context.php
@@ -265,4 +265,26 @@ class FreshRSS_Context {
 			}
 		}
 	}
+
+	/**
+	 * Determine if the auto remove is available in the current context.
+	 * This feature is available if:
+	 *   - it is activated in the configuration
+	 *   - the "read" state is not enable
+	 *   - the "unread" state is enable
+	 *
+	 * @return boolean
+	 */
+	public static function isAutoRemoveAvailable() {
+		if (!self::$conf->auto_remove_article) {
+			return false;
+		}
+		if (self::isStateEnabled(FreshRSS_Entry::STATE_READ)) {
+			return false;
+		}
+		if (!self::isStateEnabled(FreshRSS_Entry::STATE_NOT_READ)) {
+			return false;
+		}
+		return true;
+	}
 }

--- a/app/views/configure/reading.phtml
+++ b/app/views/configure/reading.phtml
@@ -116,6 +116,16 @@
 		</div>
 
 		<div class="form-group">
+			<div class="group-controls">
+				<label class="checkbox" for="auto_remove_article">
+					<input type="checkbox" name="auto_remove_article" id="auto_remove_article" value="1"<?php echo FreshRSS_Context::$conf->auto_remove_article ? ' checked="checked"' : ''; ?> />
+					<?php echo _t('auto_remove_article'); ?>
+					<noscript> — <strong><?php echo _t('javascript_should_be_activated'); ?></strong></noscript>
+				</label>
+			</div>
+		</div>
+
+		<div class="form-group">
 			<label class="group-name"><?php echo _t('auto_read_when'); ?></label>
 			<div class="group-controls">
 				<label class="checkbox" for="check_open_article">

--- a/app/views/helpers/javascript_vars.phtml
+++ b/app/views/helpers/javascript_vars.phtml
@@ -18,6 +18,7 @@ $url_logout = Minz_Url::display(array(
 ), 'php');
 
 echo 'var context={',
+	'auto_remove_article:', FreshRSS_Context::isAutoRemoveAvailable() ? 'true' : 'false', ',',
 	'hide_posts:', $hide_posts ? 'false' : 'true', ',',
 	'display_order:"', Minz_Request::param('order', FreshRSS_Context::$conf->sort_order), '",',
 	'auto_mark_article:', $mark['article'] ? 'true' : 'false', ',',

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -231,6 +231,14 @@ function toggleContent(new_active, old_active) {
 		}
 		old_active.removeClass("active current");
 		new_active.addClass("current");
+		if (context['auto_remove_article'] && !old_active.hasClass('not_read')) {
+			var p = old_active.prev();
+			var n = old_active.next();
+			if (p.hasClass('day') && n.hasClass('day')) {
+				p.remove();
+			}
+			old_active.remove();
+		}
 	} else {
 		new_active.toggleClass('active');
 	}


### PR DESCRIPTION
This is a new reading option to hide articles when they are read. The hidding process occurs when the article is left for an other article. This way, even when the article is marked as read on opening, it is hidden only while navigating to an other article.
I'm not really happy with the behavior when the "mark while scrolling" option is enabled. Please review.
It is missing the i18n since we're not supposed to push them before it exists on i18n.freshrss.org. Or maybe I misunderstood the process.

See #476
