### PR TITLE
Improved: Mouse title on empty feeds

### DIFF
--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -99,11 +99,25 @@
 	// NB: Reduce whitespace in that loop
 	foreach ($feeds as $feed):
 		$f_active = FreshRSS_Context::isCurrentGet('f_' . $feed->id());
+		$f_active_class = $f_active ? ' active' : '';
+
+		$error_class = '';
+		$error_title = '';
+		if ($feed->inError()) {
+			$error_class = ' error';
+			$error_title = _t('sub.feed.error');
+		}
+
+		$empty_class = '';
+		$empty_title = '';
+		if ($feed->nbEntries() <= 0) {
+			$empty_class = ' empty';
+			$empty_title = _t('sub.feed.empty');
+		}
+		$mute_class = $feed->mute() ? ' mute' : '';
 ?>
-<li id="f_<?= $feed->id() ?>" class="item feed<?= $f_active ? ' active' : '', $feed->mute() ? ' mute' : '' ?><?=
-	$feed->inError() ? ' error' : '' ?><?= $feed->nbEntries() <= 0 ? ' empty' : ''
-	?>" title="<?= $feed->inError() ? _t('sub.feed.error') : '' ?> <?= $feed->nbEntries() <= 0 ? _t('sub.feed.empty') : ''
-	?>" data-unread="<?= $feed->nbNotRead() ?>" data-priority="<?= $feed->priority() ?>"><?php
+<li id="f_<?= $feed->id() ?>" class="item feed<?= $f_active_class, $mute_class, $error_class, $empty_class ?>" title="<?= $error_title, $empty_title ?>" 
+		data-unread="<?= $feed->nbNotRead() ?>" data-priority="<?= $feed->priority() ?>"><?php
 		if ($f_active || $nbFeedsTotal < FreshRSS_Context::$user_conf->simplify_over_n_feeds):
 	?><div class="dropdown no-mobile">
 		<div class="dropdown-target"></div><a class="dropdown-toggle" data-fweb="<?= $feed->website() ?>"><?= _i('configure') ?></a><?php /* feed_config_template */ ?>

--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -102,7 +102,8 @@
 ?>
 <li id="f_<?= $feed->id() ?>" class="item feed<?= $f_active ? ' active' : '', $feed->mute() ? ' mute' : '' ?><?=
 	$feed->inError() ? ' error' : '' ?><?= $feed->nbEntries() <= 0 ? ' empty' : ''
-	?>" title="<?= $feed->inError() ? _t('sub.feed.error') : '' ?>" data-unread="<?= $feed->nbNotRead() ?>" data-priority="<?= $feed->priority() ?>"><?php
+	?>" title="<?= $feed->inError() ? _t('sub.feed.error') : '' ?> <?= $feed->nbEntries() <= 0 ? _t('sub.feed.empty') : ''
+	?>" data-unread="<?= $feed->nbNotRead() ?>" data-priority="<?= $feed->priority() ?>"><?php
 		if ($f_active || $nbFeedsTotal < FreshRSS_Context::$user_conf->simplify_over_n_feeds):
 	?><div class="dropdown no-mobile">
 		<div class="dropdown-target"></div><a class="dropdown-toggle" data-fweb="<?= $feed->website() ?>"><?= _i('configure') ?></a><?php /* feed_config_template */ ?>

