### PR TITLE
Change the autoload process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test: bin/phpunit ## Run the test suite
 
 .PHONY: lint
 lint: bin/phpcs ## Run the linter on the PHP files
-	$(PHP) ./bin/phpcs . -p -s
+	$(PHP) ./bin/phpcs . -p -s --ignore=data/cache/
 
 .PHONY: lint-fix
 lint-fix: bin/phpcbf ## Fix the errors detected by the linter

--- a/cli/check.translation.php
+++ b/cli/check.translation.php
@@ -1,10 +1,14 @@
 #!/usr/bin/env php
 <?php
 
-require_once __DIR__ . '/i18n/I18nCompletionValidator.php';
-require_once __DIR__ . '/i18n/I18nData.php';
-require_once __DIR__ . '/i18n/I18nFile.php';
-require_once __DIR__ . '/i18n/I18nUsageValidator.php';
+require(__DIR__ . '/../constants.php');
+require(LIB_PATH . '/lib_rss.php');	//Includes class autoloader
+
+use \RecursiveDirectoryIterator;
+use Cli\I18n\I18nCompletionValidator;
+use Cli\I18n\I18nData;
+use Cli\I18n\I18nFile;
+use Cli\I18n\I18nUsageValidator;
 
 $i18nFile = new I18nFile();
 $i18nData = new I18nData($i18nFile->load());

