### PR TITLE
WebSub explicit hub.lease_seconds

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -32,6 +32,9 @@ class FreshRSS_Feed extends Minz_Model {
 	const ARCHIVING_RETENTION_COUNT_LIMIT = 10000;
 	const ARCHIVING_RETENTION_PERIOD = 'P3M';
 
+	/** Number of seconds for which we would like to have the WebSub subscription active */
+	const WEBSUB_LEASE_SECONDS = 864000;
+
 	/** @var int */
 	private $id = 0;
 	/** @var string */
@@ -948,6 +951,7 @@ class FreshRSS_Feed extends Minz_Model {
 						'hub.mode' => $state ? 'subscribe' : 'unsubscribe',
 						'hub.topic' => $url,
 						'hub.callback' => $callbackUrl,
+						'hub.lease_seconds' => self::WEBSUB_LEASE_SECONDS,
 						)),
 					CURLOPT_USERAGENT => FRESHRSS_USERAGENT,
 					CURLOPT_MAXREDIRS => 10,


### PR DESCRIPTION
https://www.w3.org/TR/websub/#subscriber-sends-subscription-request
We ask for a lease of 10 days just like the default for
https://github.com/flusio/Webubbub/blob/6007039eb7bb29a1a6af7f6546a8c8995c2475a5/src/models/Subscription.php#L48

Before, WebSub hubs such as https://github.com/flusio/Webubbub would fall back to 1 day if we do not specify anything, which is a bit too short for FreshRSS logic.

