### PR TITLE
Fix: Login link - icon linked

### DIFF
--- a/app/layout/header.phtml
+++ b/app/layout/header.phtml
@@ -89,7 +89,7 @@
 	</nav>
 	<?php } elseif (FreshRSS_Auth::accessNeedsAction()) { ?>
 	<div class="item configure">
-		<?= _i('login') ?><a class="signin" href="<?= _url('auth', 'login') ?>"><?= _t('gen.auth.login') ?></a>
+		<a class="signin" href="<?= _url('auth', 'login') ?>"><?= _i('login') ?><?= _t('gen.auth.login') ?></a>
 	</div>
 	<?php } ?>
 </header>


### PR DESCRIPTION
After: When the mouse hovers over the icon then it links to the login form too
![grafik](https://user-images.githubusercontent.com/1645099/187286694-b8b25061-80c3-46ef-8776-9913d8c67c2a.png)


Changes proposed in this pull request:

- phtml

How to test the feature manually:

1. logout
2. hover the mouse over the login icon
3. the icon is linked

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
