### PR TITLE
Improved: show feed errors

### DIFF
--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -102,7 +102,7 @@
 ?>
 <li id="f_<?= $feed->id() ?>" class="item feed<?= $f_active ? ' active' : '', $feed->mute() ? ' mute' : '' ?><?=
 	$feed->inError() ? ' error' : '' ?><?= $feed->nbEntries() <= 0 ? ' empty' : ''
-	?>" data-unread="<?= $feed->nbNotRead() ?>" data-priority="<?= $feed->priority() ?>"><?php
+	?>" title="<?= $feed->inError() ? _t('sub.feed.error') : '' ?>" data-unread="<?= $feed->nbNotRead() ?>" data-priority="<?= $feed->priority() ?>"><?php
 		if ($f_active || $nbFeedsTotal < FreshRSS_Context::$user_conf->simplify_over_n_feeds):
 	?><div class="dropdown no-mobile">
 		<div class="dropdown-target"></div><a class="dropdown-toggle" data-fweb="<?= $feed->website() ?>"><?= _i('configure') ?></a><?php /* feed_config_template */ ?>

--- a/app/views/subscription/index.phtml
+++ b/app/views/subscription/index.phtml
@@ -49,11 +49,12 @@
 						$empty = $feed->nbEntries() == 0 ? ' empty' : '';
 				?>
 				<li class="item feed<?= $error, $empty, $feed->mute() ? ' mute' : '' ?>"
+					title="<?= $feed->inError() ? _t('sub.feed.error') : '' ?>"
 					draggable="true"
 					data-feed-id="<?= $feed->id() ?>">
 					<a class="configure open-slider" href="<?= _url('subscription', 'feed', 'id', $feed->id()) ?>"><?= _i('configure') ?></a>
 					<?php if (FreshRSS_Context::$user_conf->show_favicons): ?><img class="favicon" src="<?= $feed->favicon() ?>" alt="✇" loading="lazy" /><?php endif; ?>
-					<?= $feed->name() ?>
+					<span class="item-title"><?= $feed->name() ?></span>
 				</li>
 				<?php
 					}

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -1661,9 +1661,14 @@ input:checked + .slide-container .properties {
 }
 
 .item.share.error a::after,
-.category .title.error::before {
+.category .title.error::before,
+.item.feed.error .item-title::before {
 	content: " ⚠ ";
 	color: #bd362f;
+}
+
+.feed.item.error.active .item-title::before {
+	color: white;
 }
 
 .category .title:not([data-unread="0"])::after,

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -1661,9 +1661,14 @@ input:checked + .slide-container .properties {
 }
 
 .item.share.error a::after,
-.category .title.error::before {
+.category .title.error::before,
+.item.feed.error .item-title::before {
 	content: " ⚠ ";
 	color: #bd362f;
+}
+
+.feed.item.error.active .item-title::before {
+	color: white;
 }
 
 .category .title:not([data-unread="0"])::after,


### PR DESCRIPTION
Closes #4464

Before:
![grafik](https://user-images.githubusercontent.com/1645099/181827085-eedd6de8-f1b9-43f2-a727-185078fa75c8.png)


After (Origine):
![grafik](https://user-images.githubusercontent.com/1645099/181827118-40a6e431-bbc5-4136-afe8-023ccb1a3e8d.png)

After (Mapco):
![grafik](https://user-images.githubusercontent.com/1645099/181827186-a310a49c-2afb-420b-aa1f-c358b2b8844b.png)

After (Mapco):
![grafik](https://user-images.githubusercontent.com/1645099/181827326-bf542188-c9ca-4e37-813a-6e8babb4dc63.png)

![grafik](https://user-images.githubusercontent.com/1645099/181827679-ef8d518b-e6fd-4bf5-804c-076dc08bf95d.png)


Changes proposed in this pull request:

- add a triangle symbol next to the feed name in sidebar and in subscription management
- give a mouse over text, when an error occured

How to test the feature manually:

1. find a feed with an error
2. mouse over it (see the text)
3. see the red triangle

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
