### PR TITLE
Add category order

### DIFF
--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -173,7 +173,7 @@ class FreshRSS_index_Controller extends Minz_ActionController {
 	private function updateContext() {
 		if (empty(FreshRSS_Context::$categories)) {
 			$catDAO = FreshRSS_Factory::createCategoryDao();
-			FreshRSS_Context::$categories = $catDAO->listCategories();
+			FreshRSS_Context::$categories = $catDAO->listSortedCategories();
 		}
 
 		// Update number of read / unread variables.

--- a/app/Controllers/subscriptionController.php
+++ b/app/Controllers/subscriptionController.php
@@ -19,7 +19,7 @@ class FreshRSS_subscription_Controller extends Minz_ActionController {
 
 		$catDAO->checkDefault();
 		$feedDAO->updateTTL();
-		$this->view->categories = $catDAO->listCategories(false);
+		$this->view->categories = $catDAO->listSortedCategories(false);
 		$this->view->default_category = $catDAO->getDefault();
 	}
 
@@ -215,6 +215,9 @@ class FreshRSS_subscription_Controller extends Minz_ActionController {
 					'keep_unreads' => Minz_Request::paramBoolean('keep_unreads'),
 				]);
 			}
+
+			$position = Minz_Request::param('position');
+			$category->_attributes('position', '' === $position ? null : (int) $position);
 
 			$values = [
 				'name' => Minz_Request::param('name', ''),

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -98,14 +98,14 @@ class FreshRSS_Category extends Minz_Model {
 	}
 
 	public function _attributes($key, $value) {
-		if ($key == '') {
+		if ('' == $key) {
 			if (is_string($value)) {
 				$value = json_decode($value, true);
 			}
 			if (is_array($value)) {
 				$this->attributes = $value;
 			}
-		} elseif ($value === null) {
+		} elseif (null === $value) {
 			unset($this->attributes[$key]);
 		} else {
 			$this->attributes[$key] = $value;

--- a/app/Models/CategoryDAO.php
+++ b/app/Models/CategoryDAO.php
@@ -201,6 +201,29 @@ class FreshRSS_CategoryDAO extends Minz_ModelPdo implements FreshRSS_Searchable 
 		}
 	}
 
+	public function listSortedCategories($prePopulateFeeds = true, $details = false) {
+		$categories = $this->listCategories($prePopulateFeeds, $details);
+
+		if (!is_array($categories)) {
+			return $categories;
+		}
+
+		usort($categories, function ($a, $b) {
+			$aPosition = $a->attributes('position');
+			$bPosition = $b->attributes('position');
+			if ($aPosition === $bPosition) {
+				return ($a->name() < $b->name()) ? -1 : 1;
+			} elseif (null === $aPosition) {
+				return 1;
+			} elseif (null === $bPosition) {
+				return -1;
+			}
+			return ($aPosition < $bPosition) ? -1 : 1;
+		});
+
+		return $categories;
+	}
+
 	public function listCategories($prePopulateFeeds = true, $details = false) {
 		if ($prePopulateFeeds) {
 			$sql = 'SELECT c.id AS c_id, c.name AS c_name, c.attributes AS c_attributes, '
@@ -343,6 +366,7 @@ class FreshRSS_CategoryDAO extends Minz_ModelPdo implements FreshRSS_Searchable 
 					$feedDao->daoToFeed($feedsDao, $previousLine['c_id'])
 				);
 				$cat->_id($previousLine['c_id']);
+				$cat->_attributes('', $previousLine['c_attributes']);
 				$list[$previousLine['c_id']] = $cat;
 
 				$feedsDao = array();	//Prepare for next category
@@ -359,6 +383,7 @@ class FreshRSS_CategoryDAO extends Minz_ModelPdo implements FreshRSS_Searchable 
 				$feedDao->daoToFeed($feedsDao, $previousLine['c_id'])
 			);
 			$cat->_id($previousLine['c_id']);
+			$cat->_attributes('', $previousLine['c_attributes']);
 			$list[$previousLine['c_id']] = $cat;
 		}
 

--- a/app/i18n/cz/sub.php
+++ b/app/i18n/cz/sub.php
@@ -17,6 +17,8 @@ return array(
 		'empty' => 'Vyprázdit kategorii',
 		'information' => 'Informace',
 		'new' => 'Nová kategorie',
+		'position' => 'Position',	//TODO - Translation
+		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
 		'title' => 'Název',
 	),
 	'feed' => array(

--- a/app/i18n/cz/sub.php
+++ b/app/i18n/cz/sub.php
@@ -17,8 +17,8 @@ return array(
 		'empty' => 'Vyprázdit kategorii',
 		'information' => 'Informace',
 		'new' => 'Nová kategorie',
-		'position' => 'Position',	//TODO - Translation
-		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
+		'position' => 'Display position',	//TODO - Translation
+		'position_help' => 'To control category sort order',	//TODO - Translation
 		'title' => 'Název',
 	),
 	'feed' => array(

--- a/app/i18n/de/sub.php
+++ b/app/i18n/de/sub.php
@@ -17,6 +17,8 @@ return array(
 		'empty' => 'Leere Kategorie',
 		'information' => 'Information',
 		'new' => 'Neue Kategorie',
+		'position' => 'Position',	//TODO - Translation
+		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
 		'title' => 'Titel',
 	),
 	'feed' => array(

--- a/app/i18n/de/sub.php
+++ b/app/i18n/de/sub.php
@@ -17,8 +17,8 @@ return array(
 		'empty' => 'Leere Kategorie',
 		'information' => 'Information',
 		'new' => 'Neue Kategorie',
-		'position' => 'Position',	//TODO - Translation
-		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
+		'position' => 'Display position',	//TODO - Translation
+		'position_help' => 'To control category sort order',	//TODO - Translation
 		'title' => 'Titel',
 	),
 	'feed' => array(

--- a/app/i18n/en/sub.php
+++ b/app/i18n/en/sub.php
@@ -17,8 +17,8 @@ return array(
 		'empty' => 'Empty category',
 		'information' => 'Information',
 		'new' => 'New category',
-		'position' => 'Position',
-		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',
+		'position' => 'Display position',
+		'position_help' => 'To control category sort order',
 		'title' => 'Title',
 	),
 	'feed' => array(

--- a/app/i18n/en/sub.php
+++ b/app/i18n/en/sub.php
@@ -17,6 +17,8 @@ return array(
 		'empty' => 'Empty category',
 		'information' => 'Information',
 		'new' => 'New category',
+		'position' => 'Position',
+		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',
 		'title' => 'Title',
 	),
 	'feed' => array(

--- a/app/i18n/es/sub.php
+++ b/app/i18n/es/sub.php
@@ -17,8 +17,8 @@ return array(
 		'empty' => 'Vaciar categoría',
 		'information' => 'Información',
 		'new' => 'Nueva categoría',
-		'position' => 'Position',	//TODO - Translation
-		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
+		'position' => 'Display position',	//TODO - Translation
+		'position_help' => 'To control category sort order',	//TODO - Translation
 		'title' => 'Título',
 	),
 	'feed' => array(

--- a/app/i18n/es/sub.php
+++ b/app/i18n/es/sub.php
@@ -17,6 +17,8 @@ return array(
 		'empty' => 'Vaciar categoría',
 		'information' => 'Información',
 		'new' => 'Nueva categoría',
+		'position' => 'Position',	//TODO - Translation
+		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
 		'title' => 'Título',
 	),
 	'feed' => array(

--- a/app/i18n/fr/sub.php
+++ b/app/i18n/fr/sub.php
@@ -17,8 +17,8 @@ return array(
 		'empty' => 'Catégorie vide',
 		'information' => 'Informations',
 		'new' => 'Nouvelle catégorie',
-		'position' => 'Position',
-		'position_help' => 'Position d’affichage. Quand deux catégories ont la même position, elles sont affichées en ordre alphabétique. Les catégories sans position sont affichées à la suite de celle qui en ont une.',
+		'position' => 'Position d’affichage',
+		'position_help' => 'Pour contrôler l’ordre de tri des catégories',
 		'title' => 'Titre',
 	),
 	'feed' => array(

--- a/app/i18n/fr/sub.php
+++ b/app/i18n/fr/sub.php
@@ -17,6 +17,8 @@ return array(
 		'empty' => 'Catégorie vide',
 		'information' => 'Informations',
 		'new' => 'Nouvelle catégorie',
+		'position' => 'Position',
+		'position_help' => 'Position d’affichage. Quand deux catégories ont la même position, elles sont affichées en ordre alphabétique. Les catégories sans position sont affichées à la suite de celle qui en ont une.',
 		'title' => 'Titre',
 	),
 	'feed' => array(

--- a/app/i18n/he/sub.php
+++ b/app/i18n/he/sub.php
@@ -17,8 +17,8 @@ return array(
 		'empty' => 'Empty category',	//TODO - Translation
 		'information' => 'מידע',
 		'new' => 'קטגוריה חדשה',
-		'position' => 'Position',	//TODO - Translation
-		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
+		'position' => 'Display position',	//TODO - Translation
+		'position_help' => 'To control category sort order',	//TODO - Translation
 		'title' => 'כותרת',
 	),
 	'feed' => array(

--- a/app/i18n/he/sub.php
+++ b/app/i18n/he/sub.php
@@ -17,6 +17,8 @@ return array(
 		'empty' => 'Empty category',	//TODO - Translation
 		'information' => 'מידע',
 		'new' => 'קטגוריה חדשה',
+		'position' => 'Position',	//TODO - Translation
+		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
 		'title' => 'כותרת',
 	),
 	'feed' => array(

--- a/app/i18n/it/sub.php
+++ b/app/i18n/it/sub.php
@@ -17,8 +17,8 @@ return array(
 		'empty' => 'Categoria vuota',
 		'information' => 'Informazioni',
 		'new' => 'Nuova categoria',
-		'position' => 'Position',	//TODO - Translation
-		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
+		'position' => 'Display position',	//TODO - Translation
+		'position_help' => 'To control category sort order',	//TODO - Translation
 		'title' => 'Titolo',
 	),
 	'feed' => array(

--- a/app/i18n/it/sub.php
+++ b/app/i18n/it/sub.php
@@ -17,6 +17,8 @@ return array(
 		'empty' => 'Categoria vuota',
 		'information' => 'Informazioni',
 		'new' => 'Nuova categoria',
+		'position' => 'Position',	//TODO - Translation
+		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
 		'title' => 'Titolo',
 	),
 	'feed' => array(

--- a/app/i18n/kr/sub.php
+++ b/app/i18n/kr/sub.php
@@ -17,8 +17,8 @@ return array(
 		'empty' => '빈 카테고리',
 		'information' => '정보',
 		'new' => '새 카테고리',
-		'position' => 'Position',	//TODO - Translation
-		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
+		'position' => 'Display position',	//TODO - Translation
+		'position_help' => 'To control category sort order',	//TODO - Translation
 		'title' => '제목',
 	),
 	'feed' => array(

--- a/app/i18n/kr/sub.php
+++ b/app/i18n/kr/sub.php
@@ -17,6 +17,8 @@ return array(
 		'empty' => '빈 카테고리',
 		'information' => '정보',
 		'new' => '새 카테고리',
+		'position' => 'Position',	//TODO - Translation
+		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
 		'title' => '제목',
 	),
 	'feed' => array(

--- a/app/i18n/nl/sub.php
+++ b/app/i18n/nl/sub.php
@@ -17,8 +17,8 @@ return array(
 		'empty' => 'Lege categorie',
 		'information' => 'Informatie',
 		'new' => 'Nieuwe categorie',
-		'position' => 'Position',	//TODO - Translation
-		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
+		'position' => 'Display position',	//TODO - Translation
+		'position_help' => 'To control category sort order',	//TODO - Translation
 		'title' => 'Titel',
 	),
 	'feed' => array(

--- a/app/i18n/nl/sub.php
+++ b/app/i18n/nl/sub.php
@@ -17,6 +17,8 @@ return array(
 		'empty' => 'Lege categorie',
 		'information' => 'Informatie',
 		'new' => 'Nieuwe categorie',
+		'position' => 'Position',	//TODO - Translation
+		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
 		'title' => 'Titel',
 	),
 	'feed' => array(

--- a/app/i18n/oc/sub.php
+++ b/app/i18n/oc/sub.php
@@ -16,6 +16,8 @@ return array(
 		'empty' => 'Categoria voida',
 		'information' => 'Informacions',
 		'new' => 'Nòva categoria',
+		'position' => 'Position',	//TODO - Translation
+		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
 		'title' => 'Títol',
 	),
 	'feed' => array(

--- a/app/i18n/oc/sub.php
+++ b/app/i18n/oc/sub.php
@@ -16,8 +16,8 @@ return array(
 		'empty' => 'Categoria voida',
 		'information' => 'Informacions',
 		'new' => 'Nòva categoria',
-		'position' => 'Position',	//TODO - Translation
-		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
+		'position' => 'Display position',	//TODO - Translation
+		'position_help' => 'To control category sort order',	//TODO - Translation
 		'title' => 'Títol',
 	),
 	'feed' => array(

--- a/app/i18n/pt-br/sub.php
+++ b/app/i18n/pt-br/sub.php
@@ -17,8 +17,8 @@ return array(
 		'empty' => 'Categoria vazia',
 		'information' => 'Informações',
 		'new' => 'Nova categoria',
-		'position' => 'Position',	//TODO - Translation
-		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
+		'position' => 'Display position',	//TODO - Translation
+		'position_help' => 'To control category sort order',	//TODO - Translation
 		'title' => 'Título',
 	),
 	'feed' => array(

--- a/app/i18n/pt-br/sub.php
+++ b/app/i18n/pt-br/sub.php
@@ -17,6 +17,8 @@ return array(
 		'empty' => 'Categoria vazia',
 		'information' => 'Informações',
 		'new' => 'Nova categoria',
+		'position' => 'Position',	//TODO - Translation
+		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
 		'title' => 'Título',
 	),
 	'feed' => array(

--- a/app/i18n/ru/sub.php
+++ b/app/i18n/ru/sub.php
@@ -17,8 +17,8 @@ return array(
 		'empty' => 'Empty category',	//TODO - Translation
 		'information' => 'Information',	//TODO - Translation
 		'new' => 'New category',	//TODO - Translation
-		'position' => 'Position',	//TODO - Translation
-		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
+		'position' => 'Display position',	//TODO - Translation
+		'position_help' => 'To control category sort order',	//TODO - Translation
 		'title' => 'Title',	//TODO - Translation
 	),
 	'feed' => array(

--- a/app/i18n/ru/sub.php
+++ b/app/i18n/ru/sub.php
@@ -17,6 +17,8 @@ return array(
 		'empty' => 'Empty category',	//TODO - Translation
 		'information' => 'Information',	//TODO - Translation
 		'new' => 'New category',	//TODO - Translation
+		'position' => 'Position',	//TODO - Translation
+		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
 		'title' => 'Title',	//TODO - Translation
 	),
 	'feed' => array(

--- a/app/i18n/sk/sub.php
+++ b/app/i18n/sk/sub.php
@@ -16,6 +16,8 @@ return array(
 		'empty' => 'Prázdna kategória',
 		'information' => 'Informácia',
 		'new' => 'Nová kategória',
+		'position' => 'Position',	//TODO - Translation
+		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
 		'title' => 'Názov',
 	),
 	'feed' => array(

--- a/app/i18n/sk/sub.php
+++ b/app/i18n/sk/sub.php
@@ -16,8 +16,8 @@ return array(
 		'empty' => 'Prázdna kategória',
 		'information' => 'Informácia',
 		'new' => 'Nová kategória',
-		'position' => 'Position',	//TODO - Translation
-		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
+		'position' => 'Display position',	//TODO - Translation
+		'position_help' => 'To control category sort order',	//TODO - Translation
 		'title' => 'Názov',
 	),
 	'feed' => array(

--- a/app/i18n/tr/sub.php
+++ b/app/i18n/tr/sub.php
@@ -17,6 +17,8 @@ return array(
 		'empty' => 'Boş kategori',
 		'information' => 'Bilgi',
 		'new' => 'Yeni kategori',
+		'position' => 'Position',	//TODO - Translation
+		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
 		'title' => 'Başlık',
 	),
 	'feed' => array(

--- a/app/i18n/tr/sub.php
+++ b/app/i18n/tr/sub.php
@@ -17,8 +17,8 @@ return array(
 		'empty' => 'Boş kategori',
 		'information' => 'Bilgi',
 		'new' => 'Yeni kategori',
-		'position' => 'Position',	//TODO - Translation
-		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
+		'position' => 'Display position',	//TODO - Translation
+		'position_help' => 'To control category sort order',	//TODO - Translation
 		'title' => 'Başlık',
 	),
 	'feed' => array(

--- a/app/i18n/zh-cn/sub.php
+++ b/app/i18n/zh-cn/sub.php
@@ -17,6 +17,8 @@ return array(
 		'empty' => '空分类',
 		'information' => '信息',
 		'new' => '新分类',
+		'position' => 'Position',	//TODO - Translation
+		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
 		'title' => '标题',
 	),
 	'feed' => array(

--- a/app/i18n/zh-cn/sub.php
+++ b/app/i18n/zh-cn/sub.php
@@ -17,8 +17,8 @@ return array(
 		'empty' => '空分类',
 		'information' => '信息',
 		'new' => '新分类',
-		'position' => 'Position',	//TODO - Translation
-		'position_help' => 'Display position. When two categories have the same position, they are displayed in alphabetical order. Categories with no position are displayed after those with one.',	//TODO - Translation
+		'position' => 'Display position',	//TODO - Translation
+		'position_help' => 'To control category sort order',	//TODO - Translation
 		'title' => '标题',
 	),
 	'feed' => array(

--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -63,11 +63,12 @@
 		<?php
 			foreach ($this->categories as $cat) {
 				$feeds = $cat->feeds();
+				$position = $cat->attributes('position');
 				if (!empty($feeds)) {
 					$c_active = FreshRSS_Context::isCurrentGet('c_' . $cat->id());
 					$c_show = $c_active || FreshRSS_Context::$user_conf->display_categories;
 		?>
-		<li class="tree-folder category<?= $c_active ? ' active' : '' ?>" data-unread="<?= $cat->nbNotRead() ?>">
+		<li class="tree-folder category<?= $c_active ? ' active' : '' ?>"<?= null === $position ? '' : "data-position='$position'" ?> data-unread="<?= $cat->nbNotRead() ?>">
 			<div class="tree-folder-title">
 				<a class="dropdown-toggle" href="#"><?= _i($c_show ? 'up' : 'down') ?></a>
 				<a class="title<?= $cat->hasFeedsWithError() ? ' error' : '' ?>" data-unread="<?= format_number($cat->nbNotRead()) ?>" href="<?= _url('index', $actual_view, 'get', 'c_' . $cat->id()) ?>"><?= $cat->name() ?></a>

--- a/app/views/helpers/category/update.phtml
+++ b/app/views/helpers/category/update.phtml
@@ -17,6 +17,13 @@
 				?> />
 			</div>
 		</div>
+		<div class="form-group">
+			<label class="group-name" for="position"><?= _t('sub.category.position') ?></label>
+			<div class="group-controls">
+				<input type="number" name="position" id="position" min="1" value="<?= $this->category->attributes('position') ?>" />
+				<?= _i('help') ?> <?= _t('sub.category.position_help') ?>
+			</div>
+		</div>
 
 		<div class="form-group form-actions">
 			<div class="group-controls">


### PR DESCRIPTION
Each category has a new 'priority' attribute. It is used to sort categories in
views. Categories with the same priority are sorted alphabetically. Categories
with no priority are displayed after those with one.

For example, if we have the following categories:
- A (priority: 2)
- B (no priority)
- C (priority: 1)
- D (priority: 2)
- E (no priority)
- F (priority: 1)

They will be displayed in the following order:
- C
- F
- A
- D
- B
- E

See #190