--- a/app/views/index/global.phtml
+++ b/app/views/index/global.phtml
@@ -41,13 +41,26 @@
 			<?php
 				foreach ($feeds as $feed) {
 					$nb_not_read = $feed->nbNotRead();
-					$error = $feed->inError() ? ' error' : '';
-					$empty = $feed->nbEntries() === 0 ? ' empty' : '';
+
+					$error_class = '';
+					$error_title = '';
+					if ($feed->inError()) {
+						$error_class = ' error';
+						$error_title = _t('sub.feed.error');
+					}
+
+					$empty_class = '';
+					$empty_title = '';
+					if ($feed->nbEntries() == 0) {
+						$empty_class = ' empty';
+						$empty_title = _t('sub.feed.empty');
+					}
+					$mute_class = $feed->mute() ? ' mute' : '';
+
 					$url_base['params']['get'] = 'f_' . $feed->id();
 			?>
-			<li id="f_<?= $feed->id() ?>" class="item feed<?= $error, $empty, $feed->mute() ? ' mute' : '' ?>"
-				data-unread="<?= $feed->nbNotRead() ?>" data-priority="<?= $feed->priority() ?>"
-				title="<?= strlen($error) > 0 ? _t('sub.feed.error') : ''?> <?= strlen($empty) > 0 ? _t('sub.feed.empty') : ''	?>">
+			<li id="f_<?= $feed->id() ?>" class="item feed<?= $error_class, $empty_class, $mute_class ?>" title="<?= $error_title, $empty_title ?>"
+				data-unread="<?= $feed->nbNotRead() ?>" data-priority="<?= $feed->priority() ?>">
 				<?php if (FreshRSS_Context::$user_conf->show_favicons): ?><img class="favicon" src="<?= $feed->favicon() ?>" alt="✇" loading="lazy" /><?php endif; ?>
 				<a class="item-title" data-unread="<?= format_number($feed->nbNotRead()) ?>" href="<?= Minz_Url::display($url_base) ?>"><?= $feed->name() ?></a>
 			</li>

--- a/app/views/index/global.phtml
+++ b/app/views/index/global.phtml
@@ -46,7 +46,8 @@
 					$url_base['params']['get'] = 'f_' . $feed->id();
 			?>
 			<li id="f_<?= $feed->id() ?>" class="item feed<?= $error, $empty, $feed->mute() ? ' mute' : '' ?>"
-				data-unread="<?= $feed->nbNotRead() ?>" data-priority="<?= $feed->priority() ?>">
+				data-unread="<?= $feed->nbNotRead() ?>" data-priority="<?= $feed->priority() ?>"
+				title="<?= strlen($error) > 0 ? _t('sub.feed.error') : ''?> <?= strlen($empty) > 0 ? _t('sub.feed.empty') : ''	?>">
 				<?php if (FreshRSS_Context::$user_conf->show_favicons): ?><img class="favicon" src="<?= $feed->favicon() ?>" alt="✇" loading="lazy" /><?php endif; ?>
 				<a class="item-title" data-unread="<?= format_number($feed->nbNotRead()) ?>" href="<?= Minz_Url::display($url_base) ?>"><?= $feed->name() ?></a>
 			</li>

--- a/app/views/stats/idle.phtml
+++ b/app/views/stats/idle.phtml
@@ -42,7 +42,7 @@
 						}
 						$mute_class = $feed->mute() ? ' mute' : '';
 				?>
-					<li class="item feed<?= $error_class, $empty_class, $mute_class ?>" title="<?= $error_title, $empty_title	?>">
+					<li class="item feed<?= $error_class, $empty_class, $mute_class ?>" title="<?= $error_title, $empty_title ?>">
 						<a class="configure open-slider" href="<?= _url('stats', 'feed', 'id', $feedInPeriod['id'], 'sub', 'idle') ?>" title="<?= _t('gen.action.manage') ?>"><?= _i('configure') ?></a>
 						<?php if (FreshRSS_Context::$user_conf->show_favicons): ?><img class="favicon" src="<?= $feedInPeriod['favicon'] ?>" alt="✇" loading="lazy" /><?php endif; ?>
 						<span title="<?= timestamptodate($feedInPeriod['last_date'], false) ?>"><?= $feedInPeriod['name'] ?>

--- a/app/views/stats/idle.phtml
+++ b/app/views/stats/idle.phtml
@@ -29,7 +29,8 @@
 						$error = $feed == null || $feed->inError() ? ' error' : '';
 						$empty = $feed != null && $feed->nbEntries() == 0 ? ' empty' : '';
 				?>
-					<li class="item feed<?= $error, $empty, $feed->mute() ? ' mute' : '' ?>">
+					<li class="item feed<?= $error, $empty, $feed->mute() ? ' mute' : '' ?>" title="<?= strlen($error) > 0 ? _t('sub.feed.error') : '' 
+					?> <?= strlen($empty) > 0 ? _t('sub.feed.empty') : ''	?>">
 						<a class="configure open-slider" href="<?= _url('stats', 'feed', 'id', $feedInPeriod['id'], 'sub', 'idle') ?>" title="<?= _t('gen.action.manage') ?>"><?= _i('configure') ?></a>
 						<?php if (FreshRSS_Context::$user_conf->show_favicons): ?><img class="favicon" src="<?= $feedInPeriod['favicon'] ?>" alt="✇" loading="lazy" /><?php endif; ?>
 						<span title="<?= timestamptodate($feedInPeriod['last_date'], false) ?>"><?= $feedInPeriod['name'] ?>

