### PR TITLE
Allow redirection after login

### DIFF
--- a/app/Controllers/authController.php
+++ b/app/Controllers/authController.php
@@ -160,7 +160,7 @@ class FreshRSS_auth_Controller extends FreshRSS_ActionController {
 				Minz_Translate::init(FreshRSS_Context::$user_conf->language);
 
 				// All is good, go back to the index.
-				Minz_Request::good(_t('feedback.auth.login.success'), [ 'c' => 'index', 'a' => 'index' ]);
+				Minz_Request::good(_t('feedback.auth.login.success'), Minz_Url::unserialize(Minz_Request::param('original_request')));
 			} else {
 				Minz_Log::warning("Password mismatch for user={$username}, nonce={$nonce}, c={$challenge}");
 

--- a/app/views/auth/formLogin.phtml
+++ b/app/views/auth/formLogin.phtml
@@ -8,6 +8,7 @@
 
 	<form id="crypto-form" method="post" action="<?= _url('auth', 'login') ?>">
 		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
+		<input type="hidden" name="original_request" value="<?= Minz_Url::serialize(Minz_Request::originalRequest())?>" />
 
 		<div class="form-group">
 			<label for="username"><?= _t('gen.auth.username') ?></label>

--- a/lib/Minz/FrontController.php
+++ b/lib/Minz/FrontController.php
@@ -36,7 +36,7 @@ class Minz_FrontController {
 
 			Minz_Request::init();
 
-			$url = $this->buildUrl();
+			$url = Minz_Url::build();
 			$url['params'] = array_merge (
 				$url['params'],
 				$_POST
@@ -48,24 +48,6 @@ class Minz_FrontController {
 		}
 
 		$this->dispatcher = Minz_Dispatcher::getInstance();
-	}
-
-	/**
-	 * Returns an array representing the URL as passed in the address bar
-	 * @return array URL representation
-	 */
-	private function buildUrl() {
-		$url = array();
-
-		$url['c'] = $_GET['c'] ?? Minz_Request::defaultControllerName();
-		$url['a'] = $_GET['a'] ?? Minz_Request::defaultActionName();
-		$url['params'] = $_GET;
-
-		// post-traitement
-		unset($url['params']['c']);
-		unset($url['params']['a']);
-
-		return $url;
 	}
 
 	/**

--- a/lib/Minz/Request.php
+++ b/lib/Minz/Request.php
@@ -15,6 +15,8 @@ class Minz_Request {
 	private static $default_controller_name = 'index';
 	private static $default_action_name = 'index';
 
+	private static $originalRequest;
+
 	/**
 	 * Getteurs
 	 */
@@ -91,6 +93,9 @@ class Minz_Request {
 			'a' => self::$action_name,
 			'params' => self::$params,
 		);
+	}
+	public static function originalRequest() {
+		return self::$originalRequest;
 	}
 	public static function modifiedCurrentRequest(array $extraParams = null) {
 		$currentRequest = self::currentRequest();
@@ -327,6 +332,10 @@ class Minz_Request {
 	 *                > sinon, le dispatcher recharge en interne
 	 */
 	public static function forward($url = array(), $redirect = false) {
+		if (Minz_Request::originalRequest() === null && strpos('auth', json_encode($url)) !== false) {
+			self::$originalRequest = $url;
+		}
+
 		if (!is_array($url)) {
 			header('Location: ' . $url);
 			exit();

--- a/lib/Minz/Url.php
+++ b/lib/Minz/Url.php
@@ -128,6 +128,40 @@ class Minz_Url {
 
 		return $url_checked;
 	}
+
+	public static function serialize($url = []) {
+		try {
+			return base64_encode(json_encode($url, JSON_THROW_ON_ERROR));
+		} catch (\Throwable $exception) {
+			return '';
+		}
+	}
+
+	public static function unserialize($url = '') {
+		try {
+			return json_decode(base64_decode($url), true, JSON_THROW_ON_ERROR);
+		} catch (\Throwable $exception) {
+			return '';
+		}
+	}
+
+	/**
+	 * Returns an array representing the URL as passed in the address bar
+	 * @return array URL representation
+	 */
+	public static function build () {
+		$url = [
+			'c' => $_GET['c'] ?? Minz_Request::defaultControllerName(),
+			'a' => $_GET['a'] ?? Minz_Request::defaultActionName(),
+			'params' => $_GET,
+		];
+
+		// post-traitement
+		unset($url['params']['c']);
+		unset($url['params']['a']);
+
+		return $url;
+	}
 }
 
 /**


### PR DESCRIPTION
Before, if you've tried to reach a page without being logged, you'll be automatically redirected to the index page after login. Now, the original page is used after login.

Closes #3663

Changes proposed in this pull request:

- allows redirection after login

How to test the feature manually:

1. try to reach a specific page without being logged-in.
2. log-in.
3. validate that the displayed page is the targeted page.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
