### PR TITLE
Clean 3+ years old auto-updates

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -24,7 +24,6 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 				Minz_Error::error(403);
 			}
 		}
-		$this->updateTTL();
 	}
 
 	/**
@@ -852,15 +851,5 @@ class FreshRSS_feed_Controller extends Minz_ActionController {
 		} catch (Exception $e) {
 			$this->view->fatalError = _t('feedback.sub.feed.selector_preview.http_error');
 		}
-	}
-
-	/**
-	 * This method update TTL values for feeds if needed.
-	 * It changes the old default value (-2) to the new default value (0).
-	 * It changes the old disabled value (-1) to the default disabled value.
-	 */
-	private function updateTTL() {
-		$feedDAO = FreshRSS_Factory::createFeedDao();
-		$feedDAO->updateTTL();
 	}
 }

--- a/app/Controllers/subscriptionController.php
+++ b/app/Controllers/subscriptionController.php
@@ -18,7 +18,6 @@ class FreshRSS_subscription_Controller extends Minz_ActionController {
 		$feedDAO = FreshRSS_Factory::createFeedDao();
 
 		$catDAO->checkDefault();
-		$feedDAO->updateTTL();
 		$this->view->categories = $catDAO->listSortedCategories(false);
 		$this->view->default_category = $catDAO->getDefault();
 	}

--- a/app/Models/CategoryDAO.php
+++ b/app/Models/CategoryDAO.php
@@ -148,7 +148,7 @@ SQL;
 		} else {
 			$info = $stm == null ? $this->pdo->errorInfo() : $stm->errorInfo();
 			if ($this->autoUpdateDb($info)) {
-				return $this->updateCategory($valuesTmp);
+				return $this->updateCategory($id, $valuesTmp);
 			}
 			Minz_Log::error('SQL error updateCategory: ' . json_encode($info));
 			return false;

--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -22,26 +22,6 @@ class FreshRSS_EntryDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 		return str_replace('INSERT INTO ', 'INSERT IGNORE INTO ', $sql);
 	}
 
-	//TODO: Move the database auto-updates to DatabaseDAO
-	protected function createEntryTempTable() {
-		$ok = false;
-		$hadTransaction = $this->pdo->inTransaction();
-		if ($hadTransaction) {
-			$this->pdo->commit();
-		}
-		try {
-			require(APP_PATH . '/SQL/install.sql.' . $this->pdo->dbType() . '.php');
-			Minz_Log::warning('SQL CREATE TABLE entrytmp...');
-			$ok = $this->pdo->exec($SQL_CREATE_TABLE_ENTRYTMP . $SQL_CREATE_INDEX_ENTRY_1) !== false;
-		} catch (Exception $ex) {
-			Minz_Log::error(__method__ . ' error: ' . $ex->getMessage());
-		}
-		if ($hadTransaction) {
-			$this->pdo->beginTransaction();
-		}
-		return $ok;
-	}
-
 	private function updateToMediumBlob() {
 		if ($this->pdo->dbType() !== 'mysql') {
 			return false;
@@ -68,8 +48,6 @@ SQL;
 				if (stripos($errorInfo[2], 'tag') !== false) {
 					$tagDAO = FreshRSS_Factory::createTagDao();
 					return $tagDAO->createTagTable();	//v1.12.0
-				} elseif (stripos($errorInfo[2], 'entrytmp') !== false) {
-					return $this->createEntryTempTable();	//v1.7.0
 				}
 			}
 		}

--- a/app/Models/EntryDAOPGSQL.php
+++ b/app/Models/EntryDAOPGSQL.php
@@ -24,8 +24,6 @@ class FreshRSS_EntryDAOPGSQL extends FreshRSS_EntryDAOSQLite {
 				if (stripos($errorInfo[2], 'tag') !== false) {
 					$tagDAO = FreshRSS_Factory::createTagDao();
 					return $tagDAO->createTagTable();	//v1.12.0
-				} elseif (stripos($errorInfo[2], 'entrytmp') !== false) {
-					return $this->createEntryTempTable();	//v1.7.0
 				}
 			}
 		}

--- a/app/Models/EntryDAOSQLite.php
+++ b/app/Models/EntryDAOSQLite.php
@@ -26,12 +26,6 @@ class FreshRSS_EntryDAOSQLite extends FreshRSS_EntryDAO {
 				return $tagDAO->createTagTable();	//v1.12.0
 			}
 		}
-		if ($tableInfo = $this->pdo->query("SELECT sql FROM sqlite_master where name='entrytmp'")) {
-			$showCreate = $tableInfo->fetchColumn();
-			if (stripos($showCreate, 'entrytmp') === false) {
-				return $this->createEntryTempTable();	//v1.7.0
-			}
-		}
 		return false;
 	}
 

