### PR TITLE
Fix #4231

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -435,7 +435,7 @@ function toggleContent(new_active, old_active, skipping) {
 
 		let new_pos = new_active.offsetParent.offsetTop + new_active.offsetTop - nav_menu_height;
 
-		if (prev_article && new_active.offsetTop - prev_article.offsetTop <= 150) {
+		if (prev_article && prev_article.offsetParent && new_active.offsetTop - prev_article.offsetTop <= 150) {
 			new_pos = prev_article.offsetParent.offsetTop + prev_article.offsetTop - nav_menu_height;
 			if (relative_move) {
 				new_pos -= box_to_move.offsetTop;
@@ -1103,7 +1103,7 @@ function init_stream(stream) {
 			if (ev.target.closest('.content, .item.website, .item.link, .dropdown')) {
 				return true;
 			}
-			if (!context.sides_close_article && ev.target.matches('div.flux_content')) {
+			if (!context.sides_close_article && ev.target.matches('.flux_content')) {
 				// setting for not-closing after clicking outside article area
 				return false;
 			}


### PR DESCRIPTION
### What does it close

Closes #4231. 

Actually, there are two issues to be fixed:
1. Since `div.flux_content` has been changed to `article.flux_content`    in HTML, we should address that in JS too. Or, to take one step further, select it using `.flux_content` directly.
2. For the article already at the first position, its `prev_article` would select `#new-article` whose css attribute `display` is `none` in most cases, which breaks the new position calculation.

### How to test the feature manually:

Please refer to #4231

### Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
