### PR TITLE
Improved: reader view with framed articles

### DIFF
--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -908,10 +908,16 @@ a.btn,
 /*=== READER VIEW */
 /*================*/
 #stream.reader .flux {
-	padding: 0 0 50px;
+	padding: 25px 0 25px;
 	background: #f0f0f0;
 	color: #333;
 	border: none;
+}
+
+#stream.reader .flux .content {
+	padding: 3rem;
+	background-color: #fff;
+	border: 1px solid #ddd;
 }
 
 #stream.reader .flux .author {

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -908,10 +908,16 @@ a.btn,
 /*=== READER VIEW */
 /*================*/
 #stream.reader .flux {
-	padding: 0 0 50px;
+	padding: 25px 0 25px;
 	background: #f0f0f0;
 	color: #333;
 	border: none;
+}
+
+#stream.reader .flux .content {
+	padding: 3rem;
+	background-color: #fff;
+	border: 1px solid #ddd;
 }
 
 #stream.reader .flux .author {


### PR DESCRIPTION
Reader view:

Before:
Each article is frameless
![Screenshot 2022-09-28 at 20-20-55 (181) Gizmodo · FreshRSS](https://user-images.githubusercontent.com/1645099/192859904-3eabce8e-7d6d-4e02-9d9e-7e20eb9ea1bb.png)

After:
![Screenshot 2022-09-28 at 20-11-10 (183) Gizmodo · FreshRSS](https://user-images.githubusercontent.com/1645099/192860024-769cf699-6fcf-4019-93a3-ec71b45378e8.png)


Changes proposed in this pull request:

- Themes: Origine + Origine compact


How to test the feature manually:

1. go to reader view


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
