### PR TITLE
Improved: Article summary. Cut the text with better CSS

### DIFF
--- a/app/views/helpers/index/normal/entry_header.phtml
+++ b/app/views/helpers/index/normal/entry_header.phtml
@@ -62,9 +62,7 @@
 			?></span><?php
 		endif;
 		if ($topline_summary):
-			?><div class="summary">
-				<?= mb_substr(strip_tags($this->entry->content()), 0, 500, 'UTF-8') ?>
-			</div><?php
+			?><div class="summary"><?= mb_substr(strip_tags($this->entry->content()), 0, 500, 'UTF-8') ?></div><?php
 		endif;
 	?></a></li>
 	<?php if ($topline_date) { ?><li class="item date"><time datetime="<?= $this->entry->machineReadableDate() ?>"><?= $this->entry->date() ?></time>&nbsp;</li><?php } ?>

--- a/app/views/helpers/index/normal/entry_header.phtml
+++ b/app/views/helpers/index/normal/entry_header.phtml
@@ -62,7 +62,7 @@
 			?></span><?php
 		endif;
 		if ($topline_summary):
-			?><div class="summary"><?= mb_substr(strip_tags($this->entry->content()), 0, 500, 'UTF-8') ?></div><?php
+			?><div class="summary"><?= trim(mb_substr(strip_tags($this->entry->content()), 0, 500, 'UTF-8')) ?></div><?php
 		endif;
 	?></a></li>
 	<?php if ($topline_date) { ?><li class="item date"><time datetime="<?= $this->entry->machineReadableDate() ?>"><?= $this->entry->date() ?></time>&nbsp;</li><?php } ?>

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1206,14 +1206,15 @@ a.website:hover .favicon {
 }
 
 .flux .item.title .summary {
-	max-height: 3em;
+	display: -webkit-box;
 	color: var(--frss-font-color-grey-dark);
 	font-size: 0.9em;
 	line-height: 1.5em;
 	font-weight: normal;
-	white-space: initial;
-	overflow: hidden;
 	text-overflow: ellipsis;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	white-space: break-spaces;
 }
 
 .flux .item.title .author {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1206,14 +1206,15 @@ a.website:hover .favicon {
 }
 
 .flux .item.title .summary {
-	max-height: 3em;
+	display: -webkit-box;
 	color: var(--frss-font-color-grey-dark);
 	font-size: 0.9em;
 	line-height: 1.5em;
 	font-weight: normal;
-	white-space: initial;
-	overflow: hidden;
 	text-overflow: ellipsis;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	white-space: break-spaces;
 }
 
 .flux .item.title .author {


### PR DESCRIPTION
Ref #3805

After:
(before it looks similar)
![grafik](https://user-images.githubusercontent.com/1645099/193357711-5038df5c-902f-4116-a1da-ef19f97a196b.png)


Changes proposed in this pull request:

- CSS: instead of using a max-height: using `-webkit-line-clamp: 2;`. 


How to test the feature manually:

1. enable "summary" in config -> display
2. see normal view


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
