### PR TITLE
No XPath error on empty list

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -636,10 +636,6 @@ class FreshRSS_Feed extends Minz_Model {
 			return null;
 		}
 
-		if (count($view->entries) < 1) {
-			return null;
-		}
-
 		$simplePie = customSimplePie();
 		$simplePie->set_raw_data($view->renderToString());
 		$simplePie->init();


### PR DESCRIPTION
Set feed error state to true if the *list* of items cannot be find by XPath, but do not set the error state to true if that list happens to be empty (the resulting feed will be with an *empty* state instead of *error* state)
Follow-up of https://github.com/FreshRSS/FreshRSS/pull/4220
