### PR TITLE
Fix lazyimg single quotes

### DIFF
--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -458,11 +458,16 @@ function validateEmailAddress($email) {
  * Add support of image lazy loading
  * Move content from src attribute to data-original
  * @param string $content is the text we want to parse
+ * @return string
  */
 function lazyimg($content) {
-	return preg_replace(
-		'/<((?:img|iframe)[^>]+?)src=[\'"]([^"\']+)[\'"]([^>]*)>/i',
-		'<$1src="' . Minz_Url::display('/themes/icons/grey.gif') . '" data-original="$2"$3>',
+	return preg_replace([
+			'/<((?:img|iframe)[^>]+?)src="([^"]+)"([^>]*)>/i',
+			"/<((?:img|iframe)[^>]+?)src='([^']+)'([^>]*)>/i",
+		], [
+			'<$1src="' . Minz_Url::display('/themes/icons/grey.gif') . '" data-original="$2"$3>',
+			"<$1src='" . Minz_Url::display('/themes/icons/grey.gif') . "' data-original='$2'$3>",
+		],
 		$content
 	);
 }


### PR DESCRIPTION
Little bug for cases with single quote in URL such as

```html
<img src="123?format='jpg'" />
```

Could probably be replaced by `loading="lazy"` in the future, and with a better DOM-aware method, for instance during SimplePie `add_attributes()`