### PR TITLE
fix #3653: Anon. reading: bookmarking leads to error

### DIFF
--- a/app/views/index/reader.phtml
+++ b/app/views/index/reader.phtml
@@ -37,12 +37,14 @@ $content_width = FreshRSS_Context::$user_conf->content_width;
 						$readUrl['params']['is_read'] = 0;
 					}
 				?>
+				<? if (FreshRSS_Auth::hasAccess()) { ?>
 				<a class="read" href="<?= Minz_Url::display($readUrl) ?>">
 					<?= _i($item->isRead() ? 'read' : 'unread') ?>
 				</a>
 				<a class="bookmark" href="<?= Minz_Url::display($favoriteUrl) ?>">
 					<?= _i($item->isFavorite() ? 'starred' : 'non-starred') ?>
 				</a>
+				<?php } ?>
 				<a class="website" href="<?= _url('index', 'reader', 'get', 'f_' . $feed->id()) ?>">
 					<?php if (FreshRSS_Context::$user_conf->show_favicons): ?>
 						<img class="favicon" src="<?= $feed->favicon() ?>" alt="✇" loading="lazy" />


### PR DESCRIPTION
Closes #3653

before:
![grafik](https://user-images.githubusercontent.com/1645099/136845943-8c5f57c5-000d-4633-bd13-815ed71f29a2.png)

after:
![grafik](https://user-images.githubusercontent.com/1645099/136845990-827979ec-cb3c-4359-bd47-e7162efb68b4.png)


Changes proposed in this pull request:
- not logged in user cannot anymore mark a article as unread (red envelope) or bookmark it (yellow star)


How to test the feature manually:
1. user is not logged in
2. Reading view
3. red envelop: not visible anymore
4. yellow star: not visible anymore

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
