### PR TITLE
Fix: logs page=0 error

### DIFF
--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -371,7 +371,10 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 		$logs = FreshRSS_LogDAO::lines();	//TODO: ask only the necessary lines
 
 		//gestion pagination
-		$page = Minz_Request::param('page', 1);
+		$page = intval(Minz_Request::param('page', 1));
+		if ($page < 1) {
+			$page = 1;
+		}
 		$this->view->logsPaginator = new Minz_Paginator($logs);
 		$this->view->logsPaginator->_nbItemsPerPage(50);
 		$this->view->logsPaginator->_currentPage($page);

--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -372,9 +372,6 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 
 		//gestion pagination
 		$page = intval(Minz_Request::param('page', 1));
-		if ($page < 1) {
-			$page = 1;
-		}
 		$this->view->logsPaginator = new Minz_Paginator($logs);
 		$this->view->logsPaginator->_nbItemsPerPage(50);
 		$this->view->logsPaginator->_currentPage($page);

--- a/app/views/helpers/logs_pagination.phtml
+++ b/app/views/helpers/logs_pagination.phtml
@@ -17,9 +17,12 @@
 		</li>
 
 		<?php $params[$getteur] = $this->currentPage - 1; ?>
+
+		<?php if ($this->currentPage > 1) { ?>
 		<li class="item pager-previous">
 			<a href="<?= Minz_Url::display(array('c' => $c, 'a' => $a, 'params' => $params)) ?>">‹ <?= _t('conf.logs.pagination.previous') ?></a>
 		</li>
+		<?php } ?>
 
 		<?php if ($this->currentPage - 2 > 1) { ?>
 		<li class="item">…</a></li>
@@ -46,9 +49,11 @@
 		<?php } ?>
 
 		<?php $params[$getteur] = $this->currentPage + 1; ?>
+		<?php if ($this->currentPage < $this->nbPage) { ?>
 		<li class="item pager-next">
 			<a href="<?= Minz_Url::display(array('c' => $c, 'a' => $a, 'params' => $params)) ?>"><?= _t('conf.logs.pagination.next') ?> ›</a>
 		</li>
+		<?php } ?>
 		<?php $params[$getteur] = $this->nbPage; ?>
 		<li class="item pager-last">
 			<a href="<?= Minz_Url::display(array('c' => $c, 'a' => $a, 'params' => $params)) ?>"><?= _t('conf.logs.pagination.last') ?> »</a>

--- a/app/views/helpers/logs_pagination.phtml
+++ b/app/views/helpers/logs_pagination.phtml
@@ -18,11 +18,13 @@
 
 		<?php $params[$getteur] = $this->currentPage - 1; ?>
 
-		<?php if ($this->currentPage > 1) { ?>
+		
 		<li class="item pager-previous">
+			<?php if ($this->currentPage > 1) { ?>
 			<a href="<?= Minz_Url::display(array('c' => $c, 'a' => $a, 'params' => $params)) ?>">‹ <?= _t('conf.logs.pagination.previous') ?></a>
+			<?php } ?>
 		</li>
-		<?php } ?>
+		
 
 		<?php if ($this->currentPage - 2 > 1) { ?>
 		<li class="item">…</a></li>
@@ -49,11 +51,13 @@
 		<?php } ?>
 
 		<?php $params[$getteur] = $this->currentPage + 1; ?>
-		<?php if ($this->currentPage < $this->nbPage) { ?>
+		
 		<li class="item pager-next">
+			<?php if ($this->currentPage < $this->nbPage) { ?>
 			<a href="<?= Minz_Url::display(array('c' => $c, 'a' => $a, 'params' => $params)) ?>"><?= _t('conf.logs.pagination.next') ?> ›</a>
+			<?php } ?>
 		</li>
-		<?php } ?>
+		
 		<?php $params[$getteur] = $this->nbPage; ?>
 		<li class="item pager-last">
 			<a href="<?= Minz_Url::display(array('c' => $c, 'a' => $a, 'params' => $params)) ?>"><?= _t('conf.logs.pagination.last') ?> »</a>

--- a/app/views/helpers/logs_pagination.phtml
+++ b/app/views/helpers/logs_pagination.phtml
@@ -31,8 +31,8 @@
 		<?php
 		for ($i = $this->currentPage - 2; $i <= $this->currentPage + 2; $i++) {
 			if($i > 0 && $i <= $this->nbPage) {
+				$params[$getteur] = $i;
 				if ($i != $this->currentPage) {
-					$params[$getteur] = $i;
 					$class = '';
 					$aria = 'false';
 				} else {

--- a/lib/Minz/Request.php
+++ b/lib/Minz/Request.php
@@ -27,6 +27,13 @@ class Minz_Request {
 	public static function params() {
 		return self::$params;
 	}
+	/**
+	 * Read the URL parameter
+	 * @param string $key Key name
+	 * @param mixed $default default value, if no parameter is given
+	 * @param bool $specialchars special characters
+	 * @return mixed value of the parameter
+	 */
 	public static function param($key, $default = false, $specialchars = false) {
 		if (isset(self::$params[$key])) {
 			$p = self::$params[$key];


### PR DESCRIPTION
Ref. #4204

Changes proposed in this pull request:

- fix the error, with page=0, that was linked on the page number link itself and the prev link, when page 1 is displayed


How to test the feature manually:

1. go to config -> logs
2. the `prev` link is not shown, when page 1 is displayed
3. the `next` link is not shown, when last page is displayed
4. the link to the page itself displays the page without an error message

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
