### PR TITLE
Remove HTTP Referer for HTML download

### DIFF
--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -405,12 +405,10 @@ function getHtml(string $url, array $attributes = []): string {
 	$ch = curl_init();
 	curl_setopt_array($ch, [
 		CURLOPT_URL => $url,
-		CURLOPT_REFERER => SimplePie_Misc::url_remove_credentials($url),
 		CURLOPT_HTTPHEADER => array('Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'),
 		CURLOPT_USERAGENT => FRESHRSS_USERAGENT,
 		CURLOPT_CONNECTTIMEOUT => $feed_timeout > 0 ? $feed_timeout : $limits['timeout'],
 		CURLOPT_TIMEOUT => $feed_timeout > 0 ? $feed_timeout : $limits['timeout'],
-		//CURLOPT_FAILONERROR => true;
 		CURLOPT_MAXREDIRS => 4,
 		CURLOPT_RETURNTRANSFER => true,
 		CURLOPT_FOLLOWLOCATION => true,


### PR DESCRIPTION
Having this header leads to errors on sites such as LinkedIn. The usage of this header is also decreasing. Finally, we were not sending the actual Referer but just the same URL as the one being fetched.
I suggest to remove for now, and see whether anyone needs it, in which case an option would be possible.
