### PR TITLE
Improved: Focus and show password buttons

### DIFF
--- a/p/scripts/extra.js
+++ b/p/scripts/extra.js
@@ -99,7 +99,7 @@ function init_crypto_form() {
 // </crypto form (Web login)>
 
 function showPW(ev) {
-	if (ev.buttons || ev.key == " " || ev.key.toUpperCase() == 'ENTER') {
+	if (ev.buttons || ev.key == ' ' || ev.key.toUpperCase() == 'ENTER') {
 		const passwordField = document.getElementById(this.getAttribute('data-toggle'));
 		passwordField.setAttribute('type', 'text');
 		this.classList.add('active');

--- a/p/scripts/extra.js
+++ b/p/scripts/extra.js
@@ -98,20 +98,28 @@ function init_crypto_form() {
 }
 // </crypto form (Web login)>
 
+function showPW(ev) {
+	if (ev.buttons || ev.key == " " || ev.key.toUpperCase() == 'ENTER') {
+		const passwordField = document.getElementById(this.getAttribute('data-toggle'));
+		passwordField.setAttribute('type', 'text');
+		this.classList.add('active');
+	}
+	return false;
+}
+
+function hidePW() {
+	const passwordField = document.getElementById(this.getAttribute('data-toggle'));
+	passwordField.setAttribute('type', 'password');
+	this.classList.remove('active');
+	return false;
+}
+
 function init_password_observers() {
-	document.querySelectorAll('.toggle-password').forEach(function (a) {
-		a.onmousedown = function (ev) {
-			const passwordField = document.getElementById(this.getAttribute('data-toggle'));
-			passwordField.setAttribute('type', 'text');
-			this.classList.add('active');
-			return false;
-		};
-		a.onmouseup = function (ev) {
-			const passwordField = document.getElementById(this.getAttribute('data-toggle'));
-			passwordField.setAttribute('type', 'password');
-			this.classList.remove('active');
-			return false;
-		};
+	document.querySelectorAll('.toggle-password').forEach(function (btn) {
+		btn.addEventListener('mousedown', showPW);
+		btn.addEventListener('keydown', showPW);
+		btn.addEventListener('mouseup', hidePW);
+		btn.addEventListener('keyup', hidePW);
 	});
 }
 

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -281,6 +281,11 @@ a.btn {
 	font-weight: bold;
 }
 
+.btn:focus-visible,
+input[type="checkbox"]:focus-visible {
+	outline: 2px solid #ccc;
+}
+
 /*=== Navigation */
 .nav-list .nav-header,
 .nav-list .item {

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -281,6 +281,11 @@ a.btn {
 	font-weight: bold;
 }
 
+.btn:focus-visible,
+input[type="checkbox"]:focus-visible {
+	outline: 2px solid #ccc;
+}
+
 /*=== Navigation */
 .nav-list .nav-header,
 .nav-list .item {


### PR DESCRIPTION
Changes proposed in this pull request:

- make tabbed focus (`:focus-visible`) visible
- make show password buttons usable with keyboard

![focus-visible](https://user-images.githubusercontent.com/1645099/152701635-17b6738d-2644-4b1c-beb3-fcd5c3b52fc4.gif)

How to test the feature manually:

1. edit the settings of a feed
2. tab through the form
3. see the border around buttons
4. make password visible with `Enter` or `Space` keys

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
