### PR TITLE
Add freshrss network when creating container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ ifndef TAG
 endif
 
 PORT ?= 8080
+NETWORK ?= freshrss-network
 
 ifdef NO_DOCKER
 	PHP = $(shell which php)
@@ -38,6 +39,7 @@ build: ## Build a Docker image
 
 .PHONY: start
 start: ## Start the development environment (use Docker)
+	docker network create --driver bridge $(NETWORK) || true
 	$(foreach extension,$(extensions),$(eval volumes=$(volumes) --volume $(extension):/var/www/FreshRSS/extensions/$(notdir $(extension)):z))
 	docker run \
 		--rm \
@@ -46,11 +48,13 @@ start: ## Start the development environment (use Docker)
 		--publish $(PORT):80 \
 		--env FRESHRSS_ENV=development \
 		--name freshrss-dev \
+		--network $(NETWORK) \
 		freshrss/freshrss:$(TAG)
 
 .PHONY: stop
 stop: ## Stop FreshRSS container if any
-	docker stop freshrss-dev
+	docker stop freshrss-dev || true
+	docker network rm $(NETWORK) || true
 
 ######################
 ## Tests and linter ##


### PR DESCRIPTION
This will ease the connection between freshrss container and other containers.

Changes proposed in this pull request:

- Add a network for freshrss container

How to test the feature manually:

1. launch the command `make start`.
2. launch the command `docker network ls` and validate that the network is created.
3. launch the command `docker network inspect freshrss` and validate that the freshrss-dev container is linked.
4. launch the command `make stop`.
5. launch the command `docker network ls` and validate that the network is deleted.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
