### PR TITLE
SimplePie fix base

### DIFF
--- a/lib/SimplePie/SimplePie/Item.php
+++ b/lib/SimplePie/SimplePie/Item.php
@@ -152,15 +152,22 @@ class SimplePie_Item
 	}
 
 	/**
-	 * Get the base URL value from the parent feed
-	 *
-	 * Uses `<xml:base>`
+	 * Get the base URL value.
+	 * Uses `<xml:base>`, or item link, or feed base URL.
 	 *
 	 * @param array $element
 	 * @return string
 	 */
 	public function get_base($element = array())
 	{
+		if (!empty($element['xml_base_explicit']) && isset($element['xml_base']))
+		{
+			return $element['xml_base'];
+		}
+		$link = $this->get_permalink();
+		if ($link != null) {
+			return $link;
+		}
 		return $this->feed->get_base($element);
 	}
 

--- a/lib/SimplePie/SimplePie/Item.php
+++ b/lib/SimplePie/SimplePie/Item.php
@@ -160,8 +160,7 @@ class SimplePie_Item
 	 */
 	public function get_base($element = array())
 	{
-		if (!empty($element['xml_base_explicit']) && isset($element['xml_base']))
-		{
+		if (!empty($element['xml_base_explicit']) && isset($element['xml_base'])) {
 			return $element['xml_base'];
 		}
 		$link = $this->get_permalink();


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/4562
See `<xml:base>` example in https://datatracker.ietf.org/doc/html/rfc4287#section-1.1
First uses item `<xml:base>` if it exists, or the item own link, or the feed's base URL rules (feed URL, or Web site URL)

Only maybe for 1.20.0 if sufficient testing is provided, otherwise 1.21.0