### PR TITLE
Fix: Space between favicon and feed name

### DIFF
--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -95,6 +95,7 @@ img {
 }
 
 img.favicon {
+	margin: 0 0.25rem 0 0;
 	width: 16px;
 	height: 16px;
 	vertical-align: middle;

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -95,7 +95,7 @@ img {
 }
 
 img.favicon {
-	margin: 0 0.25rem 0 0;
+	margin: 0 0 0 0.25rem;
 	width: 16px;
 	height: 16px;
 	vertical-align: middle;

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -95,6 +95,7 @@ img {
 }
 
 img.favicon {
+	margin: 0 0.25rem 0 0;
 	width: 16px;
 	height: 16px;
 	vertical-align: middle;


### PR DESCRIPTION
Before:
No space between favicon and feed name
![grafik](https://user-images.githubusercontent.com/1645099/169691455-f7806529-57ce-48be-876b-0a1ba7d76b3a.png)


After:
some space between favicon and feed name
![grafik](https://user-images.githubusercontent.com/1645099/169691418-fa4b3c81-d3e8-4b44-ac9e-87df42230a7e.png)


Changes proposed in this pull request:

- template.css


How to test the feature manually:

1. see the feed list


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
