### PR TITLE
Added bottom nav padding for iOS #4740

### DIFF
--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -10,7 +10,7 @@ if (_t('gen.dir') === 'rtl') {
 ?>>
 	<head>
 		<meta charset="UTF-8" />
-		<meta name="viewport" content="initial-scale=1.0" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 		<?= FreshRSS_View::headStyle() ?>
 		<script id="jsonVars" type="application/json">
 <?php $this->renderHelper('javascript_vars'); ?>

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1454,6 +1454,7 @@ a.website:hover .favicon {
 	bottom: 0; left: 0;
 	width: 300px;
 	table-layout: fixed;
+	padding-bottom: env(safe-area-inset-bottom);
 }
 
 #nav_entries .item {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1454,6 +1454,7 @@ a.website:hover .favicon {
 	bottom: 0; right: 0;
 	width: 300px;
 	table-layout: fixed;
+	padding-bottom: env(safe-area-inset-bottom);
 }
 
 #nav_entries .item {


### PR DESCRIPTION
Closes #4740 

Changes proposed in this pull request:
- Added additional bottom padding to the navigation when required. This means the navigation no longer overlaps the safe area in iOS. The viewport meta tag changes were required for safe-area-inset-bottom to have a value.

How to test the feature manually:
1. Add FreshRSS to the iOS Home screen
2. Open the application
3. Note that the menu no longer overlaps the safe area

I have observed the following based on my testing:
* Desktop browser - no change
* Safari in iOS, portrait - no change (iOS has the URL bar at the bottom which covers the safe area)
* Safari in iOS, landscape - The bottom navigation has the padding added pushing it above the safe area
* iOS as home screen app - The navigation has the padding addedd
* Android - Unfortunately I have no android device on which to test. However unless the device specifically sets 'safe-area-inset-bottom' it should have no change

![WIN_20221018_13_48_43_Pro](https://user-images.githubusercontent.com/60839662/196324194-ce83d65c-4628-4c41-9da0-0dbba644bc1f.jpg)

Pull request checklist:

- [X] clear commit messages
- [X] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
