### PR TITLE
Fix login page when user does not exist

### DIFF
--- a/app/Controllers/authController.php
+++ b/app/Controllers/authController.php
@@ -72,7 +72,7 @@ class FreshRSS_auth_Controller extends FreshRSS_ActionController {
 		}
 
 		$auth_type = FreshRSS_Context::$system_conf->auth_type;
-		FreshRSS_Context::initUser('_');
+		FreshRSS_Context::initUser('_', false);
 		switch ($auth_type) {
 			case 'form':
 				Minz_Request::forward(array('c' => 'auth', 'a' => 'formLogin'));


### PR DESCRIPTION
Closes #3706, #3057

Changes proposed in this pull request:

- Force the use of the default user before rendering the login page

How to test the feature manually:

1. Add a user with a theme different from the installation theme.
2. Try to login with a wrong password.
3. Validate that the displayed theme is the installation theme and not the user theme

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
