### PR TITLE
Specific HTML load for lib_phpQuery.php

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -484,7 +484,7 @@ class FreshRSS_Entry extends Minz_Model {
 			/**
 			 * @var phpQueryObject @doc
 			 */
-			$doc = phpQuery::newDocument($html);
+			$doc = phpQuery::newDocumentHTML($html);
 
 			if ($maxRedirs > 0) {
 				//Follow any HTML redirection

--- a/lib/lib_phpQuery.php
+++ b/lib/lib_phpQuery.php
@@ -436,8 +436,7 @@ class DOMDocumentWrapper {
 	}
 	protected function isXML($markup) {
 //		return strpos($markup, '<?xml') !== false && stripos($markup, 'xhtml') === false;
-		$head = substr($markup, 0, 100);
-		return strpos($head, '<'.'?xml') !== false && stripos($head, '<html ') === false;
+		return strpos(substr($markup, 0, 100), '<'.'?xml') !== false;
 	}
 	protected function contentTypeToArray($contentType) {
 		$matches = explode(';', trim(strtolower($contentType)));


### PR DESCRIPTION
And reverts a less appropriate workaround for the same thing in https://github.com/FreshRSS/FreshRSS/pull/4220 : https://github.com/FreshRSS/FreshRSS/pull/4220/files#diff-cf1d88b6ac0010f2fcca497769da042f2475b670dc67c6e80869e823ec995183R439-R440
Avoids XML errors when believing that a document might be XML/XHTML.
