### PR TITLE
[Fix] - OPML blizzard icon: not shown

### DIFF
--- a/app/Models/Themes.php
+++ b/app/Models/Themes.php
@@ -101,7 +101,7 @@ class FreshRSS_Themes extends Minz_Model {
 			'next' => '⏩',
 			'non-starred' => '☆',
 			'notice' => 'ℹ️',	//ⓘ
-			'opml-dyn' => '🗲',
+			'opml-dyn' => '⚡',
 			'prev' => '⏪',
 			'read' => '☑️',	//☑
 			'rss' => '📣',	//☄


### PR DESCRIPTION
Closes #4634
I'm change the icon for this ⚡ (https://emojipedia.org/high-voltage/) because the icon "Lightning Mood" is broken (https://emojipedia.org/lightning-mood/)  and this is more similar.

Changes proposed in this pull request:

- Change icon for ⚡
-
-

How to test the feature manually:

1. go to subscription management
2. edit a category
3.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
