### PR TITLE
CLI allow empty DB prefix

### DIFF
--- a/cli/do-install.php
+++ b/cli/do-install.php
@@ -26,7 +26,7 @@ $dBparams = array(
 		'db-user:',
 		'db-password:',
 		'db-base:',
-		'db-prefix:',
+		'db-prefix::',
 	);
 
 $options = getopt('', array_merge($params, $dBparams));

--- a/cli/reconfigure.php
+++ b/cli/reconfigure.php
@@ -22,7 +22,7 @@ $dBparams = array(
 		'db-user:',
 		'db-password:',
 		'db-base:',
-		'db-prefix:',
+		'db-prefix::',
 	);
 
 $options = getopt('', array_merge($params, $dBparams));


### PR DESCRIPTION
Allow an empty `--db-prefix` parameter (i.e. optional) in CLI to have no DB prefix

https://php.net/function.getopt
