### PR TITLE
Set feed error state when XPath does not match

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -375,6 +375,9 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 					$simplePie = $simplePiePush;	//Used by WebSub
 				} elseif ($feed->kind() === FreshRSS_Feed::KIND_HTML_XPATH) {
 					$simplePie = $feed->loadHtmlXpath(false, $isNewFeed);
+					if ($simplePie == null) {
+						throw new FreshRSS_Feed_Exception('HTML+XPath Web scraping failed for [' . $feed->url(false) . ']');
+					}
 				} else {
 					$simplePie = $feed->load(false, $isNewFeed);
 				}

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -424,6 +424,7 @@ function getHtml(string $url, array $attributes = []): string {
 
 	if ($c_status != 200 || $c_error != '' || $html === false) {
 		Minz_Log::warning('Error fetching content: HTTP code ' . $c_status . ': ' . $c_error . ' ' . $url);
+		// TODO: Implement HTTP 410 Gone
 	}
 	if ($html == false) {
 		$html = '';


### PR DESCRIPTION
Gives the ability to filter HTML+XPath feeds that are not working.
Simple implementation to start with. Could be made smarter with various error codes in the future.
