### PR TITLE
Use body text color for input in Alternative Dark theme to improve contrast

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -36,7 +36,7 @@ textarea {
 input, select, textarea {
 	padding: 5px;
 	background: #262626;
-	color: #666;
+	color: #999;
 	border: 1px solid #666;
 	border-radius: 3px;
 	min-height: 25px;

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -36,7 +36,7 @@ textarea {
 input, select, textarea {
 	padding: 5px;
 	background: #262626;
-	color: #666;
+	color: #999;
 	border: 1px solid #666;
 	border-radius: 3px;
 	min-height: 25px;


### PR DESCRIPTION
Fixes #4585.

How to test the feature manually:

1. Use Alternative Dark theme

### Before
![image](https://user-images.githubusercontent.com/202757/188718289-c0a96bc6-64fc-4971-bcc7-4589af329c48.png)


### After
![image](https://user-images.githubusercontent.com/202757/188718227-8fd77163-f558-46e2-93c6-f11c4c919694.png)


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
