### PR TITLE
Fix: [BUG] "Hide after read" and "mark on scroll" clears the whole list feed by feed.

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -704,7 +704,8 @@ function onScroll() {
 		return;
 	}
 	if (context.auto_mark_scroll) {
-		const minTop = 40 + box_to_follow.scrollTop;
+		const hidden_px = -5; // negative = pixels over the edge
+		const minTop = hidden_px + box_to_follow.scrollTop;
 		document.querySelectorAll('.not_read:not(.keep_unread)').forEach(function (div) {
 			if (div.offsetHeight > 0 &&
 					div.offsetParent.offsetTop + div.offsetTop + div.offsetHeight < minTop) {


### PR DESCRIPTION
Closes #4446

Before: If the unread article is <40 pixels `below ` the top edge, it was marked as read
After: If the unread article is > 5 pixels `above ` the top edge, it is marked as read

Changes proposed in this pull request:

- `+40` pixels -> `-5` pixels
- use a `const` for better documentation/readability of the source code (maybe you can find a better const name)


How to test the feature manually:

1. enable "Mark an article as read… while scrolling" (Config -> Reading)
2. enable "Hide articles after reading" (Config -> Reading)
3. have a list of unread articles
4. scroll down
5. wait
6. it does not autom. mark articles as read one by one

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested