### PR TITLE
Fix #4447: Nord theme

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -4,7 +4,6 @@
 /*============*/
 html, body {
 	background: #171717;
-	height: 100%;
 	color: #999;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 }

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -4,7 +4,6 @@
 /*============*/
 html, body {
 	background: #171717;
-	height: 100%;
 	color: #999;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 }

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -1571,7 +1571,6 @@ form th {
 /*============*/
 html, body {
 	background: #f5f0ec;
-	height: 100%;
 	font-family: "lato", "Helvetica", "Arial", sans-serif;
 	font-size: 0.875rem;
 }

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -1571,7 +1571,6 @@ form th {
 /*============*/
 html, body {
 	background: #f5f0ec;
-	height: 100%;
 	font-family: "lato", "Helvetica", "Arial", sans-serif;
 	font-size: 0.875rem;
 }

--- a/p/themes/Ansum/ansum.scss
+++ b/p/themes/Ansum/ansum.scss
@@ -36,7 +36,6 @@
 /*============*/
 html, body {
 	background: variables.$grey-light;
-	height: 100%;
 	font-family: "lato", "Helvetica", "Arial", sans-serif;
 	font-size: 0.875rem;
 }

--- a/p/themes/BlueLagoon/BlueLagoon.css
+++ b/p/themes/BlueLagoon/BlueLagoon.css
@@ -4,7 +4,6 @@
 /*============*/
 html, body {
 	background: #fafafa;
-	height: 100%;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 	font-size: 92%;
 }

--- a/p/themes/BlueLagoon/BlueLagoon.rtl.css
+++ b/p/themes/BlueLagoon/BlueLagoon.rtl.css
@@ -4,7 +4,6 @@
 /*============*/
 html, body {
 	background: #fafafa;
-	height: 100%;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 	font-size: 92%;
 }

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -4,7 +4,6 @@
 /*============*/
 html, body {
 	background: #1c1c1c;
-	height: 100%;
 	color: #888;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 }

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -4,7 +4,6 @@
 /*============*/
 html, body {
 	background: #1c1c1c;
-	height: 100%;
 	color: #888;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 }

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -4,7 +4,6 @@
 /*============*/
 html, body {
 	background: #fafafa;
-	height: 100%;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 }
 

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -4,7 +4,6 @@
 /*============*/
 html, body {
 	background: #fafafa;
-	height: 100%;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 }
 

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -1556,7 +1556,6 @@ form th {
 /*============*/
 html, body {
 	background: #eff0f2;
-	height: 100%;
 	font-family: "lato", "Helvetica", "Arial", sans-serif;
 	font-size: 0.875rem;
 }

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -1556,7 +1556,6 @@ form th {
 /*============*/
 html, body {
 	background: #eff0f2;
-	height: 100%;
 	font-family: "lato", "Helvetica", "Arial", sans-serif;
 	font-size: 0.875rem;
 }

--- a/p/themes/Mapco/mapco.scss
+++ b/p/themes/Mapco/mapco.scss
@@ -36,7 +36,6 @@
 /*============*/
 html, body {
 	background: variables.$grey-light;
-	height: 100%;
 	font-family: "lato", "Helvetica", "Arial", sans-serif;
 	font-size: 0.875rem;
 }

--- a/p/themes/Origine-compact/origine-compact.css
+++ b/p/themes/Origine-compact/origine-compact.css
@@ -4,7 +4,6 @@
 /*============*/
 html, body {
 	background: #fafafa;
-	height: 100%;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 }
 

--- a/p/themes/Origine-compact/origine-compact.rtl.css
+++ b/p/themes/Origine-compact/origine-compact.rtl.css
@@ -4,7 +4,6 @@
 /*============*/
 html, body {
 	background: #fafafa;
-	height: 100%;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 }
 

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -4,7 +4,6 @@
 /*============*/
 html, body {
 	background: #fafafa;
-	height: 100%;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 }
 

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -4,7 +4,6 @@
 /*============*/
 html, body {
 	background: #fafafa;
-	height: 100%;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 }
 

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -4,7 +4,6 @@
 /*============*/
 html, body {
 	background: #fafafa;
-	height: 100%;
 	color: #666;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 }

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -4,7 +4,6 @@
 /*============*/
 html, body {
 	background: #fafafa;
-	height: 100%;
 	color: #666;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 }

--- a/p/themes/Screwdriver/screwdriver.css
+++ b/p/themes/Screwdriver/screwdriver.css
@@ -4,7 +4,6 @@
 /*============*/
 html, body {
 	background: #fafafa;
-	height: 100%;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 	font-size: 92%;
 }

--- a/p/themes/Screwdriver/screwdriver.rtl.css
+++ b/p/themes/Screwdriver/screwdriver.rtl.css
@@ -4,7 +4,6 @@
 /*============*/
 html, body {
 	background: #fafafa;
-	height: 100%;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 	font-size: 92%;
 }

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -44,7 +44,6 @@ select:invalid {
 
 html,
 body {
-	height: 100%;
 	font-family: Helvetica, Arial, sans-serif;
 }
 

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -44,7 +44,6 @@ select:invalid {
 
 html,
 body {
-	height: 100%;
 	font-family: Helvetica, Arial, sans-serif;
 }
 

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -58,7 +58,6 @@ $color_hover:	#fff;
 // /@extend-elements
 html,
 body {
-	height: 100%;
 	font-family: Helvetica, Arial, sans-serif;
 }
 

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -15,8 +15,8 @@
 html, body {
 	margin: 0;
 	padding: 0;
-	height: 100%;
 	background: white;
+	height: 100%;
 	color: black;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif;
 	font-size: 100%;

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -15,6 +15,7 @@
 html, body {
 	margin: 0;
 	padding: 0;
+	height: 100%;
 	background: white;
 	color: black;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif;

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -15,8 +15,8 @@
 html, body {
 	margin: 0;
 	padding: 0;
-	height: 100%;
 	background: white;
+	height: 100%;
 	color: black;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif;
 	font-size: 100%;

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -15,6 +15,7 @@
 html, body {
 	margin: 0;
 	padding: 0;
+	height: 100%;
 	background: white;
 	color: black;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif;


### PR DESCRIPTION
Closes #4447 
ref. #4400

Changes proposed in this pull request:

- `html` need `height: 100%`
- added it to `template.css`
- removed `html {height: 100%}` from the themes, because it is included in `template.css` now

How to test the feature manually:

1. use `Nord theme`
2. scroll in normal view down
3. check, that it does not loead to much next articles

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested