### PR TITLE
Prevent window opener vulnerability with space shortcut

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -803,7 +803,9 @@ function init_shortcuts() {
 				if (context.auto_mark_site) {
 					mark_read(document.querySelector('.flux.current'), true, false);
 				}
-				window.open(document.querySelector('.flux.current a.go_website').href);
+				const newWindow = window.open();
+                                newWindow.opener = null;
+				newWindow.location = document.querySelector('.flux.current a.go_website').href;
 				return false;
 			}
 			if (k === s.skip_next_entry) { next_entry(true); return false; }

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -804,8 +804,10 @@ function init_shortcuts() {
 					mark_read(document.querySelector('.flux.current'), true, false);
 				}
 				const newWindow = window.open();
-                                newWindow.opener = null;
-				newWindow.location = document.querySelector('.flux.current a.go_website').href;
+				if (newWindow) {
+					newWindow.opener = null;
+					newWindow.location = document.querySelector('.flux.current a.go_website').href;
+				}
 				return false;
 			}
 			if (k === s.skip_next_entry) { next_entry(true); return false; }


### PR DESCRIPTION
This change fixes a vulnerability introduced by `window.open()` on untrusted sources. It reproduces the effect of `rel="noreferrer"` with JS.

Cross browser solution from: https://stackoverflow.com/a/40593743

Related to #1245

## Reproduction

> tested with Firefox 68

  1. Add this RSS feed https://www.ecyseo.net/feed/rss
  2. Open the 2nd link "À propos de la faille de sécurité liée à target="_blank" **using the space key shortcut**.
  3. Click on the first of three links "http://bookmarks.ecyseo.net"

Current behaviour: the FreshRSS tab changes.
Expected behaviour: no effect on FreshRSS