### PR TITLE
Improve: reduce size when tagEntry

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1172,6 +1172,7 @@ function init_stream(stream) {
 					name_tag: tagId == 0 ? tagName : '',
 					id_entry: entryId,
 					checked: isChecked,
+					ajax: 1,
 				}));
 			}
 		}


### PR DESCRIPTION
Changes proposed in this pull request:

-When I add a tag to a article, I find that the response is too large. I think it needn't request all contents. So I add a "ajax" opinion.
-Screen Shots:
-Before
![屏幕截图 2022-05-15 141444](https://user-images.githubusercontent.com/35369979/168459803-d99f6ce2-eb0e-4a3b-b059-36fe42cda93c.png)

-After
![屏幕截图 2022-05-15 135254](https://user-images.githubusercontent.com/35369979/168459818-1e615e50-20bc-4282-9898-dfbbf3fc1fc2.png)

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

