### PR TITLE
Expose CURLOPT_IPRESOLVE to UI

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -198,6 +198,7 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 				'curl_params' => empty($opts) ? null : $opts,
 			);
 			$attributes['ssl_verify'] = Minz_Request::paramTernary('ssl_verify');
+			$attributes['ipresolve'] = Minz_Request::paramTernary('ipresolve');
 			$timeout = intval(Minz_Request::param('timeout', 0));
 			$attributes['timeout'] = $timeout > 0 ? $timeout : null;
 

--- a/app/Controllers/subscriptionController.php
+++ b/app/Controllers/subscriptionController.php
@@ -173,6 +173,7 @@ class FreshRSS_subscription_Controller extends FreshRSS_ActionController {
 			$feed->_attributes('content_action', Minz_Request::param('content_action', 'replace'));
 
 			$feed->_attributes('ssl_verify', Minz_Request::paramTernary('ssl_verify'));
+			$feed->_attributes('ipresolve', Minz_Request::paramTernary('ipresolve'));
 			$timeout = intval(Minz_Request::param('timeout', 0));
 			$feed->_attributes('timeout', $timeout > 0 ? $timeout : null);
 

--- a/app/i18n/cz/sub.php
+++ b/app/i18n/cz/sub.php
@@ -71,6 +71,7 @@ return array(
 			'help' => 'Zapište jeden filtr hledání na řádek.',
 		),
 		'information' => 'Informace',
+		'ipresolve' => 'Internet protocol',	// TODO
 		'keep_min' => 'Minimální počet článků pro ponechání',
 		'kind' => array(
 			'_' => 'Type of feed source',	// TODO

--- a/app/i18n/de/sub.php
+++ b/app/i18n/de/sub.php
@@ -71,6 +71,7 @@ return array(
 			'help' => 'Ein Suchfilter pro Zeile',
 		),
 		'information' => 'Information',	// IGNORE
+		'ipresolve' => 'Internet protocol',	// TODO
 		'keep_min' => 'Minimale Anzahl an Artikeln, die behalten wird',
 		'kind' => array(
 			'_' => 'Art der Feed-Quelle',

--- a/app/i18n/en-us/sub.php
+++ b/app/i18n/en-us/sub.php
@@ -71,6 +71,7 @@ return array(
 			'help' => 'Write one search filter per line.',	// IGNORE
 		),
 		'information' => 'Information',	// IGNORE
+		'ipresolve' => 'Internet protocol',	// TODO
 		'keep_min' => 'Minimum number of articles to keep',	// IGNORE
 		'kind' => array(
 			'_' => 'Type of feed source',	// IGNORE

--- a/app/i18n/en/sub.php
+++ b/app/i18n/en/sub.php
@@ -71,6 +71,7 @@ return array(
 			'help' => 'Write one search filter per line.',
 		),
 		'information' => 'Information',
+		'ipresolve' => 'Internet protocol',	// TODO
 		'keep_min' => 'Minimum number of articles to keep',
 		'kind' => array(
 			'_' => 'Type of feed source',

--- a/app/i18n/es/sub.php
+++ b/app/i18n/es/sub.php
@@ -71,6 +71,7 @@ return array(
 			'help' => 'Escribir un filtro de búsqueda por línea.',
 		),
 		'information' => 'Información',
+		'ipresolve' => 'Internet protocol',	// TODO
 		'keep_min' => 'Número mínimo de artículos a conservar',
 		'kind' => array(
 			'_' => 'Type of feed source',	// TODO

--- a/app/i18n/fr/sub.php
+++ b/app/i18n/fr/sub.php
@@ -71,6 +71,7 @@ return array(
 			'help' => 'Écrivez une recherche par ligne.',
 		),
 		'information' => 'Informations',
+		'ipresolve' => 'Internet protocol',	// TODO
 		'keep_min' => 'Nombre minimum d’articles à conserver',
 		'kind' => array(
 			'_' => 'Type de source de flux',

--- a/app/i18n/he/sub.php
+++ b/app/i18n/he/sub.php
@@ -71,6 +71,7 @@ return array(
 			'help' => 'Write one search filter per line.',	// TODO
 		),
 		'information' => 'מידע',
+		'ipresolve' => 'Internet protocol',	// TODO
 		'keep_min' => 'מסםר מינימלי של מאמרים לשמור',
 		'kind' => array(
 			'_' => 'Type of feed source',	// TODO

--- a/app/i18n/it/sub.php
+++ b/app/i18n/it/sub.php
@@ -71,6 +71,7 @@ return array(
 			'help' => 'Write one search filter per line.',	// TODO
 		),
 		'information' => 'Informazioni',
+		'ipresolve' => 'Internet protocol',	// TODO
 		'keep_min' => 'Numero minimo di articoli da mantenere',
 		'kind' => array(
 			'_' => 'Type of feed source',	// TODO

--- a/app/i18n/ja/sub.php
+++ b/app/i18n/ja/sub.php
@@ -71,6 +71,7 @@ return array(
 			'help' => '1行に1つの検索フィルターを設定してください',
 		),
 		'information' => 'インフォメーション',
+		'ipresolve' => 'Internet protocol',	// TODO
 		'keep_min' => '最小数の記事は保持されます',
 		'kind' => array(
 			'_' => 'Type of feed source',	// TODO

--- a/app/i18n/ko/sub.php
+++ b/app/i18n/ko/sub.php
@@ -71,6 +71,7 @@ return array(
 			'help' => '한 줄에 한 검색 필터를 작성해 주세요.',
 		),
 		'information' => '정보',
+		'ipresolve' => 'Internet protocol',	// TODO
 		'keep_min' => '최소 유지 글 개수',
 		'kind' => array(
 			'_' => '피드 소스 유형',

--- a/app/i18n/nl/sub.php
+++ b/app/i18n/nl/sub.php
@@ -71,6 +71,7 @@ return array(
 			'help' => 'Voer één zoekfilter per lijn in.',
 		),
 		'information' => 'Informatie',
+		'ipresolve' => 'Internet protocol',	// TODO
 		'keep_min' => 'Minimum aantal artikelen om te houden',
 		'kind' => array(
 			'_' => 'Feedbron-type',

--- a/app/i18n/oc/sub.php
+++ b/app/i18n/oc/sub.php
@@ -71,6 +71,7 @@ return array(
 			'help' => 'Escrivètz una recèrca per linha.',
 		),
 		'information' => 'Informacions',
+		'ipresolve' => 'Internet protocol',	// TODO
 		'keep_min' => 'Nombre minimum d’articles de servar',
 		'kind' => array(
 			'_' => 'Tipe de font de flux',

--- a/app/i18n/pl/sub.php
+++ b/app/i18n/pl/sub.php
@@ -71,6 +71,7 @@ return array(
 			'help' => 'Jedno zapytanie na linię.',
 		),
 		'information' => 'Informacja',
+		'ipresolve' => 'Internet protocol',	// TODO
 		'keep_min' => 'Minimalna liczba wiadomości do do przechowywania',
 		'kind' => array(
 			'_' => 'Rodzaj źródła kanału',

--- a/app/i18n/pt-br/sub.php
+++ b/app/i18n/pt-br/sub.php
@@ -71,6 +71,7 @@ return array(
 			'help' => 'Escreva um filtro de pesquisa por linha.',
 		),
 		'information' => 'Informações',
+		'ipresolve' => 'Internet protocol',	// TODO
 		'keep_min' => 'Número mínimo de artigos para manter',
 		'kind' => array(
 			'_' => 'Type of feed source',	// TODO

--- a/app/i18n/ru/sub.php
+++ b/app/i18n/ru/sub.php
@@ -71,6 +71,7 @@ return array(
 			'help' => 'Введите по одному поисковому фильтру в строке.',
 		),
 		'information' => 'Информация',
+		'ipresolve' => 'Internet protocol',	// TODO
 		'keep_min' => 'Оставлять статей не менее',
 		'kind' => array(
 			'_' => 'Тип источника ленты',

--- a/app/i18n/sk/sub.php
+++ b/app/i18n/sk/sub.php
@@ -71,6 +71,7 @@ return array(
 			'help' => 'Napíšte jeden výraz hľadania na riadok.',
 		),
 		'information' => 'Informácia',
+		'ipresolve' => 'Internet protocol',	// TODO
 		'keep_min' => 'Minimálny počet článkov na uchovanie',
 		'kind' => array(
 			'_' => 'Typ zdroja kanála',

--- a/app/i18n/tr/sub.php
+++ b/app/i18n/tr/sub.php
@@ -71,6 +71,7 @@ return array(
 			'help' => 'Her satıra tek arama filtresi yaz.',
 		),
 		'information' => 'Bilgi',
+		'ipresolve' => 'Internet protocol',	// TODO
 		'keep_min' => 'En az tutulacak makale sayısı',
 		'kind' => array(
 			'_' => 'Type of feed source',	// TODO

--- a/app/i18n/zh-cn/sub.php
+++ b/app/i18n/zh-cn/sub.php
@@ -71,6 +71,7 @@ return array(
 			'help' => '每行写一条过滤搜索',
 		),
 		'information' => '信息',
+		'ipresolve' => 'Internet protocol',	// TODO
 		'keep_min' => '至少保存的文章数',
 		'kind' => array(
 			'_' => '订阅源类型',

--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -611,6 +611,17 @@
 		</div>
 
 		<div class="form-group">
+			<label class="group-name" for="ipresolve"><?= _t('sub.feed.ipresolve') ?></label>
+			<div class="group-controls">
+				<select name="ipresolve" id="ipresolve" class="w50">
+					<option value=""<?= $this->feed->attributes('ipresolve') === null ? ' selected="selected"' : '' ?>><?= _t('gen.short.by_default') ?></option>
+					<option value="0"<?= $this->feed->attributes('ipresolve') === false ? ' selected="selected"' : '' ?>>IPv4</option>
+					<option value="1"<?= $this->feed->attributes('ipresolve') === true ? ' selected="selected"' : '' ?>>IPv6</option>
+				</select>
+			</div>
+		</div>
+
+		<div class="form-group">
 			<div class="group-controls">
 				<label class="checkbox" for="clear_cache">
 					<input type="checkbox" name="clear_cache" id="clear_cache" value="1"<?= $this->feed->attributes('clear_cache') ? ' checked="checked"' : '' ?> />

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -248,7 +248,7 @@ function customSimplePie($attributes = array()): SimplePie {
 		}
 	}
 	if (isset($attributes['ipresolve'])) {
-		$curl_options[CURLOPT_IPRESOLVE] = $attributes['ipresolve'] ? CURL_IPRESOLVE_V6 : CURL_IPRESOLVE_V4;
+		$curl_options[CURLOPT_IPRESOLVE] = $attributes['ipresolve'] ? "CURL_IPRESOLVE_V6" : "CURL_IPRESOLVE_V4";
 	}
 	if (!empty($attributes['curl_params']) && is_array($attributes['curl_params'])) {
 		foreach ($attributes['curl_params'] as $co => $v) {

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -247,6 +247,9 @@ function customSimplePie($attributes = array()): SimplePie {
 			$curl_options[CURLOPT_SSL_CIPHER_LIST] = 'DEFAULT@SECLEVEL=1';
 		}
 	}
+	if (isset($attributes['ipresolve'])) {
+		$curl_options[CURLOPT_IPRESOLVE] = $attributes['ipresolve'] ? CURL_IPRESOLVE_V6 : CURL_IPRESOLVE_V4;
+	}
 	if (!empty($attributes['curl_params']) && is_array($attributes['curl_params'])) {
 		foreach ($attributes['curl_params'] as $co => $v) {
 			$curl_options[$co] = $v;


### PR DESCRIPTION
Closes #4560

Changes proposed in this pull request:

- Exposing CURLOPT_RESOLVE to UI to force IPv4 or IPv6 of a feed

Do note that:
- I did not apply this change on ```app/views/subscription/add.phtml``` as I believe you usually don't know in advance that you need to specifically use IPV4 or IPV6 - what do you think? EDIT: I still have included support in ```subscriptionController.php```, damn! 🤦 
- I did not add translation for "IPv4" and "IPv6" as I believe it will be translated the same in all languages
- last but not least I am no developer, it is just a kind of "challenge", I will not be offended if this is rejected. In particular, I have high doubts about the true/false I have used, I think this is not the right way in this case but I took example out of ssl_verify, so it was easier for me. But it really seems to be working. I may have a second look if asked for and if I have time/motivation for it!

How to test the feature manually:

1. Select IPv4 for a feed, get the IP of the server and check traffic with ```tcpdump ip && host <ip>```
2. Select IPv6 for a feed, get the IP of the server and check traffic with ```tcpdump ip6 && host <ip>```

Option is located in "Advanced" part, at the end, just after "Verify SSL security"
<img width="516" alt="ApplicationFrameHost_2022-08-31_23-51-51" src="https://user-images.githubusercontent.com/7189936/187791722-8c4b8d6e-5db1-4069-a8ef-7d272d9b7857.png">


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
