### PR TITLE
Add CSS class "about" to the about link

### DIFF
--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -22,7 +22,7 @@
 		<a id="btn-add" class="btn btn-important" href="<?= _url('subscription', 'add') ?>"><?= _i('add') ?></a>
 	</div>
 	<?php } elseif (FreshRSS_Auth::accessNeedsLogin()) { ?>
-	<a href="<?= _url('index', 'about') ?>"><?= _t('index.menu.about') ?></a>
+	<a href="<?= _url('index', 'about') ?>" class="about"><?= _t('index.menu.about') ?></a>
 	<?php } ?>
 
 	<form id="mark-read-aside" method="post">


### PR DESCRIPTION


Changes proposed in this pull request:

- add the CSS class `about` to the link of the about link in the left aside bar (visible in anonymous view)

Reason:
It is very difficult to style the "About FreshRSS" link without a CSS class

See f.e. Swage theme:
![grafik](https://user-images.githubusercontent.com/1645099/184018976-334e0f25-06a5-4718-8cb3-0a70d622b7c3.png)


How to test the feature manually:
nothing special to test. Just check if the class "about" is added in anonymous mode

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested