### PR TITLE
fix: Ignore non-PHP files in migrations/ folder

### DIFF
--- a/lib/Minz/Migrator.php
+++ b/lib/Minz/Migrator.php
@@ -39,7 +39,8 @@ class Minz_Migrator
 
 		$migration_files = scandir($migrations_path);
 		$migration_files = array_filter($migration_files, function ($filename) {
-			return $filename[0] !== '.';
+			$file_extension = pathinfo($filename, PATHINFO_EXTENSION);
+			return $file_extension === 'php';
 		});
 		$migration_versions = array_map(function ($filename) {
 			return basename($filename, '.php');
@@ -135,7 +136,8 @@ class Minz_Migrator
 		}
 
 		foreach (scandir($directory) as $filename) {
-			if ($filename[0] === '.') {
+			$file_extension = pathinfo($filename, PATHINFO_EXTENSION);
+			if ($file_extension !== 'php') {
 				continue;
 			}
 


### PR DESCRIPTION
Closes https://github.com/FreshRSS/FreshRSS/issues/4044

Changes proposed in this pull request:

- Change the way to detect migration files by testing that their extension is php

How to test the feature manually:

1. Create a file not ending by `.php` under `app/migrations/ `
2. Open FreshRSS in your browser
3. Verify it doesn't fail with a fatal error
4. Remove the file

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard)
- [x] documentation updated N/A

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
