### PR TITLE
HTML+XPath fallback to feed title

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -601,7 +601,8 @@ class FreshRSS_Feed extends Minz_Model {
 			$doc->strictErrorChecking = false;
 			$doc->loadHTML($html, LIBXML_NONET | LIBXML_NOERROR | LIBXML_NOWARNING);
 			$xpath = new DOMXPath($doc);
-			$view->rss_title = $xPathFeedTitle == '' ? $this->name() : htmlspecialchars(@$xpath->evaluate('normalize-space(' . $xPathFeedTitle . ')'), ENT_COMPAT, 'UTF-8');
+			$view->rss_title = $xPathFeedTitle == '' ? $this->name() :
+				htmlspecialchars(@$xpath->evaluate('normalize-space(' . $xPathFeedTitle . ')'), ENT_COMPAT, 'UTF-8');
 			$view->rss_base = htmlspecialchars(trim($xpath->evaluate('normalize-space(//base/@href)')), ENT_COMPAT, 'UTF-8');
 			$nodes = $xpath->query($xPathItem);
 			if (empty($nodes)) {
@@ -641,6 +642,7 @@ class FreshRSS_Feed extends Minz_Model {
 
 		$simplePie = customSimplePie();
 		$simplePie->set_raw_data($view->renderToString());
+		file_put_contents('/tmp/rss.xml', $view->renderToString());
 		$simplePie->init();
 		return $simplePie;
 	}

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -642,7 +642,6 @@ class FreshRSS_Feed extends Minz_Model {
 
 		$simplePie = customSimplePie();
 		$simplePie->set_raw_data($view->renderToString());
-		file_put_contents('/tmp/rss.xml', $view->renderToString());
 		$simplePie->init();
 		return $simplePie;
 	}

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -601,7 +601,7 @@ class FreshRSS_Feed extends Minz_Model {
 			$doc->strictErrorChecking = false;
 			$doc->loadHTML($html, LIBXML_NONET | LIBXML_NOERROR | LIBXML_NOWARNING);
 			$xpath = new DOMXPath($doc);
-			$view->rss_title = $xPathFeedTitle == '' ? '' : htmlspecialchars(@$xpath->evaluate('normalize-space(' . $xPathFeedTitle . ')'), ENT_COMPAT, 'UTF-8');
+			$view->rss_title = $xPathFeedTitle == '' ? $this->name() : htmlspecialchars(@$xpath->evaluate('normalize-space(' . $xPathFeedTitle . ')'), ENT_COMPAT, 'UTF-8');
 			$view->rss_base = htmlspecialchars(trim($xpath->evaluate('normalize-space(//base/@href)')), ENT_COMPAT, 'UTF-8');
 			$nodes = $xpath->query($xPathItem);
 			if (empty($nodes)) {


### PR DESCRIPTION
Except when adding the feed, the following refreshes should fallback to feed title when generating the internal RSS representation.
Improvement of https://github.com/FreshRSS/FreshRSS/pull/4220
