### PR TITLE
favicon url change

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -229,7 +229,8 @@ class FreshRSS_Feed extends Minz_Model {
 		@unlink($path . '.txt');
 	}
 	public function favicon(): string {
-		return Minz_Url::display('/f.php?' . $this->hash());
+		// return Minz_Url::display('/f.php?' . $this->hash());
+		return Minz_Url::display('/ico-' . $this->hash() . '.ico');
 	}
 
 	public function _id($value) {

--- a/p/.htaccess
+++ b/p/.htaccess
@@ -1,3 +1,6 @@
+RewriteEngine on
+RewriteRule	^ico-([a-zA-Z0-9\-]+)\.ico$	f.php?$1
+
 <IfModule mod_dir.c>
 	DirectoryIndex	index.php index.html
 </IfModule>


### PR DESCRIPTION
Changes proposed in this pull request:

-add favicons ext in url:
-rewriterule: f.php?xxx --> ico-xxx.ico

How to test the feature manually:

1. hosted by myself

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated
---
Additional:
Because some CDN server cache static files by extension so i add it.