### PR TITLE
Fix: notification banner behind the slider

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -841,7 +841,6 @@ a.btn {
 	border-radius: 3px;
 	text-align: center;
 	font-weight: bold;
-	z-index: 10;
 	vertical-align: middle;
 }
 

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -841,7 +841,6 @@ a.btn {
 	border-radius: 3px;
 	text-align: center;
 	font-weight: bold;
-	z-index: 10;
 	vertical-align: middle;
 }
 

--- a/p/themes/Ansum/_layout.scss
+++ b/p/themes/Ansum/_layout.scss
@@ -429,7 +429,6 @@
 	left: 0;
 	right: 0;
 	text-align: center;
-	z-index: 10;
 	vertical-align: middle;
 
 	a {

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -1093,7 +1093,6 @@ form th {
 	left: 0;
 	right: 0;
 	text-align: center;
-	z-index: 10;
 	vertical-align: middle;
 }
 .notification a {

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -1093,7 +1093,6 @@ form th {
 	right: 0;
 	left: 0;
 	text-align: center;
-	z-index: 10;
 	vertical-align: middle;
 }
 .notification a {

--- a/p/themes/BlueLagoon/BlueLagoon.css
+++ b/p/themes/BlueLagoon/BlueLagoon.css
@@ -1020,7 +1020,6 @@ a.btn {
 	font-weight: bold;
 	position: absolute;
 	top: 0;
-	z-index: 10;
 	vertical-align: middle;
 }
 

--- a/p/themes/BlueLagoon/BlueLagoon.rtl.css
+++ b/p/themes/BlueLagoon/BlueLagoon.rtl.css
@@ -1020,7 +1020,6 @@ a.btn {
 	font-weight: bold;
 	position: absolute;
 	top: 0;
-	z-index: 10;
 	vertical-align: middle;
 }
 

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -898,7 +898,6 @@ a.btn {
 	box-shadow: 0 0 5px #666;
 	text-align: center;
 	font-weight: bold;
-	z-index: 10;
 	vertical-align: middle;
 }
 

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -898,7 +898,6 @@ a.btn {
 	box-shadow: 0 0 5px #666;
 	text-align: center;
 	font-weight: bold;
-	z-index: 10;
 	vertical-align: middle;
 }
 

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -900,7 +900,6 @@ a.btn {
 	border-radius: 3px;
 	text-align: center;
 	font-weight: bold;
-	z-index: 10;
 	vertical-align: middle;
 }
 

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -900,7 +900,6 @@ a.btn {
 	border-radius: 3px;
 	text-align: center;
 	font-weight: bold;
-	z-index: 10;
 	vertical-align: middle;
 }
 

--- a/p/themes/Mapco/_layout.scss
+++ b/p/themes/Mapco/_layout.scss
@@ -434,7 +434,6 @@
 	right: 0;
 	text-align: center;
 	line-height: 3em;
-	z-index: 10;
 	vertical-align: middle;
 
 	.msg {

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -1082,7 +1082,6 @@ form th {
 	right: 0;
 	text-align: center;
 	line-height: 3em;
-	z-index: 10;
 	vertical-align: middle;
 }
 .notification .msg {

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -1082,7 +1082,6 @@ form th {
 	left: 0;
 	text-align: center;
 	line-height: 3em;
-	z-index: 10;
 	vertical-align: middle;
 }
 .notification .msg {

--- a/p/themes/Origine-compact/origine-compact.css
+++ b/p/themes/Origine-compact/origine-compact.css
@@ -973,7 +973,6 @@ a.btn,
 	box-shadow: 0 0 5px #ddd;
 	text-align: center;
 	font-weight: bold;
-	z-index: 10;
 	vertical-align: middle;
 }
 

--- a/p/themes/Origine-compact/origine-compact.rtl.css
+++ b/p/themes/Origine-compact/origine-compact.rtl.css
@@ -973,7 +973,6 @@ a.btn,
 	box-shadow: 0 0 5px #ddd;
 	text-align: center;
 	font-weight: bold;
-	z-index: 10;
 	vertical-align: middle;
 }
 

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -903,7 +903,6 @@ a.btn {
 	box-shadow: 0 0 5px #ddd;
 	text-align: center;
 	font-weight: bold;
-	z-index: 10;
 	vertical-align: middle;
 }
 

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -903,7 +903,6 @@ a.btn {
 	box-shadow: 0 0 5px #ddd;
 	text-align: center;
 	font-weight: bold;
-	z-index: 10;
 	vertical-align: middle;
 }
 

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -898,7 +898,6 @@ a.signin {
 	box-shadow: 0 0 5px #ddd;
 	text-align: center;
 	font-weight: bold;
-	z-index: 10;
 	vertical-align: middle;
 }
 

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -898,7 +898,6 @@ a.signin {
 	box-shadow: 0 0 5px #ddd;
 	text-align: center;
 	font-weight: bold;
-	z-index: 10;
 	vertical-align: middle;
 }
 

--- a/p/themes/Screwdriver/screwdriver.css
+++ b/p/themes/Screwdriver/screwdriver.css
@@ -993,7 +993,6 @@ a.btn {
 	font-weight: bold;
 	position: absolute;
 	top: 0;
-	z-index: 10;
 	vertical-align: middle;
 }
 

--- a/p/themes/Screwdriver/screwdriver.rtl.css
+++ b/p/themes/Screwdriver/screwdriver.rtl.css
@@ -993,7 +993,6 @@ a.btn {
 	font-weight: bold;
 	position: absolute;
 	top: 0;
-	z-index: 10;
 	vertical-align: middle;
 }
 

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -777,7 +777,6 @@ form th {
 	border: none;
 	text-align: center;
 	font-weight: bold;
-	z-index: 10;
 	vertical-align: middle;
 	position: fixed;
 	bottom: 48px;

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -777,7 +777,6 @@ form th {
 	border: none;
 	text-align: center;
 	font-weight: bold;
-	z-index: 10;
 	vertical-align: middle;
 	position: fixed;
 	bottom: 48px;

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -979,7 +979,6 @@ form {
 	border: none;
 	text-align: center;
 	font-weight: bold;
-	z-index: 10;
 	vertical-align: middle;
 	position: fixed;
 	bottom: 48px;

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -1176,7 +1176,7 @@ br {
 	position: absolute;
 	top: 1em;
 	left: 25%; right: 25%;
-	z-index: 10;
+	z-index: 9999;
 	background: #fff;
 	border: 1px solid #aaa;
 	opacity: 1;

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -1176,7 +1176,7 @@ br {
 	position: absolute;
 	top: 1em;
 	right: 25%; left: 25%;
-	z-index: 10;
+	z-index: 9999;
 	background: #fff;
 	border: 1px solid #aaa;
 	opacity: 1;


### PR DESCRIPTION
Before:
The notification banner is behind the slider and the grey background (difficult to read and not clickable)
![grafik](https://user-images.githubusercontent.com/1645099/169691000-1b5453b4-c287-45ee-aa22-320512cf765f.png)

After:
banner is better visible and clickable
![grafik](https://user-images.githubusercontent.com/1645099/169691003-1bfbda67-5983-48f9-852d-295d4bc7e014.png)


Changes proposed in this pull request:

- CSS files: edit the z-index of template.css and deleted the z-index from all themes

How to test the feature manually:

1. Open a slider (f.e. subscription management: edit a feed)
2. save it
3. see the banner

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
