### PR TITLE
Improved: Mapco/Ansum headline sizes

### DIFF
--- a/p/themes/Ansum/_configuration.scss
+++ b/p/themes/Ansum/_configuration.scss
@@ -20,10 +20,14 @@
 
 	h1, h2 {
 		color: variables.$main-font-color;
-		font-size: 3rem;
+		font-size: 2rem;
 		margin-top: 1.75rem;
 		font-weight: 300;
 		line-height: 1.2em;
+	}
+
+	h2 {
+		font-size: 1.5rem;
 	}
 
 	a[href="./"] {

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -1144,10 +1144,13 @@ main.prompt {
 }
 .post h1, .post h2 {
 	color: #363330;
-	font-size: 3rem;
+	font-size: 2rem;
 	margin-top: 1.75rem;
 	font-weight: 300;
 	line-height: 1.2em;
+}
+.post h2 {
+	font-size: 1.5rem;
 }
 .post a[href="./"] {
 	margin: 0;

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -1144,10 +1144,13 @@ main.prompt {
 }
 .post h1, .post h2 {
 	color: #363330;
-	font-size: 3rem;
+	font-size: 2rem;
 	margin-top: 1.75rem;
 	font-weight: 300;
 	line-height: 1.2em;
+}
+.post h2 {
+	font-size: 1.5rem;
 }
 .post a[href="./"] {
 	margin: 0;

--- a/p/themes/Mapco/_configuration.scss
+++ b/p/themes/Mapco/_configuration.scss
@@ -15,10 +15,14 @@
 
 	h1, h2 {
 		color: variables.$main-font-color;
-		font-size: 3rem;
+		font-size: 2rem;
 		margin-top: 1.75rem;
 		font-weight: 300;
 		line-height: 1.2em;
+	}
+
+	h2 {
+		font-size: 1.5rem;
 	}
 
 	a[href="./"] { // This is the "Back to your feeds" button.

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -1171,10 +1171,13 @@ main.prompt {
 }
 .post h1, .post h2 {
 	color: #303136;
-	font-size: 3rem;
+	font-size: 2rem;
 	margin-top: 1.75rem;
 	font-weight: 300;
 	line-height: 1.2em;
+}
+.post h2 {
+	font-size: 1.5rem;
 }
 .post a[href="./"] {
 	margin: 0;

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -1171,10 +1171,13 @@ main.prompt {
 }
 .post h1, .post h2 {
 	color: #303136;
-	font-size: 3rem;
+	font-size: 2rem;
 	margin-top: 1.75rem;
 	font-weight: 300;
 	line-height: 1.2em;
+}
+.post h2 {
+	font-size: 1.5rem;
 }
 .post a[href="./"] {
 	margin: 0;


### PR DESCRIPTION
Ref. https://github.com/FreshRSS/FreshRSS/issues/4545 (improves (3))

Changes proposed in this pull request:

- (S)CSS of themes Mapco and Ansum


Before:
H1 and H2 were very big (3rem) and had the same size
![grafik](https://user-images.githubusercontent.com/1645099/187047996-29cc6cc3-d614-4572-afb1-c8b4f1dbe3cc.png)


After:
H1's size is 2rem, H2's size is 1.5rem
![grafik](https://user-images.githubusercontent.com/1645099/187047979-ab93482e-a9f3-4735-9605-ce301e78802a.png)


How to test the feature manually:

1. go to various config pages, f.e. label management or import/export
2. see the headlines

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested