### PR TITLE
Improved: template.css (colors)

### DIFF
--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -1350,6 +1350,7 @@ main.prompt {
 /*============*/
 html, body {
 	background: #f5f0ec;
+	color: #161a38;
 	font-family: "lato", "Helvetica", "Arial", sans-serif;
 	font-size: 0.875rem;
 }

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -1350,6 +1350,7 @@ main.prompt {
 /*============*/
 html, body {
 	background: #f5f0ec;
+	color: #161a38;
 	font-family: "lato", "Helvetica", "Arial", sans-serif;
 	font-size: 0.875rem;
 }

--- a/p/themes/Ansum/ansum.scss
+++ b/p/themes/Ansum/ansum.scss
@@ -36,6 +36,7 @@
 /*============*/
 html, body {
 	background: variables.$grey-light;
+	color: variables.$unread-font-color;
 	font-family: "lato", "Helvetica", "Arial", sans-serif;
 	font-size: 0.875rem;
 }

--- a/p/themes/BlueLagoon/BlueLagoon.css
+++ b/p/themes/BlueLagoon/BlueLagoon.css
@@ -4,6 +4,7 @@
 /*============*/
 html, body {
 	background: #fafafa;
+	color: black;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 	font-size: 92%;
 }

--- a/p/themes/BlueLagoon/BlueLagoon.rtl.css
+++ b/p/themes/BlueLagoon/BlueLagoon.rtl.css
@@ -4,6 +4,7 @@
 /*============*/
 html, body {
 	background: #fafafa;
+	color: black;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 	font-size: 92%;
 }

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -4,6 +4,7 @@
 /*============*/
 html, body {
 	background: #fafafa;
+	color: black;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 }
 

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -4,6 +4,7 @@
 /*============*/
 html, body {
 	background: #fafafa;
+	color: black;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 }
 

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -1381,6 +1381,7 @@ main.prompt {
 /*============*/
 html, body {
 	background: #eff0f2;
+	color: #36c;
 	font-family: "lato", "Helvetica", "Arial", sans-serif;
 	font-size: 0.875rem;
 }

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -1381,6 +1381,7 @@ main.prompt {
 /*============*/
 html, body {
 	background: #eff0f2;
+	color: #36c;
 	font-family: "lato", "Helvetica", "Arial", sans-serif;
 	font-size: 0.875rem;
 }

--- a/p/themes/Mapco/mapco.scss
+++ b/p/themes/Mapco/mapco.scss
@@ -36,6 +36,7 @@
 /*============*/
 html, body {
 	background: variables.$grey-light;
+	color: variables.$unread-font-color;
 	font-family: "lato", "Helvetica", "Arial", sans-serif;
 	font-size: 0.875rem;
 }

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -4,6 +4,7 @@
 /*============*/
 html, body {
 	background: #fafafa;
+	color: black;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 }
 

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -4,6 +4,7 @@
 /*============*/
 html, body {
 	background: #fafafa;
+	color: black;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 }
 

--- a/p/themes/Screwdriver/screwdriver.css
+++ b/p/themes/Screwdriver/screwdriver.css
@@ -4,6 +4,7 @@
 /*============*/
 html, body {
 	background: #fafafa;
+	color: black;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 	font-size: 92%;
 }

--- a/p/themes/Screwdriver/screwdriver.rtl.css
+++ b/p/themes/Screwdriver/screwdriver.rtl.css
@@ -4,6 +4,7 @@
 /*============*/
 html, body {
 	background: #fafafa;
+	color: black;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 	font-size: 92%;
 }

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -46,6 +46,7 @@ select:invalid {
 
 html,
 body {
+	color: black;
 	font-family: Helvetica, Arial, sans-serif;
 }
 

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -46,6 +46,7 @@ select:invalid {
 
 html,
 body {
+	color: black;
 	font-family: Helvetica, Arial, sans-serif;
 }
 

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -60,6 +60,7 @@ $color_hover:	#fff;
 // /@extend-elements
 html,
 body {
+	color: black;
 	font-family: Helvetica, Arial, sans-serif;
 }
 

--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -6,11 +6,13 @@
 /*============*/
 html, body {
 	height: 100%;
+	color: black;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 }
 
 /*=== Links */
 a, button.as-link {
+	color: blue;
 	outline: none;
 }
 

--- a/p/themes/base-theme/base.rtl.css
+++ b/p/themes/base-theme/base.rtl.css
@@ -6,11 +6,13 @@
 /*============*/
 html, body {
 	height: 100%;
+	color: black;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
 }
 
 /*=== Links */
 a, button.as-link {
+	color: blue;
 	outline: none;
 }
 

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -883,7 +883,7 @@ li.drag-hover {
 
 	#sidebar:hover,
 	.scrollbar-thin:hover {
-		scrollbar-color: rgba(0, 0, 0, 0.3) var(--template-scrollbar-track);
+		scrollbar-color: var(--template-scrollbar-handle-hover) var(--template-scrollbar-track-hover);
 	}
 }
 
@@ -907,7 +907,7 @@ li.drag-hover {
 	}
 
 	#sidebar:hover::-webkit-scrollbar-thumb,
-	.scrollbar-thin::-webkit-scrollbar-thumb {
+	.scrollbar-thin:hover::-webkit-scrollbar-thumb {
 		background: var(--template-scrollbar-handle-hover);
 	}
 }

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -7,11 +7,11 @@
 	--template-font-color-grey-dark: #666;
 	--template-font-color-grey-light: #aaa;
 	--template-font-color-light: #fff;
-	--template-background-color-error: #ff000040;
+	--template-background-color-error-transparent: #ff000040;
 	--template-font-color-error: #ff0000;
 
 	--template-background-color: #fff;
-	--template-background-color-transparent: rgba(255, 255, 255, 0.5);
+	--template-background-color-transparent: #ffffff7F;
 	--template-background-color-middle: #eee;
 	--template-background-color-dark: #ccc;
 
@@ -25,16 +25,16 @@
 
 	--template-noThumbnailImage-background-color: #ddd;
 
-	--template-darken-background-hover: rgba(90, 90, 90, 0.1);
+	--template-darken-background-hover-transparent: #66666620;
 
-	--template-modal-background-color: rgba(0, 0, 0, 0.5);
-	
-	--template-box-shadow-color: rgba(0, 0, 0, 0.2);
+	--template-modal-background-color-transparent: #0000007F;
 
-	--template-scrollbar-handle: rgba(0, 0, 0, 0.1);
-	--template-scrollbar-handle-hover: rgba(0, 0, 0, 0.3);
-	--template-scrollbar-track: rgba(0, 0, 0, 0.05);
-	--template-scrollbar-track-hover: rgba(0, 0, 0, 0.05);
+	--template-box-shadow-color-transparent: #00000033;
+
+	--template-scrollbar-handle: #00000022;
+	--template-scrollbar-handle-hover: #00000055;
+	--template-scrollbar-track: #00000011;
+	--template-scrollbar-track-hover: #00000011;
 
 	--template-loading-image: url("loader.gif");
 }
@@ -1083,7 +1083,7 @@ input[type="search"] {
 #panel .close:hover,
 #slider .toggle_aside:hover,
 .dropdown-menu .toggle_aside:hover {
-	background-color: var(--template-darken-background-hover);
+	background-color: var(--template-darken-background-hover-transparent);
 }
 
 /*=== New article notification */
@@ -1371,7 +1371,7 @@ br {
 }
 
 .notification a.close:hover {
-	background-color: var(--template-darken-background-hover);
+	background-color: var(--template-darken-background-hover-transparent);
 }
 
 .notification a.close:hover .icon {
@@ -1401,7 +1401,7 @@ br {
 	width: 100%;
 	height: 100%;
 	overflow: auto;
-	background-color: var(--template-modal-background-color);
+	background-color: var(--template-modal-background-color-transparent);
 }
 
 #popup-content {
@@ -1412,7 +1412,7 @@ br {
 	overflow: hidden;
 	background-color: var(--template-background-color);
 	border-radius: .25rem;
-	box-shadow: 3px 3px 5px var(--template-box-shadow-color);
+	box-shadow: 3px 3px 5px var(--template-box-shadow-color-transparent);
 }
 
 .popup-row {
@@ -1555,7 +1555,7 @@ br {
 	position: fixed;
 	top: 0; bottom: 0;
 	left: 0; right: 0;
-	background-color: var(--template-modal-background-color);
+	background-color: var(--template-modal-background-color-transparent);
 	opacity: 0;
 	transition: visibility .3s, opacity .3s;
 	visibility: hidden;
@@ -1599,7 +1599,7 @@ br {
 
 #slider.active:target {
 	width: 750px;
-	box-shadow: -3px 3px 5px var(--template-box-shadow-color);
+	box-shadow: -3px 3px 5px var(--template-box-shadow-color-transparent);
 }
 
 #slider.sliding {
@@ -1614,7 +1614,7 @@ br {
 }
 
 #slider.active:target + #close-slider {
-	background-color: var(--template-modal-background-color);
+	background-color: var(--template-modal-background-color-transparent);
 	font-size: 0;
 	left: 0;
 	z-index: 99;
@@ -1747,7 +1747,7 @@ input:checked + .slide-container .properties {
 }
 
 .log-item.log-error {
-	background-color: var(--template-background-color-error);
+	background-color: var(--template-background-color-error-transparent);
 }
 
 .item.share.error a::after,
@@ -1898,7 +1898,7 @@ input:checked + .slide-container .properties {
 	}
 
 	.aside:target {
-		box-shadow: 3px 3px 5px var(--template-box-shadow-color);
+		box-shadow: 3px 3px 5px var(--template-box-shadow-color-transparent);
 	}
 
 	.aside .toggle_aside,
@@ -1984,7 +1984,7 @@ input:checked + .slide-container .properties {
 		padding-top: 0;
 		margin-top: 0;
 		overflow: auto;
-		box-shadow: -3px 0 3px var(--template-box-shadow-color);
+		box-shadow: -3px 0 3px var(--template-box-shadow-color-transparent);
 	}
 
 	.configure .dropdown-target:target ~ .dropdown-toggle::after {
@@ -2015,7 +2015,7 @@ input:checked + .slide-container .properties {
 
 	.aside:target + .close-aside,
 	.configure .dropdown-target:target ~ .dropdown-close {
-		background-color: var(--template-modal-background-color);
+		background-color: var(--template-modal-background-color-transparent);
 		display: block;
 		font-size: 0;
 		position: fixed;

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -15,7 +15,9 @@
 
 	--template-noThumbnailImage-background-color: #ddd;
 
-	--template-darken-background-color: rgba(0, 0, 0, 0.5);
+	--template-darken-background-hover: rgba(90, 90, 90, 0.1);
+
+	--template-modal-background-color: rgba(0, 0, 0, 0.5);
 
 	--template-scrollbar-handle: rgba(0, 0, 0, 0.1);
 	--template-scrollbar-handle-hover: rgba(0, 0, 0, 0.3);
@@ -1063,6 +1065,12 @@ input[type="search"] {
 	visibility: visible;
 }
 
+.aside .toggle_aside:hover,
+#panel .close:hover,
+.dropdown-menu .toggle_aside:hover {
+	background-color: var(--template-darken-background-hover);
+}
+
 /*=== New article notification */
 #new-article {
 	display: none;
@@ -1348,7 +1356,7 @@ br {
 }
 
 .notification a.close:hover {
-	background: rgba(10,10,10,0.05);
+	background-color: var(--template-darken-background-hover);
 }
 
 .notification a.close:hover .icon {
@@ -1533,7 +1541,7 @@ br {
 	position: fixed;
 	top: 0; bottom: 0;
 	left: 0; right: 0;
-	background-color: var(--template-darken-background-color);
+	background-color: var(--template-modal-background-color);
 	opacity: 0;
 	transition: visibility .3s, opacity .3s;
 	visibility: hidden;
@@ -1592,7 +1600,7 @@ br {
 }
 
 #slider.active:target + #close-slider {
-	background-color: var(--template-darken-background-color);
+	background-color: var(--template-modal-background-color);
 	font-size: 0;
 	left: 0;
 	z-index: 99;
@@ -1989,7 +1997,7 @@ input:checked + .slide-container .properties {
 
 	.aside:target + .close-aside,
 	.configure .dropdown-target:target ~ .dropdown-close {
-		background-color: var(--template-darken-background-color);
+		background-color: var(--template-modal-background-color);
 		display: block;
 		font-size: 0;
 		position: fixed;

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -7,14 +7,13 @@
 	--template-font-color-grey-dark: #666;
 	--template-font-color-grey-light: #aaa;
 	--template-font-color-light: #fff;
-	--template-font-color-error: #bd362f;
+	--template-background-color-error: #ff000040;
+	--template-font-color-error: #ff0000;
 
 	--template-background-color: #fff;
 	--template-background-color-transparent: rgba(255, 255, 255, 0.5);
 	--template-background-color-middle: #eee;
 	--template-background-color-dark: #ccc;
-
-	
 
 	--template-switch-accent-color: #85D885;
 
@@ -1746,7 +1745,7 @@ input:checked + .slide-container .properties {
 }
 
 .log-item.log-error {
-	background-color: #bd362f44;
+	background-color: var(--template-background-color-error);
 }
 
 .item.share.error a::after,
@@ -1798,7 +1797,6 @@ input:checked + .slide-container .properties {
 }
 
 .feed.active .item-title:not([data-unread="0"])::after {
-	background-color: transparent;
 	color: var(--template-font-color-light);
 	border: 1px solid #fff;
 	font-weight: bold;
@@ -2167,10 +2165,6 @@ input:checked + .slide-container .properties {
 
 .preview_controls label + label {
 	margin-left: 1rem;
-}
-
-.preview_background {
-	background-color: transparent;
 }
 
 .drag-drop-marker {

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -1079,6 +1079,7 @@ input[type="search"] {
 
 .aside .toggle_aside:hover,
 #panel .close:hover,
+#slider .toggle_aside:hover,
 .dropdown-menu .toggle_aside:hover {
 	background-color: var(--template-darken-background-hover);
 }

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -2,7 +2,6 @@
 
 /*=== GENERAL */
 /*============*/
-
 :root {
 	--template-font-color-dark: #000;
 	--template-font-color-grey-dark: #666;
@@ -27,7 +26,6 @@ html, body {
 	padding: 0;
 	background: white;
 	height: 100%;
-	color: var(--template-font-color-dark);
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif;
 	font-size: 100%;
 }

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -892,25 +892,25 @@ li.drag-hover {
 @supports not (scrollbar-width: thin) {
 	#sidebar::-webkit-scrollbar,
 	.scrollbar-thin::-webkit-scrollbar {
-		background: var(--template-scrollbar-track);
+		background-color: var(--template-scrollbar-track);
 		width: 8px;
 	}
 
 	#sidebar:hover::-webkit-scrollbar,
 	.scrollbar-thin:hover::-webkit-scrollbar {
-		background: var(--template-scrollbar-track-hover);
+		background-color: var(--template-scrollbar-track-hover);
 	}
 
 	#sidebar::-webkit-scrollbar-thumb,
 	.scrollbar-thin::-webkit-scrollbar-thumb {
-		background: var(--template-scrollbar-handle);
+		background-color: var(--template-scrollbar-handle);
 		display: unset;
 		border-radius: 5px;
 	}
 
 	#sidebar:hover::-webkit-scrollbar-thumb,
 	.scrollbar-thin:hover::-webkit-scrollbar-thumb {
-		background: var(--template-scrollbar-handle-hover);
+		background-color: var(--template-scrollbar-handle-hover);
 	}
 }
 

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -11,8 +11,15 @@
 
 	--template-background-color: #fff;
 	--template-background-color-transparent: rgba(255, 255, 255, 0.5);
+	--template-background-color-middle: #eee;
+	--template-background-color-dark: #ccc;
 
-	--template-dragdrop-color: rgba(250,250,210, 0.7);
+	
+
+	--template-switch-accent-color: #85D885;
+
+	--template-dragdrop-color: #ffff00;
+	--template-dragdrop-color-transparent: #ffff0020;
 
 	--template-noThumbnailImage-background-color: #ddd;
 
@@ -112,7 +119,7 @@ sup {
 }
 
 kbd {
-	background-color: #eee;
+	background-color: var(--template-background-color-middle);
 	padding: 2px 4px 2px 24px;
 	display: inline-block;
 	color: var(--template-font-color-grey-dark);
@@ -439,7 +446,7 @@ a.btn {
 	height: 1.75em;
 	border: 0;
 	border-radius: 1em;
-	background-color: #ccc;
+	background-color: var(--template-background-color-dark);
 	cursor: pointer;
 	box-sizing: content-box;
 	background-repeat: no-repeat;
@@ -455,7 +462,7 @@ a.btn {
 }
 
 .switch.active {
-	background-color: rgb(133, 216, 133);
+	background-color: var(--template-switch-accent-color);
 	background-repeat: no-repeat;
 	background-position: center center;
 	background-image: url('../icons/enabled.svg');
@@ -486,7 +493,7 @@ a.btn {
 	top: 0.2em;
 	width: 1.5em;
 	height: 1.5em;
-	background-color: #fff;
+	background-color: var(--template-background-color);
 	background-image: url('../icons/disabled.svg');
 	background-repeat: no-repeat;
 	background-position: center center;
@@ -495,7 +502,7 @@ a.btn {
 }
 
 .switch:not([disabled]):hover::before {
-	background-color: #eee;
+	background-color: var(--template-background-color-middle);
 }
 
 .switch.active::before {
@@ -834,7 +841,7 @@ input[type="checkbox"]:focus-visible {
 }
 
 .dragging {
-	background-color: rgba(255, 255, 0, 0.7);
+	background-color: var(--template-dragdrop-color)
 }
 
 .dragging .icon {
@@ -846,11 +853,11 @@ input[type="checkbox"]:focus-visible {
 }
 
 .drag-active .drop-zone:not(.drag-disallowed) {
-	background: repeating-linear-gradient(45deg, transparent, transparent 40px, var(--template-dragdrop-color) 40px, var(--template-dragdrop-color) 60px);
+	background: repeating-linear-gradient(45deg, transparent, transparent 40px, var(--template-dragdrop-color-transparent) 40px, var(--template-dragdrop-color-transparent) 60px);
 }
 
 .drag-active .drag-hover.drop-zone {
-	background-color: var(--template-dragdrop-color);
+	background-color: var(--template-dragdrop-color-transparent);
 	transition: background 0.5s;
 }
 
@@ -866,11 +873,11 @@ li.drag-hover {
 
 @keyframes droppedKeyframe {
 	0% {
-		background-color: rgba(250,250,210, 0.7);
+		background-color: var(--template-dragdrop-color-transparent);
 	}
 
 	50% {
-		background-color: yellow;
+		background-color: var(--template-dragdrop-color);
 	}
 
 	100% {
@@ -1389,8 +1396,7 @@ br {
 	width: 100%;
 	height: 100%;
 	overflow: auto;
-	background-color: #eee;
-	background-color: rgba(0,0,0,0.4);
+	background-color: var(--template-modal-background-color);
 }
 
 #popup-content {
@@ -1943,7 +1949,7 @@ input:checked + .slide-container .properties {
 	}
 
 	.dropdown-target:target ~ .dropdown-toggle::after {
-		background-color: #fff;
+		background-color: var(--template-background-color);
 		width: 10px;
 		height: 10px;
 		content: "";
@@ -2138,7 +2144,7 @@ input:checked + .slide-container .properties {
 	padding: 1rem;
 	max-width: 1000px;
 	text-align: center;
-	background-color: #eee;
+	background-color: var(--template-background-color-middle);
 	border: 1px solid #e0e0e0;
 	border-radius: .25rem;
 }

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -15,6 +15,9 @@
 	--template-background-color-middle: #eee;
 	--template-background-color-dark: #ccc;
 
+	--template-border-color: #999;
+	--template-border-color-error: #ff0000;
+
 	--template-switch-accent-color: #85D885;
 
 	--template-dragdrop-color: #ffff00;
@@ -124,7 +127,7 @@ kbd {
 	padding: 2px 4px 2px 24px;
 	display: inline-block;
 	color: var(--template-font-color-grey-dark);
-	border: 1px solid #b4b4b4;
+	border: 1px solid var(--template-border-color);
 	border-radius: 3px;
 	text-indent: -20px;
 	white-space: pre-wrap;
@@ -243,7 +246,7 @@ textarea[rows="2"] {
 }
 
 textarea:invalid {
-	border: 2px dashed red;
+	border: 2px dashed var(--template-border-color-error);
 }
 
 .prompt textarea,
@@ -261,7 +264,7 @@ select:disabled {
 	min-width: 75px;
 	color: var(--template-font-color-grey-light);
 	font-style: italic;
-	border: 1px dashed lightgray;
+	border: 1px dashed var(--template-border-color);
 }
 
 input[type="radio"],
@@ -536,7 +539,7 @@ a.btn {
 
 .btn:focus-visible,
 input[type="checkbox"]:focus-visible {
-	outline: 2px solid #ccc;
+	outline: 2px solid var(--template-border-color);
 }
 
 /*=== Navigation */
@@ -608,7 +611,7 @@ input[type="checkbox"]:focus-visible {
 	margin: 0;
 	background-color: var(--template-background-color);
 	display: none;
-	border: 1px solid #aaa;
+	border: 1px solid var(--template-border-color);
 	min-width: 200px;
 	position: absolute;
 	right: 0;
@@ -620,6 +623,7 @@ input[type="checkbox"]:focus-visible {
 	height: 10px;
 	border-width: 1px 0 0 1px;
 	border-style: solid;
+	border-color: var(--template-border-color);
 	content: "";
 	position: absolute;
 	top: -6px;
@@ -687,7 +691,7 @@ input[type="checkbox"]:focus-visible {
 .separator {
 	display: block;
 	height: 0;
-	border-bottom: 1px solid #aaa;
+	border-bottom: 1px solid var(--template-border-color);
 }
 
 /*=== Alerts */
@@ -732,7 +736,7 @@ input[type="checkbox"]:focus-visible {
 	margin: 0 0 5em;
 	padding: 1em 0;
 	width: 100%;
-	border-top: 1px solid #aaa;
+	border-top: 1px solid var(--template-border-color);
 	text-align: center;
 }
 
@@ -783,7 +787,6 @@ input[type="checkbox"]:focus-visible {
 	display: inline-block;
 	max-width: 95%;
 	width: 20rem;
-	border: 1px solid #ccc;
 	vertical-align: top;
 }
 
@@ -864,7 +867,7 @@ input[type="checkbox"]:focus-visible {
 
 li.drag-hover {
 	margin: 0 0 5px;
-	border-bottom: 2px solid #ccc;
+	border-bottom: 2px solid var(--template-border-color);
 }
 
 .drag-drop {
@@ -1274,7 +1277,7 @@ a.website:hover .favicon {
 .content > footer {
 	margin: 2rem 0 2rem;
 	padding-top: 1rem;
-	border-top: 2px solid #ccc;
+	border-top: 2px solid var(--template-border-color);
 	clear: both;
 }
 
@@ -1348,7 +1351,7 @@ br {
 	left: 25%; right: 25%;
 	z-index: 9999;
 	background-color: var(--template-background-color);
-	border: 1px solid #aaa;
+	border: 1px solid var(--template-border-color);
 	opacity: 1;
 	line-height: 2;
 	visibility: visible;
@@ -1480,7 +1483,7 @@ br {
 #load_more.loading,
 #load_more.loading:hover {
 	padding: 10px 20px;
-	background: var(--template-loading-image) center center no-repeat #fff;
+	background: var(--template-loading-image) center center no-repeat var(--template-background-color);
 	font-size: 0;
 }
 
@@ -1591,7 +1594,6 @@ br {
 	top: 0; bottom: 0;
 	right: 0;
 	overflow: auto;
-	border-left: 1px solid #aaa;
 	z-index: 100;
 }
 
@@ -1645,7 +1647,7 @@ br {
 	display: block;
 	max-width: 640px;
 	height: 320px;
-	border: 1px solid #aaa;
+	border: 1px solid var(--template-border-color);
 	position: relative;
 	min-width: 260px;
 	margin-bottom: 30px;
@@ -1698,7 +1700,7 @@ br {
 	padding: 5px;
 	background-color: var(--template-background-color-transparent);
 	display: none;
-	border-top: 1px solid #aaa;
+	border-top: 1px solid var(--template-border-color);
 	bottom: 0;
 	left: 0; right: 0;
 	position: absolute;
@@ -1798,7 +1800,7 @@ input:checked + .slide-container .properties {
 
 .feed.active .item-title:not([data-unread="0"])::after {
 	color: var(--template-font-color-light);
-	border: 1px solid #fff;
+	border: 1px solid var(--template-border-color);
 	font-weight: bold;
 }
 
@@ -1906,7 +1908,7 @@ input:checked + .slide-container .properties {
 		display: block;
 		width: 100%;
 		height: 50px;
-		border-bottom: 1px solid #ddd;
+		border-bottom: 1px solid var(--template-border-color);
 		line-height: 50px;
 		text-align: center;
 	}
@@ -2151,7 +2153,7 @@ input:checked + .slide-container .properties {
 	max-width: 1000px;
 	text-align: center;
 	background-color: var(--template-background-color-middle);
-	border: 1px solid #e0e0e0;
+	border: 1px solid var(--template-border-color);
 	border-radius: .25rem;
 }
 

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -8,33 +8,33 @@
 	--template-font-color-grey-light: #aaa;
 	--template-font-color-light: #fff;
 	--template-background-color-error-transparent: #ff000040;
-	--template-font-color-error: #ff0000;
+	--template-font-color-error: #f00;
 
 	--template-background-color: #fff;
-	--template-background-color-transparent: #ffffff7F;
+	--template-background-color-transparent: #ffffff7f;
 	--template-background-color-middle: #eee;
 	--template-background-color-dark: #ccc;
 
 	--template-border-color: #999;
-	--template-border-color-error: #ff0000;
+	--template-border-color-error: #f00;
 
-	--template-switch-accent-color: #85D885;
+	--template-switch-accent-color: #85d885;
 
-	--template-dragdrop-color: #ffff00;
-	--template-dragdrop-color-transparent: #ffff0020;
+	--template-dragdrop-color: #ff0;
+	--template-dragdrop-color-transparent: #ff02;
 
 	--template-noThumbnailImage-background-color: #ddd;
 
-	--template-darken-background-hover-transparent: #66666620;
+	--template-darken-background-hover-transparent: #6662;
 
-	--template-modal-background-color-transparent: #0000007F;
+	--template-modal-background-color-transparent: #0007;
 
-	--template-box-shadow-color-transparent: #00000033;
+	--template-box-shadow-color-transparent: #0003;
 
-	--template-scrollbar-handle: #00000022;
-	--template-scrollbar-handle-hover: #00000055;
-	--template-scrollbar-track: #00000011;
-	--template-scrollbar-track-hover: #00000011;
+	--template-scrollbar-handle: #0002;
+	--template-scrollbar-handle-hover: #0005;
+	--template-scrollbar-track: #0001;
+	--template-scrollbar-track-hover: #0001;
 
 	--template-loading-image: url("loader.gif");
 }
@@ -890,6 +890,7 @@ li.drag-hover {
 }
 
 /*=== Scrollbar */
+
 @supports (scrollbar-width: thin) {
 	#sidebar,
 	.scrollbar-thin {

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -10,6 +10,7 @@
 	--template-font-color-error: #bd362f;
 
 	--template-background-color: #fff;
+	--template-background-color-transparent: rgba(255, 255, 255, 0.5);
 
 	--template-dragdrop-color: rgba(250,250,210, 0.7);
 
@@ -1680,19 +1681,20 @@ br {
 	transition: opacity .2s;
 	text-align: center;
 	line-height: 225%;
-	background-color: rgba(255, 255, 255, .3);
+	background-color: var(--template-background-color-transparent);
 	text-shadow: 0px 0px 15px rgb(119, 119, 119);
 }
 
 .properties {
 	padding: 5px;
-	background: rgba(255, 255, 255, 0.7);
+	background-color: var(--template-background-color-transparent);
 	display: none;
 	border-top: 1px solid #aaa;
 	bottom: 0;
 	left: 0; right: 0;
 	position: absolute;
 	z-index: 10;
+	backdrop-filter: blur(3px);
 }
 
 .properties .page-number {

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -8,6 +8,19 @@
 	--template-font-color-grey-light: #aaa;
 	--template-font-color-light: #fff;
 	--template-font-color-error: #bd362f;
+
+	--template-background-color: #fff;
+
+	--template-dragdrop-color: rgba(250,250,210, 0.7);
+
+	--template-noThumbnailImage-background-color: #ddd;
+
+	--template-darken-background-color: rgba(0, 0, 0, 0.5);
+
+	--template-scrollbar-handle: rgba(0, 0, 0, 0.1);
+	--template-scrollbar-handle-hover: rgba(0, 0, 0, 0.3);
+	--template-scrollbar-track: rgba(0, 0, 0, 0.05);
+	--template-scrollbar-track-hover: rgba(0, 0, 0, 0.05);
 }
 
 @font-face {
@@ -22,7 +35,7 @@
 html, body {
 	margin: 0;
 	padding: 0;
-	background: white;
+	background-color: var(--template-background-color);
 	height: 100%;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif;
 	font-size: 100%;
@@ -580,7 +593,7 @@ input[type="checkbox"]:focus-visible {
 
 .dropdown-menu {
 	margin: 0;
-	background: #fff;
+	background-color: var(--template-background-color);
 	display: none;
 	border: 1px solid #aaa;
 	min-width: 200px;
@@ -828,11 +841,11 @@ input[type="checkbox"]:focus-visible {
 }
 
 .drag-active .drop-zone:not(.drag-disallowed) {
-	background: repeating-linear-gradient(45deg, transparent, transparent 40px, rgba(250,250,210, 0.7) 40px, rgba(250,250,210, 0.7) 60px);
+	background: repeating-linear-gradient(45deg, transparent, transparent 40px, var(--template-dragdrop-color) 40px, var(--template-dragdrop-color) 60px);
 }
 
 .drag-active .drag-hover.drop-zone {
-	background: rgba(250,250,210, 0.7);
+	background-color: var(--template-dragdrop-color);
 	transition: background 0.5s;
 }
 
@@ -861,37 +874,41 @@ li.drag-hover {
 }
 
 /*=== Scrollbar */
-
 @supports (scrollbar-width: thin) {
 	#sidebar,
 	.scrollbar-thin {
-		scrollbar-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.05);
+		scrollbar-color: var(--template-scrollbar-handle) var(--template-scrollbar-track);
 		scrollbar-width: thin;
 	}
 
 	#sidebar:hover,
 	.scrollbar-thin:hover {
-		scrollbar-color: rgba(0, 0, 0, 0.3) rgba(0, 0, 0, 0.05);
+		scrollbar-color: rgba(0, 0, 0, 0.3) var(--template-scrollbar-track);
 	}
 }
 
 @supports not (scrollbar-width: thin) {
 	#sidebar::-webkit-scrollbar,
 	.scrollbar-thin::-webkit-scrollbar {
-		background: rgba(0, 0, 0, 0.05);
+		background: var(--template-scrollbar-track);
 		width: 8px;
+	}
+
+	#sidebar:hover::-webkit-scrollbar,
+	.scrollbar-thin:hover::-webkit-scrollbar {
+		background: var(--template-scrollbar-track-hover);
 	}
 
 	#sidebar::-webkit-scrollbar-thumb,
 	.scrollbar-thin::-webkit-scrollbar-thumb {
-		background: rgba(0, 0, 0, 0.1);
+		background: var(--template-scrollbar-handle);
 		display: unset;
 		border-radius: 5px;
 	}
 
 	#sidebar:hover::-webkit-scrollbar-thumb,
 	.scrollbar-thin::-webkit-scrollbar-thumb {
-		background: rgba(0, 0, 0, 0.3);
+		background: var(--template-scrollbar-handle-hover);
 	}
 }
 
@@ -1102,7 +1119,7 @@ a.website:hover .favicon {
 }
 
 .flux:not(.current):hover .item.title {
-	background: #fff;
+	background-color: var(--template-background-color);
 	max-width: calc(100% - 320px);
 	position: absolute;
 }
@@ -1151,7 +1168,7 @@ a.website:hover .favicon {
 }
 
 .flux .item.thumbnail img {
-	background: repeating-linear-gradient( -45deg, #ddd, #ddd 5px, transparent 5px, transparent 10px );
+	background: repeating-linear-gradient( -45deg, var(--template-noThumbnailImage-background-color), var(--template-noThumbnailImage-background-color) 5px, transparent 5px, transparent 10px );
 	display: inline-block;
 	width: 100%;
 	height: 100%;
@@ -1310,7 +1327,7 @@ br {
 	top: 1em;
 	left: 25%; right: 25%;
 	z-index: 9999;
-	background: #fff;
+	background-color: var(--template-background-color);
 	border: 1px solid #aaa;
 	opacity: 1;
 	line-height: 2;
@@ -1415,7 +1432,6 @@ br {
 
 /*=== Navigation menu (for articles) */
 #nav_entries {
-	background: #fff;
 	display: table;
 	position: fixed;
 	bottom: 0; left: 0;
@@ -1517,7 +1533,7 @@ br {
 	position: fixed;
 	top: 0; bottom: 0;
 	left: 0; right: 0;
-	background: rgba(0, 0, 0, 0.5);
+	background-color: var(--template-darken-background-color);
 	opacity: 0;
 	transition: visibility .3s, opacity .3s;
 	visibility: hidden;
@@ -1529,7 +1545,7 @@ br {
 }
 
 #panel {
-	background: #fff;
+	background-color: var(--template-background-color);
 	display: none;
 	position: fixed;
 	top: 2%; bottom: 2%;
@@ -1550,7 +1566,7 @@ br {
 
 /*=== Slider */
 #slider {
-	background: #fff;
+	background-color: var(--template-background-color);
 	width: 0;
 	position: fixed;
 	top: 0; bottom: 0;
@@ -1576,7 +1592,7 @@ br {
 }
 
 #slider.active:target + #close-slider {
-	background: rgba(0, 0, 0, 0.2);
+	background-color: var(--template-darken-background-color);
 	font-size: 0;
 	left: 0;
 	z-index: 99;
@@ -1863,7 +1879,6 @@ input:checked + .slide-container .properties {
 	#panel .close,
 	.dropdown-menu .toggle_aside,
 	#slider .toggle_aside {
-		background: #f6f6f6;
 		display: block;
 		width: 100%;
 		height: 50px;
@@ -1974,7 +1989,7 @@ input:checked + .slide-container .properties {
 
 	.aside:target + .close-aside,
 	.configure .dropdown-target:target ~ .dropdown-close {
-		background: rgba(0, 0, 0, 0.2);
+		background-color: var(--template-darken-background-color);
 		display: block;
 		font-size: 0;
 		position: fixed;
@@ -2080,7 +2095,7 @@ input:checked + .slide-container .properties {
 	}
 
 	html, body {
-		background: #fff;
+		background-color: var(--template-background-color);
 		font-family: Serif;
 	}
 

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -7,10 +7,8 @@
 	--template-font-color-grey-dark: #666;
 	--template-font-color-grey-light: #aaa;
 	--template-font-color-light: #fff;
-	--ffont-color-contrast: #0062b7;
-	--ffont-color-error: #912621;
+	--template-font-color-error: #bd362f;
 }
-
 
 @font-face {
 	font-family: 'OpenSans';
@@ -1232,7 +1230,7 @@ a.website:hover .favicon {
 
 .content > header,
 .content > footer {
-	color: var(--template-font-color-grey-dark);
+	color: var(--template-font-color-grey-light);
 	font-size: .9rem;
 }
 
@@ -1717,7 +1715,7 @@ input:checked + .slide-container .properties {
 .category .title.error::before,
 .item.feed.error .item-title::before {
 	content: " ⚠ ";
-	color: #bd362f;
+	color: var(--template-font-color-error);
 }
 
 .feed.item.error.active .item-title::before {

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -3,6 +3,16 @@
 /*=== GENERAL */
 /*============*/
 
+:root {
+	--template-font-color-dark: #000;
+	--template-font-color-grey-dark: #666;
+	--template-font-color-grey-light: #aaa;
+	--template-font-color-light: #fff;
+	--ffont-color-contrast: #0062b7;
+	--ffont-color-error: #912621;
+}
+
+
 @font-face {
 	font-family: 'OpenSans';
 	font-style: normal;
@@ -17,7 +27,7 @@ html, body {
 	padding: 0;
 	background: white;
 	height: 100%;
-	color: black;
+	color: var(--template-font-color-dark);
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif;
 	font-size: 100%;
 }
@@ -91,7 +101,7 @@ kbd {
 	background-color: #eee;
 	padding: 2px 4px 2px 24px;
 	display: inline-block;
-	color: #333;
+	color: var(--template-font-color-grey-dark);
 	border: 1px solid #b4b4b4;
 	border-radius: 3px;
 	text-indent: -20px;
@@ -227,7 +237,7 @@ input:disabled,
 select:disabled {
 	background-color: transparent;
 	min-width: 75px;
-	color: lightgray;
+	color: var(--template-font-color-grey-light);
 	font-style: italic;
 	border: 1px dashed lightgray;
 }
@@ -282,7 +292,7 @@ button.as-link:active {
 }
 
 button.as-link[disabled] {
-	color: #ddd !important;
+	color: var(--template-font-color-grey-light) !important;
 }
 
 /*=== Tables */
@@ -1106,7 +1116,7 @@ a.website:hover .favicon {
 }
 
 .flux .item.title a {
-	color: #000;
+	color: var(--template-font-color-dark);
 	text-decoration: none;
 }
 
@@ -1155,7 +1165,7 @@ a.website:hover .favicon {
 
 .flux .item.title .summary {
 	max-height: 3em;
-	color: #666;
+	color: var(--template-font-color-grey-dark);
 	font-size: 0.9em;
 	line-height: 1.5em;
 	font-weight: normal;
@@ -1166,7 +1176,7 @@ a.website:hover .favicon {
 
 .flux .item.title .author {
 	padding-left: 1rem;
-	color: #555;
+	color: var(--template-font-color-grey-dark);
 	font-size: .9rem;
 	font-weight: normal;
 }
@@ -1224,7 +1234,7 @@ a.website:hover .favicon {
 
 .content > header,
 .content > footer {
-	color: #666;
+	color: var(--template-font-color-grey-dark);
 	font-size: .9rem;
 }
 
@@ -1380,14 +1390,14 @@ br {
 	width: 27px;
 	height: 27px;
 	padding-bottom: 5px;
-	color: #aaa;
+	color: var(--template-font-color-grey-light);
 	font-size: 28px;
 	font-weight: bold;
 }
 
 #popup-close:hover,
 #popup-close:focus {
-	color: #000;
+	color: var(--template-font-color-dark);
 	text-decoration: none;
 	cursor: pointer;
 }
@@ -1638,7 +1648,7 @@ br {
 	display: none;
 	width: 65px;
 	height: 100%;
-	color: #fff;
+	color: var(--template-font-color-light);
 	font-family: "Varela Round", sans-serif;
 	font-size: 1000%;
 	position: absolute;
@@ -1656,7 +1666,6 @@ br {
 	padding: 5px;
 	background: rgba(255, 255, 255, 0.7);
 	display: none;
-	color: #000;
 	border-top: 1px solid #aaa;
 	bottom: 0;
 	left: 0; right: 0;
@@ -1714,7 +1723,7 @@ input:checked + .slide-container .properties {
 }
 
 .feed.item.error.active .item-title::before {
-	color: white;
+	color: var(--template-font-color-light);
 }
 
 .aside .category .title:not([data-unread="0"])::after,
@@ -1756,7 +1765,7 @@ input:checked + .slide-container .properties {
 
 .feed.active .item-title:not([data-unread="0"])::after {
 	background-color: transparent;
-	color: white;
+	color: var(--template-font-color-light);
 	border: 1px solid #fff;
 	font-weight: bold;
 }
@@ -2076,7 +2085,6 @@ input:checked + .slide-container .properties {
 
 	html, body {
 		background: #fff;
-		color: #000;
 		font-family: Serif;
 	}
 
@@ -2090,7 +2098,7 @@ input:checked + .slide-container .properties {
 	}
 
 	.flux_content .content a {
-		color: #000;
+		color: var(--template-font-color-dark);
 	}
 
 	.flux_content .content a::after {

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -26,6 +26,8 @@
 	--template-darken-background-hover: rgba(90, 90, 90, 0.1);
 
 	--template-modal-background-color: rgba(0, 0, 0, 0.5);
+	
+	--template-box-shadow-color: rgba(0, 0, 0, 0.2);
 
 	--template-scrollbar-handle: rgba(0, 0, 0, 0.1);
 	--template-scrollbar-handle-hover: rgba(0, 0, 0, 0.3);
@@ -1405,9 +1407,9 @@ br {
 	width: 80%;
 	height: 80%;
 	overflow: hidden;
-	background-color: #fafafa;
+	background-color: var(--template-background-color);
 	border-radius: .25rem;
-	box-shadow: 0 0 1px #737373, 1px 2px 3px #4a4a4f;
+	box-shadow: 3px 3px 5px var(--template-box-shadow-color);
 }
 
 .popup-row {
@@ -1595,6 +1597,7 @@ br {
 
 #slider.active:target {
 	width: 750px;
+	box-shadow: -3px 3px 5px var(--template-box-shadow-color);
 }
 
 #slider.sliding {
@@ -1893,6 +1896,10 @@ input:checked + .slide-container .properties {
 		display: none;
 	}
 
+	.aside:target {
+		box-shadow: 3px 3px 5px var(--template-box-shadow-color);
+	}
+
 	.aside .toggle_aside,
 	#panel .close,
 	.dropdown-menu .toggle_aside,
@@ -1976,7 +1983,7 @@ input:checked + .slide-container .properties {
 		padding-top: 0;
 		margin-top: 0;
 		overflow: auto;
-		box-shadow: -3px 0 3px #aaa;
+		box-shadow: -3px 0 3px var(--template-box-shadow-color);
 	}
 
 	.configure .dropdown-target:target ~ .dropdown-toggle::after {

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -23,6 +23,8 @@
 	--template-scrollbar-handle-hover: rgba(0, 0, 0, 0.3);
 	--template-scrollbar-track: rgba(0, 0, 0, 0.05);
 	--template-scrollbar-track-hover: rgba(0, 0, 0, 0.05);
+
+	--template-loading-image: url("loader.gif");
 }
 
 @font-face {
@@ -1469,12 +1471,12 @@ br {
 #load_more.loading,
 #load_more.loading:hover {
 	padding: 10px 20px;
-	background: url("loader.gif") center center no-repeat #fff;
+	background: var(--template-loading-image) center center no-repeat #fff;
 	font-size: 0;
 }
 
 .loading {
-	background: url("loader.gif") center center no-repeat;
+	background: var(--template-loading-image) center center no-repeat;
 	font-size: 0;
 }
 

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -2,6 +2,15 @@
 
 /*=== GENERAL */
 /*============*/
+:root {
+	--template-font-color-dark: #000;
+	--template-font-color-grey-dark: #666;
+	--template-font-color-grey-light: #aaa;
+	--template-font-color-light: #fff;
+	--ffont-color-contrast: #0062b7;
+	--ffont-color-error: #912621;
+}
+
 
 @font-face {
 	font-family: 'OpenSans';
@@ -17,7 +26,6 @@ html, body {
 	padding: 0;
 	background: white;
 	height: 100%;
-	color: black;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif;
 	font-size: 100%;
 }
@@ -91,7 +99,7 @@ kbd {
 	background-color: #eee;
 	padding: 2px 24px 2px 4px;
 	display: inline-block;
-	color: #333;
+	color: var(--template-font-color-grey-dark);
 	border: 1px solid #b4b4b4;
 	border-radius: 3px;
 	text-indent: -20px;
@@ -227,7 +235,7 @@ input:disabled,
 select:disabled {
 	background-color: transparent;
 	min-width: 75px;
-	color: lightgray;
+	color: var(--template-font-color-grey-light);
 	font-style: italic;
 	border: 1px dashed lightgray;
 }
@@ -282,7 +290,7 @@ button.as-link:active {
 }
 
 button.as-link[disabled] {
-	color: #ddd !important;
+	color: var(--template-font-color-grey-light) !important;
 }
 
 /*=== Tables */
@@ -1106,7 +1114,7 @@ a.website:hover .favicon {
 }
 
 .flux .item.title a {
-	color: #000;
+	color: var(--template-font-color-dark);
 	text-decoration: none;
 }
 
@@ -1155,7 +1163,7 @@ a.website:hover .favicon {
 
 .flux .item.title .summary {
 	max-height: 3em;
-	color: #666;
+	color: var(--template-font-color-grey-dark);
 	font-size: 0.9em;
 	line-height: 1.5em;
 	font-weight: normal;
@@ -1166,7 +1174,7 @@ a.website:hover .favicon {
 
 .flux .item.title .author {
 	padding-right: 1rem;
-	color: #555;
+	color: var(--template-font-color-grey-dark);
 	font-size: .9rem;
 	font-weight: normal;
 }
@@ -1224,7 +1232,7 @@ a.website:hover .favicon {
 
 .content > header,
 .content > footer {
-	color: #666;
+	color: var(--template-font-color-grey-dark);
 	font-size: .9rem;
 }
 
@@ -1380,14 +1388,14 @@ br {
 	width: 27px;
 	height: 27px;
 	padding-bottom: 5px;
-	color: #aaa;
+	color: var(--template-font-color-grey-light);
 	font-size: 28px;
 	font-weight: bold;
 }
 
 #popup-close:hover,
 #popup-close:focus {
-	color: #000;
+	color: var(--template-font-color-dark);
 	text-decoration: none;
 	cursor: pointer;
 }
@@ -1638,7 +1646,7 @@ br {
 	display: none;
 	width: 65px;
 	height: 100%;
-	color: #fff;
+	color: var(--template-font-color-light);
 	font-family: "Varela Round", sans-serif;
 	font-size: 1000%;
 	position: absolute;
@@ -1656,7 +1664,6 @@ br {
 	padding: 5px;
 	background: rgba(255, 255, 255, 0.7);
 	display: none;
-	color: #000;
 	border-top: 1px solid #aaa;
 	bottom: 0;
 	right: 0; left: 0;
@@ -1714,7 +1721,7 @@ input:checked + .slide-container .properties {
 }
 
 .feed.item.error.active .item-title::before {
-	color: white;
+	color: var(--template-font-color-light);
 }
 
 .aside .category .title:not([data-unread="0"])::after,
@@ -1756,7 +1763,7 @@ input:checked + .slide-container .properties {
 
 .feed.active .item-title:not([data-unread="0"])::after {
 	background-color: transparent;
-	color: white;
+	color: var(--template-font-color-light);
 	border: 1px solid #fff;
 	font-weight: bold;
 }
@@ -2076,7 +2083,6 @@ input:checked + .slide-container .properties {
 
 	html, body {
 		background: #fff;
-		color: #000;
 		font-family: Serif;
 	}
 
@@ -2090,7 +2096,7 @@ input:checked + .slide-container .properties {
 	}
 
 	.flux_content .content a {
-		color: #000;
+		color: var(--template-font-color-dark);
 	}
 
 	.flux_content .content a::after {

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -7,10 +7,37 @@
 	--template-font-color-grey-dark: #666;
 	--template-font-color-grey-light: #aaa;
 	--template-font-color-light: #fff;
-	--ffont-color-contrast: #0062b7;
-	--ffont-color-error: #912621;
-}
+	--template-background-color-error-transparent: #ff000040;
+	--template-font-color-error: #f00;
 
+	--template-background-color: #fff;
+	--template-background-color-transparent: #ffffff7f;
+	--template-background-color-middle: #eee;
+	--template-background-color-dark: #ccc;
+
+	--template-border-color: #999;
+	--template-border-color-error: #f00;
+
+	--template-switch-accent-color: #85d885;
+
+	--template-dragdrop-color: #ff0;
+	--template-dragdrop-color-transparent: #ff02;
+
+	--template-noThumbnailImage-background-color: #ddd;
+
+	--template-darken-background-hover-transparent: #6662;
+
+	--template-modal-background-color-transparent: #0007;
+
+	--template-box-shadow-color-transparent: #0003;
+
+	--template-scrollbar-handle: #0002;
+	--template-scrollbar-handle-hover: #0005;
+	--template-scrollbar-track: #0001;
+	--template-scrollbar-track-hover: #0001;
+
+	--template-loading-image: url("loader.gif");
+}
 
 @font-face {
 	font-family: 'OpenSans';
@@ -24,7 +51,7 @@
 html, body {
 	margin: 0;
 	padding: 0;
-	background: white;
+	background-color: var(--template-background-color);
 	height: 100%;
 	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif;
 	font-size: 100%;
@@ -96,11 +123,11 @@ sup {
 }
 
 kbd {
-	background-color: #eee;
+	background-color: var(--template-background-color-middle);
 	padding: 2px 24px 2px 4px;
 	display: inline-block;
 	color: var(--template-font-color-grey-dark);
-	border: 1px solid #b4b4b4;
+	border: 1px solid var(--template-border-color);
 	border-radius: 3px;
 	text-indent: -20px;
 	white-space: pre-wrap;
@@ -219,7 +246,7 @@ textarea[rows="2"] {
 }
 
 textarea:invalid {
-	border: 2px dashed red;
+	border: 2px dashed var(--template-border-color-error);
 }
 
 .prompt textarea,
@@ -237,7 +264,7 @@ select:disabled {
 	min-width: 75px;
 	color: var(--template-font-color-grey-light);
 	font-style: italic;
-	border: 1px dashed lightgray;
+	border: 1px dashed var(--template-border-color);
 }
 
 input[type="radio"],
@@ -423,7 +450,7 @@ a.btn {
 	height: 1.75em;
 	border: 0;
 	border-radius: 1em;
-	background-color: #ccc;
+	background-color: var(--template-background-color-dark);
 	cursor: pointer;
 	box-sizing: content-box;
 	background-repeat: no-repeat;
@@ -439,7 +466,7 @@ a.btn {
 }
 
 .switch.active {
-	background-color: rgb(133, 216, 133);
+	background-color: var(--template-switch-accent-color);
 	background-repeat: no-repeat;
 	background-position: center center;
 	background-image: url('../icons/enabled.svg');
@@ -470,7 +497,7 @@ a.btn {
 	top: 0.2em;
 	width: 1.5em;
 	height: 1.5em;
-	background-color: #fff;
+	background-color: var(--template-background-color);
 	background-image: url('../icons/disabled.svg');
 	background-repeat: no-repeat;
 	background-position: center center;
@@ -479,7 +506,7 @@ a.btn {
 }
 
 .switch:not([disabled]):hover::before {
-	background-color: #eee;
+	background-color: var(--template-background-color-middle);
 }
 
 .switch.active::before {
@@ -512,7 +539,7 @@ a.btn {
 
 .btn:focus-visible,
 input[type="checkbox"]:focus-visible {
-	outline: 2px solid #ccc;
+	outline: 2px solid var(--template-border-color);
 }
 
 /*=== Navigation */
@@ -582,9 +609,9 @@ input[type="checkbox"]:focus-visible {
 
 .dropdown-menu {
 	margin: 0;
-	background: #fff;
+	background-color: var(--template-background-color);
 	display: none;
-	border: 1px solid #aaa;
+	border: 1px solid var(--template-border-color);
 	min-width: 200px;
 	position: absolute;
 	left: 0;
@@ -596,6 +623,7 @@ input[type="checkbox"]:focus-visible {
 	height: 10px;
 	border-width: 1px 1px 0 0;
 	border-style: solid;
+	border-color: var(--template-border-color);
 	content: "";
 	position: absolute;
 	top: -6px;
@@ -663,7 +691,7 @@ input[type="checkbox"]:focus-visible {
 .separator {
 	display: block;
 	height: 0;
-	border-bottom: 1px solid #aaa;
+	border-bottom: 1px solid var(--template-border-color);
 }
 
 /*=== Alerts */
@@ -708,7 +736,7 @@ input[type="checkbox"]:focus-visible {
 	margin: 0 0 5em;
 	padding: 1em 0;
 	width: 100%;
-	border-top: 1px solid #aaa;
+	border-top: 1px solid var(--template-border-color);
 	text-align: center;
 }
 
@@ -759,7 +787,6 @@ input[type="checkbox"]:focus-visible {
 	display: inline-block;
 	max-width: 95%;
 	width: 20rem;
-	border: 1px solid #ccc;
 	vertical-align: top;
 }
 
@@ -818,7 +845,7 @@ input[type="checkbox"]:focus-visible {
 }
 
 .dragging {
-	background-color: rgba(255, 255, 0, 0.7);
+	background-color: var(--template-dragdrop-color)
 }
 
 .dragging .icon {
@@ -830,17 +857,17 @@ input[type="checkbox"]:focus-visible {
 }
 
 .drag-active .drop-zone:not(.drag-disallowed) {
-	background: repeating-linear-gradient(-45deg, transparent, transparent 40px, rgba(250,250,210, 0.7) 40px, rgba(250,250,210, 0.7) 60px);
+	background: repeating-linear-gradient(-45deg, transparent, transparent 40px, var(--template-dragdrop-color-transparent) 40px, var(--template-dragdrop-color-transparent) 60px);
 }
 
 .drag-active .drag-hover.drop-zone {
-	background: rgba(250,250,210, 0.7);
+	background-color: var(--template-dragdrop-color-transparent);
 	transition: background 0.5s;
 }
 
 li.drag-hover {
 	margin: 0 0 5px;
-	border-bottom: 2px solid #ccc;
+	border-bottom: 2px solid var(--template-border-color);
 }
 
 .drag-drop {
@@ -850,11 +877,11 @@ li.drag-hover {
 
 @keyframes droppedKeyframe {
 	0% {
-		background-color: rgba(250,250,210, 0.7);
+		background-color: var(--template-dragdrop-color-transparent);
 	}
 
 	50% {
-		background-color: yellow;
+		background-color: var(--template-dragdrop-color);
 	}
 
 	100% {
@@ -867,33 +894,38 @@ li.drag-hover {
 @supports (scrollbar-width: thin) {
 	#sidebar,
 	.scrollbar-thin {
-		scrollbar-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.05);
+		scrollbar-color: var(--template-scrollbar-handle) var(--template-scrollbar-track);
 		scrollbar-width: thin;
 	}
 
 	#sidebar:hover,
 	.scrollbar-thin:hover {
-		scrollbar-color: rgba(0, 0, 0, 0.3) rgba(0, 0, 0, 0.05);
+		scrollbar-color: var(--template-scrollbar-handle-hover) var(--template-scrollbar-track-hover);
 	}
 }
 
 @supports not (scrollbar-width: thin) {
 	#sidebar::-webkit-scrollbar,
 	.scrollbar-thin::-webkit-scrollbar {
-		background: rgba(0, 0, 0, 0.05);
+		background-color: var(--template-scrollbar-track);
 		width: 8px;
+	}
+
+	#sidebar:hover::-webkit-scrollbar,
+	.scrollbar-thin:hover::-webkit-scrollbar {
+		background-color: var(--template-scrollbar-track-hover);
 	}
 
 	#sidebar::-webkit-scrollbar-thumb,
 	.scrollbar-thin::-webkit-scrollbar-thumb {
-		background: rgba(0, 0, 0, 0.1);
+		background-color: var(--template-scrollbar-handle);
 		display: unset;
 		border-radius: 5px;
 	}
 
 	#sidebar:hover::-webkit-scrollbar-thumb,
-	.scrollbar-thin::-webkit-scrollbar-thumb {
-		background: rgba(0, 0, 0, 0.3);
+	.scrollbar-thin:hover::-webkit-scrollbar-thumb {
+		background-color: var(--template-scrollbar-handle-hover);
 	}
 }
 
@@ -1048,6 +1080,13 @@ input[type="search"] {
 	visibility: visible;
 }
 
+.aside .toggle_aside:hover,
+#panel .close:hover,
+#slider .toggle_aside:hover,
+.dropdown-menu .toggle_aside:hover {
+	background-color: var(--template-darken-background-hover-transparent);
+}
+
 /*=== New article notification */
 #new-article {
 	display: none;
@@ -1104,7 +1143,7 @@ a.website:hover .favicon {
 }
 
 .flux:not(.current):hover .item.title {
-	background: #fff;
+	background-color: var(--template-background-color);
 	max-width: calc(100% - 320px);
 	position: absolute;
 }
@@ -1153,7 +1192,7 @@ a.website:hover .favicon {
 }
 
 .flux .item.thumbnail img {
-	background: repeating-linear-gradient( 45deg, #ddd, #ddd 5px, transparent 5px, transparent 10px );
+	background: repeating-linear-gradient( 45deg, var(--template-noThumbnailImage-background-color), var(--template-noThumbnailImage-background-color) 5px, transparent 5px, transparent 10px );
 	display: inline-block;
 	width: 100%;
 	height: 100%;
@@ -1232,14 +1271,14 @@ a.website:hover .favicon {
 
 .content > header,
 .content > footer {
-	color: var(--template-font-color-grey-dark);
+	color: var(--template-font-color-grey-light);
 	font-size: .9rem;
 }
 
 .content > footer {
 	margin: 2rem 0 2rem;
 	padding-top: 1rem;
-	border-top: 2px solid #ccc;
+	border-top: 2px solid var(--template-border-color);
 	clear: both;
 }
 
@@ -1312,8 +1351,8 @@ br {
 	top: 1em;
 	right: 25%; left: 25%;
 	z-index: 9999;
-	background: #fff;
-	border: 1px solid #aaa;
+	background-color: var(--template-background-color);
+	border: 1px solid var(--template-border-color);
 	opacity: 1;
 	line-height: 2;
 	visibility: visible;
@@ -1333,7 +1372,7 @@ br {
 }
 
 .notification a.close:hover {
-	background: rgba(10,10,10,0.05);
+	background-color: var(--template-darken-background-hover-transparent);
 }
 
 .notification a.close:hover .icon {
@@ -1363,8 +1402,7 @@ br {
 	width: 100%;
 	height: 100%;
 	overflow: auto;
-	background-color: #eee;
-	background-color: rgba(0,0,0,0.4);
+	background-color: var(--template-modal-background-color-transparent);
 }
 
 #popup-content {
@@ -1373,9 +1411,9 @@ br {
 	width: 80%;
 	height: 80%;
 	overflow: hidden;
-	background-color: #fafafa;
+	background-color: var(--template-background-color);
 	border-radius: .25rem;
-	box-shadow: 0 0 1px #737373, -1px 2px 3px #4a4a4f;
+	box-shadow: -3px 3px 5px var(--template-box-shadow-color-transparent);
 }
 
 .popup-row {
@@ -1417,7 +1455,6 @@ br {
 
 /*=== Navigation menu (for articles) */
 #nav_entries {
-	background: #fff;
 	display: table;
 	position: fixed;
 	bottom: 0; right: 0;
@@ -1447,12 +1484,12 @@ br {
 #load_more.loading,
 #load_more.loading:hover {
 	padding: 10px 20px;
-	background: url("loader.gif") center center no-repeat #fff;
+	background: var(--template-loading-image) center center no-repeat var(--template-background-color);
 	font-size: 0;
 }
 
 .loading {
-	background: url("loader.gif") center center no-repeat;
+	background: var(--template-loading-image) center center no-repeat;
 	font-size: 0;
 }
 
@@ -1519,7 +1556,7 @@ br {
 	position: fixed;
 	top: 0; bottom: 0;
 	right: 0; left: 0;
-	background: rgba(0, 0, 0, 0.5);
+	background-color: var(--template-modal-background-color-transparent);
 	opacity: 0;
 	transition: visibility .3s, opacity .3s;
 	visibility: hidden;
@@ -1531,7 +1568,7 @@ br {
 }
 
 #panel {
-	background: #fff;
+	background-color: var(--template-background-color);
 	display: none;
 	position: fixed;
 	top: 2%; bottom: 2%;
@@ -1552,18 +1589,18 @@ br {
 
 /*=== Slider */
 #slider {
-	background: #fff;
+	background-color: var(--template-background-color);
 	width: 0;
 	position: fixed;
 	top: 0; bottom: 0;
 	left: 0;
 	overflow: auto;
-	border-right: 1px solid #aaa;
 	z-index: 100;
 }
 
 #slider.active:target {
 	width: 750px;
+	box-shadow: 3px 3px 5px var(--template-box-shadow-color-transparent);
 }
 
 #slider.sliding {
@@ -1578,7 +1615,7 @@ br {
 }
 
 #slider.active:target + #close-slider {
-	background: rgba(0, 0, 0, 0.2);
+	background-color: var(--template-modal-background-color-transparent);
 	font-size: 0;
 	right: 0;
 	z-index: 99;
@@ -1611,7 +1648,7 @@ br {
 	display: block;
 	max-width: 640px;
 	height: 320px;
-	border: 1px solid #aaa;
+	border: 1px solid var(--template-border-color);
 	position: relative;
 	min-width: 260px;
 	margin-bottom: 30px;
@@ -1656,19 +1693,20 @@ br {
 	transition: opacity .2s;
 	text-align: center;
 	line-height: 225%;
-	background-color: rgba(255, 255, 255, .3);
+	background-color: var(--template-background-color-transparent);
 	text-shadow: 0px 0px 15px rgb(119, 119, 119);
 }
 
 .properties {
 	padding: 5px;
-	background: rgba(255, 255, 255, 0.7);
+	background-color: var(--template-background-color-transparent);
 	display: none;
-	border-top: 1px solid #aaa;
+	border-top: 1px solid var(--template-border-color);
 	bottom: 0;
 	right: 0; left: 0;
 	position: absolute;
 	z-index: 10;
+	backdrop-filter: blur(3px);
 }
 
 .properties .page-number {
@@ -1710,14 +1748,14 @@ input:checked + .slide-container .properties {
 }
 
 .log-item.log-error {
-	background-color: #bd362f44;
+	background-color: var(--template-background-color-error-transparent);
 }
 
 .item.share.error a::after,
 .category .title.error::before,
 .item.feed.error .item-title::before {
 	content: " ⚠ ";
-	color: #bd362f;
+	color: var(--template-font-color-error);
 }
 
 .feed.item.error.active .item-title::before {
@@ -1762,9 +1800,8 @@ input:checked + .slide-container .properties {
 }
 
 .feed.active .item-title:not([data-unread="0"])::after {
-	background-color: transparent;
 	color: var(--template-font-color-light);
-	border: 1px solid #fff;
+	border: 1px solid var(--template-border-color);
 	font-weight: bold;
 }
 
@@ -1861,15 +1898,18 @@ input:checked + .slide-container .properties {
 		display: none;
 	}
 
+	.aside:target {
+		box-shadow: -3px 3px 5px var(--template-box-shadow-color-transparent);
+	}
+
 	.aside .toggle_aside,
 	#panel .close,
 	.dropdown-menu .toggle_aside,
 	#slider .toggle_aside {
-		background: #f6f6f6;
 		display: block;
 		width: 100%;
 		height: 50px;
-		border-bottom: 1px solid #ddd;
+		border-bottom: 1px solid var(--template-border-color);
 		line-height: 50px;
 		text-align: center;
 	}
@@ -1918,7 +1958,7 @@ input:checked + .slide-container .properties {
 	}
 
 	.dropdown-target:target ~ .dropdown-toggle::after {
-		background-color: #fff;
+		background-color: var(--template-background-color);
 		width: 10px;
 		height: 10px;
 		content: "";
@@ -1945,7 +1985,7 @@ input:checked + .slide-container .properties {
 		padding-top: 0;
 		margin-top: 0;
 		overflow: auto;
-		box-shadow: 3px 0 3px #aaa;
+		box-shadow: 3px 0 3px var(--template-box-shadow-color-transparent);
 	}
 
 	.configure .dropdown-target:target ~ .dropdown-toggle::after {
@@ -1976,7 +2016,7 @@ input:checked + .slide-container .properties {
 
 	.aside:target + .close-aside,
 	.configure .dropdown-target:target ~ .dropdown-close {
-		background: rgba(0, 0, 0, 0.2);
+		background-color: var(--template-modal-background-color-transparent);
 		display: block;
 		font-size: 0;
 		position: fixed;
@@ -2082,7 +2122,7 @@ input:checked + .slide-container .properties {
 	}
 
 	html, body {
-		background: #fff;
+		background-color: var(--template-background-color);
 		font-family: Serif;
 	}
 
@@ -2113,8 +2153,8 @@ input:checked + .slide-container .properties {
 	padding: 1rem;
 	max-width: 1000px;
 	text-align: center;
-	background-color: #eee;
-	border: 1px solid #e0e0e0;
+	background-color: var(--template-background-color-middle);
+	border: 1px solid var(--template-border-color);
 	border-radius: .25rem;
 }
 
@@ -2128,10 +2168,6 @@ input:checked + .slide-container .properties {
 
 .preview_controls label + label {
 	margin-right: 1rem;
-}
-
-.preview_background {
-	background-color: transparent;
 }
 
 .drag-drop-marker {


### PR DESCRIPTION
Similar to #4636.

All colors are now collected within CSS variables in `template.css`
It gives a better overview of used colors and adjusting in.
All variables starts with `--template` to mark them as template.css variables. They could be used by the themes to easily adjust them instead of copy&paste each CSS line.

Changes proposed in this pull request:

- CSS
- little improvements for the default configs.

How to test the feature manually:

1. check the other themes
2. hopefully nothing / not much changed there


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested