### PR TITLE
Fix warning with icons

### DIFF
--- a/app/Models/Themes.php
+++ b/app/Models/Themes.php
@@ -128,7 +128,7 @@ class FreshRSS_Themes extends Minz_Model {
 			return Minz_Url::display($url);
 		}
 
-		if (FreshRSS_Context::$user_conf->icons_as_emojis) {
+		if (FreshRSS_Context::$user_conf && FreshRSS_Context::$user_conf->icons_as_emojis) {
 			return '<span class="icon">' . $alt . '</span>';
 		}
 


### PR DESCRIPTION
Fix warning in cases when the user context is not yet available, for instance during install
Fix regression from https://github.com/FreshRSS/FreshRSS/pull/4353

