### PR TITLE
4051 read fav hooks

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -22,6 +22,7 @@ People are sorted by name so please keep this order.
 * [ASMfreaK](https://github.com/ASMfreaK): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:ASMfreaK)
 * [Bartosz Taudul](https://github.com/wolfpld): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:wolfpld), [Web](https://wolf.nereid.pl/)
 * [Benjamin Bouvier](https://github.com/bnjbvr): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:bnjbvr), [Web](https://benj.me/)
+* [Jonas Born](https://github.com/jonasborn): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:jonasborn), [Web](https://jonasborn.de/)
 * [bpatath](https://github.com/bpatath): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:bpatath)
 * [Brewal Bouvet](https://github.com/Jucgshu): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Jucgshu), [Web](https://dizolo.eu/)
 * [Brooke.](https://github.com/BrookeDot): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:BrookeDot), [Web](https://brooke.codes/)

--- a/app/Controllers/entryController.php
+++ b/app/Controllers/entryController.php
@@ -74,7 +74,7 @@ class FreshRSS_entry_Controller extends Minz_ActionController {
 			} else {
 				$type_get = $get[0];
 				$get = substr($get, 2);
-				$extensionResult = Minz_ExtensionManager::callHook('entry_read', array("id_max" => $id_max, "type" => $type_get, "is_read" => $is_read));
+				$extensionResult = Minz_ExtensionManager::callHook('entry_read_multiple', array("id_max" => $id_max, "type" => $type_get, "is_read" => $is_read));
 				if ($extensionResult !== null && is_bool($extensionResult)) {
 					$is_read = $extensionResult;
 				}

--- a/app/Controllers/entryController.php
+++ b/app/Controllers/entryController.php
@@ -64,11 +64,21 @@ class FreshRSS_entry_Controller extends Minz_ActionController {
 			}
 
 			if (!$get) {
+				$extensionResult = Minz_ExtensionManager::callHook('entry_read_multiple', array("id_max" => $id_max, "read" => $is_read));
+				if ($extensionResult !== null && is_bool($extensionResult)) {
+					$is_read = $extensionResult;
+				}
+
 				// No get? Mark all entries as read (from $id_max)
 				$entryDAO->markReadEntries($id_max, $is_read);
 			} else {
 				$type_get = $get[0];
 				$get = substr($get, 2);
+				$extensionResult = Minz_ExtensionManager::callHook('entry_read', array("id" => $id, "type" => $type_get, "status" => $is_read));
+				if ($extensionResult !== null && is_bool($extensionResult)) {
+					$is_read = $extensionResult;
+				}
+
 				switch($type_get) {
 				case 'c':
 					$entryDAO->markReadCat($get, $id_max, FreshRSS_Context::$search, FreshRSS_Context::$state, $is_read);
@@ -131,6 +141,10 @@ class FreshRSS_entry_Controller extends Minz_ActionController {
 		$is_favourite = (bool)Minz_Request::param('is_favorite', true);
 		if ($id !== false) {
 			$entryDAO = FreshRSS_Factory::createEntryDao();
+			$extensionResult = Minz_ExtensionManager::callHook('entry_favorite', array($id, $is_favourite));
+			if ($extensionResult !== null && is_bool($extensionResult)) {
+				$is_favourite = $extensionResult;
+			}
 			$entryDAO->markFavorite($id, $is_favourite);
 		}
 

--- a/app/Controllers/entryController.php
+++ b/app/Controllers/entryController.php
@@ -64,17 +64,19 @@ class FreshRSS_entry_Controller extends Minz_ActionController {
 			}
 
 			if (!$get) {
-				$extensionResult = Minz_ExtensionManager::callHook('entry_read_multiple', array("id_max" => $id_max, "is_read" => $is_read));
+				$extensionResult = Minz_ExtensionManager::callHook('entry_read', array("id_max" => $id_max, "is_read" => $is_read));
 				if ($extensionResult !== null && is_bool($extensionResult)) {
 					$is_read = $extensionResult;
 				}
 
 				// No get? Mark all entries as read (from $id_max)
-				$entryDAO->markReadEntries($id_max, $is_read);
+				if ($is_read) {
+					$entryDAO->markReadEntries($id_max);
+				}
 			} else {
 				$type_get = $get[0];
 				$get = substr($get, 2);
-				$extensionResult = Minz_ExtensionManager::callHook('entry_read_multiple', array("id_max" => $id_max, "type" => $type_get, "is_read" => $is_read));
+				$extensionResult = Minz_ExtensionManager::callHook('entry_read', array("id_max" => $id_max, "type" => $type_get, "is_read" => $is_read));
 				if ($extensionResult !== null && is_bool($extensionResult)) {
 					$is_read = $extensionResult;
 				}
@@ -108,7 +110,7 @@ class FreshRSS_entry_Controller extends Minz_ActionController {
 			}
 		} else {
 			$ids = is_array($id) ? $id : array($id);
-			$extensionResult = Minz_ExtensionManager::callHook('entry_read_multiple', array("ids" => $ids, "is_read" => $is_read));
+			$extensionResult = Minz_ExtensionManager::callHook('entry_read', array("ids" => $ids, "is_read" => $is_read));
 			if ($extensionResult !== null && is_bool($extensionResult)) {
 				$is_read = $extensionResult;
 			}
@@ -146,7 +148,7 @@ class FreshRSS_entry_Controller extends Minz_ActionController {
 		$is_favorite = (bool)Minz_Request::param('is_favorite', true);
 		if ($id !== false) {
 			$entryDAO = FreshRSS_Factory::createEntryDao();
-			$extensionResult = Minz_ExtensionManager::callHook('entry_favorite', array("id" => $id, "is_favorite" => $is_favorite));
+			$extensionResult = Minz_ExtensionManager::callHook('entry_favorite', array("ids" => [$id], "is_favorite" => $is_favorite));
 			if ($extensionResult !== null && is_bool($extensionResult)) {
 				$is_favorite = $extensionResult;
 			}

--- a/app/Controllers/entryController.php
+++ b/app/Controllers/entryController.php
@@ -64,7 +64,7 @@ class FreshRSS_entry_Controller extends Minz_ActionController {
 			}
 
 			if (!$get) {
-				$extensionResult = Minz_ExtensionManager::callHook('entry_read_multiple', array("id_max" => $id_max, "read" => $is_read));
+				$extensionResult = Minz_ExtensionManager::callHook('entry_read_multiple', array("id_max" => $id_max, "is_read" => $is_read));
 				if ($extensionResult !== null && is_bool($extensionResult)) {
 					$is_read = $extensionResult;
 				}
@@ -74,7 +74,7 @@ class FreshRSS_entry_Controller extends Minz_ActionController {
 			} else {
 				$type_get = $get[0];
 				$get = substr($get, 2);
-				$extensionResult = Minz_ExtensionManager::callHook('entry_read', array("id" => $id, "type" => $type_get, "status" => $is_read));
+				$extensionResult = Minz_ExtensionManager::callHook('entry_read', array("id_max" => $id_max, "type" => $type_get, "is_read" => $is_read));
 				if ($extensionResult !== null && is_bool($extensionResult)) {
 					$is_read = $extensionResult;
 				}
@@ -108,6 +108,11 @@ class FreshRSS_entry_Controller extends Minz_ActionController {
 			}
 		} else {
 			$ids = is_array($id) ? $id : array($id);
+			$extensionResult = Minz_ExtensionManager::callHook('entry_read_multiple', array("ids" => $ids, "is_read" => $is_read));
+			if ($extensionResult !== null && is_bool($extensionResult)) {
+				$is_read = $extensionResult;
+			}
+
 			$entryDAO->markRead($ids, $is_read);
 			$tagDAO = FreshRSS_Factory::createTagDao();
 			$tagsForEntries = $tagDAO->getTagsForEntries($ids);
@@ -138,14 +143,14 @@ class FreshRSS_entry_Controller extends Minz_ActionController {
 	 */
 	public function bookmarkAction() {
 		$id = Minz_Request::param('id');
-		$is_favourite = (bool)Minz_Request::param('is_favorite', true);
+		$is_favorite = (bool)Minz_Request::param('is_favorite', true);
 		if ($id !== false) {
 			$entryDAO = FreshRSS_Factory::createEntryDao();
-			$extensionResult = Minz_ExtensionManager::callHook('entry_favorite', array($id, $is_favourite));
+			$extensionResult = Minz_ExtensionManager::callHook('entry_favorite', array("id" => $id, "is_favorite" => $is_favorite));
 			if ($extensionResult !== null && is_bool($extensionResult)) {
-				$is_favourite = $extensionResult;
+				$is_favorite = $extensionResult;
 			}
-			$entryDAO->markFavorite($id, $is_favourite);
+			$entryDAO->markFavorite($id, $is_favorite);
 		}
 
 		if (!$this->ajax) {

--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -1062,6 +1062,10 @@ SQL;
 		}
 	}
 
+	public function listIds($idMax = 0, $onlyFavorites = false, $priorityMin = 0, $filters = null, $state = 0, $is_read = true) {
+		//TODO Add
+	}
+
 	public function listIdsWhere($type = 'a', $id = '', $state = FreshRSS_Entry::STATE_ALL,
 			$order = 'DESC', $limit = 1, $firstId = '', $filters = null) {	//For API
 		list($values, $sql) = $this->sqlListWhere($type, $id, $state, $order, $limit, $firstId, $filters);

--- a/docs/en/developers/03_Backend/05_Extensions.md
+++ b/docs/en/developers/03_Backend/05_Extensions.md
@@ -347,6 +347,9 @@ The following events are available:
 * `nav_reading_modes` (`function($reading_modes) -> array | null`): **TODO** add documentation.
 * `post_update` (`function(none) -> none`): **TODO** add documentation.
 * `simplepie_before_init` (`function($simplePie, $feed) -> none`): **TODO** add documentation.
+* `entry_favorite` (`function(array($id, $is_favorite)) -> true | false | null`): will be executed, when the favorite status of an entry is changed
+* `entry_read` (`function(array($id, $type_get, $is_read)) -> true | false | null`): will be executed, when the read status of a single element is changed
+* `entry_read_multiple` (`function(array($id_max, $is_read)) -> true | false | null`): will be executed, when the read status of multiple elements is changed
 
 ### Writing your own configure.phtml
 

--- a/docs/en/developers/03_Backend/05_Extensions.md
+++ b/docs/en/developers/03_Backend/05_Extensions.md
@@ -335,6 +335,10 @@ The following events are available:
 * `check_url_before_add` (`function($url) -> Url | null`): will be executed every time a URL is added. The URL itself will be passed as parameter. This way a website known to have feeds which doesn't advertise it in the header can still be automatically supported.
 * `entry_before_display` (`function($entry) -> Entry | null`): will be executed every time an entry is rendered. The entry itself (instance of FreshRSS\_Entry) will be passed as parameter.
 * `entry_before_insert` (`function($entry) -> Entry | null`): will be executed when a feed is refreshed and new entries will be imported into the database. The new entry (instance of FreshRSS\_Entry) will be passed as parameter.
+* `entry_favorite` (`function(array($id, $is_favorite)) -> true | false | null`): will be executed, when the favorite status of an entry is changed
+* `entry_favorite_multiple` (`function(array($ids, $is_favorite)) -> true | false | null`): will be executed, when the favorite status of multiple entries changed
+* `entry_read` (`function(array($id, $type, $is_read)) -> true | false | null`): will be executed, when the read status of single element is changed
+* `entry_read_multiple` (`function(array($ids, $is_read)) -> true | false | null`) | (`function(array($id_max, $is_read)) -> true | false | null`): will be executed, when the read status of multiple elements is changed
 * `feed_before_actualize` (`function($feed) -> Feed | null`): will be executed when a feed is updated. The feed (instance of FreshRSS\_Feed) will be passed as parameter.
 * `feed_before_insert` (`function($feed) -> Feed | null`): will be executed when a new feed is imported into the database. The new feed (instance of FreshRSS\_Feed) will be passed as parameter.
 * `freshrss_init` (`function() -> none`): will be executed at the end of the initialization of FreshRSS, useful to initialize components or to do additional access checks.

--- a/docs/en/developers/03_Backend/05_Extensions.md
+++ b/docs/en/developers/03_Backend/05_Extensions.md
@@ -335,10 +335,8 @@ The following events are available:
 * `check_url_before_add` (`function($url) -> Url | null`): will be executed every time a URL is added. The URL itself will be passed as parameter. This way a website known to have feeds which doesn't advertise it in the header can still be automatically supported.
 * `entry_before_display` (`function($entry) -> Entry | null`): will be executed every time an entry is rendered. The entry itself (instance of FreshRSS\_Entry) will be passed as parameter.
 * `entry_before_insert` (`function($entry) -> Entry | null`): will be executed when a feed is refreshed and new entries will be imported into the database. The new entry (instance of FreshRSS\_Entry) will be passed as parameter.
-* `entry_favorite` (`function(array($id, $is_favorite)) -> true | false | null`): will be executed, when the favorite status of an entry is changed
-* `entry_favorite_multiple` (`function(array($ids, $is_favorite)) -> true | false | null`): will be executed, when the favorite status of multiple entries changed
-* `entry_read` (`function(array($id, $type, $is_read)) -> true | false | null`): will be executed, when the read status of single element is changed
-* `entry_read_multiple` (`function(array($ids, $is_read)) -> true | false | null`) | (`function(array($id_max, $is_read)) -> true | false | null`): will be executed, when the read status of multiple elements is changed
+* `entry_favorite` (`function(array($id, $is_favorite)) -> true | false | null`): will be executed, when the favorite status of multiple entries changed
+* `entry_read` (`function(array($ids, $is_read)) -> true | false | null`) | (`function(array($id_max, [$type], $is_read)) -> true | false | null`): will be executed, when the read status of multiple elements is changed
 * `feed_before_actualize` (`function($feed) -> Feed | null`): will be executed when a feed is updated. The feed (instance of FreshRSS\_Feed) will be passed as parameter.
 * `feed_before_insert` (`function($feed) -> Feed | null`): will be executed when a new feed is imported into the database. The new feed (instance of FreshRSS\_Feed) will be passed as parameter.
 * `freshrss_init` (`function() -> none`): will be executed at the end of the initialization of FreshRSS, useful to initialize components or to do additional access checks.
@@ -351,9 +349,6 @@ The following events are available:
 * `nav_reading_modes` (`function($reading_modes) -> array | null`): **TODO** add documentation.
 * `post_update` (`function(none) -> none`): **TODO** add documentation.
 * `simplepie_before_init` (`function($simplePie, $feed) -> none`): **TODO** add documentation.
-* `entry_favorite` (`function(array($id, $is_favorite)) -> true | false | null`): will be executed, when the favorite status of an entry is changed
-* `entry_read` (`function(array($id, $type_get, $is_read)) -> true | false | null`): will be executed, when the read status of a single element is changed
-* `entry_read_multiple` (`function(array($id_max, $is_read)) -> true | false | null`): will be executed, when the read status of multiple elements is changed
 
 ### Writing your own configure.phtml
 

--- a/lib/Minz/ExtensionManager.php
+++ b/lib/Minz/ExtensionManager.php
@@ -27,15 +27,11 @@ class Minz_ExtensionManager {
 			'list' => array(),
 			'signature' => 'OneToOne',
 		),
-		'entry_favorite' => array(	// function(array($id, $is_favorite)) -> true | false | null
+		'entry_favorite' => array(	// function(array($ids, $is_favorite)) -> true | false | null
 			'list' => array(),
 			'signature' => 'OneToOne',
 		),
-		'entry_read' => array(	// function(array($id, $type_get, $is_read)) -> true | false | null
-			'list' => array(),
-			'signature' => 'OneToOne',
-		),
-		'entry_read_multiple' => array(	// function(array($id_max, $is_read)) -> true | false | null
+		'entry_read' => array(	// function(array($ids_max, $is_read)) -> true | false | null | function(array($id_max, [$type], $is_read)) -> true | false | null
 			'list' => array(),
 			'signature' => 'OneToOne',
 		),

--- a/lib/Minz/ExtensionManager.php
+++ b/lib/Minz/ExtensionManager.php
@@ -75,6 +75,18 @@ class Minz_ExtensionManager {
 			'list' => array(),
 			'signature' => 'PassArguments',
 		),
+		'entry_read' => array(	// function(array($id, $type_get, $is_read)) -> true | false | null
+			'list' => array(),
+			'signature' => 'OneToOne',
+		),
+		'entry_read_multiple' => array(	// function(array($id_max, $is_read)) -> true | false | null
+			'list' => array(),
+			'signature' => 'OneToOne',
+		),
+		'entry_favorite' => array(	// function(array($id, $is_favorite)) -> true | false | null
+			'list' => array(),
+			'signature' => 'OneToOne',
+		)
 	);
 	private static $ext_to_hooks = array();
 

--- a/lib/Minz/ExtensionManager.php
+++ b/lib/Minz/ExtensionManager.php
@@ -27,6 +27,18 @@ class Minz_ExtensionManager {
 			'list' => array(),
 			'signature' => 'OneToOne',
 		),
+		'entry_favorite' => array(	// function(array($id, $is_favorite)) -> true | false | null
+			'list' => array(),
+			'signature' => 'OneToOne',
+		),
+		'entry_read' => array(	// function(array($id, $type_get, $is_read)) -> true | false | null
+			'list' => array(),
+			'signature' => 'OneToOne',
+		),
+		'entry_read_multiple' => array(	// function(array($id_max, $is_read)) -> true | false | null
+			'list' => array(),
+			'signature' => 'OneToOne',
+		),
 		'feed_before_actualize' => array(	// function($feed) -> Feed | null
 			'list' => array(),
 			'signature' => 'OneToOne',
@@ -74,18 +86,6 @@ class Minz_ExtensionManager {
 		'simplepie_before_init' => array(	// function($simplePie, $feed) -> none
 			'list' => array(),
 			'signature' => 'PassArguments',
-		),
-		'entry_read' => array(	// function(array($id, $type_get, $is_read)) -> true | false | null
-			'list' => array(),
-			'signature' => 'OneToOne',
-		),
-		'entry_read_multiple' => array(	// function(array($id_max, $is_read)) -> true | false | null
-			'list' => array(),
-			'signature' => 'OneToOne',
-		),
-		'entry_favorite' => array(	// function(array($id, $is_favorite)) -> true | false | null
-			'list' => array(),
-			'signature' => 'OneToOne',
 		)
 	);
 	private static $ext_to_hooks = array();

--- a/p/api/fever.php
+++ b/p/api/fever.php
@@ -452,7 +452,7 @@ class FeverAPI
 	protected function setItemAsRead($id)
 	{
 		$is_read  = true;
-		$extensionResult = Minz_ExtensionManager::callHook('entry_read', array("id" => $id, "is_read" => $is_read));
+		$extensionResult = Minz_ExtensionManager::callHook('entry_read', array("ids" => [$id], "is_read" => $is_read));
 		if ($extensionResult !== null && is_bool($extensionResult)) {
 			$is_read = $extensionResult;
 		}
@@ -462,7 +462,7 @@ class FeverAPI
 	protected function setItemAsUnread($id)
 	{
 		$is_read  = false;
-		$extensionResult = Minz_ExtensionManager::callHook('entry_read', array("id" => $id, "is_read" => $is_read));
+		$extensionResult = Minz_ExtensionManager::callHook('entry_read', array("ids" => [$id], "is_read" => $is_read));
 		if ($extensionResult !== null && is_bool($extensionResult)) {
 			$is_read = $extensionResult;
 		}
@@ -472,7 +472,7 @@ class FeverAPI
 	protected function setItemAsSaved($id)
 	{
 		$is_favorite = true;
-		$extensionResult = Minz_ExtensionManager::callHook('entry_favorite', array("id" => $id, "is_favorite" => $is_favorite));
+		$extensionResult = Minz_ExtensionManager::callHook('entry_favorite', array("ids" => [$id], "is_favorite" => $is_favorite));
 		if ($extensionResult !== null && is_bool($extensionResult)) {
 			$is_favorite = $extensionResult;
 		}
@@ -482,7 +482,7 @@ class FeverAPI
 	protected function setItemAsUnsaved($id)
 	{
 		$is_favorite = false;
-		$extensionResult = Minz_ExtensionManager::callHook('entry_favorite', array("id" => $id, "is_favorite" => $is_favorite));
+		$extensionResult = Minz_ExtensionManager::callHook('entry_favorite', array("ids" => [$id], "is_favorite" => $is_favorite));
 		if ($extensionResult !== null && is_bool($extensionResult)) {
 			$is_favorite = $extensionResult;
 		}

--- a/p/api/fever.php
+++ b/p/api/fever.php
@@ -451,22 +451,42 @@ class FeverAPI
 
 	protected function setItemAsRead($id)
 	{
-		return $this->entryDAO->markRead($id, true);
+		$is_read  = true;
+		$extensionResult = Minz_ExtensionManager::callHook('entry_read', array("id" => $id, "is_read" => $is_read));
+		if ($extensionResult !== null && is_bool($extensionResult)) {
+			$is_read = $extensionResult;
+		}
+		return $this->entryDAO->markRead($id, $is_read);
 	}
 
 	protected function setItemAsUnread($id)
 	{
-		return $this->entryDAO->markRead($id, false);
+		$is_read  = false;
+		$extensionResult = Minz_ExtensionManager::callHook('entry_read', array("id" => $id, "is_read" => $is_read));
+		if ($extensionResult !== null && is_bool($extensionResult)) {
+			$is_read = $extensionResult;
+		}
+		return $this->entryDAO->markRead($id, $is_read);
 	}
 
 	protected function setItemAsSaved($id)
 	{
-		return $this->entryDAO->markFavorite($id, true);
+		$is_favorite = true;
+		$extensionResult = Minz_ExtensionManager::callHook('entry_favorite', array("id" => $id, "is_favorite" => $is_favorite));
+		if ($extensionResult !== null && is_bool($extensionResult)) {
+			$is_favorite = $extensionResult;
+		}
+		return $this->entryDAO->markFavorite($id, $is_favorite);
 	}
 
 	protected function setItemAsUnsaved($id)
 	{
-		return $this->entryDAO->markFavorite($id, false);
+		$is_favorite = false;
+		$extensionResult = Minz_ExtensionManager::callHook('entry_favorite', array("id" => $id, "is_favorite" => $is_favorite));
+		if ($extensionResult !== null && is_bool($extensionResult)) {
+			$is_favorite = $extensionResult;
+		}
+		return $this->entryDAO->markFavorite($id, $is_favorite);
 	}
 
 	/**

--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -802,10 +802,20 @@ function editTag($e_ids, $a, $r) {
 
 	switch ($a) {
 		case 'user/-/state/com.google/read':
-			$entryDAO->markRead($e_ids, true);
+			$is_read = true;
+			$extensionResult = Minz_ExtensionManager::callHook('entry_read_multiple', array("ids" => $e_ids, "is_read" => $is_read));
+			if ($extensionResult !== null && is_bool($extensionResult)) {
+				$is_read = $extensionResult;
+			}
+			$entryDAO->markRead($e_ids, $is_read);
 			break;
 		case 'user/-/state/com.google/starred':
-			$entryDAO->markFavorite($e_ids, true);
+			$is_favorite = true;
+			$extensionResult = Minz_ExtensionManager::callHook('entry_favorite_multiple', array("ids" => $e_ids, "is_favorite" => $is_favorite));
+			if ($extensionResult !== null && is_bool($extensionResult)) {
+				$is_favorite = $extensionResult;
+			}
+			$entryDAO->markFavorite($e_ids, $is_favorite);
 			break;
 		/*case 'user/-/state/com.google/tracking-kept-unread':
 			break;
@@ -841,10 +851,20 @@ function editTag($e_ids, $a, $r) {
 	}
 	switch ($r) {
 		case 'user/-/state/com.google/read':
-			$entryDAO->markRead($e_ids, false);
+			$is_read = false;
+			$extensionResult = Minz_ExtensionManager::callHook('entry_read_multiple', array("ids" => $e_ids, "is_read" => $is_read));
+			if ($extensionResult !== null && is_bool($extensionResult)) {
+				$is_read = $extensionResult;
+			}
+			$entryDAO->markRead($e_ids, $is_read);
 			break;
 		case 'user/-/state/com.google/starred':
-			$entryDAO->markFavorite($e_ids, false);
+			$is_favorite = false;
+			$extensionResult = Minz_ExtensionManager::callHook('entry_favorite_multiple', array("ids" => $e_ids, "is_favorite" => $is_favorite));
+			if ($extensionResult !== null && is_bool($extensionResult)) {
+				$is_favorite = $extensionResult;
+			}
+			$entryDAO->markFavorite($e_ids, $is_favorite);
 			break;
 		default:
 			if (strpos($r, 'user/-/label/') === 0) {

--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -803,7 +803,7 @@ function editTag($e_ids, $a, $r) {
 	switch ($a) {
 		case 'user/-/state/com.google/read':
 			$is_read = true;
-			$extensionResult = Minz_ExtensionManager::callHook('entry_read_multiple', array("ids" => $e_ids, "is_read" => $is_read));
+			$extensionResult = Minz_ExtensionManager::callHook('entry_read', array("ids" => $e_ids, "is_read" => $is_read));
 			if ($extensionResult !== null && is_bool($extensionResult)) {
 				$is_read = $extensionResult;
 			}
@@ -811,7 +811,7 @@ function editTag($e_ids, $a, $r) {
 			break;
 		case 'user/-/state/com.google/starred':
 			$is_favorite = true;
-			$extensionResult = Minz_ExtensionManager::callHook('entry_favorite_multiple', array("ids" => $e_ids, "is_favorite" => $is_favorite));
+			$extensionResult = Minz_ExtensionManager::callHook('entry_favorite', array("ids" => $e_ids, "is_favorite" => $is_favorite));
 			if ($extensionResult !== null && is_bool($extensionResult)) {
 				$is_favorite = $extensionResult;
 			}
@@ -852,7 +852,7 @@ function editTag($e_ids, $a, $r) {
 	switch ($r) {
 		case 'user/-/state/com.google/read':
 			$is_read = false;
-			$extensionResult = Minz_ExtensionManager::callHook('entry_read_multiple', array("ids" => $e_ids, "is_read" => $is_read));
+			$extensionResult = Minz_ExtensionManager::callHook('entry_read', array("ids" => $e_ids, "is_read" => $is_read));
 			if ($extensionResult !== null && is_bool($extensionResult)) {
 				$is_read = $extensionResult;
 			}
@@ -860,7 +860,7 @@ function editTag($e_ids, $a, $r) {
 			break;
 		case 'user/-/state/com.google/starred':
 			$is_favorite = false;
-			$extensionResult = Minz_ExtensionManager::callHook('entry_favorite_multiple', array("ids" => $e_ids, "is_favorite" => $is_favorite));
+			$extensionResult = Minz_ExtensionManager::callHook('entry_favorite', array("ids" => $e_ids, "is_favorite" => $is_favorite));
 			if ($extensionResult !== null && is_bool($extensionResult)) {
 				$is_favorite = $extensionResult;
 			}


### PR DESCRIPTION
Closes #4051

Changes proposed in this pull request:

- Added hook calls to entryController, look for  entry_read, entry_read_multiple and entry_favorite

How to test the feature manually:

1. Create a extension and register hooks for entry_read, entry_read_multiple and entry_favorite

Pull request checklist:

- [+] clear commit messages
- [+] code manually tested
- [-] unit tests written (optional if too hard)
- [+] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
