### PR TITLE
fixed: add .pagination .item a:hover to scss

### DIFF
--- a/p/themes/Ansum/_components.scss
+++ b/p/themes/Ansum/_components.scss
@@ -185,6 +185,11 @@
 			font-style: italic;
 			line-height: 3em;
 			text-decoration: none;
+
+			&:hover {
+				background: #363330;
+				color: #f5f0ec;
+			}
 		}
 	}
 }

--- a/p/themes/Mapco/_components.scss
+++ b/p/themes/Mapco/_components.scss
@@ -180,9 +180,13 @@
 			font-style: italic;
 			line-height: 3em;
 			text-decoration: none;
+
+			&:hover {
+				background: #303136;
+				color: #eff0f2;
+			}
 		}
 	}
-
 }
 
 #load_more.loading,
@@ -196,7 +200,6 @@
 	// border: 1px solid #ddd;
 	border: none;
 	border-radius: 3px;
-
 	box-shadow: 0px 2px 2px 0px rgba(0,0,0,0.25);
 
 	.box-title {
@@ -232,7 +235,6 @@
 				}
 			}
 		}
-
 
 		form {
 			input {

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -354,6 +354,7 @@ form th {
 	background: #303136;
 	color: #eff0f2;
 }
+
 #load_more.loading,
 #load_more.loading:hover {
 	background: url("loader.gif") center center no-repeat #34495e;

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -354,6 +354,7 @@ form th {
 	background: #303136;
 	color: #eff0f2;
 }
+
 #load_more.loading,
 #load_more.loading:hover {
 	background: url("loader.gif") center center no-repeat #34495e;


### PR DESCRIPTION
Changes proposed in this pull request:

- backport from `.pagination .item a:hover` from CSS file to SCSS files

How to test the feature manually:

1. the hover of pagination is affected
2. affected themes: Ansum and Mapco
3. pagination is used in configs -> logs (hover over the page numbers)

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
