### PR TITLE
Fix: header height

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -500,7 +500,6 @@ a.btn {
 /*=== Header */
 .header {
 	background: #171717;
-	height: 85px;
 }
 
 .header > .item {
@@ -528,10 +527,6 @@ a.btn {
 }
 
 /*=== Body */
-#global {
-	height: calc(100% - 85px);
-}
-
 .aside {
 	background: #262626;
 }

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -500,7 +500,6 @@ a.btn {
 /*=== Header */
 .header {
 	background: #171717;
-	height: 85px;
 }
 
 .header > .item {
@@ -528,10 +527,6 @@ a.btn {
 }
 
 /*=== Body */
-#global {
-	height: calc(100% - 85px);
-}
-
 .aside {
 	background: #262626;
 }

--- a/p/themes/Ansum/_layout.scss
+++ b/p/themes/Ansum/_layout.scss
@@ -10,6 +10,7 @@
 	background: variables.$sid-bg;
 	display: block;
 	width: auto;
+	height: 3rem;
 	table-layout: none;
 
 	.item {
@@ -101,13 +102,11 @@
 			}
 		}
 	}
-
-
 }
 
 /*=== Body */
 #global {
-	height: calc(100% - 85px);
+	height: calc(100% - 4rem);
 }
 
 

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -771,6 +771,7 @@ form th {
 	background: #fbf9f6;
 	display: block;
 	width: auto;
+	height: 3rem;
 	table-layout: none;
 }
 .header .item {
@@ -835,7 +836,7 @@ form th {
 }
 /*=== Body */
 #global {
-	height: calc(100% - 85px);
+	height: calc(100% - 4rem);
 }
 
 /*=== Prompt (centered) */

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -771,6 +771,7 @@ form th {
 	background: #fbf9f6;
 	display: block;
 	width: auto;
+	height: 3rem;
 	table-layout: none;
 }
 .header .item {
@@ -835,7 +836,7 @@ form th {
 }
 /*=== Body */
 #global {
-	height: calc(100% - 85px);
+	height: calc(100% - 4rem);
 }
 
 /*=== Prompt (centered) */

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -597,11 +597,6 @@ a.btn {
 	width: 350px;
 }
 
-/*=== Body */
-#global {
-	height: calc(100% - 85px);
-}
-
 .aside {
 	background: #1c1c1c;
 	border-right: 1px solid #333;

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -597,11 +597,6 @@ a.btn {
 	width: 350px;
 }
 
-/*=== Body */
-#global {
-	height: calc(100% - 85px);
-}
-
 .aside {
 	background: #1c1c1c;
 	border-left: 1px solid #333;

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -600,11 +600,6 @@ a.btn {
 	width: 350px;
 }
 
-/*=== Body */
-#global {
-	height: calc(100% - 85px);
-}
-
 .aside {
 	background: #ecf0f1;
 }

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -600,11 +600,6 @@ a.btn {
 	width: 350px;
 }
 
-/*=== Body */
-#global {
-	height: calc(100% - 85px);
-}
-
 .aside {
 	background: #ecf0f1;
 }

--- a/p/themes/Mapco/_layout.scss
+++ b/p/themes/Mapco/_layout.scss
@@ -10,6 +10,7 @@
 	background: variables.$sid-bg;
 	display: block;
 	width: auto;
+	height: 3rem;
 	table-layout: none;
 
 	.logo {
@@ -110,11 +111,8 @@
 
 /*=== Body */
 #global {
-	height: calc(100% - 85px);
+	height: calc(100% - 4rem);
 }
