### PR TITLE
User query automatic reconstruct of URL

### DIFF
--- a/app/Models/UserQuery.php
+++ b/app/Models/UserQuery.php
@@ -47,7 +47,10 @@ class FreshRSS_UserQuery {
 		if (isset($query['state'])) {
 			$this->state = $query['state'];
 		}
-		if (isset($query['url'])) {
+		if (empty($query['url'])) {
+			unset($query['name']);
+			$this->url = Minz_Url::display(array('params' => $query));
+		} else {
 			$this->url = $query['url'];
 		}
 	}

--- a/app/Models/UserQuery.php
+++ b/app/Models/UserQuery.php
@@ -39,6 +39,14 @@ class FreshRSS_UserQuery {
 		if (isset($query['order'])) {
 			$this->order = $query['order'];
 		}
+		if (empty($query['url'])) {
+			if (!empty($query)) {
+				unset($query['name']);
+				$this->url = Minz_Url::display(array('params' => $query));
+			}
+		} else {
+			$this->url = $query['url'];
+		}
 		if (!isset($query['search'])) {
 			$query['search'] = '';
 		}
@@ -46,12 +54,6 @@ class FreshRSS_UserQuery {
 		$this->search = new FreshRSS_BooleanSearch($query['search']);
 		if (isset($query['state'])) {
 			$this->state = $query['state'];
-		}
-		if (empty($query['url'])) {
-			unset($query['name']);
-			$this->url = Minz_Url::display(array('params' => $query));
-		} else {
-			$this->url = $query['url'];
 		}
 	}
 

--- a/app/layout/header.phtml
+++ b/app/layout/header.phtml
@@ -40,7 +40,7 @@
 			<a class="btn dropdown-toggle" href="#dropdown-configure"><?= _i('configure') ?></a>
 			<ul class="dropdown-menu scrollbar-thin">
 				<li class="dropdown-header-close"><a class="toggle_aside" href="#close"><?= _i('close') ?></a></li>
-				
+
 				<li class="dropdown-header"><?= _t('gen.menu.account') ?>: <?= htmlspecialchars(Minz_Session::param('currentUser', '_'), ENT_NOQUOTES, 'UTF-8') ?></li>
 				<li class="item"><a href="<?= _url('user', 'profile') ?>"><?= _t('gen.menu.user_profile') ?></a></li>
 				<?php if (FreshRSS_Auth::accessNeedsAction()): ?>


### PR DESCRIPTION
(Invisible through the Web UI, only when working with user configuration files manually)
Avoid the requirement of storing user queries with duplicated information (parsed parameters AND the resulting URL):

Before:
```
[
	'name' => 'Hello',
	'search' => 'Hello OR World',
	'state' => '3',
	'url' => './?search=Hello+OR+World&amp;state=3',
]
```

After:

```
[
	'name' => 'Hello',
	'search' => 'Hello OR World',
	'state' => '3',
]
```