--- a/cli/i18n/I18nCompletionValidator.php
+++ b/cli/i18n/I18nCompletionValidator.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ . '/I18nValidatorInterface.php';
+namespace Cli\I18n;
 
 class I18nCompletionValidator implements I18nValidatorInterface {
 

--- a/cli/i18n/I18nData.php
+++ b/cli/i18n/I18nData.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace Cli\I18n;
+
+use \Exception;
+
 class I18nData {
 
 	const REFERENCE_LANGUAGE = 'en';
@@ -90,7 +94,7 @@ class I18nData {
 	 */
 	private function getNonReferenceLanguages() {
 		return array_filter(array_keys($this->data), function ($value) {
-			return static::REFERENCE_LANGUAGE !== $value;
+			return self::REFERENCE_LANGUAGE !== $value;
 		});
 	}
 
@@ -106,7 +110,7 @@ class I18nData {
 			throw new Exception('The selected language already exist.');
 		}
 		if (!is_string($reference) || !array_key_exists($reference, $this->data)) {
-			$reference = static::REFERENCE_LANGUAGE;
+			$reference = self::REFERENCE_LANGUAGE;
 		}
 		$this->data[$language] = $this->data[$reference];
 	}
@@ -118,8 +122,8 @@ class I18nData {
 	 * @return bool
 	 */
 	public function isKnown($key) {
-		return array_key_exists($this->getFilenamePrefix($key), $this->data[static::REFERENCE_LANGUAGE]) &&
-			array_key_exists($key, $this->data[static::REFERENCE_LANGUAGE][$this->getFilenamePrefix($key)]);
+		return array_key_exists($this->getFilenamePrefix($key), $this->data[self::REFERENCE_LANGUAGE]) &&
+			array_key_exists($key, $this->data[self::REFERENCE_LANGUAGE][$this->getFilenamePrefix($key)]);
 	}
 
 	/**
@@ -140,11 +144,11 @@ class I18nData {
 	 * To get the siblings, we need to find all matches with the parent.
 	 */
 	private function getSiblings($key) {
-		if (!array_key_exists($this->getFilenamePrefix($key), $this->data[static::REFERENCE_LANGUAGE])) {
+		if (!array_key_exists($this->getFilenamePrefix($key), $this->data[self::REFERENCE_LANGUAGE])) {
 			return [];
 		}
 
-		$keys = array_keys($this->data[static::REFERENCE_LANGUAGE][$this->getFilenamePrefix($key)]);
+		$keys = array_keys($this->data[self::REFERENCE_LANGUAGE][$this->getFilenamePrefix($key)]);
 		$parent = $this->getParentKey($key);
 
 		return array_values(array_filter($keys, function ($element) use ($parent) {
@@ -250,14 +254,14 @@ class I18nData {
 		if (!in_array($language, $this->getAvailableLanguages())) {
 			throw new Exception('The selected language does not exist.');
 		}
-		if (!array_key_exists($this->getFilenamePrefix($key), $this->data[static::REFERENCE_LANGUAGE]) ||
-			!array_key_exists($key, $this->data[static::REFERENCE_LANGUAGE][$this->getFilenamePrefix($key)])) {
+		if (!array_key_exists($this->getFilenamePrefix($key), $this->data[self::REFERENCE_LANGUAGE]) ||
+			!array_key_exists($key, $this->data[self::REFERENCE_LANGUAGE][$this->getFilenamePrefix($key)])) {
 			throw new Exception('The selected key does not exist for the selected language.');
 		}
 
 		$value = new I18nValue($value);
-		if (static::REFERENCE_LANGUAGE === $language) {
-			$previousValue = $this->data[static::REFERENCE_LANGUAGE][$this->getFilenamePrefix($key)][$key];
+		if (self::REFERENCE_LANGUAGE === $language) {
+			$previousValue = $this->data[self::REFERENCE_LANGUAGE][$this->getFilenamePrefix($key)][$key];
 			foreach ($this->getAvailableLanguages() as $lang) {
 				$currentValue = $this->data[$lang][$this->getFilenamePrefix($key)][$key];
 				if ($currentValue->equal($previousValue)) {
@@ -305,7 +309,7 @@ class I18nData {
 	 *
 	 * @param string $key
 	 * @param string $language
-	 * @param boolean $reverse
+	 * @param bool $reverse
 	 */
 	public function ignore($key, $language, $reverse = false) {
 		$value = $this->data[$language][$this->getFilenamePrefix($key)][$key];
@@ -320,7 +324,7 @@ class I18nData {
 	 * Ignore all unmodified keys from a language, or reverse it.
 	 *
 	 * @param string $language
-	 * @param boolean $reverse
+	 * @param bool $reverse
 	 */
 	public function ignore_unmodified($language, $reverse = false) {
 		$my_language = $this->getLanguage($language);
@@ -340,7 +344,7 @@ class I18nData {
 	}
 
 	public function getReferenceLanguage() {
-		return $this->getLanguage(static::REFERENCE_LANGUAGE);
+		return $this->getLanguage(self::REFERENCE_LANGUAGE);
 	}
 
 	/**

--- a/cli/i18n/I18nFile.php
+++ b/cli/i18n/I18nFile.php
@@ -1,6 +1,9 @@
 <?php
 
-require_once __DIR__ . '/I18nValue.php';
+namespace Cli\I18n;
+
+use \DirectoryIterator;
+use \ParseError;
 
 class I18nFile {
 	public function load() {

--- a/cli/i18n/I18nUsageValidator.php
+++ b/cli/i18n/I18nUsageValidator.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ . '/I18nValidatorInterface.php';
+namespace Cli\I18n;
 
 class I18nUsageValidator implements I18nValidatorInterface {
 

--- a/cli/i18n/I18nValidatorInterface.php
+++ b/cli/i18n/I18nValidatorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Cli\I18n;
+
 interface I18nValidatorInterface {
 
 	/**

--- a/cli/i18n/I18nValue.php
+++ b/cli/i18n/I18nValue.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Cli\I18n;
+
 class I18nValue {
 	const STATE_DIRTY = 'dirty';
 	const STATE_IGNORE = 'ignore';

--- a/cli/manipulate.translation.php
+++ b/cli/manipulate.translation.php
@@ -1,10 +1,11 @@
 #!/usr/bin/env php
 <?php
 
-require_once __DIR__ . '/i18n/I18nData.php';
-require_once __DIR__ . '/i18n/I18nFile.php';
-require_once __DIR__ . '/../constants.php';
+require(__DIR__ . '/../constants.php');
+require(LIB_PATH . '/lib_rss.php');	//Includes class autoloader
 
+use Cli\I18n\I18nFile;
+use Cli\I18n\I18nData;
 
 $options = getopt("a:hk:l:o:rv:");
 

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
     "scripts": {
         "php-lint": "find . -type d -name 'vendor' -prune -o -name '*.php' -print0 | xargs -0 -n1 -P4 php -l 1>/dev/null",
         "phtml-lint": "find . -type d -name 'vendor' -prune -o -name '*.phtml' -print0 | xargs -0 -n1 -P4 php -l 1>/dev/null",
-        "phpcs": "phpcs . -s",
+        "phpcs": "phpcs . -s --ignore=data/cache/",
         "phpcbf": "phpcbf . -p -s",
         "phpstan": "phpstan analyse --memory-limit 512M .",
         "phpunit": "phpunit --bootstrap ./tests/bootstrap.php --verbose ./tests",

--- a/constants.php
+++ b/constants.php
@@ -16,6 +16,7 @@ define('INDEX_PATH', PUBLIC_PATH . PUBLIC_TO_INDEX_PATH);
 define('PUBLIC_RELATIVE', '..');
 define('LIB_PATH', FRESHRSS_PATH . '/lib');
 define('APP_PATH', FRESHRSS_PATH . '/app');
+define('CLI_PATH', FRESHRSS_PATH . '/cli');
 define('I18N_PATH', APP_PATH . '/i18n');
 define('CORE_EXTENSIONS_PATH', LIB_PATH . '/core-extensions');
 define('TESTS_PATH', FRESHRSS_PATH . '/tests');

--- a/data/cache/.gitignore
+++ b/data/cache/.gitignore
@@ -1,3 +1,4 @@
+==== BASE ====
 *.spc
 *.html
 *.xml

--- a/lib/autoload.php
+++ b/lib/autoload.php
@@ -1,0 +1,45 @@
+<?php
+
+const PREFIX_CLI_I18N = 'Cli\\I18n\\';
+const PREFIX_CSSXPATH = 'Gt\\CssXPath\\';
+const PREFIX_PHPMAILER = 'PHPMailer\\PHPMailer\\';
+
+function includeFreshrssClass($class) {
+	$components = explode('_', $class);
+	switch (count($components)) {
+		case 1:
+			include APP_PATH . "/{$components[0]}.php";
+			break;
+		case 2:
+			include APP_PATH . "/Models/{$components[1]}.php";
+			break;
+		case 3:	//Controllers, Exceptions
+			include APP_PATH . "/{$components[2]}s/{$components[1]}{$components[2]}.php";
+			break;
+	}
+}
+
+function requireClass($class, $path, $search, $replace, $prefix = null) {
+	if ($prefix !== null) {
+		$class = substr($class, strlen($prefix));
+	}
+	require $path . str_replace($search, $replace, $class) . '.php';
+}
+
+function classAutoloader($class) {
+	if (str_starts_with($class, 'FreshRSS')) {
+		includeFreshrssClass($class);
+	} elseif (str_starts_with($class, 'Minz')) {
+		requireClass($class, LIB_PATH . '/', '_', '/');
+	} elseif (str_starts_with($class, 'SimplePie')) {
+		requireClass($class, LIB_PATH . '/SimplePie/', '_', '/');
+	} elseif (str_starts_with($class, PREFIX_CLI_I18N)) {
+		requireClass($class, CLI_PATH . '/i18n/', '\\', '/', PREFIX_CLI_I18N);
+	} elseif (str_starts_with($class, PREFIX_CSSXPATH)) {
+		requireClass($class, LIB_PATH . '/phpgt/cssxpath/src/', '\\', '/', PREFIX_CSSXPATH);
+	} elseif (str_starts_with($class, PREFIX_PHPMAILER)) {
+		requireClass($class, LIB_PATH . '/phpmailer/phpmailer/src/', '\\', '/', PREFIX_PHPMAILER);
+	}
+}
+
+spl_autoload_register('classAutoloader');

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -23,6 +23,8 @@ if (COPY_SYSLOG_TO_STDERR) {
 	openlog('FreshRSS', LOG_CONS | LOG_ODELAY | LOG_PID, LOG_USER);
 }
 
+require_once LIB_PATH . '/autoload.php';
+
 /**
  * Build a directory path by concatenating a list of directory names.
  *
@@ -32,41 +34,6 @@ if (COPY_SYSLOG_TO_STDERR) {
 function join_path(...$path_parts): string {
 	return join(DIRECTORY_SEPARATOR, $path_parts);
 }
-
-//<Auto-loading>
-function classAutoloader($class) {
-	if (strpos($class, 'FreshRSS') === 0) {
-		$components = explode('_', $class);
-		switch (count($components)) {
-			case 1:
-				include(APP_PATH . '/' . $components[0] . '.php');
-				return;
-			case 2:
-				include(APP_PATH . '/Models/' . $components[1] . '.php');
-				return;
-			case 3:	//Controllers, Exceptions
-				include(APP_PATH . '/' . $components[2] . 's/' . $components[1] . $components[2] . '.php');
-				return;
-		}
-	} elseif (strpos($class, 'Minz') === 0) {
-		include(LIB_PATH . '/' . str_replace('_', '/', $class) . '.php');
-	} elseif (strpos($class, 'SimplePie') === 0) {
-		include(LIB_PATH . '/SimplePie/' . str_replace('_', '/', $class) . '.php');
-	} elseif (str_starts_with($class, 'Gt\\CssXPath\\')) {
-		$prefix = 'Gt\\CssXPath\\';
-		$base_dir = LIB_PATH . '/phpgt/cssxpath/src/';
-		$relative_class_name = substr($class, strlen($prefix));
-		require $base_dir . str_replace('\\', '/', $relative_class_name) . '.php';
-	} elseif (str_starts_with($class, 'PHPMailer\\PHPMailer\\')) {
-		$prefix = 'PHPMailer\\PHPMailer\\';
-		$base_dir = LIB_PATH . '/phpmailer/phpmailer/src/';
-		$relative_class_name = substr($class, strlen($prefix));
-		require $base_dir . str_replace('\\', '/', $relative_class_name) . '.php';
-	}
-}
-
-spl_autoload_register('classAutoloader');
-//</Auto-loading>
 
 /**
  * @param string $url

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,5 +5,5 @@ ini_set('display_errors', 1);
 
 define('COPY_LOG_TO_SYSLOG', false);
 
-require(__DIR__ . '/../constants.php');
-require(LIB_PATH . '/lib_rss.php');	//Includes class autoloader
+require __DIR__ . '/../constants.php';
+require LIB_PATH . '/lib_rss.php';	//Includes class autoloader

--- a/tests/cli/i18n/I18nCompletionValidatorTest.php
+++ b/tests/cli/i18n/I18nCompletionValidatorTest.php
@@ -1,7 +1,7 @@
 <?php
 
-require_once __DIR__ . '/../../../cli/i18n/I18nCompletionValidator.php';
-require_once __DIR__ . '/../../../cli/i18n/I18nValue.php';
+use Cli\I18n\I18nCompletionValidator;
+use Cli\I18n\I18nValue;
 
 class I18nCompletionValidatorTest extends PHPUnit\Framework\TestCase {
 	private $value;

--- a/tests/cli/i18n/I18nDataTest.php
+++ b/tests/cli/i18n/I18nDataTest.php
@@ -1,7 +1,7 @@
 <?php
 
-require_once __DIR__ . '/../../../cli/i18n/I18nData.php';
-require_once __DIR__ . '/../../../cli/i18n/I18nValue.php';
+use Cli\I18n\I18nData;
+use Cli\I18n\I18nValue;
 
 class I18nDataTest extends PHPUnit\Framework\TestCase {
 	private $referenceData;

--- a/tests/cli/i18n/I18nFileTest.php
+++ b/tests/cli/i18n/I18nFileTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ . '/../../../cli/i18n/I18nFile.php';
+use Cli\I18n\I18nFile;
 
 class I18nFileTest extends PHPUnit\Framework\TestCase {
 	public function test() {

--- a/tests/cli/i18n/I18nUsageValidatorTest.php
+++ b/tests/cli/i18n/I18nUsageValidatorTest.php
@@ -1,7 +1,7 @@
 <?php
 
-require_once __DIR__ . '/../../../cli/i18n/I18nValue.php';
-require_once __DIR__ . '/../../../cli/i18n/I18nUsageValidator.php';
+use Cli\I18n\I18nValue;
+use Cli\I18n\I18nUsageValidator;
 
 class I18nUsageValidatorTest extends PHPUnit\Framework\TestCase {
 	private $value;

--- a/tests/cli/i18n/I18nValueTest.php
+++ b/tests/cli/i18n/I18nValueTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ . '/../../../cli/i18n/I18nValue.php';
+use Cli\I18n\I18nValue;
 
 class I18nValueTest extends PHPUnit\Framework\TestCase {
 	public function testConstructorWithoutState() {


### PR DESCRIPTION
Changes proposed in this pull request:

- Change autoloading to accomodate namespaces

How to test the feature manually:

1. Use the application to check than everything is working as before.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

~~Before, the autoload process was too restricted. It was really dependant on our
code tree. It was hard to add more classes to be loaded automatically. On top
of that, it did not support autoloading classes following the PSR-4 recommendation.~~

~~Now, the autoload process is more open. It supports partially the PSR-4 recommendation,
there is no specific code to load Minz classes or PHPMailer classes. This is the
starting point to reorganize the codebase to introduce long waiting changes as seen
in #789. It would be a nice to later rework the tree, rename classes, and add namespace
in a fashion that follows the PSR-4. Then specific FRSS workarounds in the autoload
could be dropped.~~