### PR TITLE
fixed: Safari issue with .stick dropdowns

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -101,11 +101,6 @@ form th {
 }
 
 /*=== Buttons */
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
-
 .stick input,
 .stick .btn {
 	border-radius: 0;

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -101,11 +101,6 @@ form th {
 }
 
 /*=== Buttons */
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
-
 .stick input,
 .stick .btn {
 	border-radius: 0;

--- a/p/themes/Ansum/_sidebar.scss
+++ b/p/themes/Ansum/_sidebar.scss
@@ -85,9 +85,6 @@
 
 /*=== Buttons */
 .stick {
-	vertical-align: middle;
-	font-size: 0;
-
 	input, .btn {
 		border-radius: 0;
 	}

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -498,10 +498,6 @@ form th {
 }
 
 /*=== Buttons */
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
 .stick input, .stick .btn {
 	border-radius: 0;
 }

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -498,10 +498,6 @@ form th {
 }
 
 /*=== Buttons */
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
 .stick input, .stick .btn {
 	border-radius: 0;
 }

--- a/p/themes/BlueLagoon/BlueLagoon.css
+++ b/p/themes/BlueLagoon/BlueLagoon.css
@@ -129,11 +129,6 @@ button.as-link[disabled] {
 	box-shadow: 0 2px 2px #222 inset, 0px 1px rgba(255, 255, 255, 0.08);
 }
 
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
-
 .stick input,
 .stick .btn {
 	border-radius: 0;

--- a/p/themes/BlueLagoon/BlueLagoon.rtl.css
+++ b/p/themes/BlueLagoon/BlueLagoon.rtl.css
@@ -129,11 +129,6 @@ button.as-link[disabled] {
 	box-shadow: 0 2px 2px #222 inset, 0px 1px rgba(255, 255, 255, 0.08);
 }
 
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
-
 .stick input,
 .stick .btn {
 	border-radius: 0;

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -130,11 +130,6 @@ button.as-link[disabled] {
 	color: #445 !important;
 }
 
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
-
 .stick input,
 .stick .btn {
 	border-radius: 0;

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -130,11 +130,6 @@ button.as-link[disabled] {
 	color: #445 !important;
 }
 
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
-
 .stick input,
 .stick .btn {
 	border-radius: 0;

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -141,11 +141,6 @@ form th {
 }
 
 /*=== Buttons */
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
-
 .stick input,
 .stick .btn {
 	border-radius: 0;

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -141,11 +141,6 @@ form th {
 }
 
 /*=== Buttons */
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
-
 .stick input,
 .stick .btn {
 	border-radius: 0;

--- a/p/themes/Mapco/_sidebar.scss
+++ b/p/themes/Mapco/_sidebar.scss
@@ -85,9 +85,6 @@
 
 /*=== Buttons */
 .stick {
-	vertical-align: middle;
-	font-size: 0;
-
 	input, .btn {
 		border-radius: 0;
 	}

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -521,10 +521,6 @@ form th {
 }
 
 /*=== Buttons */
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
 .stick input, .stick .btn {
 	border-radius: 0;
 }

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -521,10 +521,6 @@ form th {
 }
 
 /*=== Buttons */
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
 .stick input, .stick .btn {
 	border-radius: 0;
 }

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -147,11 +147,6 @@ table td span {
 }
 
 /*=== Buttons */
-.stick {
-	font-size: 0;
-	vertical-align: middle;
-}
-
 .btn,
 a.btn {
 	margin: .3rem .3rem;

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -147,11 +147,6 @@ table td span {
 }
 
 /*=== Buttons */
-.stick {
-	font-size: 0;
-	vertical-align: middle;
-}
-
 .btn,
 a.btn {
 	margin: .3rem .3rem;

--- a/p/themes/Origine-compact/origine-compact.css
+++ b/p/themes/Origine-compact/origine-compact.css
@@ -111,11 +111,6 @@ form th {
 }
 
 /*=== Buttons */
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
-
 .stick input,
 .stick .btn {
 	border-radius: 0;

--- a/p/themes/Origine-compact/origine-compact.rtl.css
+++ b/p/themes/Origine-compact/origine-compact.rtl.css
@@ -111,11 +111,6 @@ form th {
 }
 
 /*=== Buttons */
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
-
 .stick input,
 .stick .btn {
 	border-radius: 0;

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -127,11 +127,6 @@ form th {
 }
 
 /*=== Buttons */
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
-
 .stick input,
 .stick .btn {
 	border-radius: 0;

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -127,11 +127,6 @@ form th {
 }
 
 /*=== Buttons */
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
-
 .stick input,
 .stick .btn {
 	border-radius: 0;

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -112,11 +112,6 @@ form th {
 }
 
 /*=== Buttons */
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
-
 .stick input,
 .stick .btn {
 	border-radius: 0;

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -112,11 +112,6 @@ form th {
 }
 
 /*=== Buttons */
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
-
 .stick input,
 .stick .btn {
 	border-radius: 0;

--- a/p/themes/Screwdriver/screwdriver.css
+++ b/p/themes/Screwdriver/screwdriver.css
@@ -126,12 +126,6 @@ button.as-link[disabled] {
 	border-radius: 3px;
 	box-shadow: 0 2px 2px #222 inset, 0px 1px rgba(255, 255, 255, 0.08);
 }
-
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
-
 .stick input,
 .stick .btn {
 	border-radius: 0;

--- a/p/themes/Screwdriver/screwdriver.css
+++ b/p/themes/Screwdriver/screwdriver.css
@@ -126,6 +126,7 @@ button.as-link[disabled] {
 	border-radius: 3px;
 	box-shadow: 0 2px 2px #222 inset, 0px 1px rgba(255, 255, 255, 0.08);
 }
+
 .stick input,
 .stick .btn {
 	border-radius: 0;

--- a/p/themes/Screwdriver/screwdriver.rtl.css
+++ b/p/themes/Screwdriver/screwdriver.rtl.css
@@ -126,12 +126,6 @@ button.as-link[disabled] {
 	border-radius: 3px;
 	box-shadow: 0 2px 2px #222 inset, 0px 1px rgba(255, 255, 255, 0.08);
 }
-
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
-
 .stick input,
 .stick .btn {
 	border-radius: 0;

--- a/p/themes/Screwdriver/screwdriver.rtl.css
+++ b/p/themes/Screwdriver/screwdriver.rtl.css
@@ -126,6 +126,7 @@ button.as-link[disabled] {
 	border-radius: 3px;
 	box-shadow: 0 2px 2px #222 inset, 0px 1px rgba(255, 255, 255, 0.08);
 }
+
 .stick input,
 .stick .btn {
 	border-radius: 0;

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -229,10 +229,6 @@ form th {
 	line-height: 2em;
 }
 
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
 .stick select {
 	margin-top: 0;
 }

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -229,10 +229,6 @@ form th {
 	line-height: 2em;
 }
 
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
 .stick select {
 	margin-top: 0;
 }

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -289,9 +289,6 @@ form {
 }
 
 .stick {
-	vertical-align: middle;
-	font-size: 0;
-
 	select {
 		margin-top: 0;
 	}

--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -96,11 +96,6 @@ form th {
 }
 
 /*=== Buttons */
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
-
 .stick input,
 .stick .btn {
 }

--- a/p/themes/base-theme/base.rtl.css
+++ b/p/themes/base-theme/base.rtl.css
@@ -96,11 +96,6 @@ form th {
 }
 
 /*=== Buttons */
-.stick {
-	vertical-align: middle;
-	font-size: 0;
-}
-
 .stick input,
 .stick .btn {
 }

--- a/p/themes/base-theme/template.css
+++ b/p/themes/base-theme/template.css
@@ -380,6 +380,7 @@ td.numeric {
 	display: inline-flex;
 	max-width: 100%;
 	white-space: nowrap;
+	vertical-align: middle;
 }
 
 .stick > input {
@@ -393,6 +394,10 @@ td.numeric {
 
 .stick > .btn {
 	flex-shrink: 0;
+}
+
+.stick form {
+	display: inline-flex;
 }
 
 .btn,

--- a/p/themes/base-theme/template.rtl.css
+++ b/p/themes/base-theme/template.rtl.css
@@ -380,6 +380,7 @@ td.numeric {
 	display: inline-flex;
 	max-width: 100%;
 	white-space: nowrap;
+	vertical-align: middle;
 }
 
 .stick > input {
@@ -393,6 +394,10 @@ td.numeric {
 
 .stick > .btn {
 	flex-shrink: 0;
+}
+
+.stick form {
+	display: inline-flex;
 }
 
 .btn,


### PR DESCRIPTION
ref. #4585 

before: see bug issue
after: 
(no stairs anymore)
![grafik](https://user-images.githubusercontent.com/1645099/192327183-d2d1a410-a104-4691-b4c0-dc25714f03a3.png)


Changes proposed in this pull request:

- css: do not use anymore the `font-size: 0` trick. Instead: use `display: inline-flex`
- all themes: cleaned the technical code from themes and put it into the template.css


How to test the feature manually:

1. use an Apple device with Safari browser
2. see the navigation menu bar


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
