### PR TITLE
Add more info in article repartition page

### DIFF
--- a/app/Controllers/statsController.php
+++ b/app/Controllers/statsController.php
@@ -117,6 +117,7 @@ class FreshRSS_stats_Controller extends Minz_ActionController {
 		$this->view->feed = $feedDAO->searchById($id);
 		$this->view->days = $statsDAO->getDays();
 		$this->view->months = $statsDAO->getMonths();
+		$this->view->repartition = $statsDAO->calculateEntryRepartitionPerFeed($id);
 		$this->view->repartitionHour = $statsDAO->calculateEntryRepartitionPerFeedPerHour($id);
 		$this->view->averageHour = $statsDAO->calculateEntryAveragePerFeedPerHour($id);
 		$this->view->repartitionDayOfWeek = $statsDAO->calculateEntryRepartitionPerFeedPerDayOfWeek($id);

--- a/app/Models/StatsDAO.php
+++ b/app/Models/StatsDAO.php
@@ -6,18 +6,36 @@ class FreshRSS_StatsDAO extends Minz_ModelPdo {
 
 	/**
 	 * Calculates entry repartition for all feeds and for main stream.
+	 *
+	 * @return array
+	 */
+	public function calculateEntryRepartition() {
+		return array(
+		    'main_stream' => $this->calculateEntryRepartitionPerFeed(null, true),
+		    'all_feeds' => $this->calculateEntryRepartitionPerFeed(null, false),
+		);
+	}
+
+	/**
+	 * Calculates entry repartition for the selection.
 	 * The repartition includes:
 	 *   - total entries
 	 *   - read entries
 	 *   - unread entries
 	 *   - favorite entries
 	 *
-	 * @return type
+	 * @param null|integer $feed feed id
+	 * @param boolean $only_main
+	 * @return array
 	 */
-	public function calculateEntryRepartition() {
-		$repartition = array();
-
-		// Generates the repartition for the main stream of entry
+	public function calculateEntryRepartitionPerFeed($feed = null, $only_main = false) {
+		$filter = '';
+		if ($only_main) {
+			$filter .= 'AND f.priority = 10';
+		}
+		if (!is_null($feed)) {
+			$filter .= "AND e.id_feed = {$feed}";
+		}
 		$sql = <<<SQL
 SELECT COUNT(1) AS `total`,
 COUNT(1) - SUM(e.is_read) AS `unread`,
@@ -26,27 +44,13 @@ SUM(e.is_favorite) AS `favorite`
 FROM {$this->prefix}entry AS e
 , {$this->prefix}feed AS f
 WHERE e.id_feed = f.id
-AND f.priority = 10
+{$filter}
 SQL;
 		$stm = $this->bd->prepare($sql);
 		$stm->execute();
 		$res = $stm->fetchAll(PDO::FETCH_ASSOC);
-		$repartition['main_stream'] = $res[0];
 
-		// Generates the repartition for all entries
-		$sql = <<<SQL
-SELECT COUNT(1) AS `total`,
-COUNT(1) - SUM(e.is_read) AS `unread`,
-SUM(e.is_read) AS `read`,
-SUM(e.is_favorite) AS `favorite`
-FROM {$this->prefix}entry AS e
-SQL;
-		$stm = $this->bd->prepare($sql);
-		$stm->execute();
-		$res = $stm->fetchAll(PDO::FETCH_ASSOC);
-		$repartition['all_feeds'] = $res[0];
-
-		return $repartition;
+		return $res[0];
 	}
 
 	/**
@@ -179,7 +183,7 @@ SQL;
 	 * @return integer
 	 */
 	public function calculateEntryAveragePerFeedPerHour($feed = null) {
-		return $this->calculateEntryAveragePerFeedPerPeriod(1/24, $feed);
+		return $this->calculateEntryAveragePerFeedPerPeriod(1 / 24, $feed);
 	}
 
 	/**

--- a/app/Models/StatsDAO.php
+++ b/app/Models/StatsDAO.php
@@ -151,10 +151,9 @@ SQL;
 	 * @return string
 	 */
 	protected function calculateEntryRepartitionPerFeedPerPeriod($period, $feed = null) {
+		$restrict = '';
 		if ($feed) {
 			$restrict = "WHERE e.id_feed = {$feed}";
-		} else {
-			$restrict = '';
 		}
 		$sql = <<<SQL
 SELECT DATE_FORMAT(FROM_UNIXTIME(e.date), '{$period}') AS period
@@ -214,10 +213,9 @@ SQL;
 	 * @return integer
 	 */
 	protected function calculateEntryAveragePerFeedPerPeriod($period, $feed = null) {
+		$restrict = '';
 		if ($feed) {
 			$restrict = "WHERE e.id_feed = {$feed}";
-		} else {
-			$restrict = '';
 		}
 		$sql = <<<SQL
 SELECT COUNT(1) AS count

--- a/app/views/stats/repartition.phtml
+++ b/app/views/stats/repartition.phtml
@@ -30,6 +30,23 @@
 	<?php }?>
 
 	<div class="stat">
+	    <table>
+		<tr>
+		    <th><?php echo _t('status_total'); ?></th>
+		    <th><?php echo _t('status_read'); ?></th>
+		    <th><?php echo _t('status_unread'); ?></th>
+		    <th><?php echo _t('status_favorites'); ?></th>
+		</tr>
+		<tr>
+		    <td><?php echo $this->repartition['total']; ?></td>
+		    <td><?php echo $this->repartition['read']; ?></td>
+		    <td><?php echo $this->repartition['unread']; ?></td>
+		    <td><?php echo $this->repartition['favorite']; ?></td>
+		</tr>
+	    </table>
+	</div>
+
+	<div class="stat">
 		<h2><?php echo _t('stats_entry_per_hour', $this->averageHour); ?></h2>
 		<div id="statsEntryPerHour" style="height: 300px"></div>
 	</div>


### PR DESCRIPTION
I added the same information than on the main stat page (total, read, unread and favorite) on the repartition page. Some refactoring was needed.
