### PR TITLE
SimplePie fix parsing of HTTP Links

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -837,7 +837,7 @@ class FreshRSS_Feed extends Minz_Model {
 
 	public function pubSubHubbubEnabled(): bool {
 		$url = $this->selfUrl ? $this->selfUrl : $this->url;
-		$hubFilename = PSHB_PATH . '/feeds/' . sha1($url) . '/!hub.json';
+		$hubFilename = PSHB_PATH . '/feeds/' . base64url_encode($url) . '/!hub.json';
 		if ($hubFile = @file_get_contents($hubFilename)) {
 			$hubJson = json_decode($hubFile, true);
 			if ($hubJson && empty($hubJson['error']) &&
@@ -850,7 +850,7 @@ class FreshRSS_Feed extends Minz_Model {
 
 	public function pubSubHubbubError(bool $error = true): bool {
 		$url = $this->selfUrl ? $this->selfUrl : $this->url;
-		$hubFilename = PSHB_PATH . '/feeds/' . sha1($url) . '/!hub.json';
+		$hubFilename = PSHB_PATH . '/feeds/' . base64url_encode($url) . '/!hub.json';
 		$hubFile = @file_get_contents($hubFilename);
 		$hubJson = $hubFile ? json_decode($hubFile, true) : array();
 		if (!isset($hubJson['error']) || $hubJson['error'] !== (bool)$error) {
@@ -868,7 +868,7 @@ class FreshRSS_Feed extends Minz_Model {
 		$key = '';
 		if (Minz_Request::serverIsPublic(FreshRSS_Context::$system_conf->base_url) &&
 			$this->hubUrl && $this->selfUrl && @is_dir(PSHB_PATH)) {
-			$path = PSHB_PATH . '/feeds/' . sha1($this->selfUrl);
+			$path = PSHB_PATH . '/feeds/' . base64url_encode($this->selfUrl);
 			$hubFilename = $path . '/!hub.json';
 			if ($hubFile = @file_get_contents($hubFilename)) {
 				$hubJson = json_decode($hubFile, true);
@@ -898,7 +898,7 @@ class FreshRSS_Feed extends Minz_Model {
 				);
 				file_put_contents($hubFilename, json_encode($hubJson));
 				@mkdir(PSHB_PATH . '/keys/');
-				file_put_contents(PSHB_PATH . '/keys/' . $key . '.txt', $this->selfUrl);
+				file_put_contents(PSHB_PATH . '/keys/' . $key . '.txt', base64url_encode($this->selfUrl));
 				$text = 'WebSub prepared for ' . $this->url;
 				Minz_Log::debug($text);
 				Minz_Log::debug($text, PSHB_LOG);
@@ -919,7 +919,7 @@ class FreshRSS_Feed extends Minz_Model {
 			$url = $this->url;	//Always use current URL during unsubscribe
 		}
 		if ($url && (Minz_Request::serverIsPublic(FreshRSS_Context::$system_conf->base_url) || !$state)) {
-			$hubFilename = PSHB_PATH . '/feeds/' . sha1($url) . '/!hub.json';
+			$hubFilename = PSHB_PATH . '/feeds/' . base64url_encode($url) . '/!hub.json';
 			$hubFile = @file_get_contents($hubFilename);
 			if ($hubFile === false) {
 				Minz_Log::warning('JSON not found for WebSub: ' . $this->url);

--- a/lib/SimplePie/SimplePie.php
+++ b/lib/SimplePie/SimplePie.php
@@ -2726,12 +2726,14 @@ class SimplePie
 		if (isset($this->data['headers']['link']))
 		{
 			$link_headers = $this->data['headers']['link'];
-			if (is_string($link_headers)) {
-				$link_headers = array($link_headers);
+			if (is_array($link_headers)) {
+				$link_headers = implode(',', $link_headers);
 			}
-			$matches = preg_filter('/<([^>]+)>; rel='.preg_quote($rel).'/', '$1', $link_headers);
-			if (!empty($matches)) {
-				return $matches;
+			// https://datatracker.ietf.org/doc/html/rfc8288
+			if (is_string($link_headers) &&
+				preg_match_all('/<(?P<uri>[^>]+)>\s*;\s*rel\s*=\s*(?P<quote>"?)' . preg_quote($rel) . '(?P=quote)\s*(?=,|$)/i', $link_headers, $matches))
+			{
+				return $matches['uri'];
 			}
 		}
 


### PR DESCRIPTION
@fix https://github.com/FreshRSS/FreshRSS/issues/4279 (part of)

* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link
* https://datatracker.ietf.org/doc/html/rfc8288

Before, SimplePie was not able to parse an HTTP header such as:

```
Link: <https://pubsubhubbub.appspot.com>; rel="hub", <https://pubsubhubbub.superfeedr.com>; rel=hub, <https://websubhub.com/hub>; rel="hub"
```
