### PR TITLE
Optimize for mobile view: line break in article title

### DIFF
--- a/p/themes/Origine-compact/origine-compact.css
+++ b/p/themes/Origine-compact/origine-compact.css
@@ -353,7 +353,7 @@ a.btn,
 
 .horizontal-list .item {
 	vertical-align: middle;
-	line-height: 30px;
+	line-height: 1.2;
 }
 
 /*=== Dropdown */

--- a/p/themes/Origine-compact/origine-compact.rtl.css
+++ b/p/themes/Origine-compact/origine-compact.rtl.css
@@ -353,7 +353,7 @@ a.btn,
 
 .horizontal-list .item {
 	vertical-align: middle;
-	line-height: 30px;
+	line-height: 1.2;
 }
 
 /*=== Dropdown */

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -731,7 +731,8 @@ input[type="search"] {
 }
 
 .flux .item {
-	line-height: 40px;
+	line-height: 1.5;
+	padding: 0.5em 0;
 	white-space: nowrap;
 }
 
@@ -753,16 +754,12 @@ input[type="search"] {
 .flux:not(.current):hover .item.title {
 	background: #fff;
 	max-width: calc(100% - 320px);
-	position: absolute;
-}
-
-.flux:not(.current):hover .item.title.multiline {
-	position: initial;
 }
 
 .flux .item.title a {
 	color: #000;
 	text-decoration: none;
+	white-space: normal;
 }
 
 .flux .item.thumbnail {
@@ -1454,7 +1451,6 @@ input:checked + .slide-container .properties {
 	.flux:not(.current):hover .item.title {
 		position: relative;
 		width: auto;
-		white-space: nowrap;
 	}
 
 	.notification {

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -731,7 +731,8 @@ input[type="search"] {
 }
 
 .flux .item {
-	line-height: 40px;
+	line-height: 1.5;
+	padding: 0.5em 0;
 	white-space: nowrap;
 }
 
@@ -753,16 +754,12 @@ input[type="search"] {
 .flux:not(.current):hover .item.title {
 	background: #fff;
 	max-width: calc(100% - 320px);
-	position: absolute;
-}
-
-.flux:not(.current):hover .item.title.multiline {
-	position: initial;
 }
 
 .flux .item.title a {
 	color: #000;
 	text-decoration: none;
+	white-space: normal;
 }
 
 .flux .item.thumbnail {
@@ -1454,7 +1451,6 @@ input:checked + .slide-container .properties {
 	.flux:not(.current):hover .item.title {
 		position: relative;
 		width: auto;
-		white-space: nowrap;
 	}
 
 	.notification {


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/1645099/143612822-6c7ecffd-b7df-465f-b0c1-e5605a65ae66.png)


After:
![grafik](https://user-images.githubusercontent.com/1645099/143612723-f686d884-d748-42c8-a4c3-a9d025975c82.png)


Changes proposed in this pull request:

- line breaks instead of truncated title

How to test the feature manually:

1. see normal view page


(I tested it with all templates)

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
