### PR TITLE
Improve conf menu

### DIFF
--- a/app/i18n/cz/gen.php
+++ b/app/i18n/cz/gen.php
@@ -146,6 +146,7 @@ return array(
 	),
 	'menu' => array(
 		'about' => 'O aplikaci',
+		'account' => 'Account', // Todo: Transation
 		'admin' => 'Administrace',
 		'archiving' => 'Archivace',
 		'authentication' => 'Přihlášení',

--- a/app/i18n/de/gen.php
+++ b/app/i18n/de/gen.php
@@ -146,6 +146,7 @@ return array(
 	),
 	'menu' => array(
 		'about' => 'Über',
+		'account' => 'Account',
 		'admin' => 'Administration',
 		'archiving' => 'Archivierung',
 		'authentication' => 'Authentifizierung',

--- a/app/i18n/en-us/gen.php
+++ b/app/i18n/en-us/gen.php
@@ -146,6 +146,7 @@ return array(
 	),
 	'menu' => array(
 		'about' => 'About',
+		'account' => 'Account', // Todo: Transation
 		'admin' => 'Administration',
 		'archiving' => 'Archiving',
 		'authentication' => 'Authentication',

--- a/app/i18n/en/gen.php
+++ b/app/i18n/en/gen.php
@@ -146,6 +146,7 @@ return array(
 	),
 	'menu' => array(
 		'about' => 'About',
+		'account' => 'Account',
 		'admin' => 'Administration',
 		'archiving' => 'Archiving',
 		'authentication' => 'Authentication',

--- a/app/i18n/es/gen.php
+++ b/app/i18n/es/gen.php
@@ -146,6 +146,7 @@ return array(
 	),
 	'menu' => array(
 		'about' => 'Acerca de',
+		'account' => 'Account', // Todo: Transation
 		'admin' => 'Administración',
 		'archiving' => 'Archivo',
 		'authentication' => 'Identificación',

--- a/app/i18n/fr/gen.php
+++ b/app/i18n/fr/gen.php
@@ -146,7 +146,7 @@ return array(
 	),
 	'menu' => array(
 		'about' => 'À propos',
-		'account' => 'Account', // Todo: Transation
+		'account' => 'Compte',
 		'admin' => 'Administration',
 		'archiving' => 'Archivage',
 		'authentication' => 'Authentification',

--- a/app/i18n/fr/gen.php
+++ b/app/i18n/fr/gen.php
@@ -146,6 +146,7 @@ return array(
 	),
 	'menu' => array(
 		'about' => 'À propos',
+		'account' => 'Account', // Todo: Transation
 		'admin' => 'Administration',
 		'archiving' => 'Archivage',
 		'authentication' => 'Authentification',

--- a/app/i18n/he/gen.php
+++ b/app/i18n/he/gen.php
@@ -146,6 +146,7 @@ return array(
 	),
 	'menu' => array(
 		'about' => 'אודות',
+		'account' => 'Account', // Todo: Transation
 		'admin' => 'ניהול',
 		'archiving' => 'ארכוב',
 		'authentication' => 'Authentication',	// TODO - Translation

--- a/app/i18n/it/gen.php
+++ b/app/i18n/it/gen.php
@@ -146,6 +146,7 @@ return array(
 	),
 	'menu' => array(
 		'about' => 'Informazioni',
+		'account' => 'Account', // Todo: Transation
 		'admin' => 'Amministrazione',
 		'archiving' => 'Archiviazione',
 		'authentication' => 'Autenticazione',

--- a/app/i18n/ja/gen.php
+++ b/app/i18n/ja/gen.php
@@ -146,6 +146,7 @@ return array(
 	),
 	'menu' => array(
 		'about' => 'FreshRSSについて',
+		'account' => 'Account', // Todo: Transation
 		'admin' => '管理者',
 		'archiving' => 'アーカイブ',
 		'authentication' => '認証',

--- a/app/i18n/kr/gen.php
+++ b/app/i18n/kr/gen.php
@@ -146,6 +146,7 @@ return array(
 	),
 	'menu' => array(
 		'about' => '정보',
+		'account' => 'Account', // Todo: Transation
 		'admin' => '관리',
 		'archiving' => '보관',
 		'authentication' => '인증',

--- a/app/i18n/nl/gen.php
+++ b/app/i18n/nl/gen.php
@@ -146,6 +146,7 @@ return array(
 	),
 	'menu' => array(
 		'about' => 'Over',
+		'account' => 'Account', // Todo: Transation
 		'admin' => 'Administratie',
 		'archiving' => 'Archiveren',
 		'authentication' => 'Authenticatie',

--- a/app/i18n/oc/gen.php
+++ b/app/i18n/oc/gen.php
@@ -146,6 +146,7 @@ return array(
 	),
 	'menu' => array(
 		'about' => 'A prepaus',
+		'account' => 'Account', // Todo: Transation
 		'admin' => 'Administracion',
 		'archiving' => 'Archivar',
 		'authentication' => 'Autentificacion',

--- a/app/i18n/pl/gen.php
+++ b/app/i18n/pl/gen.php
@@ -146,6 +146,7 @@ return array(
 	),
 	'menu' => array(
 		'about' => 'O serwisie',
+		'account' => 'Account', // Todo: Transation
 		'admin' => 'Administracja',
 		'archiving' => 'Archiwizacja',
 		'authentication' => 'Uwierzytelnianie',

--- a/app/i18n/pt-br/gen.php
+++ b/app/i18n/pt-br/gen.php
@@ -146,6 +146,7 @@ return array(
 	),
 	'menu' => array(
 		'about' => 'Sobre',
+		'account' => 'Account', // Todo: Transation
 		'admin' => 'Administração',
 		'archiving' => 'Arquivar',
 		'authentication' => 'Autenticação',

--- a/app/i18n/ru/gen.php
+++ b/app/i18n/ru/gen.php
@@ -146,6 +146,7 @@ return array(
 	),
 	'menu' => array(
 		'about' => 'О проекте',
+		'account' => 'Account', // Todo: Transation
 		'admin' => 'Администрирование',
 		'archiving' => 'Архивирование',
 		'authentication' => 'Аутентификация',

--- a/app/i18n/sk/gen.php
+++ b/app/i18n/sk/gen.php
@@ -146,6 +146,7 @@ return array(
 	),
 	'menu' => array(
 		'about' => 'O FreshRSS',
+		'account' => 'Account', // Todo: Transation
 		'admin' => 'Administrácia',
 		'archiving' => 'Archivácia',
 		'authentication' => 'Prihlásenie',

--- a/app/i18n/tr/gen.php
+++ b/app/i18n/tr/gen.php
@@ -146,6 +146,7 @@ return array(
 	),
 	'menu' => array(
 		'about' => 'Hakkında',
+		'account' => 'Account', // Todo: Transation
 		'admin' => 'Yönetim',
 		'archiving' => 'Arşiv',
 		'authentication' => 'Kimlik doğrulama',

--- a/app/i18n/zh-cn/gen.php
+++ b/app/i18n/zh-cn/gen.php
@@ -146,6 +146,7 @@ return array(
 	),
 	'menu' => array(
 		'about' => '关于',
+		'account' => 'Account', // Todo: Transation
 		'admin' => '管理',
 		'archiving' => '归档',
 		'authentication' => '认证',

--- a/app/layout/aside_configure.phtml
+++ b/app/layout/aside_configure.phtml
@@ -1,5 +1,14 @@
 <nav class="nav nav-list aside">
 	<ul>
+		<li class="nav-header"><?= _t('gen.menu.account') ?>: <?= htmlspecialchars(Minz_Session::param('currentUser', '_'), ENT_NOQUOTES, 'UTF-8')?></li>	
+		<li class="item<?= Minz_Request::controllerName() === 'user' && Minz_Request::actionName() === 'profile' ? ' active' : '' ?>">
+			<a href="<?= _url('user', 'profile') ?>"><?= _t('gen.menu.user_profile') ?></a>
+		</li>
+		<li class="item">
+			<a class="signout" href="<?= _url('auth', 'logout') ?>">
+				<?php
+				echo _t('gen.auth.logout'); ?> <?= _i('logout') ?></a>
+		</li>
 		<li class="nav-header"><?= _t('gen.menu.configuration') ?></li>
 		<li class="item<?= Minz_Request::actionName() === 'display' ? ' active' : '' ?>">
 			<a href="<?= _url('configure', 'display') ?>"><?= _t('gen.menu.display') ?></a>
@@ -18,9 +27,6 @@
 		</li>
 		<li class="item<?= Minz_Request::actionName() === 'queries' ? ' active' : '' ?>">
 			<a href="<?= _url('configure', 'queries') ?>"><?= _t('gen.menu.queries') ?></a>
-		</li>
-		<li class="item<?= Minz_Request::controllerName() === 'user' && Minz_Request::actionName() === 'profile' ? ' active' : '' ?>">
-			<a href="<?= _url('user', 'profile') ?>"><?= _t('gen.menu.user_profile') ?></a>
 		</li>
 		<li class="item<?= Minz_Request::controllerName() === 'extension' ? ' active' : '' ?>">
 			<a href="<?= _url('extension', 'index') ?>"><?= _t('gen.menu.extensions') ?></a>

--- a/app/layout/header.phtml
+++ b/app/layout/header.phtml
@@ -54,6 +54,14 @@ if (FreshRSS_Auth::accessNeedsAction()) {
 			<a class="btn dropdown-toggle" href="#dropdown-configure"><?= _i('configure') ?></a>
 			<ul class="dropdown-menu">
 				<li class="dropdown-close"><a href="#close">❌</a></li>
+				<li class="dropdown-header"><?= _t('gen.menu.account') ?>: <?= htmlspecialchars(Minz_Session::param('currentUser', '_'), ENT_NOQUOTES, 'UTF-8') ?></li>
+				<li class="item"><a href="<?= _url('user', 'profile') ?>"><?= _t('gen.menu.user_profile') ?></a></li>
+				<?php if (FreshRSS_Auth::accessNeedsAction()): ?>
+				<li class="item"><a class="signout" href="<?= _url('auth', 'logout') ?>"><?= _t('gen.auth.logout'); ?><?= _i('logout') ?></a></li>
+				<?php else: ?>
+				<li class="item"><span class="signout">(<?= htmlspecialchars(Minz_Session::param('currentUser', '_'), ENT_NOQUOTES, 'UTF-8') ?>)</span></li>
+				<?php endif; ?>
+				<li class="separator"></li>
 				<li class="dropdown-header"><?= _t('gen.menu.configuration') ?></li>
 				<li class="item"><a href="<?= _url('configure', 'display') ?>"><?= _t('gen.menu.display') ?></a></li>
 				<li class="item"><a href="<?= _url('configure', 'reading') ?>"><?= _t('gen.menu.reading') ?></a></li>
@@ -61,7 +69,6 @@ if (FreshRSS_Auth::accessNeedsAction()) {
 				<li class="item"><a href="<?= _url('configure', 'integration') ?>"><?= _t('gen.menu.sharing') ?></a></li>
 				<li class="item"><a href="<?= _url('configure', 'shortcut') ?>"><?= _t('gen.menu.shortcuts') ?></a></li>
 				<li class="item"><a href="<?= _url('configure', 'queries') ?>"><?= _t('gen.menu.queries') ?></a></li>
-				<li class="item"><a href="<?= _url('user', 'profile') ?>"><?= _t('gen.menu.user_profile') ?></a></li>
 				<li class="item"><a href="<?= _url('extension', 'index') ?>"><?= _t('gen.menu.extensions') ?></a></li>
 				<?= Minz_ExtensionManager::callHook('menu_configuration_entry') ?>
 
@@ -82,14 +89,6 @@ if (FreshRSS_Auth::accessNeedsAction()) {
 				<li class="item"><a href="<?= _url('index', 'logs') ?>"><?= _t('gen.menu.logs') ?></a></li>
 				<li class="item"><a href="<?= _url('index', 'about') ?>"><?= _t('gen.menu.about') ?></a></li>
 				<?= Minz_ExtensionManager::callHook('menu_other_entry') ?>
-
-				<li class="separator"></li>
-				<?php if (FreshRSS_Auth::accessNeedsAction()): ?>
-				<li class="item"><a class="signout" href="<?= _url('auth', 'logout') ?>"><?php
-					echo _i('logout') . ' ' . _t('gen.auth.logout') . ' (' . htmlspecialchars(Minz_Session::param('currentUser', '_'), ENT_NOQUOTES, 'UTF-8') . ')'; ?></a></li>
-				<?php else: ?>
-				<li class="item"><span class="signout">(<?= htmlspecialchars(Minz_Session::param('currentUser', '_'), ENT_NOQUOTES, 'UTF-8') ?>)</span></li>
-				<?php endif; ?>
 			</ul>
 		</div>
 	</nav>


### PR DESCRIPTION
Changes proposed in this pull request:
- reordered the conf menu: for personal profile settings the menu entry is now on the top of navigation list
- in the left navigation in the configuration: a logout link added (so it it similar to the dropdown menu)

Why it makes sense to change:
- As a user I search: where can I change my password and how can I log out
- in most apps it is common to find this 2 point at the top of account/settings drop down list

After:
![grafik](https://user-images.githubusercontent.com/1645099/137027459-356c5115-bc03-4e19-b646-3b707ad5efb9.png)



How to test the feature manually:
1. open the configration drop down list
2. see the navigation on the left side in the configuration


Pull request checklist:
- [x] clear commit messages
- [x] code manually tested