### PR TITLE
Improve showing notification banner

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1353,6 +1353,10 @@ function init_notifications() {
 		clearInterval(notification_interval);
 	})
 
+	notification.addEventListener('mouseleave',function(){
+		notification_interval = setTimeout(closeNotification, 1000);
+	})
+
 	if (notification.querySelector('.msg').innerHTML.length > 0) {
 		notification_working = true;
 		if (notification.classList.contains('good')) {

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1349,6 +1349,10 @@ function init_notifications() {
 		return false;
 	};
 
+	notification.addEventListener('mouseenter',function(){
+		clearInterval(notification_interval);
+	})
+
 	if (notification.querySelector('.msg').innerHTML.length > 0) {
 		notification_working = true;
 		if (notification.classList.contains('good')) {

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1327,7 +1327,7 @@ function openNotification(msg, status) {
 	notification.querySelector('.msg').innerHTML = msg;
 	notification.className = 'notification';
 	notification.classList.add(status);
-	if (status = 'good') {
+	if (status == 'good') {
 		notification_interval = setTimeout(closeNotification, 4000);
 	} else {
 		// no status or f.e. status = 'bad', give some more time to read
@@ -1344,17 +1344,17 @@ function closeNotification() {
 function init_notifications() {
 	notification = document.getElementById('notification');
 
-	notification.querySelector('a.close').addEventListener('click',function (ev) {
+	notification.querySelector('a.close').addEventListener('click', function (ev) {
 		closeNotification();
 		ev.preventDefault();
 		return false;
 	});
 
-	notification.addEventListener('mouseenter',function(){
+	notification.addEventListener('mouseenter', function (){
 		clearInterval(notification_interval);
 	});
 
-	notification.addEventListener('mouseleave',function(){
+	notification.addEventListener('mouseleave', function (){
 		notification_interval = setTimeout(closeNotification, 1000);
 	});
 

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1352,11 +1352,11 @@ function init_notifications() {
 
 	notification.addEventListener('mouseenter',function(){
 		clearInterval(notification_interval);
-	})
+	});
 
 	notification.addEventListener('mouseleave',function(){
 		notification_interval = setTimeout(closeNotification, 1000);
-	})
+	});
 
 	if (notification.querySelector('.msg').innerHTML.length > 0) {
 		notification_working = true;

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1355,7 +1355,7 @@ function init_notifications() {
 	});
 
 	notification.addEventListener('mouseleave', function () {
-		notification_interval = setTimeout(closeNotification, 1000);
+		notification_interval = setTimeout(closeNotification, 3000);
 	});
 
 	if (notification.querySelector('.msg').innerHTML.length > 0) {

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1327,8 +1327,12 @@ function openNotification(msg, status) {
 	notification.querySelector('.msg').innerHTML = msg;
 	notification.className = 'notification';
 	notification.classList.add(status);
-
-	notification_interval = setTimeout(closeNotification, 4000);
+	if (status = 'good') {
+		notification_interval = setTimeout(closeNotification, 4000);
+	} else {
+		// no status or f.e. status = 'bad', give some more time to read
+		notification_interval = setTimeout(closeNotification, 8000);
+	}
 }
 
 function closeNotification() {
@@ -1347,7 +1351,12 @@ function init_notifications() {
 
 	if (notification.querySelector('.msg').innerHTML.length > 0) {
 		notification_working = true;
-		notification_interval = setTimeout(closeNotification, 4000);
+		if (notification.classList.contains('good')) {
+			notification_interval = setTimeout(closeNotification, 4000);
+		} else {
+			// no status or f.e. status = 'bad', give some more time to read
+			notification_interval = setTimeout(closeNotification, 8000);
+		}
 	}
 }
 // </notification>

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1350,11 +1350,11 @@ function init_notifications() {
 		return false;
 	});
 
-	notification.addEventListener('mouseenter', function (){
+	notification.addEventListener('mouseenter', function () {
 		clearInterval(notification_interval);
 	});
 
-	notification.addEventListener('mouseleave', function (){
+	notification.addEventListener('mouseleave', function () {
 		notification_interval = setTimeout(closeNotification, 1000);
 	});
 

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1344,10 +1344,11 @@ function closeNotification() {
 function init_notifications() {
 	notification = document.getElementById('notification');
 
-	notification.querySelector('a.close').onclick = function () {
+	notification.querySelector('a.close').addEventListener('click',function (ev) {
 		closeNotification();
+		ev.preventDefault();
 		return false;
-	};
+	});
 
 	notification.addEventListener('mouseenter',function(){
 		clearInterval(notification_interval);

--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -876,13 +876,11 @@ a.btn {
 
 /*=== Notification and actualize notification */
 .notification {
-	padding: 0 0 0 5px;
 	font-size: 0.9em;
 	border: 1px solid #eeb;
 	border-radius: 3px;
 	text-align: center;
 	font-weight: bold;
-	line-height: 3em;
 	z-index: 10;
 	vertical-align: middle;
 }
@@ -897,6 +895,10 @@ a.btn {
 	background: #fdd;
 	color: #844;
 	border: 1px solid #ecc;
+}
+
+.notification a{
+	color: #0062be;
 }
 
 .notification a.close {

--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -897,7 +897,7 @@ a.btn {
 	border: 1px solid #ecc;
 }
 
-.notification a{
+.notification a {
 	color: #0062be;
 }
 

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -897,7 +897,7 @@ a.btn {
 	border: 1px solid #ecc;
 }
 
-.notification a{
+.notification a {
 	color: #0062be;
 }
 

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -876,13 +876,11 @@ a.btn {
 
 /*=== Notification and actualize notification */
 .notification {
-	padding: 0 5px 0 0;
 	font-size: 0.9em;
 	border: 1px solid #eeb;
 	border-radius: 3px;
 	text-align: center;
 	font-weight: bold;
-	line-height: 3em;
 	z-index: 10;
 	vertical-align: middle;
 }
@@ -897,6 +895,10 @@ a.btn {
 	background: #fdd;
 	color: #844;
 	border: 1px solid #ecc;
+}
+
+.notification a{
+	color: #0062be;
 }
 
 .notification a.close {

--- a/p/themes/Ansum/_layout.scss
+++ b/p/themes/Ansum/_layout.scss
@@ -409,9 +409,12 @@
 	left: 0;
 	right: 0;
 	text-align: center;
-	line-height: 3em;
 	z-index: 10;
 	vertical-align: middle;
+
+	a {
+		color: #000;
+	}
 
 	.msg {
 		display: inline-block;

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -1116,9 +1116,11 @@ form th {
 	left: 0;
 	right: 0;
 	text-align: center;
-	line-height: 3em;
 	z-index: 10;
 	vertical-align: middle;
+}
+.notification a {
+	color: #000;
 }
 .notification .msg {
 	display: inline-block;

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -1116,9 +1116,11 @@ form th {
 	right: 0;
 	left: 0;
 	text-align: center;
-	line-height: 3em;
 	z-index: 10;
 	vertical-align: middle;
+}
+.notification a {
+	color: #000;
 }
 .notification .msg {
 	display: inline-block;

--- a/p/themes/BlueLagoon/BlueLagoon.css
+++ b/p/themes/BlueLagoon/BlueLagoon.css
@@ -1017,7 +1017,6 @@ a.btn {
 
 /*=== Notification and actualize notification */
 .notification {
-	padding: 0 0 0 5px;
 	background: #222;
 	color: #fff;
 	font-size: 0.9em;
@@ -1026,7 +1025,6 @@ a.btn {
 	box-shadow: 0px 0px 4px rgba(0,0,0,0.45), 0 -1px rgba(255,255,255,0.08) inset, 0 2px 2px #171717 inset;
 	text-align: center;
 	font-weight: bold;
-	line-height: 3em;
 	position: absolute;
 	top: 0;
 	z-index: 10;
@@ -1045,6 +1043,14 @@ a.btn {
 .notification a.close {
 	padding: 0 15px;
 	line-height: 3em;
+}
+
+.notification a.close:hover {
+	background: rgba(255,255,255,0.2);
+}
+
+.notification a.close:hover .icon {
+	filter: brightness(2);
 }
 
 .notification#actualizeProgress {

--- a/p/themes/BlueLagoon/BlueLagoon.rtl.css
+++ b/p/themes/BlueLagoon/BlueLagoon.rtl.css
@@ -1017,7 +1017,6 @@ a.btn {
 
 /*=== Notification and actualize notification */
 .notification {
-	padding: 0 5px 0 0;
 	background: #222;
 	color: #fff;
 	font-size: 0.9em;
@@ -1026,7 +1025,6 @@ a.btn {
 	box-shadow: 0px 0px 4px rgba(0,0,0,0.45), 0 -1px rgba(255,255,255,0.08) inset, 0 2px 2px #171717 inset;
 	text-align: center;
 	font-weight: bold;
-	line-height: 3em;
 	position: absolute;
 	top: 0;
 	z-index: 10;
@@ -1045,6 +1043,14 @@ a.btn {
 .notification a.close {
 	padding: 0 15px;
 	line-height: 3em;
+}
+
+.notification a.close:hover {
+	background: rgba(255,255,255,0.2);
+}
+
+.notification a.close:hover .icon {
+	filter: brightness(2);
 }
 
 .notification#actualizeProgress {

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -897,7 +897,6 @@ a.btn {
 
 /*=== Notification and actualize notification */
 .notification {
-	padding: 0 0 0 5px;
 	background: #111;
 	color: #c95;
 	font-size: 0.9em;
@@ -906,7 +905,6 @@ a.btn {
 	box-shadow: 0 0 5px #666;
 	text-align: center;
 	font-weight: bold;
-	line-height: 3em;
 	z-index: 10;
 	vertical-align: middle;
 }

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -897,7 +897,6 @@ a.btn {
 
 /*=== Notification and actualize notification */
 .notification {
-	padding: 0 5px 0 0;
 	background: #111;
 	color: #c95;
 	font-size: 0.9em;
@@ -906,7 +905,6 @@ a.btn {
 	box-shadow: 0 0 5px #666;
 	text-align: center;
 	font-weight: bold;
-	line-height: 3em;
 	z-index: 10;
 	vertical-align: middle;
 }

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -909,7 +909,6 @@ a.btn {
 
 /*=== Notification and actualize notification */
 .notification {
-	padding: 0 0 0 5px;
 	background: #ddd;
 	color: #666;
 	font-size: 0.9em;
@@ -917,7 +916,6 @@ a.btn {
 	border-radius: 3px;
 	text-align: center;
 	font-weight: bold;
-	line-height: 3em;
 	z-index: 10;
 	vertical-align: middle;
 }
@@ -930,6 +928,10 @@ a.btn {
 .notification.bad {
 	background: #e74c3c;
 	color: #fff;
+}
+
+.notification a {
+	color: #000;
 }
 
 .notification a.close {

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -909,7 +909,6 @@ a.btn {
 
 /*=== Notification and actualize notification */
 .notification {
-	padding: 0 5px 0 0;
 	background: #ddd;
 	color: #666;
 	font-size: 0.9em;
@@ -917,7 +916,6 @@ a.btn {
 	border-radius: 3px;
 	text-align: center;
 	font-weight: bold;
-	line-height: 3em;
 	z-index: 10;
 	vertical-align: middle;
 }
@@ -930,6 +928,10 @@ a.btn {
 .notification.bad {
 	background: #e74c3c;
 	color: #fff;
+}
+
+.notification a {
+	color: #000;
 }
 
 .notification a.close {

--- a/p/themes/Origine-compact/origine-compact.css
+++ b/p/themes/Origine-compact/origine-compact.css
@@ -974,14 +974,12 @@ a.btn,
 
 /*=== Notification and actualize notification */
 .notification {
-	padding: 0 0 0 5px;
 	font-size: 0.9em;
 	border: 1px solid #eeb;
 	border-radius: 3px;
 	box-shadow: 0 0 5px #ddd;
 	text-align: center;
 	font-weight: bold;
-	line-height: 3em;
 	z-index: 10;
 	vertical-align: middle;
 }

--- a/p/themes/Origine-compact/origine-compact.rtl.css
+++ b/p/themes/Origine-compact/origine-compact.rtl.css
@@ -974,14 +974,12 @@ a.btn,
 
 /*=== Notification and actualize notification */
 .notification {
-	padding: 0 5px 0 0;
 	font-size: 0.9em;
 	border: 1px solid #eeb;
 	border-radius: 3px;
 	box-shadow: 0 0 5px #ddd;
 	text-align: center;
 	font-weight: bold;
-	line-height: 3em;
 	z-index: 10;
 	vertical-align: middle;
 }

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -912,14 +912,12 @@ a.btn {
 
 /*=== Notification and actualize notification */
 .notification {
-	padding: 0 0 0 5px;
 	font-size: 0.9em;
 	border: 1px solid #eeb;
 	border-radius: 3px;
 	box-shadow: 0 0 5px #ddd;
 	text-align: center;
 	font-weight: bold;
-	line-height: 3em;
 	z-index: 10;
 	vertical-align: middle;
 }

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -912,14 +912,12 @@ a.btn {
 
 /*=== Notification and actualize notification */
 .notification {
-	padding: 0 5px 0 0;
 	font-size: 0.9em;
 	border: 1px solid #eeb;
 	border-radius: 3px;
 	box-shadow: 0 0 5px #ddd;
 	text-align: center;
 	font-weight: bold;
-	line-height: 3em;
 	z-index: 10;
 	vertical-align: middle;
 }

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -904,14 +904,12 @@ a.signin {
 
 /*=== Notification and actualize notification */
 .notification {
-	padding: 0 0 0 5px;
 	font-size: 0.9em;
 	border: 1px solid #eeb;
 	border-radius: 3px;
 	box-shadow: 0 0 5px #ddd;
 	text-align: center;
 	font-weight: bold;
-	line-height: 3em;
 	z-index: 10;
 	vertical-align: middle;
 }

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -904,14 +904,12 @@ a.signin {
 
 /*=== Notification and actualize notification */
 .notification {
-	padding: 0 5px 0 0;
 	font-size: 0.9em;
 	border: 1px solid #eeb;
 	border-radius: 3px;
 	box-shadow: 0 0 5px #ddd;
 	text-align: center;
 	font-weight: bold;
-	line-height: 3em;
 	z-index: 10;
 	vertical-align: middle;
 }

--- a/p/themes/Screwdriver/screwdriver.css
+++ b/p/themes/Screwdriver/screwdriver.css
@@ -1000,7 +1000,6 @@ a.btn {
 
 /*=== Notification and actualize notification */
 .notification {
-	padding: 0 0 0 5px;
 	background: #222;
 	color: #fff;
 	font-size: 0.9em;
@@ -1009,7 +1008,6 @@ a.btn {
 	box-shadow: 0px 0px 4px rgba(0,0,0,0.45), 0 -1px rgba(255,255,255,0.08) inset, 0 2px 2px #171717 inset;
 	text-align: center;
 	font-weight: bold;
-	line-height: 3em;
 	position: absolute;
 	top: 0;
 	z-index: 10;

--- a/p/themes/Screwdriver/screwdriver.rtl.css
+++ b/p/themes/Screwdriver/screwdriver.rtl.css
@@ -1000,7 +1000,6 @@ a.btn {
 
 /*=== Notification and actualize notification */
 .notification {
-	padding: 0 5px 0 0;
 	background: #222;
 	color: #fff;
 	font-size: 0.9em;
@@ -1009,7 +1008,6 @@ a.btn {
 	box-shadow: 0px 0px 4px rgba(0,0,0,0.45), 0 -1px rgba(255,255,255,0.08) inset, 0 2px 2px #171717 inset;
 	text-align: center;
 	font-weight: bold;
-	line-height: 3em;
 	position: absolute;
 	top: 0;
 	z-index: 10;

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -778,8 +778,7 @@ form th {
 	left: 0;
 	top: auto;
 }
-.notification.good,
-.notification .bad {
+.notification.good, .notification.bad {
 	color: #fcfcfc;
 }
 .notification.good {

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -778,8 +778,7 @@ form th {
 	right: 0;
 	top: auto;
 }
-.notification.good,
-.notification.bad {
+.notification.good, .notification.bad {
 	color: #fcfcfc;
 }
 .notification.good {

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -779,7 +779,7 @@ form th {
 	top: auto;
 }
 .notification.good,
-.notification .bad {
+.notification.bad {
 	color: #fcfcfc;
 }
 .notification.good {

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -979,7 +979,7 @@ form {
 	@extend %aside-width;
 
 	&.good,
-	.bad {
+	&.bad {
 		color: $color_light;
 	}
 

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -892,6 +892,7 @@ br {
 
 /*=== Notification and actualize notification */
 .notification {
+	padding: 10px 50px 10px 10px;
 	position: absolute;
 	top: 1em;
 	left: 25%; right: 25%;
@@ -899,6 +900,7 @@ br {
 	background: #fff;
 	border: 1px solid #aaa;
 	opacity: 1;
+	line-height: 2;
 	visibility: visible;
 	transition: visibility 0s, opacity .3s linear;
 }
@@ -913,6 +915,14 @@ br {
 	top: 0; bottom: 0;
 	right: 0;
 	display: inline-block;
+}
+
+.notification a.close:hover {
+	background: rgba(10,10,10,0.05);
+}
+
+.notification a.close:hover .icon {
+	filter: brightness(2);
 }
 
 #actualizeProgress {

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -892,6 +892,7 @@ br {
 
 /*=== Notification and actualize notification */
 .notification {
+	padding: 10px 10px 10px 50px;
 	position: absolute;
 	top: 1em;
 	right: 25%; left: 25%;
@@ -899,6 +900,7 @@ br {
 	background: #fff;
 	border: 1px solid #aaa;
 	opacity: 1;
+	line-height: 2;
 	visibility: visible;
 	transition: visibility 0s, opacity .3s linear;
 }
@@ -913,6 +915,14 @@ br {
 	top: 0; bottom: 0;
 	left: 0;
 	display: inline-block;
+}
+
+.notification a.close:hover {
+	background: rgba(10,10,10,0.05);
+}
+
+.notification a.close:hover .icon {
+	filter: brightness(2);
 }
 
 #actualizeProgress {


### PR DESCRIPTION
# Part 1:

While I reproduced #3686 I saw that the time to read the notification is to short (4 seconds).

Changes proposed in this pull request:

- if it is a 'bad' (=red) notification, than the time is doubled to disappear (= 8 seconds)
- if the user moves the mouse pointer over the notification, the timer stopps
- if the user's mouse pointer leaves the notification it will disappear after 1 second
- changed the onlick-event of the close icon to addEventListener

How to test the feature manually:
![grafik](https://user-images.githubusercontent.com/1645099/144708690-3e835838-21f6-4c65-ae22-3debfc8ab21b.png)

1. go to subscription management: page 'add a feed or category'
2. press the 'add' button of 'add a category' (leave the input empty!)
3. a read notification will appear
4. test the changes

# Part 2
Before:
The text inside of the notification could be hidden behind the close button and the grey button could be invisible over the text. And the line-height is strange.
![grafik](https://user-images.githubusercontent.com/1645099/144713666-8751d5f2-1ed4-4fbf-bc09-f70e34a77a53.png)

After:
No text anymore behind the close button.
![grafik](https://user-images.githubusercontent.com/1645099/144713726-74499170-6bc4-419d-a66a-9932cf2f6557.png)

While hovering the grey icon will become white
![grafik](https://user-images.githubusercontent.com/1645099/144713739-3261e485-2db6-4c61-808b-149593879d38.png)

I checked all themes and improved it in some little cases (f.e. readable links)

# Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
