### PR TITLE
Workaround invalid OPMLs

### DIFF
--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -83,7 +83,7 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 				'url' => $feed->url(),
 				'kind' => $feed->kind(),
 				'category' => $feed->categoryId(),
-				'name' => $feed->name(),
+				'name' => $feed->name(true),
 				'website' => $feed->website(),
 				'description' => $feed->description(),
 				'lastUpdate' => 0,
@@ -113,7 +113,7 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 			// Update some values of the existing feed using the import
 			$values = [
 				'kind' => $feed->kind(),
-				'name' => $feed->name(),
+				'name' => $feed->name(true),
 				'website' => $feed->website(),
 				'description' => $feed->description(),
 				'pathEntries' => $feed->pathEntries(),

--- a/app/Services/ImportService.php
+++ b/app/Services/ImportService.php
@@ -123,6 +123,9 @@ class FreshRSS_Import_Service {
 	 * @return FreshRSS_Feed|null a feed.
 	 */
 	private function addFeedOpml($feed_elt, $parent_cat, $dryRun = false) {
+		if (empty($feed_elt['xmlUrl'])) {
+			return null;
+		}
 		if ($parent_cat == null) {
 			// This feed has no parent category so we get the default one
 			$this->catDAO->checkDefault();
@@ -135,15 +138,9 @@ class FreshRSS_Import_Service {
 
 		// We get different useful information
 		$url = Minz_Helper::htmlspecialchars_utf8($feed_elt['xmlUrl']);
-		$name = Minz_Helper::htmlspecialchars_utf8($feed_elt['text']);
-		$website = '';
-		if (isset($feed_elt['htmlUrl'])) {
-			$website = Minz_Helper::htmlspecialchars_utf8($feed_elt['htmlUrl']);
-		}
-		$description = '';
-		if (isset($feed_elt['description'])) {
-			$description = Minz_Helper::htmlspecialchars_utf8($feed_elt['description']);
-		}
+		$name = Minz_Helper::htmlspecialchars_utf8($feed_elt['text'] ?? '');
+		$website = Minz_Helper::htmlspecialchars_utf8($feed_elt['htmlUrl'] ?? '');
+		$description = Minz_Helper::htmlspecialchars_utf8($feed_elt['description'] ?? '');
 
 		try {
 			// Create a Feed object and add it in DB

--- a/lib/lib_opml.php
+++ b/lib/lib_opml.php
@@ -189,16 +189,17 @@ function libopml_parse_string($xml, $strict = true) {
 		'body' => array()
 	);
 
-	// First, we get all "head" elements. Head is required but its sub-elements
-	// are optional.
-	foreach ($opml->head->children() as $key => $value) {
-		if (in_array($key, unserialize(HEAD_ELEMENTS), true)) {
-			$array['head'][$key] = (string)$value;
-		} elseif ($strict) {
-			throw new LibOPML_Exception(
-				$key . ' is not part of the OPML 2.0 specification'
-			);
+	if (isset($opml->head)) {
+		// We get all "head" elements. Head is required but its sub-elements are optional.
+		foreach ($opml->head->children() as $key => $value) {
+			if (in_array($key, unserialize(HEAD_ELEMENTS), true)) {
+				$array['head'][$key] = (string)$value;
+			} elseif ($strict) {
+				throw new LibOPML_Exception($key . ' is not part of the OPML 2.0 specification');
+			}
 		}
+	} elseif ($strict) {
+		throw new LibOPML_Exception('Required OPML head element is missing!');
 	}
 
 	// Then, we get body oulines. Body must contain at least one outline


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/4590
Accept OPML files lacking `<head>` element and `text` attributes, e.g. from non-compliant https://opml-gen.ovh/
