### PR TITLE
Clean-up: ".nav-head" deleted from (S)CSS

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -348,19 +348,6 @@ a.btn {
 	text-align: center;
 }
 
-.nav-head {
-	margin: 0;
-	background: var(--background-color-light);
-	border-bottom: 1px solid var(--border-color-dark);
-	text-align: right;
-}
-
-.nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -348,19 +348,6 @@ a.btn {
 	text-align: center;
 }
 
-.nav-head {
-	margin: 0;
-	background: var(--background-color-light);
-	border-bottom: 1px solid var(--border-color-dark);
-	text-align: left;
-}
-
-.nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;

--- a/p/themes/Ansum/_sidebar.scss
+++ b/p/themes/Ansum/_sidebar.scss
@@ -224,23 +224,6 @@
 		padding: 3px;
 		text-align: center;
 	}
-
-	.nav-head {
-		margin: 0;
-		text-align: right;
-		// background: #34495e;
-		color: variables.$white;
-
-		a {
-			color: variables.$white;
-		}
-
-		.item {
-			padding: 5px 10px;
-			font-size: 0.9rem;
-			line-height: 1.5rem;
-		}
-	}
 }
 
 /*=== Aside main page (categories) */

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -609,19 +609,6 @@ form th {
 	padding: 3px;
 	text-align: center;
 }
