### PR TITLE
fixed: Shortcuts in "Anonym. Mode" broken (#3897)

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -201,6 +201,12 @@ const pending_entries = {};
 let mark_read_queue = [];
 
 function send_mark_read_queue(queue, asRead, callback) {
+	if (!queue || queue.length === 0) {
+		if (callback) {
+			callback();
+		}
+		return;
+	}
 	const req = new XMLHttpRequest();
 	req.open('POST', '.?c=entry&a=read' + (asRead ? '' : '&is_read=0'), true);
 	req.responseType = 'json';
@@ -282,11 +288,7 @@ const delayedFunction = send_mark_queue_tick;
 
 function delayedClick(a) {
 	if (a) {
-		if (context.anonymous) {
-			a.click();
-		} else {
-			delayedFunction(function () { a.click(); });
-		}
+		delayedFunction(function () { a.click(); });
 	}
 }
 

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -953,10 +953,10 @@ function init_shortcuts() {
 		if (k === s.close_dropdown) { location.hash = null; return false; }
 		if (k === s.help) { window.open(context.urls.help); return false; }
 		if (k === s.focus_search) { document.getElementById('search').focus(); return false; }
-		if (k === s.normal_view) { delayedClick(document.querySelector('#nav_menu_views .view-normal')); return false; }
-		if (k === s.reading_view) { delayedClick(document.querySelector('#nav_menu_views .view-reader')); return false; }
-		if (k === s.global_view) { delayedClick(document.querySelector('#nav_menu_views .view-global')); return false; }
-		if (k === s.rss_view) { delayedClick(document.querySelector('#nav_menu_views .view-rss')); return false; }
+		if (k === s.normal_view) { document.querySelector('#nav_menu_views .view-normal').click(); return false; }
+		if (k === s.reading_view) { document.querySelector('#nav_menu_views .view-reader').click(); return false; }
+		if (k === s.global_view) { document.querySelector('#nav_menu_views .view-global').click(); return false; }
+		if (k === s.rss_view) { document.querySelector('#nav_menu_views .view-rss').click(); return false; }
 		if (k === s.toggle_media) { toggle_media(); return false; }
 		return true;
 	});

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -953,10 +953,10 @@ function init_shortcuts() {
 		if (k === s.close_dropdown) { location.hash = null; return false; }
 		if (k === s.help) { window.open(context.urls.help); return false; }
 		if (k === s.focus_search) { document.getElementById('search').focus(); return false; }
-		if (k === s.normal_view) { document.querySelector('#nav_menu_views .view-normal').click(); return false; }
-		if (k === s.reading_view) { document.querySelector('#nav_menu_views .view-reader').click(); return false; }
-		if (k === s.global_view) { document.querySelector('#nav_menu_views .view-global').click(); return false; }
-		if (k === s.rss_view) { document.querySelector('#nav_menu_views .view-rss').click(); return false; }
+		if (k === s.normal_view) { delayedClick(document.querySelector('#nav_menu_views .view-normal')); return false; }
+		if (k === s.reading_view) { delayedClick(document.querySelector('#nav_menu_views .view-reader')); return false; }
+		if (k === s.global_view) { delayedClick(document.querySelector('#nav_menu_views .view-global')); return false; }
+		if (k === s.rss_view) { delayedClick(document.querySelector('#nav_menu_views .view-rss')); return false; }
 		if (k === s.toggle_media) { toggle_media(); return false; }
 		return true;
 	});

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -282,7 +282,11 @@ const delayedFunction = send_mark_queue_tick;
 
 function delayedClick(a) {
 	if (a) {
-		delayedFunction(function () { a.click(); });
+		if (context.anonymous) {
+			a.click();
+		} else {
+			delayedFunction(function () { a.click(); });
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #3897

Changes proposed in this pull request:
- do not use delayedClick(). Use the same onclick event as clicking on the view buttons


How to test the feature manually:
1. click `1`, or `2` or `3` or `4` (default shortcuts)
2. change to the view without an error


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
