### PR TITLE
Improved: Feed configuration: Archiving

### DIFF
--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -254,12 +254,10 @@
 
 		<div class="form-group">
 			<div class="group-controls">
-				<div class="stick">
-					<input type="text" value="<?= _t('sub.feed.number_entries', $nbEntries) ?>" disabled="disabled" />
-					<a class="btn" href="<?= _url('feed', 'actualize', 'id', $this->feed->id(), '#', 'slider') ?>">
-						<?= _i('refresh') ?> <?= _t('gen.action.actualize') ?>
-					</a>
-				</div>
+				<?= _t('sub.feed.number_entries', $nbEntries) ?>
+				<a class="btn" href="<?= _url('feed', 'actualize', 'id', $this->feed->id(), '#', 'slider') ?>">
+					<?= _i('refresh') ?> <?= _t('gen.action.actualize') ?>
+				</a>
 			</div>
 		</div>
 		<?php


### PR DESCRIPTION
Before:
The `<input>` is always `disabled="disabled"`
![grafik](https://user-images.githubusercontent.com/1645099/191085267-da7d74a5-be56-4183-b8ca-74a3fa8e489a.png)

After:
just text
![grafik](https://user-images.githubusercontent.com/1645099/191085395-7a46cfc1-3195-49cb-906d-db93f475cd0b.png)


Changes proposed in this pull request:

- phtml


How to test the feature manually:

1. open feed configuration
2. see "Archiving" section


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested