### PR TITLE
fix: border of the slider is not hidden in mobile view

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2062,7 +2062,7 @@ input:checked + .slide-container .properties {
 	.aside {
 		position: fixed;
 		top: 0; bottom: 0;
-		left: 0;
+		left: -1px;
 		width: 0;
 		overflow: hidden;
 		z-index: 100;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2062,7 +2062,7 @@ input:checked + .slide-container .properties {
 	.aside {
 		position: fixed;
 		top: 0; bottom: 0;
-		right: 0;
+		right: -1px;
 		width: 0;
 		overflow: hidden;
 		z-index: 100;


### PR DESCRIPTION
Mobile view:

Before:
there is 1 Pixel from the aside navigation
![grafik](https://user-images.githubusercontent.com/1645099/194363342-f3875f81-8672-4c56-a333-adf63fe33468.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/194363571-28aa6c3a-3ecb-4fb1-8b26-3c5f324f8616.png)


Changes proposed in this pull request:

- CSS


How to test the feature manually:

1. mobile view
2. go to normal view
3. zoom in and check the left hand side border of the unread articles
4. in Origine theme: see 2 pixels red border

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested