### PR TITLE
Improved: Reader view: Mark article as read while scrolling

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1109,7 +1109,7 @@ function init_stream(stream) {
 
 		el = ev.target.closest('.flux_header, .flux_content');
 		if (el) {	// flux_toggle
-			if (ev.target.closest('.content, .item.website, .item.link, .dropdown')) {
+			if (ev.target.closest('.reader, .content, .item.website, .item.link, .dropdown')) {
 				return true;
 			}
 			if (!context.sides_close_article && ev.target.matches('.flux_content')) {


### PR DESCRIPTION
## Before

Reader view:

when the user clicks left or right hand side of the article then the article gets marked as read
![grafik](https://user-images.githubusercontent.com/1645099/192818079-c3be6336-f614-491e-a829-5884abe8df63.png)

![grafik](https://user-images.githubusercontent.com/1645099/192818177-fb715f5a-f748-46d7-9ed7-dd8be2909dc5.png)

It is not a good UX, because it is unexpected to mark the article as read while clicking on an empty space.


When the user scrolls down and will expect, that all articles are marked as read while scrolling, the "clicked" article keeps in the stream. But the "clicked" article keeps. Also when it is again marked as unread.


## After:
Click left/right fro the article does not change the reading status
When scrolling, all unread articles disappear after scrolling.

Changes proposed in this pull request:

- main.js (add an exception for the click events, that aborts the click event when reader view is selected)


How to test the feature manually:

Reading settings:
![grafik](https://user-images.githubusercontent.com/1645099/192824714-15fbda58-908d-4749-801e-72dd68a26d1b.png)


1. Filter: show only unread articles
2. View: Reader
3. click left/right of the article
4. Scroll down
5. scroll up
6. no unread article anymore above

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