--- a/app/views/stats/idle.phtml
+++ b/app/views/stats/idle.phtml
@@ -29,7 +29,7 @@
 						$error = $feed == null || $feed->inError() ? ' error' : '';
 						$empty = $feed != null && $feed->nbEntries() == 0 ? ' empty' : '';
 				?>
-					<li class="item feed<?= $error, $empty, $feed->mute() ? ' mute' : '' ?>" title="<?= strlen($error) > 0 ? _t('sub.feed.error') : '' 
+					<li class="item feed<?= $error, $empty, $feed->mute() ? ' mute' : '' ?>" title="<?= strlen($error) > 0 ? _t('sub.feed.error') : ''
 					?> <?= strlen($empty) > 0 ? _t('sub.feed.empty') : ''	?>">
 						<a class="configure open-slider" href="<?= _url('stats', 'feed', 'id', $feedInPeriod['id'], 'sub', 'idle') ?>" title="<?= _t('gen.action.manage') ?>"><?= _i('configure') ?></a>
 						<?php if (FreshRSS_Context::$user_conf->show_favicons): ?><img class="favicon" src="<?= $feedInPeriod['favicon'] ?>" alt="✇" loading="lazy" /><?php endif; ?>

--- a/app/views/stats/idle.phtml
+++ b/app/views/stats/idle.phtml
@@ -26,11 +26,23 @@
 				<?php
 					foreach ($feedsInPeriod as $feedInPeriod) {
 						$feed = $this->feeds[$feedInPeriod['id']] ?? null;
-						$error = $feed == null || $feed->inError() ? ' error' : '';
-						$empty = $feed != null && $feed->nbEntries() == 0 ? ' empty' : '';
+
+						$error_class = '';
+						$error_title = '';
+						if ($feed == null || $feed->inError()) {
+							$error_class = ' error';
+							$error_title = _t('sub.feed.error');
+						}
+
+						$empty_class = '';
+						$empty_title = '';
+						if ($feed != null && $feed->nbEntries() == 0) {
+							$empty_class = ' empty';
+							$empty_title = _t('sub.feed.empty');
+						}
+						$mute_class = $feed->mute() ? ' mute' : '';
 				?>
-					<li class="item feed<?= $error, $empty, $feed->mute() ? ' mute' : '' ?>" title="<?= strlen($error) > 0 ? _t('sub.feed.error') : ''
-					?> <?= strlen($empty) > 0 ? _t('sub.feed.empty') : ''	?>">
+					<li class="item feed<?= $error_class, $empty_class, $mute_class ?>" title="<?= $error_title, $empty_title	?>">
 						<a class="configure open-slider" href="<?= _url('stats', 'feed', 'id', $feedInPeriod['id'], 'sub', 'idle') ?>" title="<?= _t('gen.action.manage') ?>"><?= _i('configure') ?></a>
 						<?php if (FreshRSS_Context::$user_conf->show_favicons): ?><img class="favicon" src="<?= $feedInPeriod['favicon'] ?>" alt="✇" loading="lazy" /><?php endif; ?>
 						<span title="<?= timestamptodate($feedInPeriod['last_date'], false) ?>"><?= $feedInPeriod['name'] ?>

--- a/app/views/subscription/index.phtml
+++ b/app/views/subscription/index.phtml
@@ -45,13 +45,24 @@
 						if ($this->onlyFeedsWithError && !$feed->inError()) {
 							continue;
 						}
-						$error = $feed->inError() ? ' error' : '';
-						$empty = $feed->nbEntries() == 0 ? ' empty' : '';
+
+						$error_class = '';
+						$error_title = '';
+						if ($feed->inError()) {
+							$error_class = ' error';
+							$error_title = _t('sub.feed.error');
+						}
+
+						$empty_class = '';
+						$empty_title = '';
+						if ($feed->nbEntries() == 0) {
+							$empty_class = ' empty';
+							$empty_title = _t('sub.feed.empty');
+						}
+						$mute_class = $feed->mute() ? ' mute' : '';
 				?>
-				<li class="item feed<?= $error, $empty, $feed->mute() ? ' mute' : '' ?>"
-					title="<?= strlen($error) > 0 ? _t('sub.feed.error') : '' ?> <?= strlen($empty) > 0 ? _t('sub.feed.empty') : ''	?>"
-					draggable="true"
-					data-feed-id="<?= $feed->id() ?>">
+				<li class="item feed<?= $error_class, $empty_class, $mute_class ?>" title="<?= $error_title, $empty_title	?>"
+					draggable="true" data-feed-id="<?= $feed->id() ?>">
 					<a class="configure open-slider" href="<?= _url('subscription', 'feed', 'id', $feed->id()) ?>" title="<?= _t('gen.action.manage') ?>"><?= _i('configure') ?></a>
 					<?php if (FreshRSS_Context::$user_conf->show_favicons): ?><img class="favicon" src="<?= $feed->favicon() ?>" alt="✇" loading="lazy" /><?php endif; ?>
 					<span class="item-title"><?= $feed->name() ?></span>

--- a/app/views/subscription/index.phtml
+++ b/app/views/subscription/index.phtml
@@ -61,7 +61,7 @@
 						}
 						$mute_class = $feed->mute() ? ' mute' : '';
 				?>
