### PR TITLE
fix: Fix preg_match in enforceHttpEncoding

### DIFF
--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -351,7 +351,7 @@ function cleanCache(int $hours = 720) {
  * @return string an HTML string with XML encoding information for DOMDocument::loadHTML()
  */
 function enforceHttpEncoding(string $html, string $contentType = ''): string {
-	$httpCharset = preg_match('/\bcharset=([0-9a-z_-]{2,12})$/i', $contentType, $matches) === false ? '' : $matches[1];
+	$httpCharset = preg_match('/\bcharset=([0-9a-z_-]{2,12})$/i', $contentType, $matches) === 1 ? $matches[1] : '';
 	if ($httpCharset == '') {
 		// No charset defined by HTTP, do nothing
 		return $html;


### PR DESCRIPTION
Changes proposed in this pull request:

- test correctly the success of `preg_match` in `enforceHttpEncoding`

How to test the feature manually:

1. setup a XPath feed with a website not declaring a `charset` in its content type
2. refresh the feed
3. verify there is no errors

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard) N/A
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
