### PR TITLE
fix: space key opens empty tab

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1005,9 +1005,8 @@ function init_shortcuts() {
 			const link_go_website = document.querySelector('.flux.current a.go_website');
 			const newWindow = window.open();
 			if (link_go_website && newWindow) {
-					newWindow.opener = null;
-					newWindow.location = link_go_website.href;
-				}
+				newWindow.opener = null;
+				newWindow.location = link_go_website.href;
 				ev.preventDefault();
 			}
 			return;

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1003,9 +1003,8 @@ function init_shortcuts() {
 			}
 
 			const link_go_website = document.querySelector('.flux.current a.go_website');
-			if (link_go_website) {
-				const newWindow = window.open();
-				if (newWindow) {
+			const newWindow = window.open();
+			if (link_go_website && newWindow) {
 					newWindow.opener = null;
 					newWindow.location = link_go_website.href;
 				}

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1001,12 +1001,16 @@ function init_shortcuts() {
 			if (context.auto_mark_site) {
 				mark_read(document.querySelector('.flux.current'), true, false);
 			}
-			const newWindow = window.open();
-			if (newWindow) {
-				newWindow.opener = null;
-				newWindow.location = document.querySelector('.flux.current a.go_website').href;
+
+			const link_go_website = document.querySelector('.flux.current a.go_website');
+			if (link_go_website) {
+				const newWindow = window.open();
+				if (newWindow) {
+					newWindow.opener = null;
+					newWindow.location = link_go_website.href;
+				}
+				ev.preventDefault();
 			}
-			ev.preventDefault();
 			return;
 		}
 		if (k === s.skip_next_entry) { next_entry(true); ev.preventDefault(); return; }


### PR DESCRIPTION
Closes #4579

Changes proposed in this pull request:

- JavaScript


How to test the feature manually:

1. check if "space" is set as shortcut for the "open website"
2. press space key every where (nothing special will happen, maybe the window will scroll down)
3. press space key, when an article is focused: it will open a new tab with the link

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
