### PR TITLE
fixed: Origine compact

### DIFF
--- a/p/themes/Origine-compact/origine-compact.css
+++ b/p/themes/Origine-compact/origine-compact.css
@@ -126,8 +126,12 @@ a.btn,
 
 /*=== Index menu */
 /*=== Feed articles */
-.flux_header .title {
+.flux_header {
 	font-size: 0.8rem;
+}
+
+.flux .item {
+	padding: 0;
 }
 
 .flux .item.thumbnail {

--- a/p/themes/Origine-compact/origine-compact.rtl.css
+++ b/p/themes/Origine-compact/origine-compact.rtl.css
@@ -126,8 +126,12 @@ a.btn,
 
 /*=== Index menu */
 /*=== Feed articles */
-.flux_header .title {
+.flux_header {
 	font-size: 0.8rem;
+}
+
+.flux .item {
+	padding: 0;
 }
 
 .flux .item.thumbnail {


### PR DESCRIPTION
Regression from #4671
Ref #4666

Fixed: Origine Compact is compact again

Changes proposed in this pull request:

- CSS


How to test the feature manually:

1. Use Origine compact
2. see the normal view


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