-
-
-
 
 /*=== Prompt (centered) */
 .prompt {

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -758,6 +758,7 @@ form th {
 	background: #303136;
 	display: block;
 	width: auto;
+	height: 3rem;
 	table-layout: none;
 }
 .header .logo {
@@ -825,7 +826,7 @@ form th {
 }
 /*=== Body */
 #global {
-	height: calc(100% - 85px);
+	height: calc(100% - 4rem);
 }
 
 /*=== Prompt (centered) */

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -758,6 +758,7 @@ form th {
 	background: #303136;
 	display: block;
 	width: auto;
+	height: 3rem;
 	table-layout: none;
 }
 .header .logo {
@@ -825,7 +826,7 @@ form th {
 }
 /*=== Body */
 #global {
-	height: calc(100% - 85px);
+	height: calc(100% - 4rem);
 }
 
 /*=== Prompt (centered) */

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -431,10 +431,6 @@ img.favicon {
 /*=== STRUCTURE */
 /*===============*/
 /*=== Header */
-.header {
-	height: 85px;
-}
-
 .header > .item {
 	padding: 10px;
 	vertical-align: middle;
@@ -467,10 +463,6 @@ img.favicon {
 }
 
 /*=== Body */
-#global {
-	height: calc(100% - 85px);
-}
-
 .aside {
 	background-color: var(--accent-bg);
 	border-radius: 12px;

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -431,10 +431,6 @@ img.favicon {
 /*=== STRUCTURE */
 /*===============*/
 /*=== Header */
-.header {
-	height: 85px;
-}
-
 .header > .item {
 	padding: 10px;
 	vertical-align: middle;
@@ -467,10 +463,6 @@ img.favicon {
 }
 
 /*=== Body */
-#global {
-	height: calc(100% - 85px);
-}
-
 .aside {
 	background-color: var(--accent-bg);
 	border-radius: 12px;

--- a/p/themes/Origine-compact/origine-compact.css
+++ b/p/themes/Origine-compact/origine-compact.css
@@ -627,7 +627,7 @@ a.btn,
 
 /*=== Body */
 #global {
-	height: calc(100% - 85px);
+	height: calc(100vh - 40px);
 }
 
 .aside {

--- a/p/themes/Origine-compact/origine-compact.rtl.css
+++ b/p/themes/Origine-compact/origine-compact.rtl.css
@@ -627,7 +627,7 @@ a.btn,
 
 /*=== Body */
 #global {
-	height: calc(100% - 40px);
+	height: calc(100vh - 40px);
 }
 
 .aside {

--- a/p/themes/Origine-compact/origine-compact.rtl.css
+++ b/p/themes/Origine-compact/origine-compact.rtl.css
@@ -627,7 +627,7 @@ a.btn,
 
 /*=== Body */
 #global {
-	height: calc(100% - 85px);
+	height: calc(100% - 40px);
 }
 
 .aside {

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -599,10 +599,6 @@ a.btn {
 }
 
 /*=== Body */
-#global {
-	height: calc(100% - 85px);
-}
-
 .aside {
 	background: #fff;
 	border-right: 1px solid #aaa;

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -599,10 +599,6 @@ a.btn {
 }
 
 /*=== Body */
-#global {
-	height: calc(100% - 85px);
-}
-
 .aside {
 	background: #fff;
 	border-left: 1px solid #aaa;

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -570,10 +570,6 @@ a.signin {
 }
 
 /*=== Body */
-#global {
-	height: calc(100% - 85px);
-}
-
 .aside {
 	background: #fff;
 	border-right: 1px solid #aaa;

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -570,10 +570,6 @@ a.signin {
 }
 
 /*=== Body */
-#global {
-	height: calc(100% - 85px);
-}
-
 .aside {
 	background: #fff;
 	border-left: 1px solid #aaa;

--- a/p/themes/Screwdriver/screwdriver.css
+++ b/p/themes/Screwdriver/screwdriver.css
@@ -645,7 +645,7 @@ a.btn {
 /*=== Body */
 #global {
 	background: #ede7de;
-	height: calc(100% - 60px);
+	height: calc(100% - 55px);
 }
 
 .aside {

--- a/p/themes/Screwdriver/screwdriver.rtl.css
+++ b/p/themes/Screwdriver/screwdriver.rtl.css
@@ -645,7 +645,7 @@ a.btn {
 /*=== Body */
 #global {
 	background: #ede7de;
-	height: calc(100% - 60px);
+	height: calc(100% - 55px);
 }
 
 .aside {

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -570,6 +570,9 @@ form th {
 		background: rgba(255, 255, 255, 0.3);
 	}
 }
+.header {
+	height: auto;
+}
 .header > .item {
 	vertical-align: middle;
 }
@@ -665,6 +668,10 @@ form th {
 }
 .prompt p {
 	margin: 20px 0;
+}
+
+#global {
+	height: 100vh;
 }
 
 #new-article {

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -570,6 +570,9 @@ form th {
 		background: rgba(255, 255, 255, 0.3);
 	}
 }
+.header {
+	height: auto;
+}
 .header > .item {
 	vertical-align: middle;
 }
@@ -665,6 +668,10 @@ form th {
 }
 .prompt p {
 	margin: 20px 0;
+}
+
+#global {
+	height: 100vh;
 }
 
 #new-article {

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -874,6 +874,7 @@ li.drag-hover {
 .header {
 	display: table;
 	width: 100%;
+	height: 85px;
 	table-layout: fixed;
 }
 
@@ -909,7 +910,7 @@ input[type="search"] {
 	background: inherit;
 	display: table;
 	width: 100%;
-	height: 100%;
+	height: calc(100vh - 85px);
 	table-layout: fixed;
 }
 

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -874,6 +874,7 @@ li.drag-hover {
 .header {
 	display: table;
 	width: 100%;
+	height: 85px;
 	table-layout: fixed;
 }
 
@@ -909,7 +910,7 @@ input[type="search"] {
 	background: inherit;
 	display: table;
 	width: 100%;
-	height: 100%;
+	height: calc(100vh - 85px);
 	table-layout: fixed;
 }
 


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/1645099/179499292-d34d81e2-70b4-425e-9a18-3d26c4c545b1.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/179499388-d64df1b6-4c43-443b-b38a-01cfae8ba2ed.png)


Changes proposed in this pull request:

- Set a fixed height to the header
- calculate the height of the `#global`
- default header height is now 85px (some themes have another height)

How to test the feature manually:

1. test it with every theme
2. go to normal view and mark all articles as read
3. check the left navigation footer

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested