### PR TITLE
Fix bug in user query 4360

### DIFF
--- a/app/layout/nav_menu.phtml
+++ b/app/layout/nav_menu.phtml
@@ -39,9 +39,12 @@
 					<a href="<?= _url('configure', 'queries') ?>"><?= _i('configure') ?></a>
 				</li>
 
-				<?php foreach (FreshRSS_Context::$user_conf->queries as $query) { ?>
+				<?php
+					foreach (FreshRSS_Context::$user_conf->queries as $raw_query) {
+						$query = new FreshRSS_UserQuery($raw_query);
+				?>
 				<li class="item query">
-					<a href="<?= $query['url'] ?>"><?= $query['name'] ?></a>
+					<a href="<?= $query->getUrl() ?>"><?= $query->getName() ?></a>
 				</li>
 				<?php } ?>
 


### PR DESCRIPTION
Fix bug when taking advantage of https://github.com/FreshRSS/FreshRSS/pull/4360
At one place, the raw URL parameter was accessed instead of being reconstructed

