### PR TITLE
Add title rewriting

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -588,6 +588,7 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 				}
 
 				$mark_updated_article_unread = $feed->attributeBoolean('mark_updated_article_unread') ?? FreshRSS_Context::userConf()->mark_updated_article_unread;
+				$title_rewriting_handler = $feed->titleRewriteHandler();
 
 				// For this feed, check existing GUIDs already in database.
 				$existingHashForGuids = $entryDAO->listHashForFeedGuids($feed->id(), $newGuids);
@@ -602,6 +603,10 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 					}
 					$newGuids[$entry->guid()] = true;
 					$entry->_lastSeen($mtime);
+
+					if ($title_rewriting_handler instanceof FreshRSS_TitleRewriting_Handler) {
+						$entry->_title($title_rewriting_handler->rewrite($entry->title(), $feed->name()));
+					}
 
 					if (isset($existingHashForGuids[$entry->guid()])) {
 						$existingHash = $existingHashForGuids[$entry->guid()];

--- a/app/Controllers/subscriptionController.php
+++ b/app/Controllers/subscriptionController.php
@@ -321,6 +321,7 @@ class FreshRSS_subscription_Controller extends FreshRSS_ActionController {
 			$conditions = array_filter($conditions, fn(string $condition): bool => trim($condition) !== '');
 			$feed->_attribute('path_entries_conditions', empty($conditions) ? null : $conditions);
 			$feed->_attribute('path_entries_filter', Minz_Request::paramString('path_entries_filter', true));
+			$feed->_attribute('title_rewriting', Minz_Request::paramString('title_rewriting'));
 
 			// @phpstan-ignore offsetAccess.nonOffsetAccessible
 			$favicon_path = isset($_FILES['newFavicon']) ? $_FILES['newFavicon']['tmp_name'] : '';

--- a/app/Exceptions/ParsingException.php
+++ b/app/Exceptions/ParsingException.php
@@ -1,0 +1,4 @@
+<?php
+
+class FreshRSS_Parsing_Exception extends RuntimeException {
+}

--- a/app/Handlers/TitleRewritingHandler.php
+++ b/app/Handlers/TitleRewritingHandler.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @phpstan-type FilterNames 'ireplace'|'replace'|'trim'
+ * @phpstan-type VariableNames 'feed'|'title'
+ * @phpstan-type SupportedFilter array{name: FilterNames, parameters: int[]}
+ * @phpstan-type Filter array{name: FilterNames, parameters?: array<array-key, string>}
+ * @phpstan-type Rule array{variable: VariableNames, filters?: list<Filter>}
+ */
+class FreshRSS_TitleRewriting_Handler {
+	private const TOKEN_VARIABLE_START = '{';
+	private const TOKEN_VARIABLE_END = '}';
+	private const TOKEN_VARIABLE_FILTER = '|';
+	private const TOKEN_VARIABLE_FILTER_PARAM_START = '(';
+	private const TOKEN_VARIABLE_FILTER_PARAM_END = ')';
+	private const TOKEN_VARIABLE_FILTER_PARAM_DELIMITER = ',';
+	private const TOKEN_SPACE = ' ';
+	private const TOKEN_PARAM_STRING_DELIMITER = '"';
+
+	/** @var list<VariableNames> */
+	private const SUPPORTED_VARIABLES = [
+		'title',
+		'feed',
+	];
+	/** @var list<SupportedFilter> */
+	private const SUPPORTED_FILTERS = [
+		[
+			'name' => 'trim',
+			'parameters' => [
+				0,
+				1,
+			],
+		],
+		[
+			'name' => 'replace',
+			'parameters' => [
+				2
+			],
+		],
+		[
+			'name' => 'ireplace',
+			'parameters' => [
+				2
+			],
+		],
+	];
+
+	/** @var list<Rule> */
+	private array $rules = [];
+
+	public function __construct(string $rules) {
+		$this->parseRules($rules);
+		$this->cleanRules();
+	}
+
+	private function parseRules(string $rules): void {
+		if ($rules === '') {
+			return;
+		}
+
+		$isParsingVariable = false;
+		$isParsingFilter = false;
+		$isParsingString = true;
+		$isParsingParameter = false;
+		$isParsingParameterString = false;
+		$currentSegment = '';
+		$tokens = mb_str_split($rules);
+		$length = count($tokens);
+		$chunks = [];
+		/** @var VariableNames|null */
+		$variable = null;
+		/** @var list<Filter> */
+		$filters = [];
+		/** @var FilterNames|null */
+		$filter = null;
+		/** @var array<array-key, string> */
+		$parameters = [];
+
+		for ($i = 0; $i < $length; $i++) {
+			$current = $tokens[$i];
+			$next = null;
+
+			if (($i + 1) < $length) {
+				$next = $tokens[$i + 1];
+			}
+
+			// Error detection
+			if ($current === self::TOKEN_VARIABLE_FILTER) {
+				if ($isParsingParameter && !$isParsingParameterString) { // @phpstan-ignore-line
+					throw new FreshRSS_Parsing_Exception('Missing filter end delimiter');
+				}
+			} elseif ($current === self::TOKEN_VARIABLE_END) {
+				if ($next === self::TOKEN_VARIABLE_END) {
+					if ($isParsingParameter) {
+						throw new FreshRSS_Parsing_Exception('Missing filter end delimiter');
+					}
+				}
+			}
+
+			// Parsing
+			if ($current === self::TOKEN_PARAM_STRING_DELIMITER) {
+				if ($isParsingParameter) {
+					if ($isParsingParameterString) { // @phpstan-ignore-line
+						$isParsingParameterString = false;
+						continue;
+					}
+
+					$isParsingParameterString = true;
+					$currentSegment = '';
+					continue;
+				}
+			} elseif ($current === self::TOKEN_VARIABLE_START) {
+				if ($next === self::TOKEN_VARIABLE_START) {
+					if ($isParsingString && $currentSegment !== '') {
+						$chunks[] = $currentSegment;
+					}
+					$i++;
+					$currentSegment = '';
+					$isParsingString = false;
+					$isParsingVariable = true;
+					$isParsingFilter = false;
+					$isParsingParameter = false;
+					continue;
+				}
+			} elseif ($current === self::TOKEN_VARIABLE_END) {
+				if ($next === self::TOKEN_VARIABLE_END) {
+					if ($isParsingVariable) {
+						if ($currentSegment !== '') {
+							if ($isParsingFilter) {
+								$filters[] = [
+									'name' => $currentSegment,
+								];
+								$chunks[] = [
+									'variable' => $variable,
+									'filters' => $filters,
+								];
+							} else {
+								$chunks[] = [
+									'variable' => $currentSegment,
+								];
+							}
+						} else {
+							$chunks[] = [
+								'variable' => $variable,
+								'filters' => $filters,
+							];
+						}
+					}
+					$i++;
+					$currentSegment = '';
+					$variable = null;
+					$filters = [];
+					$isParsingVariable = false;
+					$isParsingFilter = false;
+					$isParsingString = true;
+					$isParsingParameter = false;
+					continue;
+				}
+			} elseif ($current === self::TOKEN_SPACE) {
+				if ($isParsingVariable && !$isParsingParameterString) { // @phpstan-ignore-line
+					continue;
+				}
+			} elseif ($current === self::TOKEN_VARIABLE_FILTER) {
+				if ($isParsingVariable && !$isParsingParameterString) { // @phpstan-ignore-line
+					if ($currentSegment !== '') {
+						if ($isParsingFilter) {
+							$filters[] = [
+								'name' => $currentSegment,
+							];
+						} else {
+							$variable = $currentSegment;
+						}
+					}
+					$currentSegment = '';
+					$isParsingFilter = true;
+					$isParsingParameter = false;
+					continue;
+				}
+			} elseif ($current === self::TOKEN_VARIABLE_FILTER_PARAM_START) {
+				if ($isParsingFilter && !$isParsingParameterString) { // @phpstan-ignore-line
+					$filter = $currentSegment;
+					$currentSegment = '';
+					$isParsingParameter = true;
+					continue;
+				}
+			} elseif ($current === self::TOKEN_VARIABLE_FILTER_PARAM_END) {
+				if ($isParsingFilter && !$isParsingParameterString) { // @phpstan-ignore-line
+					$parameters[] = $currentSegment;
+					$filters[] = [
+						'name' => $filter,
+						'parameters' => $parameters,
+					];
+
+					$currentSegment = '';
+					$filter = null;
+					$parameters = [];
+					$isParsingParameter = false;
+					continue;
+				}
+			} elseif ($current === self::TOKEN_VARIABLE_FILTER_PARAM_DELIMITER) {
+				if ($isParsingFilter && !$isParsingParameterString) { // @phpstan-ignore-line
+					$parameters[] = $currentSegment;
+					$currentSegment = '';
+					continue;
+				}
+			}
+
+			$currentSegment .= $current;
+		}
+		if ($isParsingString && $currentSegment !== '') {
+			$chunks[] = $currentSegment;
+		}
+
+		if ($isParsingVariable) {
+			throw new FreshRSS_Parsing_Exception('Missing variable end delimiter');
+		}
+
+		$this->rules = $chunks; // @phpstan-ignore-line
+	}
+
+	private function cleanRules(): void {
+		$filterNames = array_column(self::SUPPORTED_FILTERS, 'name');
+		/** @var array<FilterNames, int[]> $filterParams */
+		$filterParams = array_reduce(self::SUPPORTED_FILTERS, static function ($carry, $item) {
+			$carry[$item['name']] = $item['parameters']; // @phpstan-ignore-line
+			return $carry;
+		}, []);
+
+		foreach ($this->rules as $chunkKey => $chunk) {
+			if (is_string($chunk)) {
+				continue;
+			}
+			if (!in_array($chunk['variable'], self::SUPPORTED_VARIABLES, true)) {
+				unset($this->rules[$chunkKey]); // @phpstan-ignore-line
+			}
+			if (array_key_exists('filters', $chunk)) {
+				$filters = [];
+				foreach ($chunk['filters'] as $filterKey => $filter) {
+					if (!in_array($filter['name'], $filterNames, true)) {
+						continue;
+					}
+					if (!in_array(count($filter['parameters'] ?? []), $filterParams[$filter['name']], true)) {
+						continue;
+					}
+					$filters[] = $filter;
+				}
+				if ($filters === []) {
+					unset($this->rules[$chunkKey]['filters']);
+				} else {
+					$this->rules[$chunkKey]['filters'] = $filters;
+				}
+			}
+		}
+	}
+
+	private function trim(string $variable, ?string $parameter = null): string {
+		if ($parameter === null) {
+			return trim($variable);
+		}
+		return trim($variable, $parameter);
+	}
+
+	private function replace(string $variable, string $search, string $replace): string {
+		return str_replace($search, $replace, $variable);
+	}
+
+	private function ireplace(string $variable, string $search, string $replace): string {
+		return str_ireplace($search, $replace, $variable);
+	}
+
+	public function rewrite(string $title, string $feed): string {
+		$value = '';
+		foreach ($this->rules as $rule) {
+			if (is_string($rule)) {
+				$value .= $rule;
+				continue;
+			}
+			$variable = ${$rule['variable']}; // @phpstan-ignore-line
+			foreach ($rule['filters'] ?? [] as $filter) {
+				/** @var string $variable */
+				$variable = call_user_func_array([$this, $filter['name']], array_merge([$variable], $filter['parameters'] ?? []));
+			}
+			$value .= $variable;
+		}
+
+		return $value;
+	}
+}

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -379,6 +379,16 @@ class FreshRSS_Feed extends Minz_Model {
 		return $this->ttl;
 	}
 
+	/**
+	 * @return void|FreshRSS_TitleRewriting_Handler
+	 */
+	public function titleRewriteHandler() {
+		$titleRewritingRule = $this->attributeString('title_rewriting');
+		if ($titleRewritingRule !== '' && $titleRewritingRule !== null) {
+			return new FreshRSS_TitleRewriting_Handler(html_entity_decode($titleRewritingRule));
+		}
+	}
+
 	public function mute(): bool {
 		return $this->mute;
 	}

--- a/app/i18n/cs/conf.php
+++ b/app/i18n/cs/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'Při otevření připnout článek na začátek',
 		'title' => 'Čtení',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Výchozí zobrazení',
 			'global' => 'Zobrazení přehledu',

--- a/app/i18n/cs/sub.php
+++ b/app/i18n/cs/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Časový limit v sekundách',
 		'title' => 'Název',
 		'title_add' => 'Přidat kanál RSS',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'Neobnovovat automaticky častěji než',
 		'unicityCriteria' => array(
 			'_' => 'Article unicity criteria',	// TODO

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'Wenn geöffnet, den Artikel ganz oben anheften',
 		'title' => 'Lesen',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Standard-Ansicht',
 			'global' => 'Globale Ansicht',

--- a/app/i18n/de/sub.php
+++ b/app/i18n/de/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Zeitlimit in Sekunden',
 		'title' => 'Titel',
 		'title_add' => 'Einen RSS-Feed hinzufügen',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'Aktualisiere automatisch nicht öfter als',
 		'unicityCriteria' => array(
 			'_' => 'Einzigartigkeit eines Artikels',

--- a/app/i18n/el/conf.php
+++ b/app/i18n/el/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'Stick the article to the top when opened',	// TODO
 		'title' => 'Reading',	// TODO
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Default view',	// TODO
 			'global' => 'Global view',	// TODO

--- a/app/i18n/el/sub.php
+++ b/app/i18n/el/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Timeout in seconds',	// TODO
 		'title' => 'Title',	// TODO
 		'title_add' => 'Add an RSS feed',	// TODO
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'Do not automatically refresh more often than',	// TODO
 		'unicityCriteria' => array(
 			'_' => 'Article unicity criteria',	// TODO

--- a/app/i18n/en-us/conf.php
+++ b/app/i18n/en-us/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'Stick the article to the top when opened',	// IGNORE
 		'title' => 'Reading',	// IGNORE
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Default view',	// IGNORE
 			'global' => 'Global view',	// IGNORE

--- a/app/i18n/en-us/sub.php
+++ b/app/i18n/en-us/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Timeout in seconds',	// IGNORE
 		'title' => 'Title',	// IGNORE
 		'title_add' => 'Add an RSS feed',	// IGNORE
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'Do not automatically refresh more often than',	// IGNORE
 		'unicityCriteria' => array(
 			'_' => 'Article unicity criteria',	// IGNORE

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'Stick the article to the top when opened',
 		'title' => 'Reading',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Default view',
 			'global' => 'Global view',

--- a/app/i18n/en/sub.php
+++ b/app/i18n/en/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Timeout in seconds',
 		'title' => 'Title',
 		'title_add' => 'Add an RSS feed',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'Do not automatically refresh more often than',
 		'unicityCriteria' => array(
 			'_' => 'Article unicity criteria',

--- a/app/i18n/es/conf.php
+++ b/app/i18n/es/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'Pegar el artículo a la parte superior al abrirlo',
 		'title' => 'Lectura',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Vista por defecto',
 			'global' => 'Vista Global',

--- a/app/i18n/es/sub.php
+++ b/app/i18n/es/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Tiempo de espera en segundos',
 		'title' => 'Título',
 		'title_add' => 'Añadir fuente RSS',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'No actualizar de forma automática con una frecuencia mayor a',
 		'unicityCriteria' => array(
 			'_' => 'Criterio de único artículo',

--- a/app/i18n/fa/conf.php
+++ b/app/i18n/fa/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => ' وقتی باز شد مقاله را به بالا بچسبانید',
 		'title' => ' خواندن',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => ' نمای پیش فرض',
 			'global' => ' نمای جهانی',

--- a/app/i18n/fa/sub.php
+++ b/app/i18n/fa/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => ' تایم اوت در ثانیه',
 		'title' => ' عنوان',
 		'title_add' => ' یک فید RSS اضافه کنید',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => ' به‌طور خودکار بیشتر از آن رفرش نکنید',
 		'unicityCriteria' => array(
 			'_' => 'معیارهای وحدت مقاله',

--- a/app/i18n/fi/conf.php
+++ b/app/i18n/fi/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'Kiinnitä artikkeli ylimmäksi avattaessa',
 		'title' => 'Lukeminen',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Oletusnäkymä',
 			'global' => 'Yleinen näkymä',

--- a/app/i18n/fi/sub.php
+++ b/app/i18n/fi/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Aikakatkaisu sekunteina',
 		'title' => 'Otsikko',
 		'title_add' => 'Lisää RSS-syöte',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'Älä päivitä automaattisesti useammin kuin',
 		'unicityCriteria' => array(
 			'_' => 'Artikkelin yksilöivät ehdot',

--- a/app/i18n/fr/conf.php
+++ b/app/i18n/fr/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'Aligner l’article en haut quand il est ouvert',
 		'title' => 'Lecture',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Vue par défaut',
 			'global' => 'Vue globale',

--- a/app/i18n/fr/sub.php
+++ b/app/i18n/fr/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Délai d’attente en secondes',
 		'title' => 'Titre',
 		'title_add' => 'Ajouter un flux RSS',
+		'title_rewriting' => array(
+			'help' => 'Explorez la documentation en ligne pour obtenir des détails sur la ré-écriture des titres',
+		),
 		'ttl' => 'Ne pas automatiquement rafraîchir plus souvent que',
 		'unicityCriteria' => array(
 			'_' => 'Critère d’unicité des articles',

--- a/app/i18n/he/conf.php
+++ b/app/i18n/he/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'הצמדת המאמר לחלק העליון כאשר הוא פתוח',
 		'title' => 'קריאה',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'תצוגת ברירת המחדל',
 			'global' => 'תצוגה גלובלית',

--- a/app/i18n/he/sub.php
+++ b/app/i18n/he/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Timeout in seconds',	// TODO
 		'title' => 'כותרת',
 		'title_add' => 'הוספת הזנה',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'אין לרענן אוטומטית יותר מ',
 		'unicityCriteria' => array(
 			'_' => 'Article unicity criteria',	// TODO

--- a/app/i18n/hu/conf.php
+++ b/app/i18n/hu/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'A cikk gördüljön felülre, amikor megnyitásra kerül',
 		'title' => 'Olvasás',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Alapértelmezett nézet',
 			'global' => 'Globális nézet',

--- a/app/i18n/hu/sub.php
+++ b/app/i18n/hu/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Időtúllépés ideje másodpercekben',
 		'title' => 'Cím',
 		'title_add' => 'RSS hírforrás hozzáadása',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'Ne frissítsd automatikusan többször mint',
 		'unicityCriteria' => array(
 			'_' => 'Cikk egységességi feltételek',

--- a/app/i18n/id/conf.php
+++ b/app/i18n/id/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'Sematkan artikel ke bagian atas saat dibuka',
 		'title' => 'Membaca',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Tampilan baku',
 			'global' => 'Tampilan global',

--- a/app/i18n/id/sub.php
+++ b/app/i18n/id/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Timeout dalam detik',
 		'title' => 'Judul',
 		'title_add' => 'Tambah umpan RSS',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'Jangan perbarui secara otomatis lebih banyak daripada',
 		'unicityCriteria' => array(
 			'_' => 'Kriteria keunikan artikel',

--- a/app/i18n/it/conf.php
+++ b/app/i18n/it/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'Blocca il contenuto a inizio pagina quando aperto',
 		'title' => 'Lettura',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Visualizzazione predefinita',
 			'global' => 'Vista globale per categorie',

--- a/app/i18n/it/sub.php
+++ b/app/i18n/it/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Timeout in secondi',
 		'title' => 'Titolo',
 		'title_add' => 'Aggiungi RSS feed',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'Non aggiornare automaticamente piu di',
 		'unicityCriteria' => array(
 			'_' => 'Criteri di unicità dell’articolo',

--- a/app/i18n/ja/conf.php
+++ b/app/i18n/ja/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => '開いたときにトップを記事にする',
 		'title' => 'リーディング',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'デフォルトビュー',
 			'global' => 'グローバルビュー',

--- a/app/i18n/ja/sub.php
+++ b/app/i18n/ja/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'タイムアウトする時間(秒)',
 		'title' => 'タイトル',
 		'title_add' => 'RSS フィードを追加する',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => '自動更新の頻度',
 		'unicityCriteria' => array(
 			'_' => '記事の同一判定',

--- a/app/i18n/ko/conf.php
+++ b/app/i18n/ko/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => '글이 펼쳐진 경우 최상단에 고정하기',
 		'title' => '읽기',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => '기본 보기 모드',
 			'global' => '전체 모드',

--- a/app/i18n/ko/sub.php
+++ b/app/i18n/ko/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => '타임아웃 (초)',
 		'title' => '제목',
 		'title_add' => 'RSS 피드 추가',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => '다음 시간이 지나기 전에 새로고침 금지',
 		'unicityCriteria' => array(
 			'_' => 'Article unicity criteria',	// TODO

--- a/app/i18n/lv/conf.php
+++ b/app/i18n/lv/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'Uzlīmēt rakstu augšā, kad atvērts',
 		'title' => 'Lasīšana',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Noklusējuma skats',
 			'global' => 'Globālais skats',

--- a/app/i18n/lv/sub.php
+++ b/app/i18n/lv/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Laika limits sekundēs',
 		'title' => 'Tituls',
 		'title_add' => 'Pievienot RSS barotni',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'Automātiski neatjaunināt biežāk par',
 		'unicityCriteria' => array(
 			'_' => 'Article unicity criteria',	// TODO

--- a/app/i18n/nl/conf.php
+++ b/app/i18n/nl/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'Koppel artikel aan de bovenkant als het geopend wordt',
 		'title' => 'Lees modus',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Standaard weergave',
 			'global' => 'Globale weergave',

--- a/app/i18n/nl/sub.php
+++ b/app/i18n/nl/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Time-out in seconden',
 		'title' => 'Titel',
 		'title_add' => 'Voeg een RSS-feed toe',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'Vernieuw automatisch niet vaker dan',
 		'unicityCriteria' => array(
 			'_' => 'Criteria voor uniciteit van artikel',

--- a/app/i18n/oc/conf.php
+++ b/app/i18n/oc/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'Gardar l’article amont quand es dobèrt',
 		'title' => 'Lectura',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Vista per defaut',
 			'global' => 'Vista generala',

--- a/app/i18n/oc/sub.php
+++ b/app/i18n/oc/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Temps d’espèra en segondas',
 		'title' => 'Títol',
 		'title_add' => 'Ajustar un flux RSS',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'Actualizar pas automaticament mai sovent que',
 		'unicityCriteria' => array(
 			'_' => 'Article unicity criteria',	// TODO

--- a/app/i18n/pl/conf.php
+++ b/app/i18n/pl/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'Przesuń wiadomość na górę strony po otworzeniu',
 		'title' => 'Czytanie',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Domyślny widok',
 			'global' => 'Widok globalny',

--- a/app/i18n/pl/sub.php
+++ b/app/i18n/pl/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Limit czasu, w sekundach',
 		'title' => 'Tytuł',
 		'title_add' => 'Dodaj kanał',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'Nie odświeżaj automatycznie częściej niż',
 		'unicityCriteria' => array(
 			'_' => 'Kryteria unikalności kanału',

--- a/app/i18n/pt-br/conf.php
+++ b/app/i18n/pt-br/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'Coloque o artigo no topo quando aberto',
 		'title' => 'Lendo',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Visualização padrão',
 			'global' => 'Visualização global',

--- a/app/i18n/pt-br/sub.php
+++ b/app/i18n/pt-br/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Timeout em segundos',
 		'title' => 'Título',
 		'title_add' => 'Adicionar o RSS feed',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'Não atualize automaticamente mais que',
 		'unicityCriteria' => array(
 			'_' => 'Article unicity criteria',	// TODO

--- a/app/i18n/pt-pt/conf.php
+++ b/app/i18n/pt-pt/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'Coloque o artigo no topo quando aberto',
 		'title' => 'Lendo',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Visualização padrão',
 			'global' => 'Visualização global',

--- a/app/i18n/pt-pt/sub.php
+++ b/app/i18n/pt-pt/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Timeout em segundos',
 		'title' => 'Título',
 		'title_add' => 'Adicionar o RSS feed',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'Não atualize automaticamente mais que',
 		'unicityCriteria' => array(
 			'_' => 'Article unicity criteria',	// TODO

--- a/app/i18n/ru/conf.php
+++ b/app/i18n/ru/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'Прикрепить статью к верху при открытии',
 		'title' => 'Чтение',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Вид по умолчанию',
 			'global' => 'Глобальный вид',

--- a/app/i18n/ru/sub.php
+++ b/app/i18n/ru/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Таймаут в секундах',
 		'title' => 'Заголовок',
 		'title_add' => 'Добавить RSS-ленту',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'Не обновлять автоматически чаще, чем каждые',
 		'unicityCriteria' => array(
 			'_' => 'Article unicity criteria',	// TODO

--- a/app/i18n/sk/conf.php
+++ b/app/i18n/sk/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'Po otvorení posunúť článok hore',
 		'title' => 'Čítanie',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Prednastavené zobrazenie',
 			'global' => 'Prehľadné zobrazenie',

--- a/app/i18n/sk/sub.php
+++ b/app/i18n/sk/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Doba platnosti dá v sekundách',
 		'title' => 'Nadpis',
 		'title_add' => 'Pridať kanál RSS',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'Automaticky neaktualizovať častejšie ako',
 		'unicityCriteria' => array(
 			'_' => 'Article unicity criteria',	// TODO

--- a/app/i18n/tr/conf.php
+++ b/app/i18n/tr/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'Makale açıldığında üstte sabitle',
 		'title' => 'Okuma',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Varsayılan görünüm',
 			'global' => 'Genel görünüm',

--- a/app/i18n/tr/sub.php
+++ b/app/i18n/tr/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Zaman aşımı (saniye cinsinden)',
 		'title' => 'Başlık',
 		'title_add' => 'RSS beslemesi ekle',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'Otomatik yenileme sıklığını şundan fazla yapma',
 		'unicityCriteria' => array(
 			'_' => 'Makale benzersizlik kriteri',

--- a/app/i18n/uk/conf.php
+++ b/app/i18n/uk/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => 'Закріплювати статтю вгорі при відкритті',
 		'title' => 'Читання',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => 'Типовий показ',
 			'global' => 'Глобальний показ',

--- a/app/i18n/uk/sub.php
+++ b/app/i18n/uk/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => 'Тайм-аут у секундах',
 		'title' => 'Заголовок',
 		'title_add' => 'Додати RSS-стрічку',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => 'Частота автоматичного оновлення',
 		'unicityCriteria' => array(
 			'_' => 'Критерій унікальності статей',

--- a/app/i18n/zh-cn/conf.php
+++ b/app/i18n/zh-cn/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => '打开文章时将其置顶',
 		'title' => '阅读',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => '默认视图',
 			'global' => '全屏视图',

--- a/app/i18n/zh-cn/sub.php
+++ b/app/i18n/zh-cn/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => '超时时间（秒）',
 		'title' => '标题',
 		'title_add' => '添加订阅源',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => '最小自动更新间隔',
 		'unicityCriteria' => array(
 			'_' => 'Article unicity criteria',	// TODO

--- a/app/i18n/zh-tw/conf.php
+++ b/app/i18n/zh-tw/conf.php
@@ -290,6 +290,7 @@ return array(
 		),
 		'sticky_post' => '打開文章時將其置於頁首',
 		'title' => '閱讀',
+		'title_rewriting' => 'Title rewriting rule',	// TODO
 		'view' => array(
 			'default' => '預設視圖',
 			'global' => '全屏視圖',

--- a/app/i18n/zh-tw/sub.php
+++ b/app/i18n/zh-tw/sub.php
@@ -234,6 +234,9 @@ return array(
 		'timeout' => '超時時間（秒）',
 		'title' => '標題',
 		'title_add' => '添加訂閱源',
+		'title_rewriting' => array(
+			'help' => 'Check online documentation for title rewriting information',	// TODO
+		),
 		'ttl' => '最小自動更新間隔',
 		'unicityCriteria' => array(
 			'_' => 'Article unicity criteria',	// TODO

--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -318,6 +318,14 @@
 				</div>
 			</div>
 
+			<div class="form-group">
+				<label class="group-name" for="title_rewriting"><?= _t('conf.reading.title_rewriting') ?></label>
+				<div class="group-controls">
+					<input type="text" name="title_rewriting" id="title_rewriting" class="w100" value="<?= $this->feed->attributeString('title_rewriting') ?>" />
+					<p class="help"><?= _i('help') ?> <?= _t('sub.feed.title_rewriting.help') ?></p>
+				</div>
+			</div>
+
 			<div class="form-group form-actions">
 				<div class="group-controls">
 					<button type="submit" class="btn btn-important"><?= _t('gen.action.submit') ?></button>

--- a/docs/en/users/04_Subscriptions.md
+++ b/docs/en/users/04_Subscriptions.md
@@ -91,6 +91,50 @@ Complementary tools can be used to retrieve full article content, such as:
 
 Articles can be automatically marked as read based on some search terms. See [filtering](./10_filter.md) for more information on how to create these filters.
 
+### Title rewriting
+
+Article titles can be automatically rewritten upon insertion based on the title rewriting rule.
+The rewriting rule use a simple templating system that allows to define literal strings, variables, and filters.
+
+#### Variables
+
+There are two supported variables.
+_title_ is the article title, and _feed_ is the feed name.
+Variables are enclosed by doubled curly braces (`{{` and `}}`).
+For instance, using the following rule will display the current article title (which is useless at this point):
+```text
+{{ title }}
+```
+
+#### Filters
+
+Filters are applied on variables, so they are enclosed in the variable doubled curly braces.
+They can be chained by using a pipe (`|`).
+They are applied sequentially, so their order is important.
+There are three supported filters.
+
+| Filter     | Parameters  | Action                               | PHP function                                                        |
+| ---------- | ----------- | ------------------------------------ | ------------------------------------------------------------------- |
+| _ireplace_ | two         | same as replace but case insensitive | [str_ireplace](https://www.php.net/manual/en/function.str-ireplace) |
+| _replace_  | two         | replace a string with another        | [str_replace](https://www.php.net/manual/en/function.str-replace)   |
+| _trim_     | zero or one | remove characters from both ends     | [trim](https://www.php.net/manual/en/function.trim)                 |
+
+**NOTE** Parameters need to be enclosed in double quotes (`"`), and cannot contain a double quote, even when escaped.
+
+#### Literal strings
+
+Everything that is not enclosed in a variable is considered as a literal string.
+It can contain any characters with the exception of doubled opening curly braces (`{{`).
+
+#### Examples
+
+1. `{{ title | trim }}` will display the article title with spacing removed from both ends.
+1. `{{ title | replace("Spiderman", "Spoiler alert!") }}` will display the article title with every occurrence of _Spiderman_ replaced by _Spoiler alert!_.
+1. `{{ title | replace("Spiderman", "Spoiler alert!") | replace("Superman", "Spoiler alert!") }}` will display the article title with every occurrence of _Spiderman_ and _Superman_ replaced by _Spoiler alert!_.
+1. `{{ feed }} - {{ title }}` will display the feed name followed by a dash (`-`), followed by the article title.
+
+**NOTE** For more examples, you can check tests definitions.
+
 ## Import / export
 
 See [SQLite export/import]( https://github.com/FreshRSS/FreshRSS/tree/edge/cli) as an alternative.

--- a/docs/i18n/flags/gen/cs.svg
+++ b/docs/i18n/flags/gen/cs.svg
@@ -2,6 +2,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="70" height="20">
 	<g fill="white" font-size="12" font-family="Verdana" text-anchor="middle">
 		<rect rx="3" width="70" height="20" fill="gold" />
-		<text x="34" y="14">🇨🇿 89%</text>
+		<text x="34" y="14">🇨🇿 88%</text>
 	</g>
 </svg>

--- a/docs/i18n/flags/gen/fr.svg
+++ b/docs/i18n/flags/gen/fr.svg
@@ -2,6 +2,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="70" height="20">
 	<g fill="white" font-size="12" font-family="Verdana" text-anchor="middle">
 		<rect rx="3" width="70" height="20" fill="green" />
-		<text x="34" y="14">🇫🇷 100%</text>
+		<text x="34" y="14">🇫🇷 99%</text>
 	</g>
 </svg>

--- a/docs/i18n/flags/gen/it.svg
+++ b/docs/i18n/flags/gen/it.svg
@@ -2,6 +2,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="70" height="20">
 	<g fill="white" font-size="12" font-family="Verdana" text-anchor="middle">
 		<rect rx="3" width="70" height="20" fill="green" />
-		<text x="34" y="14">🇮🇹 97%</text>
+		<text x="34" y="14">🇮🇹 96%</text>
 	</g>
 </svg>

--- a/docs/i18n/flags/gen/ko.svg
+++ b/docs/i18n/flags/gen/ko.svg
@@ -2,6 +2,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="70" height="20">
 	<g fill="white" font-size="12" font-family="Verdana" text-anchor="middle">
 		<rect rx="3" width="70" height="20" fill="gold" />
-		<text x="34" y="14">🇰🇷 89%</text>
+		<text x="34" y="14">🇰🇷 88%</text>
 	</g>
 </svg>

--- a/docs/i18n/flags/gen/nl.svg
+++ b/docs/i18n/flags/gen/nl.svg
@@ -2,6 +2,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="70" height="20">
 	<g fill="white" font-size="12" font-family="Verdana" text-anchor="middle">
 		<rect rx="3" width="70" height="20" fill="green" />
-		<text x="34" y="14">🇳🇱 100%</text>
+		<text x="34" y="14">🇳🇱 99%</text>
 	</g>
 </svg>

--- a/docs/i18n/flags/gen/pl.svg
+++ b/docs/i18n/flags/gen/pl.svg
@@ -2,6 +2,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="70" height="20">
 	<g fill="white" font-size="12" font-family="Verdana" text-anchor="middle">
 		<rect rx="3" width="70" height="20" fill="green" />
-		<text x="34" y="14">🇵🇱 100%</text>
+		<text x="34" y="14">🇵🇱 99%</text>
 	</g>
 </svg>

--- a/docs/i18n/flags/gen/ru.svg
+++ b/docs/i18n/flags/gen/ru.svg
@@ -2,6 +2,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="70" height="20">
 	<g fill="white" font-size="12" font-family="Verdana" text-anchor="middle">
 		<rect rx="3" width="70" height="20" fill="gold" />
-		<text x="34" y="14">🇷🇺 89%</text>
+		<text x="34" y="14">🇷🇺 88%</text>
 	</g>
 </svg>

--- a/docs/i18n/flags/gen/tr.svg
+++ b/docs/i18n/flags/gen/tr.svg
@@ -2,6 +2,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="70" height="20">
 	<g fill="white" font-size="12" font-family="Verdana" text-anchor="middle">
 		<rect rx="3" width="70" height="20" fill="green" />
-		<text x="34" y="14">🇹🇷 97%</text>
+		<text x="34" y="14">🇹🇷 96%</text>
 	</g>
 </svg>

--- a/docs/i18n/flags/gen/uk.svg
+++ b/docs/i18n/flags/gen/uk.svg
@@ -2,6 +2,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="70" height="20">
 	<g fill="white" font-size="12" font-family="Verdana" text-anchor="middle">
 		<rect rx="3" width="70" height="20" fill="green" />
-		<text x="34" y="14">🇺🇦 100%</text>
+		<text x="34" y="14">🇺🇦 99%</text>
 	</g>
 </svg>

--- a/docs/i18n/flags/gen/zh-cn.svg
+++ b/docs/i18n/flags/gen/zh-cn.svg
@@ -2,6 +2,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="70" height="20">
 	<g fill="white" font-size="12" font-family="Verdana" text-anchor="middle">
 		<rect rx="3" width="70" height="20" fill="gold" />
-		<text x="34" y="14">🇨🇳 89%</text>
+		<text x="34" y="14">🇨🇳 88%</text>
 	</g>
 </svg>

--- a/docs/i18n/flags/gen/zh-tw.svg
+++ b/docs/i18n/flags/gen/zh-tw.svg
@@ -2,6 +2,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="70" height="20">
 	<g fill="white" font-size="12" font-family="Verdana" text-anchor="middle">
 		<rect rx="3" width="70" height="20" fill="gold" />
-		<text x="34" y="14">🇹🇼 89%</text>
+		<text x="34" y="14">🇹🇼 88%</text>
 	</g>
 </svg>

--- a/tests/app/Handlers/TitleRewritingHandlerTest.php
+++ b/tests/app/Handlers/TitleRewritingHandlerTest.php
@@ -1,0 +1,473 @@
+<?php
+
+declare(strict_types=1);
+
+class TitleRewritingHandlerTest extends PHPUnit\Framework\TestCase {
+	/**
+	 * @dataProvider provideValidTemplate
+	 * @param array<int, mixed> $rules
+	 */
+	public function test__construct_whenValidTemplate_storeRule(string $template, array $rules): void {
+		$handler = new FreshRSS_TitleRewriting_Handler($template);
+		$reflectionClass = new ReflectionClass($handler);
+		$property = $reflectionClass->getProperty('rules');
+		$property->setAccessible(true);
+		self::assertEquals($rules, $property->getValue($handler));
+	}
+
+	public static function provideValidTemplate(): \Generator {
+		yield 'no rule' => [
+			'',
+			[],
+		];
+		yield 'simple string' => [
+			'hello',
+			[
+				'hello',
+			],
+		];
+		yield 'string containing pipe' => [
+			'hello | world',
+			[
+				'hello | world',
+			],
+		];
+		yield 'string containing opening parenthesis' => [
+			'hello ( world',
+			[
+				'hello ( world',
+			],
+		];
+		yield 'string containing closing parenthesis' => [
+			'hello ) world',
+			[
+				'hello ) world',
+			],
+		];
+		yield 'string containing comma' => [
+			'hello , world',
+			[
+				'hello , world',
+			],
+		];
+		yield 'string containing quote' => [
+			'hello " world',
+			[
+				'hello " world',
+			],
+		];
+		yield 'string containing single curly braces' => [
+			'hello {} world',
+			[
+				'hello {} world',
+			],
+		];
+		yield 'simple variable' => [
+			'{{ title }}',
+			[
+				[
+					'variable' => 'title',
+				],
+			],
+		];
+		yield 'variable with simple filter' => [
+			'{{ title | trim }}',
+			[
+				[
+					'variable' => 'title',
+					'filters' => [
+						[
+							'name' => 'trim',
+						],
+					],
+				],
+			],
+		];
+		yield 'variable with filter and parameters' => [
+			'{{ title | replace("0", "o") }}',
+			[
+				[
+					'variable' => 'title',
+					'filters' => [
+						[
+							'name' => 'replace',
+							'parameters' => [
+								'0',
+								'o',
+							],
+						],
+					],
+				]
+			],
+		];
+		yield 'variable with filter and empty parameter' => [
+			'{{ title | replace("o", "") }}',
+			[
+				[
+					'variable' => 'title',
+					'filters' => [
+						[
+							'name' => 'replace',
+							'parameters' => [
+								'o',
+								'',
+							],
+						],
+					],
+				],
+			],
+		];
+		yield 'variable with filter and parameters with pipe' => [
+			'{{ title | ireplace("|", "o") }}',
+			[
+				[
+					'variable' => 'title',
+					'filters' => [
+						[
+							'name' => 'ireplace',
+							'parameters' => [
+								'|',
+								'o',
+							],
+						],
+					],
+				]
+			],
+		];
+		yield 'variable with filter and parameters with opening parenthesis' => [
+			'{{ title | replace("(", "o") }}',
+			[
+				[
+					'variable' => 'title',
+					'filters' => [
+						[
+							'name' => 'replace',
+							'parameters' => [
+								'(',
+								'o',
+							],
+						],
+					],
+				]
+			],
+		];
+		yield 'variable with filter and parameters with closing parenthesis' => [
+			'{{ title | replace(")", "o") }}',
+			[
+				[
+					'variable' => 'title',
+					'filters' => [
+						[
+							'name' => 'replace',
+							'parameters' => [
+								')',
+								'o',
+							],
+						],
+					],
+				]
+			],
+		];
+		yield 'variable with filter and parameters with comma' => [
+			'{{ title | replace(",", "o") }}',
+			[
+				[
+					'variable' => 'title',
+					'filters' => [
+						[
+							'name' => 'replace',
+							'parameters' => [
+								',',
+								'o',
+							],
+						],
+					],
+				]
+			],
+		];
+		yield 'variable with filter and parameters with space' => [
+			'{{ title | replace(" ", "o") }}',
+			[
+				[
+					'variable' => 'title',
+					'filters' => [
+						[
+							'name' => 'replace',
+							'parameters' => [
+								' ',
+								'o',
+							],
+						],
+					],
+				]
+			],
+		];
+		yield 'variable with multiple filters and the last one has no parameter' => [
+			'{{ title | replace("0", "o") | replace("1", "i") | trim }}',
+			[
+				[
+					'variable' => 'title',
+					'filters' => [
+						[
+							'name' => 'replace',
+							'parameters' => [
+								'0',
+								'o',
+							],
+						],
+						[
+							'name' => 'replace',
+							'parameters' => [
+								'1',
+								'i',
+							],
+						],
+						[
+							'name' => 'trim',
+						],
+					],
+				]
+			],
+		];
+		yield 'variable with multiple filters and the last one has parameters' => [
+			'{{ title | trim | replace("0", "o") | replace("1", "i") }}',
+			[
+				[
+					'variable' => 'title',
+					'filters' => [
+						[
+							'name' => 'trim',
+						],
+						[
+							'name' => 'replace',
+							'parameters' => [
+								'0',
+								'o',
+							],
+						],
+						[
+							'name' => 'replace',
+							'parameters' => [
+								'1',
+								'i',
+							],
+						],
+					],
+				]
+			],
+		];
+		yield 'multiple strings with multiple variables with multiple filters with multiple parameters with multiple special characters' => [
+			'hello "()|{}," world {{ title | replace("()|{},", "{}|(),") | trim("-_") }} hello "()|{}," world {{ title | replace("()|{},", "{}|(),")' .
+			' | trim("-_") }} hello "()|{}," world',
+			[
+				'hello "()|{}," world ',
+				[
+					'variable' => 'title',
+					'filters' => [
+						[
+							'name' => 'replace',
+							'parameters' => [
+								'()|{},',
+								'{}|(),',
+							],
+						],
+						[
+							'name' => 'trim',
+							'parameters' => [
+								'-_',
+							],
+						],
+					],
+				],
+				' hello "()|{}," world ',
+				[
+					'variable' => 'title',
+					'filters' => [
+						[
+							'name' => 'replace',
+							'parameters' => [
+								'()|{},',
+								'{}|(),',
+							],
+						],
+						[
+							'name' => 'trim',
+							'parameters' => [
+								'-_',
+							],
+						],
+					],
+				],
+				' hello "()|{}," world',
+			]
+		];
+		yield 'unknown variable' => [
+			'{{ unknown }}',
+			[],
+		];
+		yield 'unknown filter' => [
+			'{{ title | unknown }}',
+			[
+				[
+					'variable' => 'title',
+				],
+			],
+		];
+		yield 'unknown and known filter' => [
+			'{{ title | unknown | trim }}',
+			[
+				[
+					'variable' => 'title',
+					'filters' => [
+						[
+							'name' => 'trim',
+						],
+					],
+				],
+			],
+		];
+		yield 'trim filter with extra parameter' => [
+			'{{ title | trim("1", "2") }}',
+			[
+				[
+					'variable' => 'title',
+				],
+			],
+		];
+		yield 'replace filter with no parameter' => [
+			'{{ title | replace }}',
+			[
+				[
+					'variable' => 'title',
+				],
+			],
+		];
+		yield 'replace filter with one parameter missing' => [
+			'{{ title | replace("1") }}',
+			[
+				[
+					'variable' => 'title',
+				],
+			],
+		];
+		yield 'replace filter with extra parameter' => [
+			'{{ title | replace("1", "2", "3") }}',
+			[
+				[
+					'variable' => 'title',
+				],
+			],
+		];
+		yield 'ireplace filter with no parameter' => [
+			'{{ title | ireplace }}',
+			[
+				[
+					'variable' => 'title',
+				],
+			],
+		];
+		yield 'ireplace filter with one parameter missing' => [
+			'{{ title | ireplace("1") }}',
+			[
+				[
+					'variable' => 'title',
+				],
+			],
+		];
+		yield 'ireplace filter with extra parameter' => [
+			'{{ title | ireplace("1", "2", "3") }}',
+			[
+				[
+					'variable' => 'title',
+				],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider provideInvalidTemplate
+	 */
+	public function test__construct_whenInvalidTemplate_throwsException(string $template, string $exceptionMessage): void {
+		$this->expectException(FreshRSS_Parsing_Exception::class);
+		$this->expectExceptionMessage($exceptionMessage);
+
+		new FreshRSS_TitleRewriting_Handler($template);
+	}
+
+	public static function provideInvalidTemplate(): \Generator {
+		yield 'missing variable end delimiter' => ['{{ title', 'Missing variable end delimiter'];
+		yield 'missing filter end delimiter' => ['{{ title | replace( }}', 'Missing filter end delimiter'];
+	}
+
+	/**
+	 * @dataProvider provideRewriteRule
+	 */
+	public function test_rewrite(string $template, string $title, string $feed, string $expected): void {
+		$handler = new FreshRSS_TitleRewriting_Handler($template);
+		self::assertEquals($expected, $handler->rewrite($title, $feed));
+	}
+
+	public static function provideRewriteRule(): \Generator {
+		yield 'no rewrite' => [
+			'',
+			'some article title',
+			'some feed name',
+			'',
+		];
+		yield 'single string' => [
+			'hello world',
+			'some article title',
+			'some feed name',
+			'hello world',
+		];
+		yield 'single variable' => [
+			'{{ title }}',
+			'some article title',
+			'some feed name',
+			'some article title',
+		];
+		yield 'single variable with simple trim' => [
+			'{{ title | trim }}',
+			'    some article title    ',
+			'some feed name',
+			'some article title',
+		];
+		yield 'single variable with trim with parameter' => [
+			'{{ title | trim("-") }}',
+			'---some article title---',
+			'some feed name',
+			'some article title',
+		];
+		yield 'single variable with multiple trim' => [
+			'{{ title | trim("-") | trim }}',
+			'---   some article title   ---',
+			'some feed name',
+			'some article title',
+		];
+		yield 'single variable with replace' => [
+			'{{ title | replace("---", "###") }}',
+			'---some article title---',
+			'some feed name',
+			'###some article title###',
+		];
+		yield 'single variable with replace and empty parameter' => [
+			'{{ title | replace("---", "") }}',
+			'---some article title---',
+			'some feed name',
+			'some article title',
+		];
+		yield 'multiple variables' => [
+			'{{ feed }}{{ title }}',
+			'some article title',
+			'some feed name',
+			'some feed namesome article title',
+		];
+		yield 'multiple variables with multiple filters with multiple strings' => [
+			'| {{ feed | replace("some", "    ") | ireplace("Feed", "    ") | trim }} | {{ title | replace("some", "-") | replace("title", "-") |' .
+			' trim("-") | trim }} |',
+			'some article title',
+			'some feed name',
+			'| name | article |',
+		];
+	}
+}


### PR DESCRIPTION
Closes #4335, #4684

Changes proposed in this pull request:

- Rewrite article title upon creation.

How to test the feature manually:

1. Add a new title rewriting rule in the feed configuration page.
2. Load new articles.
3. Check that the titles are following the rewrite rule.
4. Enjoy!

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).

The title rewriting feature allows title rewriting upon article creation in the database. Once the rewriting is done, it cannot be undone.

At the moment, there is 2 variables and 3 filters available in the simple templating system.