### PR TITLE
Normal view: improve feed filter link

### DIFF
--- a/app/views/helpers/index/normal/entry_header.phtml
+++ b/app/views/helpers/index/normal/entry_header.phtml
@@ -30,9 +30,10 @@
 			?></li><?php
 		}
 	}
-	?><li class="item website"><a href="<?= _url('index', 'index', 'get', 'f_' . $this->feed->id()) ?>" title="<?= _t('gen.action.filter') ?>">
-		<?php if (FreshRSS_Context::$user_conf->show_favicons): ?><img class="favicon" src="<?= $this->feed->favicon() ?>" alt="✇" loading="lazy" /><?php endif; ?>
-		<span><?= $this->feed->name() ?></span></a>
+	?><li class="item website">
+		<a href="<?= _url('index', 'index', 'get', 'f_' . $this->feed->id()) ?>" title="<?= _t('gen.action.filter') ?>: <?= $this->feed->name() ?>">
+			<?php if (FreshRSS_Context::$user_conf->show_favicons): ?><img class="favicon" src="<?= $this->feed->favicon() ?>" alt="✇" loading="lazy" /><?php endif; ?><span><?= $this->feed->name() ?></span>
+		</a>
 	</li>
 
 	<?php

--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -73,7 +73,7 @@ $today = @strtotime('today');
 			<div class="content <?= $content_width ?>">
 				<h1 class="title"><a target="_blank" rel="noreferrer" class="go_website" href="<?= $this->entry->link() ?>"><?= $this->entry->title() ?></a></h1>
 				<div class="subtitle">
-					<div class="website"><a href="<?= _url('index', 'index', 'get', 'f_' . $this->feed->id()) ?>">
+					<div class="website"><a href="<?= _url('index', 'index', 'get', 'f_' . $this->feed->id()) ?>" title="<?= _t('gen.action.filter') ?>: <?= $this->feed->name() ?>">
 						<?php if (FreshRSS_Context::$user_conf->show_favicons): ?>
 							<img class="favicon" src="<?= $this->feed->favicon() ?>" alt="✇" loading="lazy" />
 						<?php endif; ?>

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -746,6 +746,11 @@ input[type="search"] {
 	padding-right: 10px;
 }
 
+.website a:hover .favicon,
+a.website:hover .favicon {
+	filter: grayscale(100%);
+}
+
 .flux.not_read .item.title,
 .flux.current .item.title {
 	font-weight: bold;
@@ -835,10 +840,6 @@ input[type="search"] {
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
-}
-
-.flux .item.website a:hover .favicon {
-	filter: grayscale(100%);
 }
 
 .flux .item.share > a,

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -743,6 +743,7 @@ input[type="search"] {
 
 .flux .item.website {
 	width: 200px;
+	padding-right: 10px;
 }
 
 .flux.not_read .item.title,
@@ -831,10 +832,13 @@ input[type="search"] {
 
 .flux .item > a {
 	display: block;
-	text-decoration: none;
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
+}
+
+.flux .item.website a:hover .favicon {
+	filter: grayscale(100%);
 }
 
 .flux .item.share > a,

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -743,7 +743,7 @@ input[type="search"] {
 
 .flux .item.website {
 	width: 200px;
-	padding-right: 10px;
+	padding-left: 10px;
 }
 
 .flux.not_read .item.title,

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -746,6 +746,11 @@ input[type="search"] {
 	padding-left: 10px;
 }
 
+.website a:hover .favicon,
+a.website:hover .favicon {
+	filter: grayscale(100%);
+}
+
 .flux.not_read .item.title,
 .flux.current .item.title {
 	font-weight: bold;
@@ -835,10 +840,6 @@ input[type="search"] {
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
-}
-
-.flux .item.website a:hover .favicon {
-	filter: grayscale(100%);
 }
 
 .flux .item.share > a,

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -743,6 +743,7 @@ input[type="search"] {
 
 .flux .item.website {
 	width: 200px;
+	padding-right: 10px;
 }
 
 .flux.not_read .item.title,
@@ -831,10 +832,13 @@ input[type="search"] {
 
 .flux .item > a {
 	display: block;
-	text-decoration: none;
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
+}
+
+.flux .item.website a:hover .favicon {
+	filter: grayscale(100%);
 }
 
 .flux .item.share > a,


### PR DESCRIPTION
Closes #2714

Changes proposed in this pull request:
![grafik](https://user-images.githubusercontent.com/1645099/143949909-fca9bdf8-7d0a-4413-bdaf-9e31d263a48c.png)
- 10 pixel padding between feed name and article title (improved as suggested in #2714). So a little gap between open-article-link and filter-feed-link
- hover the feed name: underline added to signalize, that there is another link as the highlighted line
- hover the feed name: feed name in mouse title added (to understand that you click on the feed name and not on the article title. Additionally shortened feed name is full readable)
- hover the feed name: the favicon gets a greyscale filter to impress that the feed name is hovered
 

How to test the feature manually:

1. hover with your mouse over the feed name column in normal view

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
