### PR TITLE
Add support for extension user files

### DIFF
--- a/lib/Minz/Extension.php
+++ b/lib/Minz/Extension.php
@@ -148,19 +148,22 @@ abstract class Minz_Extension {
 	 *
 	 * @param $filename name of the file to serve.
 	 * @param $type the type (js or css) of the file to serve.
+	 * @param $isStatic indicates if the file is a static file or a user file. Default is static.
 	 * @return the url corresponding to the file.
 	 */
-	public function getFileUrl($filename, $type) {
-		$dir = substr(strrchr($this->path, '/'), 1);
-		$file_name_url = urlencode($dir . '/static/' . $filename);
+	public function getFileUrl($filename, $type, $isStatic = true) {
+		if ($isStatic) {
+			$dir = basename($this->path);
+			$file_name_url = urlencode("{$dir}/static/{$filename}");
+			$mtime = @filemtime("{$this->path}/static/{$filename}");
+		} else {
+			$username = Minz_Session::param('currentUser');
+			$path = USERS_PATH . "/{$username}/{$this->config_key}/{$this->getName()}/{$filename}";
+			$file_name_url = urlencode("{$username}/{$this->config_key}/{$this->getName()}/{$filename}");
+			$mtime = @filemtime($path);
+		}
 
-		$absolute_path = $this->path . '/static/' . $filename;
-		$mtime = @filemtime($absolute_path);
-
-		$url = '/ext.php?f=' . $file_name_url .
-		       '&amp;t=' . $type .
-		       '&amp;' . $mtime;
-		return Minz_Url::display($url, 'php');
+		return Minz_Url::display("/ext.php?f={$file_name_url}&amp;t={$type}&amp;{$mtime}", 'php');
 	}
 
 	/**
@@ -269,7 +272,7 @@ abstract class Minz_Extension {
 		$this->user_configuration = $configuration;
 	}
 
-	public function removeUserConfiguration(){
+	public function removeUserConfiguration() {
 		if (!$this->isUserConfigurationEnabled()) {
 			return;
 		}
@@ -287,5 +290,25 @@ abstract class Minz_Extension {
 		FreshRSS_Context::$user_conf->save();
 
 		$this->user_configuration = null;
+	}
+
+	public function saveFile(string $filename, string $content) {
+		$username = Minz_Session::param('currentUser');
+		$path = USERS_PATH . "/{$username}/{$this->config_key}/{$this->getName()}";
+
+		if (!file_exists($path)) {
+			mkdir($path, 0777, true);
+		}
+
+		file_put_contents("{$path}/{$filename}", $content);
+	}
+
+	public function removeFile(string $filename) {
+		$username = Minz_Session::param('currentUser');
+		$path = USERS_PATH . "/{$username}/{$this->config_key}/{$this->getName()}/{$filename}";
+
+		if (file_exists($path)) {
+			unlink($path);
+		}
 	}
 }

--- a/p/ext.php
+++ b/p/ext.php
@@ -32,10 +32,15 @@ function get_absolute_filename(string $file_name) {
 		return $third_party_extension;
 	}
 
+	$user = realpath(USERS_PATH . '/' . $file_name);
+	if (false !== $user) {
+		return $user;
+	}
+
 	return '';
 }
 
-function is_valid_path_extension($path, $extensionPath) {
+function is_valid_path_extension($path, $extensionPath, $isStatic = true) {
 	// It must be under the extension path.
 	$real_ext_path = realpath($extensionPath);
 
@@ -48,7 +53,12 @@ function is_valid_path_extension($path, $extensionPath) {
 		return false;
 	}
 
-	// File to serve must be under a `ext_dir/static/` directory.
+	// User files do not need further validations
+	if (!$isStatic) {
+		return true;
+	}
+
+	// Static files to serve must be under a `ext_dir/static/` directory.
 	$path_relative_to_ext = substr($path, strlen($real_ext_path) + 1);
 	list(,$static,$file) = sscanf($path_relative_to_ext, '%[^/]/%[^/]/%s');
 	if (null === $file || 'static' !== $static) {
@@ -69,7 +79,7 @@ function is_valid_path_extension($path, $extensionPath) {
  *
  */
 function is_valid_path($path) {
-	return is_valid_path_extension($path, CORE_EXTENSIONS_PATH) || is_valid_path_extension($path, THIRDPARTY_EXTENSIONS_PATH);
+	return is_valid_path_extension($path, CORE_EXTENSIONS_PATH) || is_valid_path_extension($path, THIRDPARTY_EXTENSIONS_PATH) || is_valid_path_extension($path, USERS_PATH, $false);
 }
 
 function sendBadRequestResponse(string $message = null) {


### PR DESCRIPTION
Closes #1709 (possibly)

Changes proposed in this pull request:

- Add support for extension user files
-
-

How to test the feature manually:

1.
2.
3.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/master/docs/en/developers/04_Pull_requests.md).

Extension user files can be stored easily in the user folder instead of the
static folder.