### PR TITLE
Fix: wrong i18n key in integration.phtml

### DIFF
--- a/app/views/configure/integration.phtml
+++ b/app/views/configure/integration.phtml
@@ -72,7 +72,7 @@
 						<div class="stick">
 							<input type="url" id="share_<?= $key ?>_url" name="share[<?= $key ?>][url]" class="long" value="<?= $share->baseUrl() ?>"
 								data-leave-validation="<?= $share->baseUrl() ?>" required />
-							<a class="btn open-url" target="_blank" rel="noreferrer" href="<?= $share->baseUrl() ?>" title="<?= _t('gen.action.see_url') ?>" data-input="share_<?= $key ?>_url"><?= _i('link') ?></a>
+							<a class="btn open-url" target="_blank" rel="noreferrer" href="<?= $share->baseUrl() ?>" title="<?= _t('gen.action.open_url') ?>" data-input="share_<?= $key ?>_url"><?= _i('link') ?></a>
 						</div>
 						<p class="help"><?= _i('help') ?> <a href="<?= $share->help() ?>" target="_blank" rel="noreferrer"><?= _t('conf.sharing.more_information') ?></a></p>
 					</div>


### PR DESCRIPTION
Fix the found wrong i18n key in integration.phtml (see #4269)

Changes proposed in this pull request:

- fixed the key name

