### PR TITLE
Headline structure improvement (part 3)

### DIFF
--- a/app/views/user/details.phtml
+++ b/app/views/user/details.phtml
@@ -7,7 +7,7 @@
 <div class="post">
 	<a href="<?= _url('user', 'manage'); ?>"><?= _t('admin.user.back_to_manage'); ?></a>
 
-	<legend><?= $this->username ?><?php if ($isAdmin) echo ' ― ', _t('admin.user.admin'); ?></legend>
+	<h1><?= $this->username ?><?php if ($isAdmin) echo ' ― ', _t('admin.user.admin'); ?></h1>
 	<form method="post" action="<?= _url('user', 'manage', 'username', $this->username); ?>">
 		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken(); ?>" />
 


### PR DESCRIPTION
Closes #3673

Similar to #3851 and #3851

have overseen a `<legend>` that should be a `<h1>`

After the fix:
![grafik](https://user-images.githubusercontent.com/1645099/137212783-11fa0c96-82b5-4d61-8b2b-47a4a8383039.png)



Pull request checklist:
- [x] clear commit messages
- [x] code manually tested
