### PR TITLE
Fix PHP 7.0 warning

### DIFF
--- a/app/Models/EntryDAOSQLite.php
+++ b/app/Models/EntryDAOSQLite.php
@@ -115,7 +115,7 @@ DROP TABLE IF EXISTS `tmp`;
 	 * @param boolean $is_read
 	 * @return integer|false affected rows
 	 */
-	public function markRead($ids, $is_read = true) {
+	public function markRead($ids, bool $is_read = true) {
 		FreshRSS_UserDAO::touch();
 		if (is_array($ids)) {	//Many IDs at once (used by API)
 			//if (true) {	//Speed heuristics	//TODO: Not implemented yet for SQLite (so always call IDs one by one)


### PR DESCRIPTION
Regression from https://github.com/FreshRSS/FreshRSS/pull/4202
> Warning: Declaration of FreshRSS_EntryDAOSQLite::markRead($ids, $is_read = true) should be compatible with FreshRSS_EntryDAO::markRead($ids, bool $is_read = true) in /var/www/FreshRSS/app/Models/EntryDAOSQLite.php on line 3

