### PR TITLE
Slider: close via shortcut

### DIFF
--- a/app/views/extension/index.phtml
+++ b/app/views/extension/index.phtml
@@ -80,9 +80,6 @@
 </main>
 
 <?php $class = isset($this->extension) ? ' active' : ''; ?>
-<a href="#" id="close-slider" class="<?= $class ?>">
-	<?= _i('close') ?>
-</a>
 <aside id="slider" class="scrollbar-thin<?= $class ?>">
 	<?php
 		if (isset($this->extension)) {
@@ -90,3 +87,6 @@
 		}
 	?>
 </aside>
+<a href="#" id="close-slider" class="<?= $class ?>">
+	<?= _i('close') ?>
+</a>

--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -135,10 +135,10 @@ $today = @strtotime('today');
 <?php endif; ?>
 
 <?php $class = $this->displaySlider ? ' active' : ''; ?>
+<aside id="slider" class="scrollbar-thin<?= $class ?>">
+</aside>
 <a href="#" id="close-slider" class="<?= $class ?>">
 	<?= _i('close') ?>
 </a>
-<aside id="slider" class="scrollbar-thin<?= $class ?>">
-</aside>
 
 <?php if ($nbEntries > 0 && FreshRSS_Context::$user_conf->show_nav_buttons) $this->partial('nav_entries'); ?>

--- a/app/views/stats/idle.phtml
+++ b/app/views/stats/idle.phtml
@@ -51,9 +51,6 @@
 </main>
 
 <?php $class = $this->displaySlider ? ' active' : ''; ?>
-<a href="#" id="close-slider" class="<?= $class ?>">
-	<?= _i('close') ?>
-</a>
 <aside id="slider" class="scrollbar-thin<?= $class ?>">
 	<?php
 		if (isset($this->feed)) {
@@ -61,3 +58,6 @@
 		}
 	?>
 </aside>
+<a href="#" id="close-slider" class="<?= $class ?>">
+	<?= _i('close') ?>
+</a>

--- a/app/views/subscription/index.phtml
+++ b/app/views/subscription/index.phtml
@@ -76,9 +76,6 @@
 </main>
 
 <?php $class = $this->displaySlider ? ' active' : ''; ?>
-<a href="#" id="close-slider" class="<?= $class ?>">
-	<?= _i('close') ?>
-</a>
 <aside id="slider" class="scrollbar-thin<?= $class ?>">
 	<?php
 		if (isset($this->feed)) {
@@ -88,3 +85,6 @@
 		}
 	?>
 </aside>
+<a href="#" id="close-slider" class="<?= $class ?>">
+	<?= _i('close') ?>
+</a>

--- a/p/scripts/extra.js
+++ b/p/scripts/extra.js
@@ -148,7 +148,7 @@ function open_slider_listener(ev) {
 	const a = ev.target.closest('.open-slider');
 	if (a) {
 		if (!context.ajax_loading) {
-			location.href = '#'; // close menu/dropdown
+			location.href = '#slider'; // close menu/dropdown
 			context.ajax_loading = true;
 
 			const req = new XMLHttpRequest();
@@ -156,11 +156,8 @@ function open_slider_listener(ev) {
 			req.responseType = 'document';
 			req.onload = function (e) {
 				const slider = document.getElementById('slider');
-				const closer = document.getElementById('close-slider');
 				slider.scrollTop = 0;
 				slider.innerHTML = this.response.body.innerHTML;
-				slider.classList.add('active');
-				closer.classList.add('active');
 				context.ajax_loading = false;
 				slider.dispatchEvent(freshrssSliderLoadEvent);
 			};
@@ -177,8 +174,6 @@ function init_slider(slider) {
 	closer.addEventListener('click', function (ev) {
 		if (data_leave_validation(slider) || confirm(context.i18n.confirmation_default)) {
 			slider.querySelectorAll('form').forEach(function (f) { f.reset(); });
-			closer.classList.remove('active');
-			slider.classList.remove('active');
 			return true;
 		} else {
 			return false;

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -864,7 +864,6 @@ function init_column_categories() {
 }
 
 function init_shortcuts() {
-	console.log('shortcuts');
 	Object.keys(context.shortcuts).forEach(function (k) {
 		context.shortcuts[k] = (context.shortcuts[k] || '').toUpperCase();
 	});

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -864,6 +864,7 @@ function init_column_categories() {
 }
 
 function init_shortcuts() {
+	console.log('shortcuts');
 	Object.keys(context.shortcuts).forEach(function (k) {
 		context.shortcuts[k] = (context.shortcuts[k] || '').toUpperCase();
 	});
@@ -1718,7 +1719,6 @@ function init_normal() {
 	}
 	init_column_categories();
 	init_stream(stream);
-	init_shortcuts();
 	init_actualize();
 	faviconNbUnread();
 
@@ -1735,6 +1735,7 @@ function init_normal() {
 
 function init_main_beforeDOM() {
 	document.scrollingElement.scrollTop = 0;
+	init_shortcuts();
 	if (['normal', 'reader', 'global'].indexOf(context.current_view) >= 0) {
 		init_normal();
 	}

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -1444,7 +1444,7 @@ br {
 	z-index: 100;
 }
 
-#slider.active {
+#slider:target {
 	width: 750px;
 }
 
@@ -1455,7 +1455,7 @@ br {
 	cursor: pointer;
 }
 
-#close-slider.active {
+#slider:target + #close-slider {
 	background: rgba(0, 0, 0, 0.2);
 	font-size: 0;
 	left: 0;
@@ -1466,7 +1466,7 @@ br {
 	display: none;
 }
 
-#close-slider.active img {
+#slider:target + #close-slider img {
 	padding: 0.5rem;
 	display: inline-block;
 	position: absolute;

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -1444,7 +1444,7 @@ br {
 	z-index: 100;
 }
 
-#slider.active {
+#slider:target {
 	width: 750px;
 }
 
@@ -1455,7 +1455,7 @@ br {
 	cursor: pointer;
 }
 
-#close-slider.active {
+#slider:target + #close-slider {
 	background: rgba(0, 0, 0, 0.2);
 	font-size: 0;
 	right: 0;
@@ -1466,7 +1466,7 @@ br {
 	display: none;
 }
 
-#close-slider.active img {
+#slider:target + #close-slider img {
 	padding: 0.5rem;
 	display: inline-block;
 	position: absolute;


### PR DESCRIPTION
Before:
It made me odd, that the slider cannot be closed via a shortcut (f.e. `ESC`).

After:
The sliders can be closed via the shortcut that closes the menu.

Additional: Via shortcut (f.e. `F1`), you can now open the documentation everywhere.

Changes proposed in this pull request:

- sliders open/close via anchor (the same as the menus) (before: sliders worked only with JavaScript)
- shortcuts are available everywhere (before: only in the feed streams)
- HTML: slider closer is now after the slider (same as the menus)

How to test the feature manually:

1. open the sliders (f.e. subscription management -> config a feed or category; or config an extension manager ->config an extension)
2. the slider opens
3. close the slider via "close menus" shortcut  (f.e. `ESC`)

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested