### PR TITLE
Remove ajax parameter when modifying the request

### DIFF
--- a/lib/Minz/Request.php
+++ b/lib/Minz/Request.php
@@ -98,6 +98,7 @@ class Minz_Request {
 		return self::$originalRequest;
 	}
 	public static function modifiedCurrentRequest(array $extraParams = null) {
+		unset(self::$params['ajax']);
 		$currentRequest = self::currentRequest();
 		if (null !== $extraParams) {
 			$currentRequest['params'] = array_merge($currentRequest['params'], $extraParams);


### PR DESCRIPTION
Closes #4726

Changes proposed in this pull request:

- Fix author filter when clicking on article author link

How to test the feature manually:

1. Check the related issue for steps to reproduce
2. It should work properly.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).

Before, when clicking on the author name to use as a filter, the displayed page was a result page from the ajax query. This was due to the use of the ajax parameter in the query.
Now, the ajax parameter is removed from the query before displaying the filters.