### PR TITLE
WebSub: Use hash instead of base64 to handle long URLs

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -831,7 +831,7 @@ class FreshRSS_Feed extends Minz_Model {
 
 	public function pubSubHubbubEnabled(): bool {
 		$url = $this->selfUrl ? $this->selfUrl : $this->url;
-		$hubFilename = PSHB_PATH . '/feeds/' . base64url_encode($url) . '/!hub.json';
+		$hubFilename = PSHB_PATH . '/feeds/' . sha1($url) . '/!hub.json';
 		if ($hubFile = @file_get_contents($hubFilename)) {
 			$hubJson = json_decode($hubFile, true);
 			if ($hubJson && empty($hubJson['error']) &&
@@ -844,7 +844,7 @@ class FreshRSS_Feed extends Minz_Model {
 
 	public function pubSubHubbubError(bool $error = true): bool {
 		$url = $this->selfUrl ? $this->selfUrl : $this->url;
-		$hubFilename = PSHB_PATH . '/feeds/' . base64url_encode($url) . '/!hub.json';
+		$hubFilename = PSHB_PATH . '/feeds/' . sha1($url) . '/!hub.json';
 		$hubFile = @file_get_contents($hubFilename);
 		$hubJson = $hubFile ? json_decode($hubFile, true) : array();
 		if (!isset($hubJson['error']) || $hubJson['error'] !== (bool)$error) {
@@ -862,7 +862,7 @@ class FreshRSS_Feed extends Minz_Model {
 		$key = '';
 		if (Minz_Request::serverIsPublic(FreshRSS_Context::$system_conf->base_url) &&
 			$this->hubUrl && $this->selfUrl && @is_dir(PSHB_PATH)) {
-			$path = PSHB_PATH . '/feeds/' . base64url_encode($this->selfUrl);
+			$path = PSHB_PATH . '/feeds/' . sha1($this->selfUrl);
 			$hubFilename = $path . '/!hub.json';
 			if ($hubFile = @file_get_contents($hubFilename)) {
 				$hubJson = json_decode($hubFile, true);
@@ -892,7 +892,7 @@ class FreshRSS_Feed extends Minz_Model {
 				);
 				file_put_contents($hubFilename, json_encode($hubJson));
 				@mkdir(PSHB_PATH . '/keys/');
-				file_put_contents(PSHB_PATH . '/keys/' . $key . '.txt', base64url_encode($this->selfUrl));
+				file_put_contents(PSHB_PATH . '/keys/' . $key . '.txt', $this->selfUrl);
 				$text = 'WebSub prepared for ' . $this->url;
 				Minz_Log::debug($text);
 				Minz_Log::debug($text, PSHB_LOG);
@@ -913,7 +913,7 @@ class FreshRSS_Feed extends Minz_Model {
 			$url = $this->url;	//Always use current URL during unsubscribe
 		}
 		if ($url && (Minz_Request::serverIsPublic(FreshRSS_Context::$system_conf->base_url) || !$state)) {
-			$hubFilename = PSHB_PATH . '/feeds/' . base64url_encode($url) . '/!hub.json';
+			$hubFilename = PSHB_PATH . '/feeds/' . sha1($url) . '/!hub.json';
 			$hubFile = @file_get_contents($hubFilename);
 			if ($hubFile === false) {
 				Minz_Log::warning('JSON not found for WebSub: ' . $this->url);

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -700,15 +700,6 @@ function remove_query_by_get($get, $queries) {
 	return $final_queries;
 }
 
-//RFC 4648
-function base64url_encode($data) {
-	return strtr(rtrim(base64_encode($data), '='), '+/', '-_');
-}
-//RFC 4648
-function base64url_decode($data) {
-	return base64_decode(strtr($data, '-_', '+/'));
-}
-
 function _i($icon, $url_only = false) {
 	return FreshRSS_Themes::icon($icon, $url_only);
 }

--- a/p/api/pshb.php
+++ b/p/api/pshb.php
@@ -20,8 +20,8 @@ if (!ctype_xdigit($key)) {
 	die('Invalid feed key format!');
 }
 chdir(PSHB_PATH);
-$canonical64 = @file_get_contents('keys/' . $key . '.txt');
-if ($canonical64 === false) {
+$canonical = @file_get_contents('keys/' . $key . '.txt');
+if ($canonical === false) {
 	if (!empty($_REQUEST['hub_mode']) && $_REQUEST['hub_mode'] === 'unsubscribe') {
 		Minz_Log::warning('Warning: Accept unknown unsubscribe', PSHB_LOG);
 		header('Connection: close');
@@ -31,17 +31,13 @@ if ($canonical64 === false) {
 	Minz_Log::warning('Warning: Feed key not found!: ' . $key, PSHB_LOG);
 	die('Feed key not found!');
 }
-$canonical64 = trim($canonical64);
-if (!preg_match('/^[A-Za-z0-9_-]+$/D', $canonical64)) {
-	header('HTTP/1.1 500 Internal Server Error');
-	Minz_Log::error('Error: Invalid key reference!: ' . $canonical64, PSHB_LOG);
-	die('Invalid key reference!');
-}
-$hubFile = @file_get_contents('feeds/' . $canonical64 . '/!hub.json');
+$canonical = trim($canonical);
+$canonicalHash = sha1($canonical);
+$hubFile = @file_get_contents('feeds/' . $canonicalHash . '/!hub.json');
 if ($hubFile === false) {
 	header('HTTP/1.1 404 Not Found');
 	unlink('keys/' . $key . '.txt');
-	Minz_Log::error('Error: Feed info not found!: ' . $canonical64, PSHB_LOG);
+	Minz_Log::error('Error: Feed info not found!: ' . $canonical, PSHB_LOG);
 	die('Feed info not found!');
 }
 $hubJson = json_decode($hubFile, true);
@@ -50,18 +46,17 @@ if (!$hubJson || empty($hubJson['key']) || $hubJson['key'] !== $key) {
 	Minz_Log::error('Error: Invalid key cross-check!: ' . $key, PSHB_LOG);
 	die('Invalid key cross-check!');
 }
-chdir('feeds/' . $canonical64);
+chdir('feeds/' . $canonicalHash);
 $users = glob('*.txt', GLOB_NOSORT);
 if (empty($users)) {
 	header('HTTP/1.1 410 Gone');
-	$url = base64url_decode($canonical64);
-	Minz_Log::warning('Warning: Nobody subscribes to this feed anymore!: ' . $url, PSHB_LOG);
+	Minz_Log::warning('Warning: Nobody subscribes to this feed anymore!: ' . $canonical, PSHB_LOG);
 	unlink('../../keys/' . $key . '.txt');
-	$feed = new FreshRSS_Feed($url);
+	$feed = new FreshRSS_Feed($canonical);
 	$feed->pubSubHubbubSubscribe(false);
 	unlink('!hub.json');
 	chdir('..');
-	recursive_unlink($canonical64);
+	recursive_unlink('feeds/' . $canonicalHash);
 	die('Nobody subscribes to this feed anymore!');
 }
 
@@ -104,11 +99,11 @@ unset($ORIGINAL_INPUT);
 $links = $simplePie->get_links('self');
 $self = isset($links[0]) ? $links[0] : null;
 
-if ($self !== base64url_decode($canonical64)) {
+if ($self !== $canonical) {
 	//header('HTTP/1.1 422 Unprocessable Entity');
-	Minz_Log::warning('Warning: Self URL [' . $self . '] does not match registered canonical URL!: ' . base64url_decode($canonical64), PSHB_LOG);
+	Minz_Log::warning('Warning: Self URL [' . $self . '] does not match registered canonical URL!: ' . $canonical, PSHB_LOG);
 	//die('Self URL does not match registered canonical URL!');
-	$self = base64url_decode($canonical64);
+	$self = $canonical;
 }
 
 Minz_ExtensionManager::init();

--- a/p/api/pshb.php
+++ b/p/api/pshb.php
@@ -27,7 +27,7 @@ if ($canonical === false) {
 		header('Connection: close');
 		exit(isset($_REQUEST['hub_challenge']) ? $_REQUEST['hub_challenge'] : '');
 	}
-	header('HTTP/1.1 404 Not Found');
+	header('HTTP/1.1 410 Gone');
 	Minz_Log::warning('Warning: Feed key not found!: ' . $key, PSHB_LOG);
 	die('Feed key not found!');
 }
@@ -35,7 +35,7 @@ $canonical = trim($canonical);
 $canonicalHash = sha1($canonical);
 $hubFile = @file_get_contents('feeds/' . $canonicalHash . '/!hub.json');
 if ($hubFile === false) {
-	header('HTTP/1.1 404 Not Found');
+	header('HTTP/1.1 410 Gone');
 	unlink('keys/' . $key . '.txt');
 	Minz_Log::error('Error: Feed info not found!: ' . $canonical, PSHB_LOG);
 	die('Feed info not found!');


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/4279 (part of)

Supports long URLs with WebSub