### PR TITLE
add archive.ph as sharing service

### DIFF
--- a/app/i18n/cz/gen.php
+++ b/app/i18n/cz/gen.php
@@ -188,6 +188,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Známé základní stránky',
+		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Schránka',
 		'diaspora' => 'Diaspora*',	// IGNORE

--- a/app/i18n/de/gen.php
+++ b/app/i18n/de/gen.php
@@ -188,6 +188,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known-Seite (https://withknown.com)',
+		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Zwischenablage',
 		'diaspora' => 'Diaspora*',	// IGNORE

--- a/app/i18n/en-us/gen.php
+++ b/app/i18n/en-us/gen.php
@@ -188,6 +188,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known based sites',	// IGNORE
+		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Clipboard',	// IGNORE
 		'diaspora' => 'Diaspora*',	// IGNORE

--- a/app/i18n/en/gen.php
+++ b/app/i18n/en/gen.php
@@ -188,6 +188,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known based sites',
+		'archivePH' => 'archive.ph',
 		'blogotext' => 'Blogotext',
 		'clipboard' => 'Clipboard',
 		'diaspora' => 'Diaspora*',

--- a/app/i18n/es/gen.php
+++ b/app/i18n/es/gen.php
@@ -188,6 +188,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Sitios basados en conocidos',
+		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Portapapeles',
 		'diaspora' => 'Diaspora*',	// IGNORE

--- a/app/i18n/fr/gen.php
+++ b/app/i18n/fr/gen.php
@@ -188,6 +188,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Sites basés sur Known',
+		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Presse-papier',
 		'diaspora' => 'Diaspora*',	// IGNORE

--- a/app/i18n/he/gen.php
+++ b/app/i18n/he/gen.php
@@ -188,6 +188,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known based sites',	// TODO
+		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Clipboard',	// TODO
 		'diaspora' => 'Diaspora*',	// IGNORE

--- a/app/i18n/it/gen.php
+++ b/app/i18n/it/gen.php
@@ -188,6 +188,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Siti basati su Known',
+		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Clipboard',	// TODO
 		'diaspora' => 'Diaspora*',	// IGNORE

--- a/app/i18n/ja/gen.php
+++ b/app/i18n/ja/gen.php
@@ -188,6 +188,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'よく使われるサイト',
+		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'クリップボード',
 		'diaspora' => 'Diaspora*',	// IGNORE

--- a/app/i18n/ko/gen.php
+++ b/app/i18n/ko/gen.php
@@ -188,6 +188,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known based sites',	// IGNORE
+		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => '클립보드',
 		'diaspora' => 'Diaspora*',	// IGNORE

--- a/app/i18n/nl/gen.php
+++ b/app/i18n/nl/gen.php
@@ -188,6 +188,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known-gebaseerde sites',
+		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Klembord',
 		'diaspora' => 'Diaspora*',	// IGNORE

--- a/app/i18n/oc/gen.php
+++ b/app/i18n/oc/gen.php
@@ -188,6 +188,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Sites basats sus Known',
+		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Quicha-papiers.',
 		'diaspora' => 'Diaspora*',	// IGNORE

--- a/app/i18n/pl/gen.php
+++ b/app/i18n/pl/gen.php
@@ -188,6 +188,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Strony bazujące na usłudze Known',
+		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Schowek',
 		'diaspora' => 'Diaspora*',	// IGNORE

--- a/app/i18n/pt-br/gen.php
+++ b/app/i18n/pt-br/gen.php
@@ -188,6 +188,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Sites no Known',
+		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Área de transferência',
 		'diaspora' => 'Diaspora*',	// IGNORE

--- a/app/i18n/ru/gen.php
+++ b/app/i18n/ru/gen.php
@@ -188,6 +188,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Сайты на Known',
+		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Буфер обмена',
 		'diaspora' => 'Diaspora*',	// IGNORE

--- a/app/i18n/sk/gen.php
+++ b/app/i18n/sk/gen.php
@@ -188,6 +188,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Stránky založené na Known',
+		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Schránka',
 		'diaspora' => 'Diaspora*',	// IGNORE

--- a/app/i18n/tr/gen.php
+++ b/app/i18n/tr/gen.php
@@ -188,6 +188,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Bilinen siteler',
+		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Kopyala',
 		'diaspora' => 'Diaspora*',	// IGNORE

--- a/app/i18n/zh-cn/gen.php
+++ b/app/i18n/zh-cn/gen.php
@@ -188,6 +188,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => '基于 Known 的站点',
+		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => '剪贴板',
 		'diaspora' => 'Diaspora*',	// IGNORE

--- a/app/shares.php
+++ b/app/shares.php
@@ -26,6 +26,13 @@
  */
 
 return array(
+	'archivePH' => array(
+		'url' => 'https://archive.ph/submit/?url=~LINK~',
+		'transform' => array(),
+		'help' => 'https://archive.ph/',
+		'form' => 'simple',
+		'method' => 'GET',
+	),
 	'blogotext' => array(
 		'deprecated' => true,
 		'url' => '~URL~/admin/links.php?url=~LINK~',


### PR DESCRIPTION
Closes #4527

Changes proposed in this pull request:

- add archive.ph as sharing service

How to test the feature manually:

1. add "archive.ph" as sharing service (config -> sharing)
2. share an article
3. it opens a new tab with archive.ph and the selected URL (maybe you need to solve the spam protection)

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
