### PR TITLE
Correct manage link on stats page

### DIFF
--- a/app/views/stats/repartition.phtml
+++ b/app/views/stats/repartition.phtml
@@ -31,7 +31,7 @@
 	</select>
 
 	<?php if ($this->feed) {?>
-		<a class="btn" href="<?= _url('subscription', 'index', 'id', $this->feed->id()) ?>">
+		<a class="btn" href="<?= _url('subscription', 'feed', 'id', $this->feed->id()) ?>">
 			<?= _i('configure') ?> <?= _t('gen.action.manage') ?>
 		</a>
 	<?php }?>


### PR DESCRIPTION
Wasn't working before

Changes proposed in this pull request:

- Update the link used

How to test the feature manually:

1. Go to subscription management -> statistics -> Articles repartition -> choose a feed
2. Click on Manage
3. Before the link wasn't working, now it does

You still get a strange redirection when you submit a change. Maybe we should instead open the view on the side but I didn't know how to do it.

Pull request checklist:

- [ ] clear commit messages
- [ ] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
