### PR TITLE
Add text wrap on pre tags

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1333,6 +1333,7 @@ a.website:hover .favicon {
 
 .content pre {
 	overflow: auto;
+	white-space: pre-wrap;
 }
 
 .subtitle > div {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1333,6 +1333,7 @@ a.website:hover .favicon {
 
 .content pre {
 	overflow: auto;
+	white-space: pre-wrap;
 }
 
 .subtitle > div {


### PR DESCRIPTION
Changes proposed in this pull request:

- Add text wrap on pre tags

How to test the feature manually:

1. Find an article with an embedded pre tag.
2. Check that the content does not need a scrollbar.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).

Before, text contained in pre tags was displayed on really long lines with a scrollbar when it was overflowing.
Now, text content is wrapped around the maximum size of the display, thus removing the use of the scrollbar.

# Before
![Screen Shot 2022-10-19 at 09 36 11](https://user-images.githubusercontent.com/3056148/196706748-6cee8da9-2ff0-4479-8fa5-2c8d244d2d0d.png)

# After
![Screen Shot 2022-10-19 at 09 35 46](https://user-images.githubusercontent.com/3056148/196706730-e6560bd7-ec6c-41c0-ae50-e7ab0a7587bf.png)
