### PR TITLE
Fix show settings page after adding new feed (#4612)

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -240,7 +240,7 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 			}
 
 			// Entries are in DB, we redirect to feed configuration page.
-			$url_redirect['a'] = 'index';
+			$url_redirect['a'] = 'feed';
 			$url_redirect['params']['id'] = '' . $feed->id();
 			Minz_Request::good(_t('feedback.sub.feed.added', $feed->name()), $url_redirect);
 		} else {
@@ -261,7 +261,7 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 			$feed = $feedDAO->searchByUrl($this->view->feed->url());
 			if ($feed) {
 				// Already subscribe so we redirect to the feed configuration page.
-				$url_redirect['a'] = 'index';
+				$url_redirect['a'] = 'feed';
 				$url_redirect['params']['id'] = $feed->id();
 				Minz_Request::good(_t('feedback.sub.feed.already_subscribed', $feed->name()), $url_redirect);
 			}


### PR DESCRIPTION
Closes #4612

Changes proposed in this pull request:

- Correctly show the feed settings after adding a new feed.

How to test the feature manually:

- Add a feed using either bookmarklet, or the in-app form
- You should get redirected to the feed settings instead of the list of the subscribed feeds

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
