### PR TITLE
#2573 remove trailing slash to prevent normalizing by nginx

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -328,7 +328,7 @@ server {
 	}
 
 	location /freshrss/ {
-		proxy_pass http://freshrss/;
+		proxy_pass http://freshrss;
 		add_header X-Frame-Options SAMEORIGIN;
 		add_header X-XSS-Protection "1; mode=block";
 		proxy_redirect off;


### PR DESCRIPTION
Update https://github.com/FreshRSS/FreshRSS/blob/dev/Docker/README.md#alternative-reverse-proxy-using-nginx by request.