-				<li class="item feed<?= $error_class, $empty_class, $mute_class ?>" title="<?= $error_title, $empty_title	?>"
+				<li class="item feed<?= $error_class, $empty_class, $mute_class ?>" title="<?= $error_title, $empty_title ?>"
 					draggable="true" data-feed-id="<?= $feed->id() ?>">
 					<a class="configure open-slider" href="<?= _url('subscription', 'feed', 'id', $feed->id()) ?>" title="<?= _t('gen.action.manage') ?>"><?= _i('configure') ?></a>
 					<?php if (FreshRSS_Context::$user_conf->show_favicons): ?><img class="favicon" src="<?= $feed->favicon() ?>" alt="✇" loading="lazy" /><?php endif; ?>

--- a/app/views/subscription/index.phtml
+++ b/app/views/subscription/index.phtml
@@ -49,10 +49,10 @@
 						$empty = $feed->nbEntries() == 0 ? ' empty' : '';
 				?>
 				<li class="item feed<?= $error, $empty, $feed->mute() ? ' mute' : '' ?>"
-					title="<?= $feed->inError() ? _t('sub.feed.error') : '' ?>"
+					title="<?= strlen($error) > 0 ? _t('sub.feed.error') : '' ?> <?= strlen($empty) > 0 ? _t('sub.feed.empty') : ''	?>"
 					draggable="true"
 					data-feed-id="<?= $feed->id() ?>">
-					<a class="configure open-slider" href="<?= _url('subscription', 'feed', 'id', $feed->id()) ?>"><?= _i('configure') ?></a>
+					<a class="configure open-slider" href="<?= _url('subscription', 'feed', 'id', $feed->id()) ?>" title="<?= _t('gen.action.manage') ?>"><?= _i('configure') ?></a>
 					<?php if (FreshRSS_Context::$user_conf->show_favicons): ?><img class="favicon" src="<?= $feed->favicon() ?>" alt="✇" loading="lazy" /><?php endif; ?>
 					<span class="item-title"><?= $feed->name() ?></span>
 				</li>


### PR DESCRIPTION
before:
empty feeds are marked with orange font color.

after:
The mouse gives the information
![grafik](https://user-images.githubusercontent.com/1645099/190509922-1bb6794b-82c0-47f2-accc-e3b3ea7964df.png)

![grafik](https://user-images.githubusercontent.com/1645099/190510325-e02d0dd7-2700-4fc7-bf2d-d4c1139b43bf.png)

![grafik](https://user-images.githubusercontent.com/1645099/190510515-15c17e9f-e329-4dc4-a6c1-e17b31f2e466.png)


Changes proposed in this pull request:

- phtml


How to test the feature manually:

1. have a feed that is empty
2. hover the mouse over the feed title


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested