### PR TITLE
Improved: eslint + stylelint: Do not scan extension folder

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 *.min.js
+extensions/
 node_modules/
 p/scripts/vendor/
 vendor/

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,3 +1,4 @@
+extensions/
 node_modules/
 p/scripts/vendor/
 vendor/


### PR DESCRIPTION

Changes proposed in this pull request:

- eslint does not scan anymore the `extensions` folder
- stylelint does not scan anymore the `extensions` folder

In my dev environment, I have installed some extensions too. Eslint and Stylelint find there some issues. It fills my console and costs time.