### PR TITLE
Fix transaction rollbacks during auto-update

### DIFF
--- a/app/Models/CategoryDAO.php
+++ b/app/Models/CategoryDAO.php
@@ -15,6 +15,9 @@ class FreshRSS_CategoryDAO extends Minz_ModelPdo implements FreshRSS_Searchable 
 	}
 
 	protected function addColumn($name) {
+		if ($this->pdo->inTransaction()) {
+			$this->pdo->commit();
+		}
 		Minz_Log::warning(__method__ . ': ' . $name);
 		try {
 			if ($name === 'kind') {	//v1.20.0

--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -62,6 +62,9 @@ SQL;
 	}
 
 	protected function addColumn(string $name) {
+		if ($this->pdo->inTransaction()) {
+			$this->pdo->commit();
+		}
 		Minz_Log::warning(__method__ . ': ' . $name);
 		try {
 			if ($name === 'attributes') {	//v1.20.0

--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -3,6 +3,9 @@
 class FreshRSS_FeedDAO extends Minz_ModelPdo implements FreshRSS_Searchable {
 
 	protected function addColumn(string $name) {
+		if ($this->pdo->inTransaction()) {
+			$this->pdo->commit();
+		}
 		Minz_Log::warning(__method__ . ': ' . $name);
 		try {
 			if ($name === 'kind') {	//v1.20.0


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/4600
We first need to commit the SQL transaction before being able to auto-update. Avoid errors such as:
> 25P02: 7 ERROR:  current transaction is aborted, commands ignored until end of transaction block
