### PR TITLE
Docker: don't add crontab unless needed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 	* Docker: development image `:oldest` is now based on `alpine:3.5` with PHP 7.0.33 and Apache 2.4.35 [#3666](https://github.com/FreshRSS/FreshRSS/pull/3666)
 	* Docker: default image updated to Debian 11 Bullseye with PHP 7.4.21 and Apache 2.4.48 [#3782](https://github.com/FreshRSS/FreshRSS/pull/3782)
 	* Docker: alternative image updated to Alpine 3.14 with PHP 8.0.10 and Apache 2.4.48 [#3715](https://github.com/FreshRSS/FreshRSS/pull/3715)
+	* Docker: only add the crontab when CRON_MIN is set.
 	* Images on Docker Hub are automatically scanned for software vulnerabilities
 * UI
 	* New thumbnail and/or summary options for the normal view [#3805](https://github.com/FreshRSS/FreshRSS/pull/3805)

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -150,3 +150,4 @@ People are sorted by name so please keep this order.
 * [wtoscer](https://github.com/wtoscer): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:wtoscer)
 * [Yamakuni](https://github.com/Yamakuni): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Yamakuni), [Web](https://ofanch.me/)
 * [yzqzss|一座桥在水上](https://github.com/yzqzss): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:yzqzss), [Web](https://blog.othing.xyz/)
+* [Zoredache](https://github.com/zoredache): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:zoredache)

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -45,7 +45,7 @@ RUN sed -r -i "/^\s*(CustomLog|ErrorLog|Listen) /s/^/#/" /etc/apache2/apache2.co
 	touch /var/www/FreshRSS/Docker/env.txt && \
 	echo "7,37 * * * * . /var/www/FreshRSS/Docker/env.txt; \
 		su www-data -s /bin/sh -c 'php /var/www/FreshRSS/app/actualize_script.php' \
-		2>> /proc/1/fd/2 > /tmp/FreshRSS.log" | crontab -
+		2>> /proc/1/fd/2 > /tmp/FreshRSS.log" > /var/www/FreshRSS/Docker/crontab.default
 
 ENV COPY_LOG_TO_SYSLOG On
 ENV COPY_SYSLOG_TO_STDERR On

--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -42,7 +42,7 @@ RUN rm -f /etc/apache2/conf.d/languages.conf /etc/apache2/conf.d/info.conf \
 	touch /var/www/FreshRSS/Docker/env.txt && \
 	echo "27,57 * * * * . /var/www/FreshRSS/Docker/env.txt; \
 		su apache -s /bin/sh -c 'php /var/www/FreshRSS/app/actualize_script.php' \
-		2>> /proc/1/fd/2 > /tmp/FreshRSS.log" | crontab -
+		2>> /proc/1/fd/2 > /tmp/FreshRSS.log" > /var/www/FreshRSS/Docker/crontab.default
 
 ENV COPY_LOG_TO_SYSLOG On
 ENV COPY_SYSLOG_TO_STDERR On

--- a/Docker/Dockerfile-Newest
+++ b/Docker/Dockerfile-Newest
@@ -42,7 +42,7 @@ RUN rm -f /etc/apache2/conf.d/languages.conf /etc/apache2/conf.d/info.conf \
 	touch /var/www/FreshRSS/Docker/env.txt && \
 	echo "27,57 * * * * . /var/www/FreshRSS/Docker/env.txt; \
 		su apache -s /bin/sh -c 'php /var/www/FreshRSS/app/actualize_script.php' \
-		2>> /proc/1/fd/2 > /tmp/FreshRSS.log" | crontab -
+		2>> /proc/1/fd/2 > /tmp/FreshRSS.log" > /var/www/FreshRSS/Docker/crontab.default
 
 ENV COPY_LOG_TO_SYSLOG On
 ENV COPY_SYSLOG_TO_STDERR On

--- a/Docker/Dockerfile-Oldest
+++ b/Docker/Dockerfile-Oldest
@@ -42,7 +42,7 @@ RUN rm -f /etc/apache2/conf.d/languages.conf /etc/apache2/conf.d/info.conf \
 	touch /var/www/FreshRSS/Docker/env.txt && \
 	echo "27,57 * * * * . /var/www/FreshRSS/Docker/env.txt; \
 		su apache -s /bin/sh -c 'php /var/www/FreshRSS/app/actualize_script.php' \
-		2>> /proc/1/fd/2 > /tmp/FreshRSS.log" | crontab -
+		2>> /proc/1/fd/2 > /tmp/FreshRSS.log" > /var/www/FreshRSS/Docker/crontab.default
 
 ENV COPY_LOG_TO_SYSLOG On
 ENV COPY_SYSLOG_TO_STDERR On

--- a/Docker/Dockerfile-QEMU-ARM
+++ b/Docker/Dockerfile-QEMU-ARM
@@ -51,7 +51,7 @@ RUN sed -r -i "/^\s*(CustomLog|ErrorLog|Listen) /s/^/#/" /etc/apache2/apache2.co
 	touch /var/www/FreshRSS/Docker/env.txt && \
 	echo "17,47 * * * * . /var/www/FreshRSS/Docker/env.txt; \
 		su www-data -s /bin/sh -c 'php /var/www/FreshRSS/app/actualize_script.php' \
-		2>> /proc/1/fd/2 > /tmp/FreshRSS.log" | crontab -
+		2>> /proc/1/fd/2 > /tmp/FreshRSS.log"  > /var/www/FreshRSS/Docker/crontab.default
 
 # Seems needed for arm32v7/ubuntu on Docker Hub
 RUN update-ca-certificates -f

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -248,6 +248,21 @@ docker run -d --restart unless-stopped --log-opt max-size=10m \
   cron -f
 ```
 
+#### For the Debian image (default) using a custom cron.d fragment
+
+This method gives you the most flexibility most flexiblity to
+execute various freshrss cli commands.
+
+```sh
+docker run -d --restart unless-stopped --log-opt max-size=10m \
+  -v freshrss-data:/var/www/FreshRSS/data \
+  -v freshrss-extensions:/var/www/FreshRSS/extensions \
+  -v ./freshrss_crontab:/etc/cron.d/freshrss \
+  --net freshrss-network \
+  --name freshrss_cron freshrss/freshrss \
+  cron -f
+```
+
 #### For the Alpine image
 
 ```sh

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -20,7 +20,8 @@ if [ -n "$CRON_MIN" ]; then
 		echo "export COPY_SYSLOG_TO_STDERR=$COPY_SYSLOG_TO_STDERR"
 		echo "export FRESHRSS_ENV=$FRESHRSS_ENV"
 	) >/var/www/FreshRSS/Docker/env.txt
-	crontab -l | sed -r "\\#FreshRSS#s#^[^ ]+ #$CRON_MIN #" | crontab -
+	sed </var/www/FreshRSS/Docker/crontab.default \
+		-r "s#^[^ ]+ #$CRON_MIN #" | crontab -
 fi
 
 if [ -n "$FRESHRSS_INSTALL" ]; then


### PR DESCRIPTION
Adding the crontab as part of the image build makes it more complicated
to add custom entries to the crontab. Adjusting the image and entrypoint
to make it so that the crontab is only added when CRON_MIN is set
simplifies having a custom crontab.

I have an example [compose file](https://github.com/zoredache/FreshRSS_Example/blob/main/docker-compose.yml) and [crontab](https://github.com/zoredache/FreshRSS_Example/blob/main/cron/freshrss) so you can see what I am trying to do here.

Changes proposed in this pull request:

- Only add the crontab when the environment variable CRON_MIN is set.

How to test the feature manually:

I detailed how I tested this manually on [this page](https://github.com/zoredache/FreshRSS_Example/blob/main/Testing_my_PR.md). But basically, you build the image, and then run the container without the CRON_MIN set, and there is no crontab, and when CRON_MIN is set, notice that the crontab does exist, and the minute value has been updated as requested.

Pull request checklist:

- [*] clear commit messages
- [*] code manually tested
- [*] documentation updated
