### PR TITLE
fix: Theme Swage - Text overflow in dropdown menu

### DIFF
--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -1294,6 +1294,7 @@ button.as-link {
 
 #nav_menu_actions ul.dropdown-menu {
 	left: 0;
+	right: auto;
 }
 
 #nav_menu_read_all ul.dropdown-menu {

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -1293,6 +1293,7 @@ button.as-link {
 }
 
 #nav_menu_actions ul.dropdown-menu {
+	left: auto;
 	right: 0;
 }
 

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -1293,8 +1293,8 @@ button.as-link {
 }
 
 #nav_menu_actions ul.dropdown-menu {
-	left: auto;
 	right: 0;
+	left: auto;
 }
 
 #nav_menu_read_all ul.dropdown-menu {

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -1596,6 +1596,7 @@ button.as-link {
 #nav_menu_actions {
 	ul.dropdown-menu {
 		left: 0;
+		right: auto;
 	}
 }
 


### PR DESCRIPTION
Fix text overflow in user query dropdown menu in theme "Swage", especially German text

Before:
![grafik](https://user-images.githubusercontent.com/1645099/186243686-223c64ec-255e-4c0b-a998-d484cba042dd.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/186243747-1ff9e1ad-c429-47a9-8e63-9cb84f5c6015.png)


Changes proposed in this pull request:

- (S)CSS

How to test the feature manually:

1. use Swage theme
2. use f.e. German
3. open user query dropdown menu


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