-.nav-list .nav-head {
-	margin: 0;
-	text-align: right;
-	color: #fff;
-}
-.nav-list .nav-head a {
-	color: #fff;
-}
-.nav-list .nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
 
 /*=== Aside main page (categories) */
 .aside_feed .tree-folder-title > .title:not([data-unread="0"]) {

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -609,19 +609,6 @@ form th {
 	padding: 3px;
 	text-align: center;
 }
-.nav-list .nav-head {
-	margin: 0;
-	text-align: left;
-	color: #fff;
-}
-.nav-list .nav-head a {
-	color: #fff;
-}
-.nav-list .nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
 
 /*=== Aside main page (categories) */
 .aside_feed .tree-folder-title > .title:not([data-unread="0"]) {

--- a/p/themes/BlueLagoon/BlueLagoon.css
+++ b/p/themes/BlueLagoon/BlueLagoon.css
@@ -326,19 +326,6 @@ a.btn {
 	text-align: center;
 }
 
-.nav-head {
-	margin: 0;
-	background: linear-gradient(0deg, #ede7de 0%, #fff 100%) #ede7de;
-	background: -webkit-linear-gradient(bottom, #ede7de 0%, #fff 100%);
-	text-align: right;
-}
-
-.nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;

--- a/p/themes/BlueLagoon/BlueLagoon.rtl.css
+++ b/p/themes/BlueLagoon/BlueLagoon.rtl.css
@@ -326,19 +326,6 @@ a.btn {
 	text-align: center;
 }
 
-.nav-head {
-	margin: 0;
-	background: linear-gradient(0deg, #ede7de 0%, #fff 100%) #ede7de;
-	background: -webkit-linear-gradient(bottom, #ede7de 0%, #fff 100%);
-	text-align: left;
-}
-
-.nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -323,19 +323,6 @@ a.btn {
 	text-align: center;
 }
 
-.nav-head {
-	margin: 0;
-	text-align: right;
-	background: #1c1c1c;
-	border-bottom: 1px solid #333;
-}
-
-.nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -323,19 +323,6 @@ a.btn {
 	text-align: center;
 }
 
-.nav-head {
-	margin: 0;
-	text-align: left;
-	background: #1c1c1c;
-	border-bottom: 1px solid #333;
-}
-
-.nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -310,23 +310,6 @@ a.btn {
 	text-align: center;
 }
 
-.nav-head {
-	margin: 0;
-	text-align: right;
-	background: #34495e;
-	color: #fff;
-}
-
-.nav-head a {
-	color: #fff;
-}
-
-.nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 0.5rem 0 0;

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -310,23 +310,6 @@ a.btn {
 	text-align: center;
 }
 
-.nav-head {
-	margin: 0;
-	text-align: left;
-	background: #34495e;
-	color: #fff;
-}
-
-.nav-head a {
-	color: #fff;
-}
-
-.nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 0.5rem 0 0;

--- a/p/themes/Mapco/_sidebar.scss
+++ b/p/themes/Mapco/_sidebar.scss
@@ -223,22 +223,6 @@
 		padding: 3px;
 		text-align: center;
 	}
-
-	.nav-head {
-		margin: 0;
-		text-align: right;
-		color: variables.$white;
-
-		a {
-			color: variables.$white;
-		}
-
-		.item {
-			padding: 5px 10px;
-			font-size: 0.9rem;
-			line-height: 1.5rem;
-		}
-	}
 }
 
 /*=== Aside main page (categories) */

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -621,19 +621,6 @@ form th {
 	padding: 3px;
 	text-align: center;
 }
-.nav-list .nav-head {
-	margin: 0;
-	text-align: right;
-	color: #fff;
-}
-.nav-list .nav-head a {
-	color: #fff;
-}
-.nav-list .nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
 
 /*=== Aside main page (categories) */
 .aside_feed .tree-folder-title > .title:not([data-unread="0"]) {

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -621,19 +621,6 @@ form th {
 	padding: 3px;
 	text-align: center;
 }
-.nav-list .nav-head {
-	margin: 0;
-	text-align: left;
-	color: #fff;
-}
-.nav-list .nav-head a {
-	color: #fff;
-}
-.nav-list .nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
 
 /*=== Aside main page (categories) */
 .aside_feed .tree-folder-title > .title:not([data-unread="0"]) {

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -199,17 +199,6 @@ a.btn {
 	line-height: 2.5em;
 }
 
-.nav-head {
-	margin: 0;
-	text-align: right;
-}
-
-.nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
-
 .dropdown-menu {
 	margin: 5px 0 0;
 	padding: 5px 0;

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -199,17 +199,6 @@ a.btn {
 	line-height: 2.5em;
 }
 
-.nav-head {
-	margin: 0;
-	text-align: left;
-}
-
-.nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
-
 .dropdown-menu {
 	margin: 5px 0 0;
 	padding: 5px 0;

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -318,20 +318,6 @@ a.btn,
 	text-align: center;
 }
 
-.nav-head {
-	margin: 0;
-	background: #fff;
-	background: linear-gradient(to bottom, #fff, #f0f0f0);
-	border-bottom: 1px solid #ddd;
-	text-align: right;
-}
-
-.nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -318,20 +318,6 @@ a.btn,
 	text-align: center;
 }
 
-.nav-head {
-	margin: 0;
-	background: #fff;
-	background: linear-gradient(to bottom, #fff, #f0f0f0);
-	border-bottom: 1px solid #ddd;
-	text-align: left;
-}
-
-.nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -284,19 +284,6 @@ a.btn {
 	text-align: center;
 }
 
-.nav-head {
-	margin: 0;
-	background: #fff;
-	background: linear-gradient(to bottom, #fff, #f0f0f0);
-	text-align: right;
-}
-
-.nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -284,19 +284,6 @@ a.btn {
 	text-align: center;
 }
 
-.nav-head {
-	margin: 0;
-	background: #fff;
-	background: linear-gradient(to bottom, #fff, #f0f0f0);
-	text-align: left;
-}
-
-.nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;

--- a/p/themes/Screwdriver/screwdriver.css
+++ b/p/themes/Screwdriver/screwdriver.css
@@ -330,19 +330,6 @@ a.btn {
 	text-align: center;
 }
 
-.nav-head {
-	margin: 0;
-	background: linear-gradient(0deg, #ede7de 0%, #fff 100%) #ede7de;
-	background: -webkit-linear-gradient(bottom, #ede7de 0%, #fff 100%);
-	text-align: right;
-}
-
-.nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;

--- a/p/themes/Screwdriver/screwdriver.rtl.css
+++ b/p/themes/Screwdriver/screwdriver.rtl.css
@@ -330,19 +330,6 @@ a.btn {
 	text-align: center;
 }
 
-.nav-head {
-	margin: 0;
-	background: linear-gradient(0deg, #ede7de 0%, #fff 100%) #ede7de;
-	background: -webkit-linear-gradient(bottom, #ede7de 0%, #fff 100%);
-	text-align: left;
-}
-
-.nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -329,21 +329,6 @@ form th {
 	text-decoration: none;
 }
 
-.nav-head {
-	margin: 0;
-	text-align: right;
-	background: #22303d;
-	color: #fcfcfc;
-}
-.nav-head a {
-	color: #fcfcfc;
-}
-.nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
-
 .dropdown-menu {
 	padding: 0.5rem 0 1rem 0;
 	font-size: 0.8rem;

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -329,21 +329,6 @@ form th {
 	text-decoration: none;
 }
 
-.nav-head {
-	margin: 0;
-	text-align: left;
-	background: #22303d;
-	color: #fcfcfc;
-}
-.nav-head a {
-	color: #fcfcfc;
-}
-.nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
-
 .dropdown-menu {
 	padding: 0.5rem 0 1rem 0;
 	font-size: 0.8rem;

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -427,23 +427,6 @@ form {
 	}
 }
 
-.nav-head {
-	margin: 0;
-	text-align: right;
-	background: $color_aside;
-	color: $color_light;
-
-	a {
-		color: $color_light;
-	}
-
-	.item {
-		padding: 5px 10px;
-		font-size: 0.9rem;
-		line-height: 1.5rem;
-	}
-}
-
 .dropdown-menu {
 	padding: 0.5rem 0 1rem 0;
 	font-size: 0.8rem;

--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -225,17 +225,6 @@ a.btn {
 	text-align: center;
 }
 
-.nav-head {
-	margin: 0;
-	text-align: right;
-}
-
-.nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;

--- a/p/themes/base-theme/base.rtl.css
+++ b/p/themes/base-theme/base.rtl.css
@@ -225,17 +225,6 @@ a.btn {
 	text-align: center;
 }
 
-.nav-head {
-	margin: 0;
-	text-align: left;
-}
-
-.nav-head .item {
-	padding: 5px 10px;
-	font-size: 0.9rem;
-	line-height: 1.5rem;
-}
-
 /*=== Dropdown */
 .dropdown-menu {
 	margin: 5px 0 0;

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -560,14 +560,6 @@ input[type="checkbox"]:focus-visible {
 	text-overflow: ellipsis;
 }
 
-.nav-head {
-	display: block;
-}
-
-.nav-head .item {
-	display: inline-block;
-}
-
 /*=== Horizontal-list */
 .horizontal-list {
 	margin: 0;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -560,14 +560,6 @@ input[type="checkbox"]:focus-visible {
 	text-overflow: ellipsis;
 }
 
-.nav-head {
-	display: block;
-}
-
-.nav-head .item {
-	display: inline-block;
-}
-
 /*=== Horizontal-list */
 .horizontal-list {
 	margin: 0;


### PR DESCRIPTION
`.nav-head` is not used anymore in phtml and js files.

So this PR deletes the `.nav-head` CSS lines

Changes proposed in this pull request:

- (S)CSS files

How to test the feature manually:

1. search for `nav-head` in all files
2. you will not find it anymore

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested