### PR TITLE
OPML relax error check for non-strict mode

### DIFF
--- a/lib/lib_opml.php
+++ b/lib/lib_opml.php
@@ -150,7 +150,7 @@ function preprocessing_categories($doc) {
  * Parse a string as a XML one and returns the corresponding array
  *
  * @param string $xml is the string we want to parse
- * @param bool $strict true if "text" attribute is required, false else
+ * @param bool $strict true to perform some validation (e.g. require "text" attribute), false to relax
  * @return array corresponding to the XML string and following format described above
  * @throws LibOPML_Exception
  * @access public
@@ -182,9 +182,9 @@ function libopml_parse_string($xml, $strict = true) {
 	foreach ($opml->head->children() as $key => $value) {
 		if (in_array($key, unserialize(HEAD_ELEMENTS), true)) {
 			$array['head'][$key] = (string)$value;
-		} else {
+		} elseif ($strict) {
 			throw new LibOPML_Exception(
-				$key . 'is not part of OPML format'
+				$key . ' is not part of the OPML 2.0 specification'
 			);
 		}
 	}


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/3967

`lib_opml` had a `strict` attribute, which was not applied generally

Related to https://github.com/FreshRSS/FreshRSS/pull/4342