### PR TITLE
Improved: (S)CSS .disable removed

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -239,12 +239,6 @@ a.btn {
 	background-color: #1f1f1f;
 }
 
-.nav-list .disable {
-	background: #fafafa;
-	color: #aaa;
-	text-align: center;
-}
-
 .nav-list .item > a {
 	padding: 0 10px;
 }

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -239,12 +239,6 @@ a.btn {
 	background-color: #1f1f1f;
 }
 
-.nav-list .disable {
-	background: #fafafa;
-	color: #aaa;
-	text-align: center;
-}
-
 .nav-list .item > a {
 	padding: 0 10px;
 }

--- a/p/themes/Ansum/_sidebar.scss
+++ b/p/themes/Ansum/_sidebar.scss
@@ -214,12 +214,6 @@
 		}
 	}
 
-	.disable {
-		text-align: center;
-		background: variables.$grey-lighter;
-		color: variables.$grey-medium-dark;
-	}
-
 	.nav-header {
 		padding: 0 10px;
 		font-weight: bold;

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -591,11 +591,6 @@ form th {
 .nav-list.empty a {
 	color: #f4f762;
 }
-.nav-list .disable {
-	text-align: center;
-	background: #fcfaf8;
-	color: #ba9;
-}
 .nav-list .nav-header {
 	padding: 0 10px;
 	font-weight: bold;

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -591,11 +591,6 @@ form th {
 .nav-list.empty a {
 	color: #f4f762;
 }
-.nav-list .disable {
-	text-align: center;
-	background: #fcfaf8;
-	color: #ba9;
-}
 .nav-list .nav-header {
 	padding: 0 10px;
 	font-weight: bold;

--- a/p/themes/BlueLagoon/BlueLagoon.css
+++ b/p/themes/BlueLagoon/BlueLagoon.css
@@ -291,12 +291,6 @@ a.btn {
 	border-color: -moz-use-text-color -moz-use-text-color #171717;
 }
 
-.nav-list .disable {
-	background: #fafafa;
-	color: #aaa;
-	text-align: center;
-}
-
 .nav-list .item > a {
 	padding: 0 10px;
 	color: #ccc;

--- a/p/themes/BlueLagoon/BlueLagoon.rtl.css
+++ b/p/themes/BlueLagoon/BlueLagoon.rtl.css
@@ -291,12 +291,6 @@ a.btn {
 	border-color: -moz-use-text-color -moz-use-text-color #171717;
 }
 
-.nav-list .disable {
-	background: #fafafa;
-	color: #aaa;
-	text-align: center;
-}
-
 .nav-list .item > a {
 	padding: 0 10px;
 	color: #ccc;

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -288,12 +288,6 @@ a.btn {
 	color: #888;
 }
 
-.nav-list .disable {
-	background: #fafafa;
-	color: #aaa;
-	text-align: center;
-}
-
 .nav-list .item > a {
 	padding: 0 10px;
 }

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -288,12 +288,6 @@ a.btn {
 	color: #888;
 }
 
-.nav-list .disable {
-	background: #fafafa;
-	color: #aaa;
-	text-align: center;
-}
-
 .nav-list .item > a {
 	padding: 0 10px;
 }

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -274,12 +274,6 @@ a.btn {
 	color: #fff;
 }
 
-.nav-list .disable {
-	text-align: center;
-	background: #fafafa;
-	color: #aaa;
-}
-
 .nav-list .item > a {
 	padding: 0 10px;
 }

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -274,12 +274,6 @@ a.btn {
 	color: #fff;
 }
 
-.nav-list .disable {
-	text-align: center;
-	background: #fafafa;
-	color: #aaa;
-}
-
 .nav-list .item > a {
 	padding: 0 10px;
 }

--- a/p/themes/Mapco/_sidebar.scss
+++ b/p/themes/Mapco/_sidebar.scss
@@ -213,12 +213,6 @@
 		}
 	}
 
-	.disable {
-		text-align: center;
-		background: variables.$grey-lighter;
-		color: variables.$grey-medium-dark;
-	}
-
 	.nav-header {
 		padding: 0 10px;
 		font-weight: bold;

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -614,11 +614,6 @@ form th {
 .nav-list.empty a {
 	color: #f4f762;
 }
-.nav-list .disable {
-	text-align: center;
-	background: #f9fafb;
-	color: #a6a7ae;
-}
 .nav-list .nav-header {
 	padding: 0 10px;
 	font-weight: bold;

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -614,11 +614,6 @@ form th {
 .nav-list.empty a {
 	color: #f4f762;
 }
-.nav-list .disable {
-	text-align: center;
-	background: #f9fafb;
-	color: #a6a7ae;
-}
 .nav-list .nav-header {
 	padding: 0 10px;
 	font-weight: bold;

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -996,10 +996,6 @@ input.extend {
 }
 
 /*=== Navigation */
-.nav-list .disable {
-	text-align: center;
-}
-
 .nav-list .item > a {
 	padding: 0 10px;
 }

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -996,10 +996,6 @@ input.extend {
 }
 
 /*=== Navigation */
-.nav-list .disable {
-	text-align: center;
-}
-
 .nav-list .item > a {
 	padding: 0 10px;
 }

--- a/p/themes/Origine-compact/origine-compact.css
+++ b/p/themes/Origine-compact/origine-compact.css
@@ -284,12 +284,6 @@ a.btn,
 	color: #fff;
 }
 
-.nav-list .disable {
-	background: #fafafa;
-	color: #aaa;
-	text-align: center;
-}
-
 .nav-list .item > a {
 	padding: 0 10px;
 }

--- a/p/themes/Origine-compact/origine-compact.rtl.css
+++ b/p/themes/Origine-compact/origine-compact.rtl.css
@@ -284,12 +284,6 @@ a.btn,
 	color: #fff;
 }
 
-.nav-list .disable {
-	background: #fafafa;
-	color: #aaa;
-	text-align: center;
-}
-
 .nav-list .item > a {
 	padding: 0 10px;
 }

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -275,12 +275,6 @@ a.btn {
 	color: #fff;
 }
 
-.nav-list .disable {
-	background: #fafafa;
-	color: #aaa;
-	text-align: center;
-}
-
 .nav-list .item > a,
 .nav-list .item > span {
 	padding: 0 10px;

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -275,12 +275,6 @@ a.btn {
 	color: #fff;
 }
 
-.nav-list .disable {
-	background: #fafafa;
-	color: #aaa;
-	text-align: center;
-}
-
 .nav-list .item > a,
 .nav-list .item > span {
 	padding: 0 10px;

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -250,12 +250,6 @@ a.btn {
 	color: #fff;
 }
 
-.nav-list .disable {
-	background: #fafafa;
-	color: #aaa;
-	text-align: center;
-}
-
 .nav-list .item > a {
 	padding: 0 10px;
 }

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -250,12 +250,6 @@ a.btn {
 	color: #fff;
 }
 
-.nav-list .disable {
-	background: #fafafa;
-	color: #aaa;
-	text-align: center;
-}
-
 .nav-list .item > a {
 	padding: 0 10px;
 }

--- a/p/themes/Screwdriver/screwdriver.css
+++ b/p/themes/Screwdriver/screwdriver.css
@@ -295,12 +295,6 @@ a.btn {
 	color: #d18114;
 }
 
-.nav-list .disable {
-	background: #fafafa;
-	color: #aaa;
-	text-align: center;
-}
-
 .nav-list .item > a {
 	padding: 0 10px;
 	color: #ccc;

--- a/p/themes/Screwdriver/screwdriver.rtl.css
+++ b/p/themes/Screwdriver/screwdriver.rtl.css
@@ -295,12 +295,6 @@ a.btn {
 	color: #d18114;
 }
 
-.nav-list .disable {
-	background: #fafafa;
-	color: #aaa;
-	text-align: center;
-}
-
 .nav-list .item > a {
 	padding: 0 10px;
 	color: #ccc;

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -324,11 +324,6 @@ form th {
 .nav-list .item .icon {
 	filter: brightness(3);
 }
-.nav-list .disable {
-	text-align: center;
-	background: #fcfcfc;
-	color: #969696;
-}
 .nav-list .nav-form {
 	padding: 3px;
 	text-align: center;

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -324,11 +324,6 @@ form th {
 .nav-list .item .icon {
 	filter: brightness(3);
 }
-.nav-list .disable {
-	text-align: center;
-	background: #fcfcfc;
-	color: #969696;
-}
 .nav-list .nav-form {
 	padding: 3px;
 	text-align: center;

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -419,12 +419,6 @@ form {
 		}
 	}
 
-	.disable {
-		text-align: center;
-		background: $color_light;
-		color: color.adjust( $color_light, $lightness: -40% );
-	}
-
 	.nav-form {
 		padding: 3px;
 		text-align: center;

--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -198,10 +198,6 @@ a.btn {
 .nav-list .item.active a {
 }
 
-.nav-list .disable {
-	text-align: center;
-}
-
 .nav-list .item > a {
 	padding: 0 10px;
 }

--- a/p/themes/base-theme/base.rtl.css
+++ b/p/themes/base-theme/base.rtl.css
@@ -198,10 +198,6 @@ a.btn {
 .nav-list .item.active a {
 }
 
-.nav-list .disable {
-	text-align: center;
-}
-
 .nav-list .item > a {
 	padding: 0 10px;
 }


### PR DESCRIPTION
As far as I see the CSS class `disable` is not (anymore) used

How to test the feature manually:
- search for 'disable' CSS class in templates (phtml). You will not find find it


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
