### PR TITLE
Set standard CSS for login register form

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -605,19 +605,6 @@ a.btn {
 }
 
 /*=== Prompt (centered) */
-.prompt {
-	max-width: 20rem;
-	margin-left: auto;
-	margin-right: auto;
-	padding-left: .5rem;
-	padding-right: .5rem;
-	text-align: center;
-}
-
-.prompt label {
-	text-align: left;
-}
-
 .prompt form {
 	margin-top: 2rem;
 	margin-bottom: 3rem;
@@ -639,20 +626,10 @@ a.btn {
 	justify-content: space-between;
 }
 
-.prompt .stick,
-.prompt input {
-	width: 100%;
-	box-sizing: border-box;
-}
-
 .prompt .btn.btn-important {
 	padding-left: 1.5rem;
 	padding-right: 1.5rem;
 	font-size: 1.1rem;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -605,12 +605,6 @@ a.btn {
 }
 
 /*=== Prompt (centered) */
-.prompt form {
-	margin-top: 2rem;
-	margin-bottom: 3rem;
-	text-align: left;
-}
-
 .prompt .form-group {
 	margin-bottom: 1rem;
 }

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -605,12 +605,6 @@ a.btn {
 }
 
 /*=== Prompt (centered) */
-.prompt form {
-	margin-top: 2rem;
-	margin-bottom: 3rem;
-	text-align: right;
-}
-
 .prompt .form-group {
 	margin-bottom: 1rem;
 }

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -605,19 +605,6 @@ a.btn {
 }
 
 /*=== Prompt (centered) */
-.prompt {
-	max-width: 20rem;
-	margin-right: auto;
-	margin-left: auto;
-	padding-right: .5rem;
-	padding-left: .5rem;
-	text-align: center;
-}
-
-.prompt label {
-	text-align: right;
-}
-
 .prompt form {
 	margin-top: 2rem;
 	margin-bottom: 3rem;
@@ -639,20 +626,10 @@ a.btn {
 	justify-content: space-between;
 }
 
-.prompt .stick,
-.prompt input {
-	width: 100%;
-	box-sizing: border-box;
-}
-
 .prompt .btn.btn-important {
 	padding-right: 1.5rem;
 	padding-left: 1.5rem;
 	font-size: 1.1rem;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/Ansum/_layout.scss
+++ b/p/themes/Ansum/_layout.scss
@@ -109,30 +109,9 @@
 	height: calc(100% - 4rem);
 }
 
-
-
-
 /*=== Prompt (centered) */
-.prompt {
-	text-align: center;
-}
-
-.prompt label {
-	text-align: left;
-}
-
-.prompt form {
-	margin: 10px auto 20px auto;
-	width: 200px;
-}
-
 .prompt input {
 	margin: 5px auto;
-	width: 100%;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -819,26 +819,8 @@ form th {
 }
 
 /*=== Prompt (centered) */
-.prompt {
-	text-align: center;
-}
-
-.prompt label {
-	text-align: left;
-}
-
-.prompt form {
-	margin: 10px auto 20px auto;
-	width: 200px;
-}
-
 .prompt input {
 	margin: 5px auto;
-	width: 100%;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -819,26 +819,8 @@ form th {
 }
 
 /*=== Prompt (centered) */
-.prompt {
-	text-align: center;
-}
-
-.prompt label {
-	text-align: right;
-}
-
-.prompt form {
-	margin: 10px auto 20px auto;
-	width: 200px;
-}
-
 .prompt input {
 	margin: 5px auto;
-	width: 100%;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/BlueLagoon/BlueLagoon.css
+++ b/p/themes/BlueLagoon/BlueLagoon.css
@@ -730,26 +730,6 @@ a.btn {
 }
 
 /*=== Prompt (centered) */
-.prompt {
-	max-width: 20rem;
-	margin-left: auto;
-	margin-right: auto;
-	padding-left: .5rem;
-	padding-right: .5rem;
-	text-align: center;
-	text-shadow: 0 1px rgba(255,255,255,0.08);
-}
-
-.prompt form {
-	margin-top: 2rem;
-	margin-bottom: 3rem;
-	text-align: left;
-}
-
-.prompt label {
-	text-align: left;
-}
-
 .prompt .form-group {
 	margin-bottom: 1rem;
 }
@@ -763,12 +743,6 @@ a.btn {
 	margin-top: 2rem;
 	align-items: center;
 	justify-content: space-between;
-}
-
-.prompt .stick,
-.prompt input {
-	width: 100%;
-	box-sizing: border-box;
 }
 
 .prompt input#username,.prompt input#passwordPlain {
@@ -786,10 +760,6 @@ a.btn {
 	padding-left: 1.5rem;
 	padding-right: 1.5rem;
 	font-size: 1.1rem;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/BlueLagoon/BlueLagoon.rtl.css
+++ b/p/themes/BlueLagoon/BlueLagoon.rtl.css
@@ -730,26 +730,6 @@ a.btn {
 }
 
 /*=== Prompt (centered) */
-.prompt {
-	max-width: 20rem;
-	margin-right: auto;
-	margin-left: auto;
-	padding-right: .5rem;
-	padding-left: .5rem;
-	text-align: center;
-	text-shadow: 0 1px rgba(255,255,255,0.08);
-}
-
-.prompt form {
-	margin-top: 2rem;
-	margin-bottom: 3rem;
-	text-align: right;
-}
-
-.prompt label {
-	text-align: right;
-}
-
 .prompt .form-group {
 	margin-bottom: 1rem;
 }
@@ -763,12 +743,6 @@ a.btn {
 	margin-top: 2rem;
 	align-items: center;
 	justify-content: space-between;
-}
-
-.prompt .stick,
-.prompt input {
-	width: 100%;
-	box-sizing: border-box;
 }
 
 .prompt input#username,.prompt input#passwordPlain {
@@ -786,10 +760,6 @@ a.btn {
 	padding-right: 1.5rem;
 	padding-left: 1.5rem;
 	font-size: 1.1rem;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -678,21 +678,6 @@ a.btn {
 }
 
 /*=== Prompt (centered) */
-.prompt {
-	max-width: 20rem;
-	margin-left: auto;
-	margin-right: auto;
-	padding-left: .5rem;
-	padding-right: .5rem;
-	text-align: center;
-}
-
-.prompt form {
-	margin-top: 2rem;
-	margin-bottom: 3rem;
-	text-align: left;
-}
-
 .prompt .form-group {
 	margin-bottom: 1rem;
 }
@@ -708,20 +693,10 @@ a.btn {
 	justify-content: space-between;
 }
 
-.prompt .stick,
-.prompt input {
-	width: 100%;
-	box-sizing: border-box;
-}
-
 .prompt .btn.btn-important {
 	padding-left: 1.5rem;
 	padding-right: 1.5rem;
 	font-size: 1.1rem;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -678,21 +678,6 @@ a.btn {
 }
 
 /*=== Prompt (centered) */
-.prompt {
-	max-width: 20rem;
-	margin-right: auto;
-	margin-left: auto;
-	padding-right: .5rem;
-	padding-left: .5rem;
-	text-align: center;
-}
-
-.prompt form {
-	margin-top: 2rem;
-	margin-bottom: 3rem;
-	text-align: right;
-}
-
 .prompt .form-group {
 	margin-bottom: 1rem;
 }
@@ -708,20 +693,10 @@ a.btn {
 	justify-content: space-between;
 }
 
-.prompt .stick,
-.prompt input {
-	width: 100%;
-	box-sizing: border-box;
-}
-
 .prompt .btn.btn-important {
 	padding-right: 1.5rem;
 	padding-left: 1.5rem;
 	font-size: 1.1rem;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -669,21 +669,6 @@ a.btn {
 }
 
 /*=== Prompt (centered) */
-.prompt {
-	max-width: 20rem;
-	margin-left: auto;
-	margin-right: auto;
-	padding-left: .5rem;
-	padding-right: .5rem;
-	text-align: center;
-}
-
-.prompt form {
-	margin-top: 2rem;
-	margin-bottom: 3rem;
-	text-align: left;
-}
-
 .prompt .form-group {
 	margin-bottom: 1rem;
 }
@@ -699,20 +684,10 @@ a.btn {
 	justify-content: space-between;
 }
 
-.prompt .stick,
-.prompt input {
-	width: 100%;
-	box-sizing: border-box;
-}
-
 .prompt .btn.btn-important {
 	padding-left: 1.5rem;
 	padding-right: 1.5rem;
 	font-size: 1.1rem;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -669,21 +669,6 @@ a.btn {
 }
 
 /*=== Prompt (centered) */
-.prompt {
-	max-width: 20rem;
-	margin-right: auto;
-	margin-left: auto;
-	padding-right: .5rem;
-	padding-left: .5rem;
-	text-align: center;
-}
-
-.prompt form {
-	margin-top: 2rem;
-	margin-bottom: 3rem;
-	text-align: right;
-}
-
 .prompt .form-group {
 	margin-bottom: 1rem;
 }
@@ -699,20 +684,10 @@ a.btn {
 	justify-content: space-between;
 }
 
-.prompt .stick,
-.prompt input {
-	width: 100%;
-	box-sizing: border-box;
-}
-
 .prompt .btn.btn-important {
 	padding-right: 1.5rem;
 	padding-left: 1.5rem;
 	font-size: 1.1rem;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/Mapco/_layout.scss
+++ b/p/themes/Mapco/_layout.scss
@@ -112,33 +112,8 @@
 
 /*=== Prompt (centered) */
 main.prompt {
-	margin: 3rem auto;
-	padding: 2rem;
 	background: variables.$grey-light;
-	max-width: 400px;
-	min-width: 300px;
-	width: 33%;
 	border-radius: 5px;
-}
-
-.prompt {
-	text-align: center;
-}
-
-.prompt label,
-.prompt .help {
-	text-align: left;
-}
-
-.prompt input,
-.prompt select,
-.prompt .stick {
-	width: 100%;
-	box-sizing: border-box;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -787,33 +787,8 @@ form th {
 
 /*=== Prompt (centered) */
 main.prompt {
-	margin: 3rem auto;
-	padding: 2rem;
 	background: #eff0f2;
-	max-width: 400px;
-	min-width: 300px;
-	width: 33%;
 	border-radius: 5px;
-}
-
-.prompt {
-	text-align: center;
-}
-
-.prompt label,
-.prompt .help {
-	text-align: left;
-}
-
-.prompt input,
-.prompt select,
-.prompt .stick {
-	width: 100%;
-	box-sizing: border-box;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -787,33 +787,8 @@ form th {
 
 /*=== Prompt (centered) */
 main.prompt {
-	margin: 3rem auto;
-	padding: 2rem;
 	background: #eff0f2;
-	max-width: 400px;
-	min-width: 300px;
-	width: 33%;
 	border-radius: 5px;
-}
-
-.prompt {
-	text-align: center;
-}
-
-.prompt label,
-.prompt .help {
-	text-align: right;
-}
-
-.prompt input,
-.prompt select,
-.prompt .stick {
-	width: 100%;
-	box-sizing: border-box;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -1076,26 +1076,9 @@ input.extend {
 }
 
 /*=== Prompt (centered) */
-.prompt {
-	text-align: center;
-}
-
-.prompt label {
-	text-align: left;
-}
-
-.prompt form {
-	margin: 10px auto 20px auto;
-	width: 180px;
-}
-
 .prompt input {
 	margin: 5px auto;
 	width: 100%;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== Navigation menu (for articles) */

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -1076,26 +1076,9 @@ input.extend {
 }
 
 /*=== Prompt (centered) */
-.prompt {
-	text-align: center;
-}
-
-.prompt label {
-	text-align: right;
-}
-
-.prompt form {
-	margin: 10px auto 20px auto;
-	width: 180px;
-}
-
 .prompt input {
 	margin: 5px auto;
 	width: 100%;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== Navigation menu (for articles) */

--- a/p/themes/Origine-compact/origine-compact.css
+++ b/p/themes/Origine-compact/origine-compact.css
@@ -698,21 +698,6 @@ a.btn,
 }
 
 /*=== Prompt (centered) */
-.prompt {
-	max-width: 20rem;
-	margin-left: auto;
-	margin-right: auto;
-	padding-left: .5rem;
-	padding-right: .5rem;
-	text-align: center;
-}
-
-.prompt form {
-	margin-top: 2rem;
-	margin-bottom: 3rem;
-	text-align: left;
-}
-
 .prompt .form-group {
 	margin-bottom: 1rem;
 }
@@ -728,20 +713,10 @@ a.btn,
 	justify-content: space-between;
 }
 
-.prompt .stick,
-.prompt input {
-	width: 100%;
-	box-sizing: border-box;
-}
-
 .prompt .btn.btn-important {
 	padding-left: 1.5rem;
 	padding-right: 1.5rem;
 	font-size: 1.1rem;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/Origine-compact/origine-compact.rtl.css
+++ b/p/themes/Origine-compact/origine-compact.rtl.css
@@ -698,21 +698,6 @@ a.btn,
 }
 
 /*=== Prompt (centered) */
-.prompt {
-	max-width: 20rem;
-	margin-right: auto;
-	margin-left: auto;
-	padding-right: .5rem;
-	padding-left: .5rem;
-	text-align: center;
-}
-
-.prompt form {
-	margin-top: 2rem;
-	margin-bottom: 3rem;
-	text-align: right;
-}
-
 .prompt .form-group {
 	margin-bottom: 1rem;
 }
@@ -728,20 +713,10 @@ a.btn,
 	justify-content: space-between;
 }
 
-.prompt .stick,
-.prompt input {
-	width: 100%;
-	box-sizing: border-box;
-}
-
 .prompt .btn.btn-important {
 	padding-right: 1.5rem;
 	padding-left: 1.5rem;
 	font-size: 1.1rem;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -665,21 +665,6 @@ a.btn {
 }
 
 /*=== Prompt (centered) */
-.prompt {
-	max-width: 20rem;
-	margin-left: auto;
-	margin-right: auto;
-	padding-left: .5rem;
-	padding-right: .5rem;
-	text-align: center;
-}
-
-.prompt form {
-	margin-top: 2rem;
-	margin-bottom: 3rem;
-	text-align: left;
-}
-
 .prompt .form-group {
 	margin-bottom: 1rem;
 }
@@ -695,20 +680,10 @@ a.btn {
 	justify-content: space-between;
 }
 
-.prompt .stick,
-.prompt input {
-	width: 100%;
-	box-sizing: border-box;
-}
-
 .prompt .btn.btn-important {
 	padding-left: 1.5rem;
 	padding-right: 1.5rem;
 	font-size: 1.1rem;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -665,21 +665,6 @@ a.btn {
 }
 
 /*=== Prompt (centered) */
-.prompt {
-	max-width: 20rem;
-	margin-right: auto;
-	margin-left: auto;
-	padding-right: .5rem;
-	padding-left: .5rem;
-	text-align: center;
-}
-
-.prompt form {
-	margin-top: 2rem;
-	margin-bottom: 3rem;
-	text-align: right;
-}
-
 .prompt .form-group {
 	margin-bottom: 1rem;
 }
@@ -695,20 +680,10 @@ a.btn {
 	justify-content: space-between;
 }
 
-.prompt .stick,
-.prompt input {
-	width: 100%;
-	box-sizing: border-box;
-}
-
 .prompt .btn.btn-important {
 	padding-right: 1.5rem;
 	padding-left: 1.5rem;
 	font-size: 1.1rem;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -664,21 +664,6 @@ a.signin {
 }
 
 /*=== Prompt (centered) */
-.prompt {
-	max-width: 20rem;
-	margin-left: auto;
-	margin-right: auto;
-	padding-left: .5rem;
-	padding-right: .5rem;
-	text-align: center;
-}
-
-.prompt form {
-	margin-top: 2rem;
-	margin-bottom: 3rem;
-	text-align: left;
-}
-
 .prompt .form-group {
 	margin-bottom: 1rem;
 }
@@ -694,20 +679,10 @@ a.signin {
 	justify-content: space-between;
 }
 
-.prompt .stick,
-.prompt input {
-	width: 100%;
-	box-sizing: border-box;
-}
-
 .prompt .btn.btn-important {
 	padding-left: 1.5rem;
 	padding-right: 1.5rem;
 	font-size: 1.1rem;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -664,21 +664,6 @@ a.signin {
 }
 
 /*=== Prompt (centered) */
-.prompt {
-	max-width: 20rem;
-	margin-right: auto;
-	margin-left: auto;
-	padding-right: .5rem;
-	padding-left: .5rem;
-	text-align: center;
-}
-
-.prompt form {
-	margin-top: 2rem;
-	margin-bottom: 3rem;
-	text-align: right;
-}
-
 .prompt .form-group {
 	margin-bottom: 1rem;
 }
@@ -694,20 +679,10 @@ a.signin {
 	justify-content: space-between;
 }
 
-.prompt .stick,
-.prompt input {
-	width: 100%;
-	box-sizing: border-box;
-}
-
 .prompt .btn.btn-important {
 	padding-right: 1.5rem;
 	padding-left: 1.5rem;
 	font-size: 1.1rem;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/Screwdriver/screwdriver.css
+++ b/p/themes/Screwdriver/screwdriver.css
@@ -706,19 +706,7 @@ a.btn {
 
 /*=== Prompt (centered) */
 .prompt {
-	max-width: 20rem;
-	margin-left: auto;
-	margin-right: auto;
-	padding-left: .5rem;
-	padding-right: .5rem;
-	text-align: center;
 	text-shadow: 0 1px rgba(255,255,255,0.08);
-}
-
-.prompt form {
-	margin-top: 2rem;
-	margin-bottom: 3rem;
-	text-align: left;
 }
 
 .prompt .form-group {
@@ -736,12 +724,6 @@ a.btn {
 	justify-content: space-between;
 }
 
-.prompt .stick,
-.prompt input {
-	width: 100%;
-	box-sizing: border-box;
-}
-
 .prompt input#username,.prompt input#passwordPlain {
 	background: #fff;
 	border: solid 1px #ccc;
@@ -757,10 +739,6 @@ a.btn {
 	padding-left: 1.5rem;
 	padding-right: 1.5rem;
 	font-size: 1.1rem;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/Screwdriver/screwdriver.rtl.css
+++ b/p/themes/Screwdriver/screwdriver.rtl.css
@@ -706,19 +706,7 @@ a.btn {
 
 /*=== Prompt (centered) */
 .prompt {
-	max-width: 20rem;
-	margin-right: auto;
-	margin-left: auto;
-	padding-right: .5rem;
-	padding-left: .5rem;
-	text-align: center;
 	text-shadow: 0 1px rgba(255,255,255,0.08);
-}
-
-.prompt form {
-	margin-top: 2rem;
-	margin-bottom: 3rem;
-	text-align: right;
 }
 
 .prompt .form-group {
@@ -736,12 +724,6 @@ a.btn {
 	justify-content: space-between;
 }
 
-.prompt .stick,
-.prompt input {
-	width: 100%;
-	box-sizing: border-box;
-}
-
 .prompt input#username,.prompt input#passwordPlain {
 	background: #fff;
 	border: solid 1px #ccc;
@@ -757,10 +739,6 @@ a.btn {
 	padding-right: 1.5rem;
 	padding-left: 1.5rem;
 	font-size: 1.1rem;
-}
-
-.prompt p {
-	margin: 20px 0;
 }
 
 /*=== New article notification */

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -642,26 +642,15 @@ form th {
 	max-width: 550px;
 }
 
-.prompt {
-	text-align: center;
-}
-.prompt label {
-	text-align: left;
-}
-.prompt form {
-	margin: 10px auto 20px auto;
-	width: 200px;
-}
 .prompt input {
 	margin: 5px auto;
 	width: 100%;
 }
-.prompt p {
-	margin: 20px 0;
-}
+
 #global {
 	height: 100vh;
 }
+
 #new-article {
 	background: #0062be;
 	font-size: 1em;

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -642,26 +642,15 @@ form th {
 	max-width: 550px;
 }
 
-.prompt {
-	text-align: center;
-}
-.prompt label {
-	text-align: right;
-}
-.prompt form {
-	margin: 10px auto 20px auto;
-	width: 200px;
-}
 .prompt input {
 	margin: 5px auto;
 	width: 100%;
 }
-.prompt p {
-	margin: 20px 0;
-}
+
 #global {
 	height: 100vh;
 }
+
 #new-article {
 	background: #0062be;
 	font-size: 1em;

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -814,24 +814,9 @@ form {
 }
 
 .prompt {
-	text-align: center;
-
-	label {
-		text-align: left;
-	}
-
-	form {
-		margin: 10px auto 20px auto;
-		width: 200px;
-	}
-
 	input {
 		margin: 5px auto;
 		width: 100%;
-	}
-
-	p {
-		margin: 20px 0;
 	}
 }
 

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -286,6 +286,12 @@ td.numeric {
 	text-align: center;
 }
 
+.prompt form {
+	margin-top: 2rem;
+	margin-bottom: 3rem;
+	text-align: left;
+}
+
 .prompt label,
 .prompt .help {
 	text-align: left;

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -276,6 +276,32 @@ td.numeric {
 	display: none !important;
 }
 
+/* login and register form */
+.prompt {
+	margin: 3rem auto;
+	padding: 2rem;
+	max-width: 400px;
+	min-width: 300px;
+	width: 33%;
+	text-align: center;
+}
+
+.prompt label,
+.prompt .help {
+	text-align: left;
+}
+
+.prompt input,
+.prompt select,
+.prompt .stick {
+	width: 100%;
+	box-sizing: border-box;
+}
+
+.prompt p {
+	margin: 20px 0;
+}
+
 /*=== Forms */
 .form-group::after {
 	content: "";

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -289,7 +289,7 @@ td.numeric {
 .prompt form {
 	margin-top: 2rem;
 	margin-bottom: 3rem;
-	text-align: left;
+	text-align: right;
 }
 
 .prompt label,

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -276,6 +276,32 @@ td.numeric {
 	display: none !important;
 }
 
+/* login and register form */
+.prompt {
+	margin: 3rem auto;
+	padding: 2rem;
+	max-width: 400px;
+	min-width: 300px;
+	width: 33%;
+	text-align: center;
+}
+
+.prompt label,
+.prompt .help {
+	text-align: right;
+}
+
+.prompt input,
+.prompt select,
+.prompt .stick {
+	width: 100%;
+	box-sizing: border-box;
+}
+
+.prompt p {
+	margin: 20px 0;
+}
+
 /*=== Forms */
 .form-group::after {
 	content: "";

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -286,6 +286,12 @@ td.numeric {
 	text-align: center;
 }
 
+.prompt form {
+	margin-top: 2rem;
+	margin-bottom: 3rem;
+	text-align: left;
+}
+
 .prompt label,
 .prompt .help {
 	text-align: right;


### PR DESCRIPTION
Some CSS regarding the login/register form was included in the most of themes. Some login/register forms needed a little fresh-up. So it would be a good idea to have the basic CSS of this forms in template.css included instead of in each theme.

Changes proposed in this pull request:

- (S)CSS files

How to test the feature manually:

check the login/register forms of each theme (mostly you will not see any changes)


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested