### PR TITLE
improved: CSS: clean .horizontal-list

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -295,16 +295,6 @@ a.btn {
 	line-height: 1.5rem;
 }
 
-/*=== Horizontal-list */
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-}
-
-.horizontal-list .item {
-	vertical-align: middle;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;
@@ -958,20 +948,6 @@ a.btn {
 .stat > table td,
 .stat > table th {
 	border-bottom: 1px solid #ddd;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 270px;
 }
 
 /*=== LOGS */

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -295,16 +295,6 @@ a.btn {
 	line-height: 1.5rem;
 }
 
-/*=== Horizontal-list */
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-}
-
-.horizontal-list .item {
-	vertical-align: middle;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;
@@ -958,20 +948,6 @@ a.btn {
 .stat > table td,
 .stat > table th {
 	border-bottom: 1px solid #ddd;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 270px;
 }
 
 /*=== LOGS */

--- a/p/themes/Ansum/_components.scss
+++ b/p/themes/Ansum/_components.scss
@@ -11,12 +11,9 @@
 
 /*=== Horizontal-list */
 .horizontal-list {
-	margin: 0;
 	padding: 0.1rem 0;
 
 	.item {
-		vertical-align: middle;
-
 		&:first-child {
 			padding-left: 0.5rem;
 		}

--- a/p/themes/Ansum/_configuration.scss
+++ b/p/themes/Ansum/_configuration.scss
@@ -7,11 +7,6 @@
 
 	form {
 		margin: 1rem 0;
-
-		// Extension management
-		.horizontal-list {
-			margin-bottom: 0.5rem;
-		}
 	}
 
 	&.content {

--- a/p/themes/Ansum/_stats.scss
+++ b/p/themes/Ansum/_stats.scss
@@ -16,17 +16,3 @@
 .stat > table th {
 	border-bottom: 1px solid variables.$grey-medium-light;
 }
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 270px;
-}

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -221,11 +221,7 @@ form th {
 /*=== Forms */
 /*=== Horizontal-list */
 .horizontal-list {
-	margin: 0;
 	padding: 0.1rem 0;
-}
-.horizontal-list .item {
-	vertical-align: middle;
 }
 .horizontal-list .item:first-child {
 	padding-left: 0.5rem;
@@ -1137,9 +1133,6 @@ main.prompt {
 .post form {
 	margin: 1rem 0;
 }
-.post form .horizontal-list {
-	margin-bottom: 0.5rem;
-}
 .post.content {
 	max-width: 550px;
 }
@@ -1246,20 +1239,6 @@ main.prompt {
 .stat > table td,
 .stat > table th {
 	border-bottom: 1px solid #e4d8cc;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 270px;
 }
 
 /*=== MOBILE */

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -221,11 +221,7 @@ form th {
 /*=== Forms */
 /*=== Horizontal-list */
 .horizontal-list {
-	margin: 0;
 	padding: 0.1rem 0;
-}
-.horizontal-list .item {
-	vertical-align: middle;
 }
 .horizontal-list .item:first-child {
 	padding-right: 0.5rem;
@@ -1137,9 +1133,6 @@ main.prompt {
 .post form {
 	margin: 1rem 0;
 }
-.post form .horizontal-list {
-	margin-bottom: 0.5rem;
-}
 .post.content {
 	max-width: 550px;
 }
@@ -1246,20 +1239,6 @@ main.prompt {
 .stat > table td,
 .stat > table th {
 	border-bottom: 1px solid #e4d8cc;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 270px;
 }
 
 /*=== MOBILE */

--- a/p/themes/BlueLagoon/BlueLagoon.css
+++ b/p/themes/BlueLagoon/BlueLagoon.css
@@ -349,16 +349,6 @@ a.btn {
 	line-height: 1.5rem;
 }
 
-/*=== Horizontal-list */
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-}
-
-.horizontal-list .item {
-	vertical-align: middle;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;
@@ -1138,20 +1128,6 @@ a.btn {
 	background: rgba(255,255,255,0.38);
 	border-bottom: 1px solid #ccc;
 	box-shadow: 0 1px #fff;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 250px;
 }
 
 /*=== LOGS */

--- a/p/themes/BlueLagoon/BlueLagoon.rtl.css
+++ b/p/themes/BlueLagoon/BlueLagoon.rtl.css
@@ -349,16 +349,6 @@ a.btn {
 	line-height: 1.5rem;
 }
 
-/*=== Horizontal-list */
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-}
-
-.horizontal-list .item {
-	vertical-align: middle;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;
@@ -1138,20 +1128,6 @@ a.btn {
 	background: rgba(255,255,255,0.38);
 	border-bottom: 1px solid #ccc;
 	box-shadow: 0 1px #fff;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 250px;
 }
 
 /*=== LOGS */

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -347,16 +347,6 @@ a.btn {
 	line-height: 1.5rem;
 }
 
-/*=== Horizontal-list */
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-}
-
-.horizontal-list .item {
-	vertical-align: middle;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;
@@ -1016,20 +1006,6 @@ a.btn {
 .stat > table td,
 .stat > table th {
 	border-bottom: 1px solid #333;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 270px;
 }
 
 /*=== LOGS */

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -347,16 +347,6 @@ a.btn {
 	line-height: 1.5rem;
 }
 
-/*=== Horizontal-list */
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-}
-
-.horizontal-list .item {
-	vertical-align: middle;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;
@@ -1016,20 +1006,6 @@ a.btn {
 .stat > table td,
 .stat > table th {
 	border-bottom: 1px solid #333;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 270px;
 }
 
 /*=== LOGS */

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -337,16 +337,6 @@ a.btn {
 	line-height: 1.5rem;
 }
 
-/*=== Horizontal-list */
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-}
-
-.horizontal-list .item {
-	vertical-align: middle;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 0.5rem 0 0;
@@ -1023,20 +1013,6 @@ a.btn {
 .stat > table td,
 .stat > table th {
 	border-bottom: 1px solid #ddd;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 270px;
 }
 
 /*=== LOGS */

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -337,16 +337,6 @@ a.btn {
 	line-height: 1.5rem;
 }
 
-/*=== Horizontal-list */
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-}
-
-.horizontal-list .item {
-	vertical-align: middle;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 0.5rem 0 0;
@@ -1023,20 +1013,6 @@ a.btn {
 .stat > table td,
 .stat > table th {
 	border-bottom: 1px solid #ddd;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 270px;
 }
 
 /*=== LOGS */

--- a/p/themes/Mapco/_components.scss
+++ b/p/themes/Mapco/_components.scss
@@ -11,12 +11,9 @@
 
 /*=== Horizontal-list */
 .horizontal-list {
-	margin: 0;
 	padding: 0.1rem 0;
 
 	.item {
-		vertical-align: middle;
-
 		&:first-child {
 			padding-left: 0.5rem;
 		}

--- a/p/themes/Mapco/_stats.scss
+++ b/p/themes/Mapco/_stats.scss
@@ -16,17 +16,3 @@
 .stat > table th {
 	border-bottom: 1px solid variables.$grey-medium-light;
 }
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 270px;
-}

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -220,11 +220,7 @@ form th {
 /*=== Forms */
 /*=== Horizontal-list */
 .horizontal-list {
-	margin: 0;
 	padding: 0.1rem 0;
-}
-.horizontal-list .item {
-	vertical-align: middle;
 }
 .horizontal-list .item:first-child {
 	padding-left: 0.5rem;
@@ -1272,20 +1268,6 @@ main.prompt {
 .stat > table td,
 .stat > table th {
 	border-bottom: 1px solid #d5d8db;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 270px;
 }
 
 /*=== MOBILE */

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -220,11 +220,7 @@ form th {
 /*=== Forms */
 /*=== Horizontal-list */
 .horizontal-list {
-	margin: 0;
 	padding: 0.1rem 0;
-}
-.horizontal-list .item {
-	vertical-align: middle;
 }
 .horizontal-list .item:first-child {
 	padding-right: 0.5rem;
@@ -1272,20 +1268,6 @@ main.prompt {
 .stat > table td,
 .stat > table th {
 	border-bottom: 1px solid #d5d8db;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 270px;
 }
 
 /*=== MOBILE */

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -215,12 +215,6 @@ a.btn {
 	line-height: 1.5rem;
 }
 
-/*=== Horizontal-list */
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-}
-
 .dropdown-menu {
 	margin: 5px 0 0;
 	padding: 5px 0;
@@ -742,21 +736,6 @@ li.item.active {
 .stat > table th {
 	text-align: center;
 }
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 250px;
-}
-
 
 .stat {
 	margin: 10px 0 20px;

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -215,12 +215,6 @@ a.btn {
 	line-height: 1.5rem;
 }
 
-/*=== Horizontal-list */
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-}
-
 .dropdown-menu {
 	margin: 5px 0 0;
 	padding: 5px 0;
@@ -742,21 +736,6 @@ li.item.active {
 .stat > table th {
 	text-align: center;
 }
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 250px;
-}
-
 
 .stat {
 	margin: 10px 0 20px;

--- a/p/themes/Origine-compact/origine-compact.css
+++ b/p/themes/Origine-compact/origine-compact.css
@@ -350,13 +350,10 @@ a.btn,
 
 /*=== Horizontal-list */
 .horizontal-list {
-	margin: 0;
-	padding: 0;
 	font-size: 0.9rem;
 }
 
 .horizontal-list .item {
-	vertical-align: middle;
 	line-height: 30px;
 }
 
@@ -1079,20 +1076,6 @@ a.btn,
 .stat > table td,
 .stat > table th {
 	border-bottom: 1px solid #ddd;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 270px;
 }
 
 /*=== LOGS */

--- a/p/themes/Origine-compact/origine-compact.rtl.css
+++ b/p/themes/Origine-compact/origine-compact.rtl.css
@@ -350,13 +350,10 @@ a.btn,
 
 /*=== Horizontal-list */
 .horizontal-list {
-	margin: 0;
-	padding: 0;
 	font-size: 0.9rem;
 }
 
 .horizontal-list .item {
-	vertical-align: middle;
 	line-height: 30px;
 }
 
@@ -1079,20 +1076,6 @@ a.btn,
 .stat > table td,
 .stat > table th {
 	border-bottom: 1px solid #ddd;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 270px;
 }
 
 /*=== LOGS */

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -341,16 +341,6 @@ a.btn {
 	line-height: 1.5rem;
 }
 
-/*=== Horizontal-list */
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-}
-
-.horizontal-list .item {
-	vertical-align: middle;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;
@@ -1001,20 +991,6 @@ a.btn {
 .stat > table td,
 .stat > table th {
 	border-bottom: 1px solid #ddd;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 270px;
 }
 
 /*=== LOGS */

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -341,16 +341,6 @@ a.btn {
 	line-height: 1.5rem;
 }
 
-/*=== Horizontal-list */
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-}
-
-.horizontal-list .item {
-	vertical-align: middle;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;
@@ -1001,20 +991,6 @@ a.btn {
 .stat > table td,
 .stat > table th {
 	border-bottom: 1px solid #ddd;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 270px;
 }
 
 /*=== LOGS */

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -308,16 +308,6 @@ a.btn {
 	line-height: 1.5rem;
 }
 
-/*=== Horizontal-list */
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-}
-
-.horizontal-list .item {
-	vertical-align: middle;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;
@@ -1000,20 +990,6 @@ a.signin {
 .stat > table th {
 	border-bottom: 1px solid #ddd;
 	text-align: center;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 250px;
 }
 
 /*=== LOGS */

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -308,16 +308,6 @@ a.btn {
 	line-height: 1.5rem;
 }
 
-/*=== Horizontal-list */
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-}
-
-.horizontal-list .item {
-	vertical-align: middle;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;
@@ -1000,20 +990,6 @@ a.signin {
 .stat > table th {
 	border-bottom: 1px solid #ddd;
 	text-align: center;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 250px;
 }
 
 /*=== LOGS */

--- a/p/themes/Screwdriver/screwdriver.css
+++ b/p/themes/Screwdriver/screwdriver.css
@@ -353,16 +353,6 @@ a.btn {
 	line-height: 1.5rem;
 }
 
-/*=== Horizontal-list */
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-}
-
-.horizontal-list .item {
-	vertical-align: middle;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;
@@ -1115,20 +1105,6 @@ a.btn {
 	background: rgba(255,255,255,0.38);
 	border-bottom: 1px solid #ccc;
 	box-shadow: 0 1px #fff;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 250px;
 }
 
 /*=== LOGS */

--- a/p/themes/Screwdriver/screwdriver.rtl.css
+++ b/p/themes/Screwdriver/screwdriver.rtl.css
@@ -353,16 +353,6 @@ a.btn {
 	line-height: 1.5rem;
 }
 
-/*=== Horizontal-list */
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-}
-
-.horizontal-list .item {
-	vertical-align: middle;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;
@@ -1115,20 +1105,6 @@ a.btn {
 	background: rgba(255,255,255,0.38);
 	border-bottom: 1px solid #ccc;
 	box-shadow: 0 1px #fff;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 250px;
 }
 
 /*=== LOGS */

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -352,14 +352,6 @@ form th {
 	line-height: 1.5rem;
 }
 
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-}
-.horizontal-list .item {
-	vertical-align: middle;
-}
-
 .dropdown-menu {
 	padding: 0.5rem 0 1rem 0;
 	font-size: 0.8rem;
@@ -938,17 +930,6 @@ form th {
 .stat > table td,
 .stat > table th {
 	border-bottom: 1px solid #e3e3e3;
-}
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-.stat > .horizontal-list .item:first-child {
-	width: 270px;
 }
 
 #overlay {

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -352,14 +352,6 @@ form th {
 	line-height: 1.5rem;
 }
 
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-}
-.horizontal-list .item {
-	vertical-align: middle;
-}
-
 .dropdown-menu {
 	padding: 0.5rem 0 1rem 0;
 	font-size: 0.8rem;
@@ -938,17 +930,6 @@ form th {
 .stat > table td,
 .stat > table th {
 	border-bottom: 1px solid #e3e3e3;
-}
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-.stat > .horizontal-list .item:first-child {
-	width: 270px;
 }
 
 #overlay {

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -452,15 +452,6 @@ form {
 	}
 }
 
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-
-	.item {
-		vertical-align: middle;
-	}
-}
-
 .dropdown-menu {
 	padding: 0.5rem 0 1rem 0;
 	font-size: 0.8rem;
@@ -1191,20 +1182,6 @@ form {
 		td,
 		th {
 			border-bottom: 1px solid color.adjust( $color_light, $lightness: -10%);
-		}
-	}
-
-	> .horizontal-list {
-		margin: 0 0 5px;
-
-		.item {
-			overflow: hidden;
-			white-space: nowrap;
-			text-overflow: ellipsis;
-
-			&:first-child {
-				width: 270px;
-			}
 		}
 	}
 }

--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -243,16 +243,6 @@ a.btn {
 	line-height: 1.5rem;
 }
 
-/*=== Horizontal-list */
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-}
-
-.horizontal-list .item {
-	vertical-align: middle;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;
@@ -812,20 +802,6 @@ a.btn {
 .stat > table td,
 .stat > table th {
 	text-align: center;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 250px;
 }
 
 /*=== LOGS */

--- a/p/themes/base-theme/base.rtl.css
+++ b/p/themes/base-theme/base.rtl.css
@@ -243,16 +243,6 @@ a.btn {
 	line-height: 1.5rem;
 }
 
-/*=== Horizontal-list */
-.horizontal-list {
-	margin: 0;
-	padding: 0;
-}
-
-.horizontal-list .item {
-	vertical-align: middle;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;
@@ -812,20 +802,6 @@ a.btn {
 .stat > table td,
 .stat > table th {
 	text-align: center;
-}
-
-.stat > .horizontal-list {
-	margin: 0 0 5px;
-}
-
-.stat > .horizontal-list .item {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.stat > .horizontal-list .item:first-child {
-	width: 250px;
 }
 
 /*=== LOGS */

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -532,6 +532,8 @@ input[type="checkbox"]:focus-visible {
 
 /*=== Horizontal-list */
 .horizontal-list {
+	margin: 0;
+	padding: 0;
 	display: table;
 	table-layout: fixed;
 	width: 100%;
@@ -539,6 +541,7 @@ input[type="checkbox"]:focus-visible {
 
 .horizontal-list .item {
 	display: table-cell;
+	vertical-align: middle;
 }
 
 /*=== manage-list */

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -532,6 +532,8 @@ input[type="checkbox"]:focus-visible {
 
 /*=== Horizontal-list */
 .horizontal-list {
+	margin: 0;
+	padding: 0;
 	display: table;
 	table-layout: fixed;
 	width: 100%;
@@ -539,6 +541,7 @@ input[type="checkbox"]:focus-visible {
 
 .horizontal-list .item {
 	display: table-cell;
+	vertical-align: middle;
 }
 
 /*=== manage-list */


### PR DESCRIPTION
Ref. #4192
Ref. #4181

Both PR reduced the usage of `.horizontal-list`

Now only `app\views\helpers\index\normal\entry_bottom.phtml` and `app\views\helpers\index\normal\entry_header.phtml` use `.horizontal-list`.

So it makes sense to clean the CSS.

Changes proposed in this pull request:

- (S)CSS

How to test the feature manually:
just Code

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
