### PR TITLE
delete the link style given by default

### DIFF
--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -1179,18 +1179,6 @@ a.website:hover .favicon {
 	padding-bottom: 1rem;
 }
 
-.content > header a,
-.content > footer a {
-	color: #666;
-	text-decoration: none;
-}
-
-.content > header a:hover,
-.content > footer a:hover {
-	color: #0062be;
-	text-decoration: underline;
-}
-
 .content > header .tags,
 .content > footer .tags {
 	display: flex;

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -1179,18 +1179,6 @@ a.website:hover .favicon {
 	padding-bottom: 1rem;
 }
 
-.content > header a,
-.content > footer a {
-	color: #666;
-	text-decoration: none;
-}
-
-.content > header a:hover,
-.content > footer a:hover {
-	color: #0062be;
-	text-decoration: underline;
-}
-
 .content > header .tags,
 .content > footer .tags {
 	display: flex;


### PR DESCRIPTION
Closes https://github.com/FreshRSS/FreshRSS/pull/4101#issuecomment-1193118608

Changes proposed in this pull request:

- delete the given default style by #4101


How to test the feature manually:

1. see the article header+footer in different themes


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
