### PR TITLE
Fix getNonStandardShortcuts

### DIFF
--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -538,10 +538,8 @@ function getNonStandardShortcuts($shortcuts) {
 	$standard = strtolower(implode(' ', SHORTCUT_KEYS));
 
 	$nonStandard = array_filter($shortcuts, function ($shortcut) use ($standard) {
-		if (false !== strpos($shortcut, ' ')) {
-			return true;
-		}
-		return !preg_match("/${shortcut}/i", $standard);
+		$shortcut = trim($shortcut);
+		return $shortcut !== '' & stripos($standard, $shortcut) === false;
 	});
 
 	return $nonStandard;


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/3922
Hot fix. The `getNonStandardShortcuts()` could maybe be re-written to work with array elements.
