### PR TITLE
Improve: config option for "Add some feeds" link in "no articles" alert

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -112,6 +112,7 @@ class FreshRSS_configure_Controller extends Minz_ActionController {
 			FreshRSS_Context::$user_conf->display_categories = Minz_Request::param('display_categories', 'active');
 			FreshRSS_Context::$user_conf->hide_read_feeds = Minz_Request::param('hide_read_feeds', false);
 			FreshRSS_Context::$user_conf->onread_jump_next = Minz_Request::param('onread_jump_next', false);
+			FreshRSS_Context::$user_conf->no_article_add_feed_link = Minz_Request::param('no_article_add_feed_link', false);
 			FreshRSS_Context::$user_conf->lazyload = Minz_Request::param('lazyload', false);
 			FreshRSS_Context::$user_conf->sides_close_article = Minz_Request::param('sides_close_article', false);
 			FreshRSS_Context::$user_conf->sticky_post = Minz_Request::param('sticky_post', false);

--- a/app/i18n/cz/conf.php
+++ b/app/i18n/cz/conf.php
@@ -124,6 +124,10 @@ return array(
 		'img_with_lazyload' => 'Použít "lazy load" mód pro načítaní obrázků',
 		'jump_next' => 'skočit na další nepřečtený (kanál nebo kategorii)',
 		'mark_updated_article_unread' => 'Označte aktualizované položky jako nepřečtené',
+		'no_article_add_feed_link' => array(
+			'description' => 'Show "Please add some feeds" link',	// TODO - Translation
+			'label' => 'If no articles to show',	// TODO - Translation
+		),
 		'number_divided_when_reader' => 'V režimu “Čtení” děleno dvěma.',
 		'read' => array(
 			'article_open_on_website' => 'když je otevřen původní web s článkem',

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -124,6 +124,10 @@ return array(
 		'img_with_lazyload' => 'Verwende die "träges Laden"-Methode zum Laden von Bildern',
 		'jump_next' => 'springe zum nächsten ungelesenen Geschwisterelement (Feed oder Kategorie)',
 		'mark_updated_article_unread' => 'Markieren Sie aktualisierte Artikel als ungelesen',
+		'no_article_add_feed_link' => array(
+			'description' => 'Show "Please add some feeds" link',	// TODO - Translation
+			'label' => 'If no articles to show',	// TODO - Translation
+		),
 		'number_divided_when_reader' => 'Geteilt durch 2 in der Lese-Ansicht.',
 		'read' => array(
 			'article_open_on_website' => 'wenn der Artikel auf der Original-Webseite geöffnet wird',

--- a/app/i18n/en-us/conf.php
+++ b/app/i18n/en-us/conf.php
@@ -124,6 +124,10 @@ return array(
 		'img_with_lazyload' => 'Use "lazy load" mode to load pictures',
 		'jump_next' => 'jump to next unread sibling (feed or category)',
 		'mark_updated_article_unread' => 'Mark updated articles as unread',
+		'no_article_add_feed_link' => array(
+			'description' => 'Show "Please add some feeds" link',	// TODO - Translation
+			'label' => 'If no articles to show',	// TODO - Translation
+		),
 		'number_divided_when_reader' => 'Divide by 2 in the reading view.',
 		'read' => array(
 			'article_open_on_website' => 'when the article is opened on its original website',

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -124,6 +124,10 @@ return array(
 		'img_with_lazyload' => 'Use "lazy load" mode to load pictures',
 		'jump_next' => 'jump to next unread sibling (feed or category)',
 		'mark_updated_article_unread' => 'Mark updated articles as unread',
+		'no_article_add_feed_link' => array(
+			'description' => 'Show "Please add some feeds" link',
+			'label' => 'If no articles to show',
+		),
 		'number_divided_when_reader' => 'Divide by 2 in the reading view.',
 		'read' => array(
 			'article_open_on_website' => 'when the article is opened on its original website',

--- a/app/i18n/es/conf.php
+++ b/app/i18n/es/conf.php
@@ -124,6 +124,10 @@ return array(
 		'img_with_lazyload' => 'Usar el modo de "carga perezosa" para las imágenes',
 		'jump_next' => 'saltar al siguiente archivo sin leer emparentado (fuente o categoría)',
 		'mark_updated_article_unread' => 'Marcar artículos actualizados como no leídos',
+		'no_article_add_feed_link' => array(
+			'description' => 'Show "Please add some feeds" link',	// TODO - Translation
+			'label' => 'If no articles to show',	// TODO - Translation
+		),
 		'number_divided_when_reader' => 'Dividido en 2 en la vista de lectura.',
 		'read' => array(
 			'article_open_on_website' => 'cuando el artículo se abra en su web original',

--- a/app/i18n/fr/conf.php
+++ b/app/i18n/fr/conf.php
@@ -124,6 +124,10 @@ return array(
 		'img_with_lazyload' => 'Utiliser le mode “chargement différé” pour les images',
 		'jump_next' => 'sauter au prochain voisin non lu (flux ou catégorie)',
 		'mark_updated_article_unread' => 'Marquer les articles mis à jour comme non-lus',
+		'no_article_add_feed_link' => array(
+			'description' => 'Show "Please add some feeds" link',	// TODO - Translation
+			'label' => 'If no articles to show',	// TODO - Translation
+		),
 		'number_divided_when_reader' => 'Divisé par 2 dans la vue de lecture.',
 		'read' => array(
 			'article_open_on_website' => 'lorsque l’article est ouvert sur le site d’origine',

--- a/app/i18n/he/conf.php
+++ b/app/i18n/he/conf.php
@@ -124,6 +124,10 @@ return array(
 		'img_with_lazyload' => 'שימוש ב "טעינה עצלה" על מנת לטעון תמונות',
 		'jump_next' => 'קפיצה לפריט הבא שלא נקרא (הזנה או קטגוריה)',
 		'mark_updated_article_unread' => 'Mark updated articles as unread',	// TODO - Translation
+		'no_article_add_feed_link' => array(
+			'description' => 'Show "Please add some feeds" link',	// TODO - Translation
+			'label' => 'If no articles to show',	// TODO - Translation
+		),
 		'number_divided_when_reader' => 'חלוקה ב2 במצב קריאה.',
 		'read' => array(
 			'article_open_on_website' => 'כאשר מאמר נפתח באתר המקורי',

--- a/app/i18n/it/conf.php
+++ b/app/i18n/it/conf.php
@@ -124,6 +124,10 @@ return array(
 		'img_with_lazyload' => 'Usa la modalità "caricamento ritardato" per le immagini',
 		'jump_next' => 'Salta al successivo feed o categoria non letto',
 		'mark_updated_article_unread' => 'Segna articoli aggiornati come non letti',
+		'no_article_add_feed_link' => array(
+			'description' => 'Show "Please add some feeds" link',	// TODO - Translation
+			'label' => 'If no articles to show',	// TODO - Translation
+		),
 		'number_divided_when_reader' => 'Diviso 2 nella modalità di lettura.',
 		'read' => array(
 			'article_open_on_website' => 'Quando un articolo è aperto nel suo sito di origine',

--- a/app/i18n/ja/conf.php
+++ b/app/i18n/ja/conf.php
@@ -124,6 +124,10 @@ return array(
 		'img_with_lazyload' => '"lazy load"を写真の読み込み時に使う',
 		'jump_next' => '次の未読の姉妹記事へ移る (フィードあるいはカテゴリー)',
 		'mark_updated_article_unread' => '更新された記事を未読とする',
+		'no_article_add_feed_link' => array(
+			'description' => 'Show "Please add some feeds" link',	// TODO - Translation
+			'label' => 'If no articles to show',	// TODO - Translation
+		),
 		'number_divided_when_reader' => 'reading viewを二分割する',
 		'read' => array(
 			'article_open_on_website' => '記事を元のwebサイトで開いたとき',

--- a/app/i18n/ko/conf.php
+++ b/app/i18n/ko/conf.php
@@ -124,6 +124,10 @@ return array(
 		'img_with_lazyload' => '그림을 불러오는 데에 "lazy load" 모드 사용하기',
 		'jump_next' => '다음 읽지 않은 항목으로 이동 (피드 또는 카테고리)',
 		'mark_updated_article_unread' => '갱신 된 글을 읽지 않음으로 표시',
+		'no_article_add_feed_link' => array(
+			'description' => 'Show "Please add some feeds" link',	// TODO - Translation
+			'label' => 'If no articles to show',	// TODO - Translation
+		),
 		'number_divided_when_reader' => '읽기 모드에서는 절반만 표시됩니다.',
 		'read' => array(
 			'article_open_on_website' => '글이 게재된 웹사이트를 방문했을 때',

--- a/app/i18n/nl/conf.php
+++ b/app/i18n/nl/conf.php
@@ -124,6 +124,10 @@ return array(
 		'img_with_lazyload' => 'Gebruik "lazy load" methode om afbeeldingen te laden',
 		'jump_next' => 'Ga naar volgende ongelezen (feed of categorie)',
 		'mark_updated_article_unread' => 'Markeer vernieuwd artikel als ongelezen',
+		'no_article_add_feed_link' => array(
+			'description' => 'Show "Please add some feeds" link',	// TODO - Translation
+			'label' => 'If no articles to show',	// TODO - Translation
+		),
 		'number_divided_when_reader' => 'Gedeeld door 2 in de lees modus.',
 		'read' => array(
 			'article_open_on_website' => 'als het artikel wordt geopend op de originele website',

--- a/app/i18n/oc/conf.php
+++ b/app/i18n/oc/conf.php
@@ -124,6 +124,10 @@ return array(
 		'img_with_lazyload' => 'Utilizar lo mòde “cargament tardiu” pels imatges',
 		'jump_next' => 'sautar al vesin venent pas legit (flux o categoria)',
 		'mark_updated_article_unread' => 'Marcar los articles actualizats coma pas legits',
+		'no_article_add_feed_link' => array(
+			'description' => 'Show "Please add some feeds" link',	// TODO - Translation
+			'label' => 'If no articles to show',	// TODO - Translation
+		),
 		'number_divided_when_reader' => 'Devisat per 2 dins la vista de lectura.',
 		'read' => array(
 			'article_open_on_website' => 'quand l’article es dobèrt sul site d’origina',

--- a/app/i18n/pl/conf.php
+++ b/app/i18n/pl/conf.php
@@ -124,6 +124,10 @@ return array(
 		'img_with_lazyload' => 'Opóźnij ładowanie obrazów dopóki nie będą widoczne',
 		'jump_next' => 'przejdź do następnego nieprzeczytanego kanału bądź kategorii',
 		'mark_updated_article_unread' => 'Oznacz zaktualizowane wiadomości jako nieprzeczytane',
+		'no_article_add_feed_link' => array(
+			'description' => 'Show "Please add some feeds" link',	// TODO - Translation
+			'label' => 'If no articles to show',	// TODO - Translation
+		),
 		'number_divided_when_reader' => 'Dzielone przez 2 w widoku czytania.',
 		'read' => array(
 			'article_open_on_website' => 'gdy wiadomość jest otworzona na pierwotnej stronie',

--- a/app/i18n/pt-br/conf.php
+++ b/app/i18n/pt-br/conf.php
@@ -124,6 +124,10 @@ return array(
 		'img_with_lazyload' => 'Utilizar o modo "lazy load" para carregar as imagens',
 		'jump_next' => 'Vá para o próximo irmão não lido (feed ou categoria)',
 		'mark_updated_article_unread' => 'Marcar artigos atualizados como não lidos',
+		'no_article_add_feed_link' => array(
+			'description' => 'Show "Please add some feeds" link',	// TODO - Translation
+			'label' => 'If no articles to show',	// TODO - Translation
+		),
 		'number_divided_when_reader' => 'Dividido por 2 no modo de leitura .',
 		'read' => array(
 			'article_open_on_website' => 'quando o artigo é aberto no site original',

--- a/app/i18n/ru/conf.php
+++ b/app/i18n/ru/conf.php
@@ -124,6 +124,10 @@ return array(
 		'img_with_lazyload' => 'Использовать режим "ленивой загрузки" для загрузки картинок',
 		'jump_next' => 'перейти к следующей ленте или категории',
 		'mark_updated_article_unread' => 'Отмечать обновлённые статьи непрочитанными',
+		'no_article_add_feed_link' => array(
+			'description' => 'Show "Please add some feeds" link',	// TODO - Translation
+			'label' => 'If no articles to show',	// TODO - Translation
+		),
 		'number_divided_when_reader' => 'Делится на 2 в виде для чтения.',
 		'read' => array(
 			'article_open_on_website' => 'когда статья открывается на её сайте',

--- a/app/i18n/sk/conf.php
+++ b/app/i18n/sk/conf.php
@@ -124,6 +124,10 @@ return array(
 		'img_with_lazyload' => 'Pre načítanie obrázkov použiť "lazy load"',
 		'jump_next' => 'skočiť na ďalší neprečítaný (kanál ale kategóriu)',
 		'mark_updated_article_unread' => 'Označiť aktualizované články ako neprečítané',
+		'no_article_add_feed_link' => array(
+			'description' => 'Show "Please add some feeds" link',	// TODO - Translation
+			'label' => 'If no articles to show',	// TODO - Translation
+		),
 		'number_divided_when_reader' => 'V režime čítania predeliť na dve časti.',
 		'read' => array(
 			'article_open_on_website' => 'keď je článok otvorený na svojej webovej stránke',

--- a/app/i18n/tr/conf.php
+++ b/app/i18n/tr/conf.php
@@ -124,6 +124,10 @@ return array(
 		'img_with_lazyload' => 'Resimleri yüklemek için "tembel modu" kullan',
 		'jump_next' => 'Bir sonraki benzer okunmamışa geç (akış veya kategori)',
 		'mark_updated_article_unread' => 'Güncellenen makaleleri okundu olarak işaretle',
+		'no_article_add_feed_link' => array(
+			'description' => 'Show "Please add some feeds" link',	// TODO - Translation
+			'label' => 'If no articles to show',	// TODO - Translation
+		),
 		'number_divided_when_reader' => 'Okuma modunda ikiye bölünecek.',
 		'read' => array(
 			'article_open_on_website' => 'orijinal makale sitesi açıldığında',

--- a/app/i18n/zh-cn/conf.php
+++ b/app/i18n/zh-cn/conf.php
@@ -124,6 +124,10 @@ return array(
 		'img_with_lazyload' => '延迟加载图片',
 		'jump_next' => '跳转到下一未读项（订阅源或分类）',
 		'mark_updated_article_unread' => '将更新的文章设为未读',
+		'no_article_add_feed_link' => array(
+			'description' => 'Show "Please add some feeds" link',	// TODO - Translation
+			'label' => 'If no articles to show',	// TODO - Translation
+		),
 		'number_divided_when_reader' => '阅读视图中显示一半',
 		'read' => array(
 			'article_open_on_website' => '在打开原文章后',

--- a/app/views/configure/reading.phtml
+++ b/app/views/configure/reading.phtml
@@ -248,6 +248,18 @@
 			</div>
 		</div>
 
+		<div class="form-group">
+			<label class="group-name"><?= _t('conf.reading.no_article_add_feed_link.label') ?></label>
+			<div class="group-controls">
+				<label class="checkbox" for="no_article_add_feed_link">
+					<input type="checkbox" name="no_article_add_feed_link" id="no_article_add_feed_link" value="1"<?=
+						FreshRSS_Context::$user_conf->no_article_add_feed_link ? ' checked="checked"' : '' ?>
+						data-leave-validation="<?= FreshRSS_Context::$user_conf->no_article_add_feed_link ?>"/>
+						<?= _t('conf.reading.no_article_add_feed_link.description') ?>
+				</label>
+			</div>
+		</div>
+
 		<div class="form-group form-actions">
 			<div class="group-controls">
 				<button type="submit" class="btn btn-important"><?= _t('gen.action.submit') ?></button>

--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -120,7 +120,9 @@ $today = @strtotime('today');
 	</div>
 	<div class="prompt alert alert-warn">
 		<h2 class="alert-head"><?= _t('index.feed.empty') ?></h2>
+		<?php if(FreshRSS_Context::$user_conf->no_article_add_feed_link) {?>
 		<p><a href="<?= _url('subscription', 'add') ?>"><?= _t('index.feed.add') ?></a></p>
+		<?php } ?>
 	</div>
 </main>
 <?php endif; ?>

--- a/app/views/index/reader.phtml
+++ b/app/views/index/reader.phtml
@@ -84,7 +84,9 @@ $content_width = FreshRSS_Context::$user_conf->content_width;
 	</div>
 	<div class="prompt alert alert-warn">
 		<h2 class="alert-head"><?= _t('index.feed.empty') ?></h2>
+		<?php if(FreshRSS_Context::$user_conf->no_article_add_feed_link) {?>
 		<p><a href="<?= _url('subscription', 'add') ?>"><?= _t('index.feed.add') ?></a></p>
+		<?php } ?>
 	</div>
 </main>
 <?php endif; ?>

--- a/config-user.default.php
+++ b/config-user.default.php
@@ -35,6 +35,7 @@ return array (
 	'display_categories' => 'active',	//{ active, remember, all, none }
 	'hide_read_feeds' => true,
 	'onread_jump_next' => true,
+	'no_article_add_feed_link' => true,
 	'lazyload' => true,
 	'sides_close_article' => true,
 	'sticky_post' => true,


### PR DESCRIPTION
User Story I: As a power user I do not like the "Add a feed" in the "no articles" alert, because I know how to add feeds.
User Story II: As a new user I want to know how to add (more) feeds, so that I can consume more news.

Changes proposed in this pull request:

- add a option in "Reading"
- default: option is enabled, so that new users get the link. 

settings (see last line):
![grafik](https://user-images.githubusercontent.com/1645099/145053527-4e7aee62-d5bc-4868-8c95-c01a074fab78.png)

default: enabled (checked) 
![grafik](https://user-images.githubusercontent.com/1645099/145053670-96acbd1d-a1b4-47d3-82ec-f6d0d07968a6.png)

disabled (unchecked):
![grafik](https://user-images.githubusercontent.com/1645099/145054722-0986f96d-b0ec-4ca9-ae25-8aee27e1036b.png)





How to test the feature manually:

1. switch the config
2. see the normal/reader view with a filter, that has no articles


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] do the i18n after your feedback