### PR TITLE
Improved: Subscription Management: Show the position number

### DIFF
--- a/app/Controllers/subscriptionController.php
+++ b/app/Controllers/subscriptionController.php
@@ -19,7 +19,7 @@ class FreshRSS_subscription_Controller extends FreshRSS_ActionController {
 
 		$catDAO->checkDefault();
 		$feedDAO->updateTTL();
-		$this->view->categories = $catDAO->listSortedCategories(false, true, true);
+		$this->view->categories = $catDAO->listSortedCategories(false, true);
 		$this->view->default_category = $catDAO->getDefault();
 
 		$signalError = false;

--- a/app/views/subscription/index.phtml
+++ b/app/views/subscription/index.phtml
@@ -33,13 +33,8 @@
 				$feeds = $cat->feeds();
 		?>
 		<div class="box">
-			<?php
-				$categoryDAO = FreshRSS_Factory::createCategoryDao();
-				$category = $categoryDAO->searchById($cat->id());
-				$pos = $category->attributes('position');
-				?>
 			<div class="box-title">
-				<a class="configure open-slider" href="<?= _url('subscription', 'category', 'id', $cat->id()) ?>" data-cat-position="<?= $pos ?>"><?= _i('configure') ?></a>
+				<a class="configure open-slider" href="<?= _url('subscription', 'category', 'id', $cat->id()) ?>" data-cat-position="<?= $cat->attributes('position') ?>"><?= _i('configure') ?></a>
 				<?= $cat->name() ?>
 				<?php if ($cat->kind() == FreshRSS_Category::KIND_DYNAMIC_OPML) { echo _i('opml-dyn'); } ?>
 			</div>

--- a/app/views/subscription/index.phtml
+++ b/app/views/subscription/index.phtml
@@ -33,8 +33,13 @@
 				$feeds = $cat->feeds();
 		?>
 		<div class="box">
+			<?php
+				$categoryDAO = FreshRSS_Factory::createCategoryDao();
+				$category = $categoryDAO->searchById($cat->id());
+				$pos = $category->attributes('position');
+				?>
 			<div class="box-title">
-				<a class="configure open-slider" href="<?= _url('subscription', 'category', 'id', $cat->id()) ?>"><?= _i('configure') ?></a>
+				<a class="configure open-slider" href="<?= _url('subscription', 'category', 'id', $cat->id()) ?>" data-cat-position="<?= $pos ?>"><?= _i('configure') ?></a>
 				<?= $cat->name() ?>
 				<?php if ($cat->kind() == FreshRSS_Category::KIND_DYNAMIC_OPML) { echo _i('opml-dyn'); } ?>
 			</div>

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1800,6 +1800,22 @@ input:checked + .slide-container .properties {
 	font-weight: initial;
 }
 
+.box .box-title .configure:not([data-cat-position=""])::after {
+	margin: 0.5rem 0px 0px;
+	padding: 5px 10px;
+	min-width: 20px;
+	display: block;
+	content: attr(data-cat-position);
+	position: absolute;
+	top: 0px;
+	right: 10px;
+	text-align: center;
+	font-size: 0.75rem;
+	border-radius: 12px;
+	line-height: 1;
+	font-weight: initial;
+}
+
 .feed .item-title:not([data-unread="0"])::after {
 	margin: 1em 0 0 0;
 }

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1800,6 +1800,22 @@ input:checked + .slide-container .properties {
 	font-weight: initial;
 }
 
+.box .box-title .configure:not([data-cat-position=""])::after {
+	margin: 0.5rem 0px 0px;
+	padding: 5px 10px;
+	min-width: 20px;
+	display: block;
+	content: attr(data-cat-position);
+	position: absolute;
+	top: 0px;
+	left: 10px;
+	text-align: center;
+	font-size: 0.75rem;
+	border-radius: 12px;
+	line-height: 1;
+	font-weight: initial;
+}
+
 .feed .item-title:not([data-unread="0"])::after {
 	margin: 1em 0 0 0;
 }


### PR DESCRIPTION
The issue: it is a bit tricky to order the categories. The position number is more or less invisible.

The position is visible only in the settings:
![grafik](https://user-images.githubusercontent.com/1645099/193476061-de528581-7630-4789-a5b4-9c590167bfd1.png)

Now the number is shown in the box
![grafik](https://user-images.githubusercontent.com/1645099/193476040-b9c049b5-dfbd-4d02-8c78-a40f335630cf.png)


Changes proposed in this pull request:

- PHTML and CSS

How to test the feature manually:

1. go to subscription management
2. config the position number
3. see the number on the box


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
