### PR TITLE
Fix: Global view - No articles banner

### DIFF
--- a/app/views/index/global.phtml
+++ b/app/views/index/global.phtml
@@ -57,7 +57,7 @@
 		}
 	}
 
-	if ($unreadArticles < 1 && $state_unread == true) {
+	if ($unreadArticles < 1 && $state_unread) {
 		?>
 	<div id="noArticlesToShow" class="prompt alert alert-warn">
 		<h2 class="alert-head"><?= _t('index.feed.empty') ?></h2>

--- a/app/views/index/global.phtml
+++ b/app/views/index/global.phtml
@@ -3,10 +3,13 @@
 	$this->partial('nav_menu');
 
 	$class = '';
+	$state_unread = false;
+
 	if (FreshRSS_Context::$user_conf->hide_read_feeds &&
 			FreshRSS_Context::isStateEnabled(FreshRSS_Entry::STATE_NOT_READ) &&
 			!FreshRSS_Context::isStateEnabled(FreshRSS_Entry::STATE_READ)) {
 		$class = ' state_unread';
+		$state_unread = true;
 	}
 ?>
 
@@ -54,7 +57,7 @@
 		}
 	}
 
-	if ($unreadArticles < 1) {
+	if ($unreadArticles < 1 && $state_unread == true) {
 		?>
 	<div id="noArticlesToShow" class="prompt alert alert-warn">
 		<h2 class="alert-head"><?= _t('index.feed.empty') ?></h2>


### PR DESCRIPTION
Regression #4042

Before:
No unread feeds + button "show read feeds" active: the yellow "no article" banner is shown
![grafik](https://user-images.githubusercontent.com/1645099/187538972-d76b9835-edcf-4013-922c-d18ba3d51ce2.png)



After:
![grafik](https://user-images.githubusercontent.com/1645099/187537607-a701a563-29d3-4a0f-af67-ddd50029247e.png)


Changes proposed in this pull request:

- PHTML


How to test the feature manually:

1. go global view
2. mark all feeds as read
3. activate "show read articles"
4. see the yellow banner (it will not shown anymore)

Check also: the yellow banner is shown, when no feed is shown

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested