### PR TITLE
Fix the subscription tool form

### DIFF
--- a/app/views/feed/add.phtml
+++ b/app/views/feed/add.phtml
@@ -30,8 +30,10 @@
 		<div class="form-group">
 			<label class="group-name"><?= _t('sub.feed.website') ?></label>
 			<div class="group-controls">
-				<?= $this->feed->website() ?>
-				<a class="btn" target="_blank" rel="noreferrer" href="<?= $this->feed->website() ?>"><?= _i('link') ?></a>
+				<div class="stick">
+					<input type="text" value="<?= $this->feed->website() ?>" disabled="disabled" />
+					<a class="btn" target="_blank" rel="noreferrer" href="<?= $this->feed->website() ?>"><?= _i('link') ?></a>
+				</div>
 			</div>
 		</div>
 		<?php } ?>
@@ -43,6 +45,7 @@
 					<input type="text" name="url_rss" id="url" value="<?= $this->feed->url() ?>" />
 					<a class="btn open-url" target="_blank" rel="noreferrer" href="<?= $this->feed->url() ?>" data-input="url" title="<?= _t('gen.action.open_url') ?>"><?= _i('link') ?></a>
 				</div>
+				<br />
 				<a class="btn" target="_blank" rel="noreferrer" href="https://validator.w3.org/feed/check.cgi?url=<?= $this->feed->url() ?>"><?= _t('sub.feed.validator') ?></a>
 			</div>
 		</div>
@@ -75,8 +78,8 @@
 			<label class="group-name" for="http_pass"><?= _t('sub.feed.auth.password') ?></label>
 			<div class="group-controls">
 				<div class="stick">
-					<input type="password" name="http_pass" id="http_pass" class="extend" value="<?= $auth['password'] ?>" autocomplete="new-password" />
-					<button type="button" class="btn toggle-password" data-toggle="http_user"><?= _i('key') ?></button>
+					<input type="password" name="http_pass" id="http_pass" value="<?= $auth['password'] ?>" autocomplete="new-password" />
+					<button type="button" class="btn toggle-password" data-toggle="http_pass"><?= _i('key') ?></button>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/1645099/181294680-1fa50d55-6412-48b0-94d5-74a1ee05425e.png)
1: Show password button was broken (did not show the password) + the input was expanded, when it gets the focus (very difficult to catch the button with the mouse)
2: the check button is not on a line of the URL input
3: the website url is not inside a input, so the text and the button are not on a line


After:
![grafik](https://user-images.githubusercontent.com/1645099/181294709-007f3aeb-9de4-4eed-901d-903b801983c0.png)


Changes proposed in this pull request:

- fixed the PHTML template 


How to test the feature manually:

1. use the subscription tool
2. see the form

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
