### PR TITLE
[chore] Replace direct .onkeydown override with addEventListener

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -796,7 +796,7 @@ function init_shortcuts() {
 			context.shortcuts[k] = (context.shortcuts[k] || '').toUpperCase();
 		});
 
-	document.body.onkeydown = function (ev) {
+	document.addEventListener('keydown', ev => {
 			if (ev.target.closest('input, textarea') ||
 				ev.ctrlKey || ev.metaKey || (ev.altKey && ev.shiftKey)) {
 				return true;
@@ -913,7 +913,7 @@ function init_shortcuts() {
 			if (k === s.rss_view) { delayedClick(document.querySelector('#nav_menu_views .view-rss')); return false; }
 			if (k === s.toggle_media) { toggle_media(); return false; }
 			return true;
-		};
+		});
 }
 
 function init_stream(stream) {


### PR DESCRIPTION
Removes inextensible bad example to prevent it from being copied. See <https://github.com/FreshRSS/FreshRSS/pull/3901/files#r731292613>.

How to test the feature manually:

1. Test if keyboard shortcuts still work.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
