### PR TITLE
Improvement: <button> set explicit type="submit"

### DIFF
--- a/app/views/helpers/category/update.phtml
+++ b/app/views/helpers/category/update.phtml
@@ -29,7 +29,7 @@
 
 		<div class="form-group form-actions">
 			<div class="group-controls">
-				<button class="btn btn-important"><?= _t('gen.action.submit') ?></button>
+				<button type="submit" class="btn btn-important"><?= _t('gen.action.submit') ?></button>
 				<button type="reset" class="btn"><?= _t('gen.action.cancel') ?></button>
 
 			</div>
@@ -155,7 +155,7 @@
 		</div>
 		<div class="form-group form-actions">
 			<div class="group-controls">
-				<button class="btn btn-important"><?= _t('gen.action.submit') ?></button>
+				<button type="submit" class="btn btn-important"><?= _t('gen.action.submit') ?></button>
 				<button type="reset" class="btn"><?= _t('gen.action.cancel') ?></button>
 			</div>
 		</div>
@@ -167,12 +167,12 @@
 		<?php endif;?>
 		<div class="form-group form-actions">
 			<div class="group-controls">
-				<button class="btn btn-attention confirm"
+				<button type="submit" class="btn btn-attention confirm"
 					data-str-confirm="<?= _t('gen.js.confirm_action_feed_cat') ?>"
 					formaction="<?= _url('category', 'empty', 'id', $this->category->id()) ?>"
 					formmethod="post"><?= _t('gen.action.empty') ?></button>
 				<?php if (!$this->category->isDefault()): ?>
-				<button class="btn btn-attention confirm"
+				<button type="submit" class="btn btn-attention confirm"
 					data-str-confirm="<?= _t('gen.js.confirm_action_feed_cat') ?>"
 					formaction="<?= _url('category', 'delete', 'id', $this->category->id()) ?>"
 					formmethod="post"><?= _t('gen.action.remove') ?></button>

--- a/app/views/helpers/configure/query.phtml
+++ b/app/views/helpers/configure/query.phtml
@@ -85,8 +85,8 @@
 
 		<div class="form-group form-actions">
 			<div class="group-controls">
-				<button class="btn btn-important"><?= _t('gen.action.submit') ?></button>
-				<button class="btn btn-attention confirm"
+				<button type="submit" class="btn btn-important"><?= _t('gen.action.submit') ?></button>
+				<button type="submit" class="btn btn-attention confirm"
 					data-str-confirm="<?= _t('gen.js.confirm_action_feed_cat') ?>"
 					formaction="<?= _url('configure', 'deleteQuery', 'id', $this->queryId) ?>"
 					formmethod="post"><?= _t('gen.action.remove') ?></button>

--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -127,9 +127,9 @@
 
 		<div class="form-group form-actions">
 			<div class="group-controls">
-				<button class="btn btn-important"><?= _t('gen.action.submit') ?></button>
+				<button type="submit" class="btn btn-important"><?= _t('gen.action.submit') ?></button>
 				<button type="reset" class="btn"><?= _t('gen.action.cancel') ?></button>
-				<button class="btn btn-attention confirm"
+				<button type="submit" class="btn btn-attention confirm"
 					data-str-confirm="<?= _t('gen.js.confirm_action_feed_cat') ?>"
 					formaction="<?= _url('feed', 'delete', 'id', $this->feed->id()) ?>"
 					formmethod="post"><?= _t('gen.action.remove') ?></button>
@@ -367,9 +367,9 @@
 
 		<div class="form-group form-actions">
 			<div class="group-controls">
-				<button class="btn btn-important"><?= _t('gen.action.submit') ?></button>
+				<button type="submit" class="btn btn-important"><?= _t('gen.action.submit') ?></button>
 				<button type="reset" class="btn"><?= _t('gen.action.cancel') ?></button>
-				<button class="btn btn-attention confirm" formmethod="post" formaction="<?= _url('feed', 'truncate', 'id', $this->feed->id()) ?>"><?= _t('gen.action.truncate') ?></button>
+				<button type="submit" class="btn btn-attention confirm" formmethod="post" formaction="<?= _url('feed', 'truncate', 'id', $this->feed->id()) ?>"><?= _t('gen.action.truncate') ?></button>
 			</div>
 		</div>
 
@@ -476,7 +476,7 @@
 
 		<div class="form-group form-actions">
 			<div class="group-controls">
-				<button class="btn btn-important"><?= _t('gen.action.submit') ?></button>
+				<button type="submit" class="btn btn-important"><?= _t('gen.action.submit') ?></button>
 				<button type="reset" class="btn"><?= _t('gen.action.cancel') ?></button>
 			</div>
 		</div>


### PR DESCRIPTION
Changes proposed in this pull request:

- set `type="submit"` to all `<button>` to make it explicit and consistency to the whole code

How to test the feature manually:

1. check the buttons


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
