### PR TITLE
fix depending results after changing value of "entry->isRead"

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -484,8 +484,8 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 
 						if (!$entry->isRead()) {
 							$feed->incPendingUnread();
-							$nb_new_articles++;
 						}
+						$nb_new_articles++;
 					}
 				}
 				$entryDAO->updateLastSeen($feed->id(), $oldGuids, $mtime);

--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -432,16 +432,17 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 						} else {	//This entry already exists but has been updated
 							//Minz_Log::debug('Entry with GUID `' . $entry->guid() . '` updated in feed ' . $feed->url(false) .
 								//', old hash ' . $existingHash . ', new hash ' . $entry->hash());
-							$needFeedCacheRefresh = $mark_updated_article_unread;
 							$entry->_isRead($mark_updated_article_unread ? false : null);	//Change is_read according to policy.
-							if ($mark_updated_article_unread) {
-								$feed->incPendingUnread();	//Maybe
-							}
 
 							$entry = Minz_ExtensionManager::callHook('entry_before_insert', $entry);
 							if ($entry === null) {
 								// An extension has returned a null value, there is nothing to insert.
 								continue;
+							}
+
+							if (!$entry->isRead()) {
+								$needFeedCacheRefresh = true;
+								$feed->incPendingUnread();	//Maybe
 							}
 
 							// If the entry has changed, there is a good chance for the full content to have changed as well.
@@ -480,8 +481,11 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 							$entryDAO->beginTransaction();
 						}
 						$entryDAO->addEntry($entry->toArray());
-						$feed->incPendingUnread();
-						$nb_new_articles++;
+
+						if (!$entry->isRead()) {
+							$feed->incPendingUnread();
+							$nb_new_articles++;
+						}
 					}
 				}
 				$entryDAO->updateLastSeen($feed->id(), $oldGuids, $mtime);


### PR DESCRIPTION
Changes proposed in this pull request:

- if anybody use the hook 'entry_before_insert' and change the value of the property 'entry->isRead', the depending results are correct now.
- In my case my config let all new entrys as "isRead=FALSE" as i will. A new extension which is in progress, can/should/must change the value of this property, but the depending results of this property are wrong before this fix.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
