### PR TITLE
GitHub Actions cleaner error output

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,16 +58,16 @@ jobs:
     - run: npm install
 
     - name: Check JavaScript syntax
-      run: npm run eslint
+      run: npm run --silent eslint
 
     - name: Check Markdown syntax
-      run: npm run markdownlint
+      run: npm run --silent markdownlint
 
     - name: Check Right-to-left CSS
-      run: npm run rtlcss && git diff --exit-code
+      run: npm run --silent rtlcss && git diff --exit-code
 
     - name: Check CSS syntax
-      run: npm run stylelint
+      run: npm run --silent stylelint
 
     # Shell tests
 


### PR DESCRIPTION
Silence irrelevant NPM errors when a test fails.
See e.g. https://github.com/FreshRSS/FreshRSS/runs/3999501244?check_suite_focus=true

```text
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! freshrss@ markdownlint: `markdownlint '**/*.md'`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the freshrss@ markdownlint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2021-10-25T16_15_34_166Z-debug.log
```