--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -337,7 +337,6 @@ SQL;
 	 * Use $defaultCacheDuration == -1 to return all feeds, without filtering them by TTL.
 	 */
 	public function listFeedsOrderUpdate($defaultCacheDuration = 3600, $limit = 0) {
-		$this->updateTTL();
 		$sql = 'SELECT id, url, name, website, `lastUpdate`, `pathEntries`, `httpAuth`, ttl, attributes '
 			. 'FROM `_feed` '
 			. ($defaultCacheDuration < 0 ? '' : 'WHERE ttl >= ' . FreshRSS_Feed::TTL_DEFAULT
@@ -505,24 +504,6 @@ SQL;
 		}
 
 		return $list;
-	}
-
-	public function updateTTL() {
-		$sql = 'UPDATE `_feed` SET ttl=:new_value WHERE ttl=:old_value';
-		$stm = $this->pdo->prepare($sql);
-		if (!($stm && $stm->execute(array(':new_value' => FreshRSS_Feed::TTL_DEFAULT, ':old_value' => -2)))) {
-			$info = $stm == null ? $this->pdo->errorInfo() : $stm->errorInfo();
-			Minz_Log::error('SQL warning updateTTL 1: ' . $info[2] . ' ' . $sql);
-
-			$sql2 = 'ALTER TABLE `_feed` ADD COLUMN ttl INT NOT NULL DEFAULT ' . FreshRSS_Feed::TTL_DEFAULT;	//v0.7.3
-			$stm = $this->pdo->query($sql2);
-			if ($stm === false) {
-				$info = $stm == null ? $this->pdo->errorInfo() : $stm->errorInfo();
-				Minz_Log::error('SQL error updateTTL 2: ' . $info[2] . ' ' . $sql2);
-			}
-		} else {
-			$stm->execute(array(':new_value' => -3600, ':old_value' => -1));
-		}
 	}
 
 	public function count() {

--- a/app/Models/UserDAO.php
+++ b/app/Models/UserDAO.php
@@ -5,7 +5,7 @@ class FreshRSS_UserDAO extends Minz_ModelPdo {
 		require(APP_PATH . '/SQL/install.sql.' . $this->pdo->dbType() . '.php');
 
 		try {
-			$sql = $SQL_CREATE_TABLES . $SQL_CREATE_TABLE_ENTRYTMP . $SQL_CREATE_TABLE_TAGS;
+			$sql = $SQL_CREATE_TABLES . $SQL_CREATE_TABLE_TAGS;
 			$ok = $this->pdo->exec($sql) !== false;	//Note: Only exec() can take multiple statements safely.
 		} catch (Exception $e) {
 			Minz_Log::error('Error while creating database for user ' . $this->current_user . ': ' . $e->getMessage());

--- a/app/SQL/install.sql.mysql.php
+++ b/app/SQL/install.sql.mysql.php
@@ -62,13 +62,7 @@ CREATE TABLE IF NOT EXISTS `_entry` (
 ENGINE = INNODB;
 
 INSERT IGNORE INTO `_category` (id, name) VALUES(1, "Uncategorized");
-SQL;
 
-$SQL_CREATE_INDEX_ENTRY_1 = <<<'SQL'
-CREATE INDEX `entry_feed_read_index` ON `_entry` (`id_feed`,`is_read`);	-- v1.7
-SQL;
-
-$SQL_CREATE_TABLE_ENTRYTMP = <<<'SQL'
 CREATE TABLE IF NOT EXISTS `_entrytmp` (	-- v1.7
 	`id` BIGINT NOT NULL,
 	`guid` VARCHAR(760) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,

--- a/app/SQL/install.sql.pgsql.php
+++ b/app/SQL/install.sql.pgsql.php
@@ -57,13 +57,7 @@ INSERT INTO `_category` (id, name)
 	SELECT 1, 'Uncategorized'
 	WHERE NOT EXISTS (SELECT id FROM `_category` WHERE id = 1)
 	RETURNING nextval('`_category_id_seq`');
-SQL;
 
-$SQL_CREATE_INDEX_ENTRY_1 = <<<'SQL'
-CREATE INDEX IF NOT EXISTS `_entry_feed_read_index` ON `_entry` ("id_feed","is_read");	-- v1.7
-SQL;
-
-$SQL_CREATE_TABLE_ENTRYTMP = <<<'SQL'
 CREATE TABLE IF NOT EXISTS `_entrytmp` (	-- v1.7
 	"id" BIGINT NOT NULL PRIMARY KEY,
 	"guid" VARCHAR(760) NOT NULL,

--- a/app/SQL/install.sql.sqlite.php
+++ b/app/SQL/install.sql.sqlite.php
@@ -57,13 +57,7 @@ CREATE INDEX IF NOT EXISTS entry_lastSeen_index ON `entry`(`lastSeen`);	-- //v1.
 CREATE INDEX IF NOT EXISTS entry_feed_read_index ON `entry`(`id_feed`,`is_read`);	-- v1.7
 
 INSERT OR IGNORE INTO `category` (id, name) VALUES(1, "Uncategorized");
-SQL;
 
-$SQL_CREATE_INDEX_ENTRY_1 = <<<'SQL'
-CREATE INDEX IF NOT EXISTS entry_feed_read_index ON `entry`(`id_feed`,`is_read`);	-- v1.7
-SQL;
-
-$SQL_CREATE_TABLE_ENTRYTMP = <<<'SQL'
 CREATE TABLE IF NOT EXISTS `entrytmp` (	-- v1.7
 	`id` BIGINT NOT NULL,
 	`guid` VARCHAR(760) NOT NULL,


### PR DESCRIPTION
* Minor auto-update in version 1.10.0 (3 years old) https://github.com/FreshRSS/FreshRSS/pull/1750
    * Causing slight problems, related to https://github.com/FreshRSS/FreshRSS/issues/3552
* Auto-update for temporary table in version 1.7.0 (4 years old) https://github.com/FreshRSS/FreshRSS/pull/1470
    * Just because it was older than the one just above