### PR TITLE
Fix: swage extension config button

### DIFF
--- a/app/views/helpers/extension/details.phtml
+++ b/app/views/helpers/extension/details.phtml
@@ -16,7 +16,7 @@
 	}
 	if ($this->ext_details->getType() === 'user' || FreshRSS_Auth::hasAccess('admin')) {?>
 	<button class="switch<?= $button_class ?>" form="form-extension" formaction="<?= _url('extension', $action, 'e', $name_encoded) ?>" title="<?= _t('gen.action.enable') ?>"></button>
-	<a class="open-slider" title="<?= _t('gen.action.manage') ?>" href="<?= _url('extension', 'configure', 'e', $name_encoded) ?>"><?= _i('configure') ?></a>
+	<a class="open-slider configure" title="<?= _t('gen.action.manage') ?>" href="<?= _url('extension', 'configure', 'e', $name_encoded) ?>"><?= _i('configure') ?></a>
 	<span class="ext_name<?= $name_class ?>"><?= $this->ext_details->getName() ?></span>
 <?php } else { ?>
 	<button class="switch<?= $button_class ?>" title="<?= _t('admin.extensions.system.no_rights') ?>" disabled="disabled"></button>

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -273,6 +273,14 @@ form th {
 	background: #f95c20 !important;
 }
 
+.manage-list .configure .icon {
+	filter: brightness(0.4);
+	vertical-align: sub;
+}
+.manage-list .configure:hover {
+	filter: invert(56%) sepia(87%) saturate(1185%) hue-rotate(327deg) brightness(104%) contrast(96%);
+}
+
 .switch.active {
 	background-color: #0062be;
 }

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -542,7 +542,7 @@ form th {
 }
 .box .box-content .item .configure .icon {
 	vertical-align: middle;
-	filter: invert(1);
+	filter: brightness(0.4);
 }
 .box .box-content .item .configure .icon:hover {
 	filter: invert(56%) sepia(87%) saturate(1185%) hue-rotate(327deg) brightness(104%) contrast(96%);

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -273,6 +273,14 @@ form th {
 	background: #f95c20 !important;
 }
 
+.manage-list .configure .icon {
+	filter: brightness(0.4);
+	vertical-align: sub;
+}
+.manage-list .configure:hover {
+	filter: invert(56%) sepia(87%) saturate(1185%) hue-rotate(327deg) brightness(104%) contrast(96%);
+}
+
 .switch.active {
 	background-color: #0062be;
 }

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -542,7 +542,7 @@ form th {
 }
 .box .box-content .item .configure .icon {
 	vertical-align: middle;
-	filter: invert(1);
+	filter: brightness(0.4);
 }
 .box .box-content .item .configure .icon:hover {
 	filter: invert(56%) sepia(87%) saturate(1185%) hue-rotate(327deg) brightness(104%) contrast(96%);

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -680,7 +680,7 @@ form {
 			.configure {
 				.icon {
 					vertical-align: middle;
-					filter: invert(1);
+					filter: brightness(0.4);
 
 					&:hover {
 						filter: invert(56%) sepia(87%) saturate(1185%) hue-rotate(327deg) brightness(104%) contrast(96%);

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -343,6 +343,19 @@ form {
 	}
 }
 
+.manage-list {
+	.configure {
+		.icon {
+			filter: brightness(0.4);
+			vertical-align: sub;
+		}
+
+		&:hover {
+			filter: invert(56%) sepia(87%) saturate(1185%) hue-rotate(327deg) brightness(104%) contrast(96%);
+		}
+	}
+}
+
 .switch.active {
 	background-color: #0062be;
 


### PR DESCRIPTION
Ref. #4547
Regression from #4493

Before:
![grafik](https://user-images.githubusercontent.com/1645099/187049285-0cac8599-83b1-4b1c-a5e4-167d2e0073e6.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/187049290-2819121b-50c3-436b-8d47-d1962630d695.png)


Changes proposed in this pull request:

- (S)CSS
- .phtml: added the class "configure" to the open-slider-link

How to test the feature manually:

1. go to configure -> extensions
2. see the config button of each extension

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested