### PR TITLE
Revert to Ubuntu 19.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 	* Fix styling of search input fields in Safari [#2887](https://github.com/FreshRSS/FreshRSS/pull/2887)
 	* Upgrade to jQuery 3.5.0 for statistics [#2895](https://github.com/FreshRSS/FreshRSS/pull/2895)
 * Deployment
-	* Docker: Ubuntu image updated to 20.04 with PHP 7.4.3 and Apache 2.4.41 [#2925](https://github.com/FreshRSS/FreshRSS/pull/2925)
 	* Docker: Alpine image updated to PHP 7.3.17
 	* Add reference documentation for using Apache as a reverse proxy [#2919](https://github.com/FreshRSS/FreshRSS/pull/2919)
 	* Enforce Unix line endings when checking out via git [#2879](https://github.com/FreshRSS/FreshRSS/pull/2879)

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:19.10
 
 ENV TZ UTC
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Docker/Dockerfile-QEMU-ARM
+++ b/Docker/Dockerfile-QEMU-ARM
@@ -1,7 +1,7 @@
 # Only relevant for Docker Hub or QEMU multi-architecture builds.
 # Prefer the normal `Dockerfile` if you are building manually on the targeted architecture.
 
-FROM arm32v7/ubuntu:20.04
+FROM arm32v7/ubuntu:19.10
 
 # Requires ./hooks/*
 COPY ./Docker/qemu-arm-* /usr/bin/


### PR DESCRIPTION
#Fix https://github.com/FreshRSS/FreshRSS/issues/2939
Revert https://github.com/FreshRSS/FreshRSS/pull/2925

Will upgrade back to 20.04 when Ubuntu bugs are fixed, e.g.
https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1867675