### PR TITLE
Split fever & greader into two separate pages.

### DIFF
--- a/docs/en/developers/01_Index.md
+++ b/docs/en/developers/01_Index.md
@@ -12,6 +12,7 @@ Start by creating your development environment. A guide to setting up FreshRSS's
 * [Releasing a new version](05_Release_new_version.md)
 * [Reporting bugs](06_Reporting_Bugs.md)
 * [Fever API](06_Fever_API.md)
+* [GoogleReader API](06_GoogleReader_API.md)
 
 ## Backend Development
 

--- a/docs/en/developers/06_Fever_API.md
+++ b/docs/en/developers/06_Fever_API.md
@@ -1,7 +1,8 @@
 # FreshRSS - Fever API implementation
 
-See the [page about our Google Reader compatible API](06_Mobile_access.md) for another possibility
-and general aspects of API access.
+See [Mobile access](../users/06_Mobile_access.md) for general aspects of API access.
+Additionally [page about our Google Reader compatible API](06_GoogleReader_API.md) for another possibility.
+
 
 ## RSS clients
 
@@ -11,7 +12,7 @@ But we can **only** do that for free clients.
 
 ### Usage & Authentication
 
-Before you can start using this API, you have to enable and setup API access, which is [documented here](https://freshrss.github.io/FreshRSS/en/users/06_Mobile_access.html),
+Before you can start using this API, you have to enable and setup API access, which is [documented here](../users/06_Mobile_access.md),
 and then reset the user’s API password.
 
 Then point your mobile application to the `fever.php` address (e.g. `https://freshrss.example.net/api/fever.php`).
@@ -22,6 +23,7 @@ Then point your mobile application to the `fever.php` address (e.g. `https://fre
 |:----------------------------------------------------------------------------------:|:-------------------:|:--------------------------------------------------------:|
 |[Fluent Reader](https://hyliu.me/fluent-reader/)                                    |Windows, Linux, macOS|[BSD-3-Clause](https://github.com/yang991178/fluent-reader/blob/master/LICENSE)|
 |[Fiery Feeds](https://apps.apple.com/app/fiery-feeds-rss-reader/id1158763303)       |iOS                  |Closed Source                                             |
+|[Newsflash](https://gitlab.com/news-flash/news_flash_gtk/)                          |Linux                |[GPLv3](https://gitlab.com/news-flash/news_flash_gtk/-/blob/master/LICENSE)|
 |[Unread](https://apps.apple.com/app/unread-rss-reader/id1252376153)                 |iOS                  |Closed Source                                             |
 |[Reeder](https://www.reederapp.com/)                                                |iOS                  |Closed Source                                              |
 |[ReadKit](https://apps.apple.com/app/readkit/id588726889)                           |macOS                |Closed Source                                              |

--- a/docs/en/developers/06_GoogleReader_API.md
+++ b/docs/en/developers/06_GoogleReader_API.md
@@ -1,0 +1,65 @@
+# FreshRSS - Google Reader compatible API implementation
+
+See [Mobile access](../users/06_Mobile_access.md) for general aspects of API access.
+Additionally [page about our Fever compatible API](06_Fever_API.md) for another possibility.
+
+## RSS clients
+
+There are many RSS clients that support the Fever API, but they seem to understand the Fever API a bit differently.
+If your favourite client doesn't work properly with this API, please create an issue and we'll have a look.
+But we can **only** do that for free clients.
+
+### Usage & Authentication
+
+Before you can start using this API, you have to enable and setup API access, which is [documented here](../users/06_Mobile_access.md),
+and then reset the user’s API password.
+
+Then point your mobile application to the `greader.php` address (e.g. `https://freshrss.example.net/api/greader.php`).
+
+# Compatible clients
+
+6. On the same FreshRSS API page, note the address given under “Your API address”, like `https://freshrss.example.net/api/greader.php`
+	* Type the API address in a client, together with your FreshRSS username, and the corresponding special API password.
+
+| App                                                                                | Platform            | License                                            |
+|:----------------------------------------------------------------------------------:|:-------------------:|:--------------------------------------------------------:|
+|[News+](https://play.google.com/store/apps/details?id=com.noinnion.android.newsplus) with [News+ Google Reader extension](https://github.com/noinnion/newsplus/blob/master/apk/GoogleReaderCloneExtension_101.apk) |Android|Closed Source (Free)|
+|[FeedMe 3.5.3+](https://play.google.com/store/apps/details?id=com.seazon.feedme) |Android                  |Closed Source (Free)                                             |
+|[EasyRSS](https://github.com/Alkarex/EasyRSS)                          |Android                |[GPLv3](https://github.com/Alkarex/EasyRSS/blob/master/license.txt) ([F-Droid](https://f-droid.org/packages/org.freshrss.easyrss/))|
+|[Readrops](https://github.com/readrops/Readrops) |Android                  |[GPLv3](https://github.com/readrops/Readrops/blob/develop/LICENSE)                                             |
+|[FocusReader](https://play.google.com/store/apps/details?id=allen.town.focus.reader) |Android                  |Closed Source(Free)                                              |
+|[FeedReader 2.0+](https://jangernert.github.io/FeedReader/)                           |Linux                |[GPLv3](https://github.com/jangernert/FeedReader/blob/master/LICENSE)                                              |
+|[Newsboat 2.24+](https://newsboat.org/)                           |Linux                |[MIT](https://github.com/newsboat/newsboat/blob/master/LICENSE)                                              |
+|[Vienna RSS](http://www.vienna-rss.com/)                           |MacOS                |[Apache-2.0](https://github.com/ViennaRSS/vienna-rss/blob/master/LICENCE.md)                                              |
+|[Reeder](https://www.reederapp.com/)                           |MacOS, iOS                |Closed Source                                              |
+|[FreshRSS-Notify](https://addons.mozilla.org/firefox/addon/freshrss-notify-webextension/)                           |Firefox                |Open Source                                              |
+
+# Google Reader compatible API
+
+Examples of basic queries:
+
+```sh
+# Initial login, using API password (Email and Passwd can be given either as GET, or POST - better)
+curl 'https://freshrss.example.net/api/greader.php/accounts/ClientLogin?Email=alice&Passwd=Abcdef123456'
+SID=alice/8e6845e089457af25303abc6f53356eb60bdb5f8
+Auth=alice/8e6845e089457af25303abc6f53356eb60bdb5f8
+
+# Examples of read-only requests
+curl -s -H "Authorization:GoogleLogin auth=alice/8e6845e089457af25303abc6f53356eb60bdb5f8" \
+  'https://freshrss.example.net/api/greader.php/reader/api/0/subscription/list?output=json'
+
+curl -s -H "Authorization:GoogleLogin auth=alice/8e6845e089457af25303abc6f53356eb60bdb5f8" \
+  'https://freshrss.example.net/api/greader.php/reader/api/0/unread-count?output=json'
+
+curl -s -H "Authorization:GoogleLogin auth=alice/8e6845e089457af25303abc6f53356eb60bdb5f8" \
+  'https://freshrss.example.net/api/greader.php/reader/api/0/tag/list?output=json'
+
+# Retrieve a token for requests making modifications
+curl -H "Authorization:GoogleLogin auth=alice/8e6845e089457af25303abc6f53356eb60bdb5f8" \
+  'https://freshrss.example.net/api/greader.php/reader/api/0/token'
+8e6845e089457af25303abc6f53356eb60bdb5f8ZZZZZZZZZZZZZZZZZ
+
+# Get articles, piped to jq for easier JSON reading
+curl -s -H "Authorization:GoogleLogin auth=alice/8e6845e089457af25303abc6f53356eb60bdb5f8" \
+  'https://freshrss.example.net/api/greader.php/reader/api/0/stream/contents/reading-list' | jq .
+```

--- a/docs/en/users/06_Mobile_access.md
+++ b/docs/en/users/06_Mobile_access.md
@@ -7,8 +7,8 @@ This page assumes you have completed the [server setup](../admins/03_Installatio
 	* Every user must define an API password.
 	* The reason for an API-specific password is that it may be used in less safe situations than the main password, and does not grant access to as many things.
 
-The rest of this page is about the Google Reader compatible API.
-See the [page about the Fever compatible API](06_Fever_API.md) for another possibility.
+See the [page about the Google Reader compatible API](../developers/06_GoogleReader_API.md.md) for more details.
+See the [page about the Fever compatible API](../developers/06_Fever_API.md.md) for more details.
 
 
 # Testing
@@ -39,58 +39,3 @@ See the [page about the Fever compatible API](06_Fever_API.md) for another possi
 	* If you get *FAIL 64-bit or GMP extension!*, then your PHP version does not pass the requirement of being 64-bit and/or have PHP [GMP](http://php.net/gmp) extension.
 		* The easiest is to add the GMP extension. On Debian / Ubuntu: `sudo apt install php-gmp`
 	* Update and try again from step 3.
-
-
-# Compatible clients
-
-6. On the same FreshRSS API page, note the address given under “Your API address”, like `https://freshrss.example.net/api/greader.php`
-	* Type the API address in a client, together with your FreshRSS username, and the corresponding special API password.
-
-7. Pick a client supporting a Google Reader-like API. Selection:
-	* Android
-		* [News+](https://play.google.com/store/apps/details?id=com.noinnion.android.newsplus) with [News+ Google Reader extension](https://github.com/noinnion/newsplus/blob/master/apk/GoogleReaderCloneExtension_101.apk) (Closed source)
-		* [FeedMe 3.5.3+](https://play.google.com/store/apps/details?id=com.seazon.feedme) (Closed source)
-		* [EasyRSS](https://github.com/Alkarex/EasyRSS) (Open source, [F-Droid](https://f-droid.org/packages/org.freshrss.easyrss/))
-		* [Readrops](https://github.com/readrops/Readrops) (Open source)
-		* [FocusReader](https://play.google.com/store/apps/details?id=allen.town.focus.reader) (Commercial)
-	* Linux
-		* [FeedReader 2.0+](https://jangernert.github.io/FeedReader/) (Open source)
-		* [Newsboat 2.24+](https://newsboat.org/) (Open source)
-	* MacOS
-		* [Vienna RSS](http://www.vienna-rss.com/) (Open source)
-		* [Reeder](https://www.reederapp.com/) (Commercial)
-	* iOS
-		* [Reeder](https://www.reederapp.com/) (Commercial)
-	* Firefox
-		* [FreshRSS-Notify](https://addons.mozilla.org/firefox/addon/freshrss-notify-webextension/) (Open source)
-
-
-# Google Reader compatible API
-
-Examples of basic queries:
-
-```sh
-# Initial login, using API password (Email and Passwd can be given either as GET, or POST - better)
-curl 'https://freshrss.example.net/api/greader.php/accounts/ClientLogin?Email=alice&Passwd=Abcdef123456'
-SID=alice/8e6845e089457af25303abc6f53356eb60bdb5f8
-Auth=alice/8e6845e089457af25303abc6f53356eb60bdb5f8
-
-# Examples of read-only requests
-curl -s -H "Authorization:GoogleLogin auth=alice/8e6845e089457af25303abc6f53356eb60bdb5f8" \
-  'https://freshrss.example.net/api/greader.php/reader/api/0/subscription/list?output=json'
-
-curl -s -H "Authorization:GoogleLogin auth=alice/8e6845e089457af25303abc6f53356eb60bdb5f8" \
-  'https://freshrss.example.net/api/greader.php/reader/api/0/unread-count?output=json'
-
-curl -s -H "Authorization:GoogleLogin auth=alice/8e6845e089457af25303abc6f53356eb60bdb5f8" \
-  'https://freshrss.example.net/api/greader.php/reader/api/0/tag/list?output=json'
-
-# Retrieve a token for requests making modifications
-curl -H "Authorization:GoogleLogin auth=alice/8e6845e089457af25303abc6f53356eb60bdb5f8" \
-  'https://freshrss.example.net/api/greader.php/reader/api/0/token'
-8e6845e089457af25303abc6f53356eb60bdb5f8ZZZZZZZZZZZZZZZZZ
-
-# Get articles, piped to jq for easier JSON reading
-curl -s -H "Authorization:GoogleLogin auth=alice/8e6845e089457af25303abc6f53356eb60bdb5f8" \
-  'https://freshrss.example.net/api/greader.php/reader/api/0/stream/contents/reading-list' | jq .
-```


### PR DESCRIPTION
Changes proposed in this pull request:

- add newsflash to fever-api clients
- split APIs into two separate pages.

Pull request checklist:
- [x] documentation updated
