### PR TITLE
tec: Add a make lint command in the Makefile

### DIFF
--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -5,7 +5,7 @@ SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN apk add --no-cache \
 	apache2 php7-apache2 \
 	php7 php7-curl php7-gmp php7-intl php7-mbstring php7-xml php7-zip \
-	php7-ctype php7-dom php7-fileinfo php7-iconv php7-json php7-opcache php7-phar php7-session php7-simplexml php7-xmlreader php7-zlib \
+	php7-ctype php7-dom php7-fileinfo php7-iconv php7-json php7-opcache php7-phar php7-session php7-simplexml php7-xmlreader php7-xmlwriter php7-tokenizer php7-zlib \
 	php7-pdo_sqlite php7-pdo_mysql php7-pdo_pgsql
 
 RUN mkdir -p /var/www/FreshRSS /run/apache2/

--- a/Makefile
+++ b/Makefile
@@ -51,17 +51,35 @@ start: ## Start the development environment (use Docker)
 stop: ## Stop FreshRSS container if any
 	docker stop freshrss-dev
 
-###########
-## Tests ##
-###########
-bin/phpunit: ## Install PHPUnit for test purposes
+######################
+## Tests and linter ##
+######################
+.PHONY: test
+test: bin/phpunit ## Run the test suite
+	$(PHP) ./bin/phpunit --bootstrap ./tests/bootstrap.php ./tests
+
+.PHONY: lint
+lint: bin/phpcs ## Run the linter on the PHP files
+	$(PHP) ./bin/phpcs . --standard=phpcs.xml --warning-severity=0 --extensions=php -p
+
+.PHONY: lint-fix
+lint-fix: bin/phpcbf ## Fix the errors detected by the linter
+	$(PHP) ./bin/phpcbf . --standard=phpcs.xml --warning-severity=0 --extensions=php -p
+
+bin/phpunit:
 	mkdir -p bin/
 	wget -O bin/phpunit https://phar.phpunit.de/phpunit-7.5.9.phar
 	echo '5404288061420c3921e53dd3a756bf044be546c825c5e3556dea4c51aa330f69 bin/phpunit' | sha256sum -c - || rm bin/phpunit
 
-.PHONY: test
-test: bin/phpunit ## Run the test suite
-	$(PHP) ./bin/phpunit --bootstrap ./tests/bootstrap.php ./tests
+bin/phpcs:
+	mkdir -p bin/
+	wget -O bin/phpcs https://github.com/squizlabs/PHP_CodeSniffer/releases/download/3.5.5/phpcs.phar
+	echo '4a2f6aff1b1f760216bb00c0b3070431131e3ed91307436bb1bfb252281a804a bin/phpcs' | sha256sum -c - || rm bin/phpcs
+
+bin/phpcbf:
+	mkdir -p bin/
+	wget -O bin/phpcbf https://github.com/squizlabs/PHP_CodeSniffer/releases/download/3.5.5/phpcbf.phar
+	echo '6f64fe00dee53fa7b256f63656dc0154f5964666fc7e535fac86d0078e7dea41 bin/phpcbf' | sha256sum -c - || rm bin/phpcbf
 
 ##########
 ## I18N ##

--- a/docs/en/developers/03_Running_tests.md
+++ b/docs/en/developers/03_Running_tests.md
@@ -18,6 +18,15 @@ Then, it executes PHPUnit in a Docker container. If you don't use Docker, you ca
 $ NO_DOCKER=true make test
 ```
 
+The linter can be run with a `make` command as well:
+
+```console
+$ make lint # to execute the linter on the PHP files
+$ make lint-fix # or, to fix the errors detected by the linter
+```
+
+Similarly to PHPUnit, it downloads a [PHP\_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) binary (i.e. `phpcs` or `phpcbf` depending on the command) and verifies its checksum.
+
 ## Travis
 
 Tests are automatically run when you open a pull request on GitHub. It is done with [Travis CI](https://travis-ci.org/FreshRSS/FreshRSS/). This is done to ensure there is no regressions in your code. We cannot merge a PR if the tests fail so we'll ask you to fix bugs before to review your code.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,6 +7,9 @@
 	<exclude-pattern>./lib/PHPMailer/</exclude-pattern>
 	<exclude-pattern>./lib/http-conditional.php</exclude-pattern>
 	<exclude-pattern>./lib/lib_phpQuery.php</exclude-pattern>
+	<exclude-pattern>./data/config.php</exclude-pattern>
+	<exclude-pattern>./data/users/*/config.php</exclude-pattern>
+	<exclude-pattern>./extensions/</exclude-pattern>
 	<!-- Duplicate class names are not allowed -->
 	<rule ref="Generic.Classes.DuplicateClassName"/>
 	<!-- Statements must not be empty -->


### PR DESCRIPTION
Closes #2722 (I almost forget about this ticket :))

Note: this PR is not urgent so it can wait for the 1.16.1 to be released.

Changes proposed in this pull request:

- Add `php7-xmlwriter` and `php7-tokenizer` to the Alpine image (required by PHP_CodeSniffer)
- Exclude some config files and extensions path from the linter
- Add `make lint` and `make lint-fix` commands to the Makefile

How to test the feature manually:

Execute `make lint` and `make lint-fix` in a console, and verifies it downloads the binaries and executes the linter.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard) (N/A)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).
