### PR TITLE
Use keyword "static"

### DIFF
--- a/app/Services/ImportService.php
+++ b/app/Services/ImportService.php
@@ -70,7 +70,7 @@ class FreshRSS_Import_Service {
 		$limits = FreshRSS_Context::$system_conf->limits;
 
 		//Sort with categories first
-		usort($opml_elements, function ($a, $b) {
+		usort($opml_elements, static function ($a, $b) {
 			return strcmp(
 				(isset($a['xmlUrl']) ? 'Z' : 'A') . (isset($a['text']) ? $a['text'] : ''),
 				(isset($b['xmlUrl']) ? 'Z' : 'A') . (isset($b['text']) ? $b['text'] : ''));


### PR DESCRIPTION
static closure
While methods may be static or not, function has no such alternative : they just can’t be static. Yet, there is one final type of method that may be static : static closures.
Closure are functions that may be stored in a variable : functions may have their name stored in a variable, though. Closure also have the ability to aggregate variables from the context of their creation, for future use. As such, $this is available in a closure that is created inside an object.
See more ... https://www.exakat.io/en/5-usages-of-static-keyword-in-php/
