### PR TITLE
fix: width of "no article" banner

### DIFF
--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -295,13 +295,8 @@ td.numeric {
 	display: none !important;
 }
 
-/* login and register form */
+/* prompt: login + register form + alert message banner */
 .prompt {
-	margin: 3rem auto;
-	padding: 2rem;
-	max-width: 400px;
-	min-width: 300px;
-	width: 33%;
 	text-align: center;
 }
 

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -295,13 +295,8 @@ td.numeric {
 	display: none !important;
 }
 
-/* login and register form */
+/* prompt: login + register form + alert message banner */
 .prompt {
-	margin: 3rem auto;
-	padding: 2rem;
-	max-width: 400px;
-	min-width: 300px;
-	width: 33%;
 	text-align: center;
 }
 


### PR DESCRIPTION
Regression from #4504

before (Origine):
![grafik](https://user-images.githubusercontent.com/1645099/186525899-8b1c4211-3a83-44b8-bcdd-46ffbeea9c63.png)


After (Origine):
![grafik](https://user-images.githubusercontent.com/1645099/186525938-9f3fcf4f-f1e3-4a38-ad5a-0a4a6bd8b40e.png)


Before (Mapco):
![grafik](https://user-images.githubusercontent.com/1645099/186525967-3e538f5d-0685-463f-abda-cfac51934046.png)

After (Mapco):
![grafik](https://user-images.githubusercontent.com/1645099/186526003-a1f3fabf-ddb6-474f-a18d-30a578ded6f8.png)


Changes proposed in this pull request:

- CSS


How to test the feature manually:

see the banner size of "no article" banner

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
