### PR TITLE
Fixed: "tag" -> "label"

### DIFF
--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -102,7 +102,7 @@ return array(
 			'order' => 'Nach Datum sortieren',
 			'search' => 'Suchbegriff',
 			'state' => 'Eigenschaft',
-			'tags' => 'Nach Tag filtern',
+			'tags' => 'Nach Labels filtern',
 			'type' => 'Filter-Typ',
 		),
 		'get_all' => 'Alle Artikel anzeigen',

--- a/app/i18n/de/feedback.php
+++ b/app/i18n/de/feedback.php
@@ -115,9 +115,9 @@ return array(
 		'purge_completed' => 'Bereinigung abgeschlossen (%d Artikel gelöscht)',
 	),
 	'tag' => array(
-		'created' => 'Tag „%s“ wurde erstellt.',
-		'name_exists' => 'Tag Name existiert bereits.',
-		'renamed' => 'Der Tag „%s“ wurde umbenannt in „%s“.',
+		'created' => 'Label „%s“ wurde erstellt.',
+		'name_exists' => 'Label-Name existiert bereits.',
+		'renamed' => 'Das Label „%s“ wurde umbenannt in „%s“.',
 	),
 	'update' => array(
 		'can_apply' => 'FreshRSS wird nun auf die <strong>Version %s</strong> aktualisiert.',

--- a/app/i18n/el/conf.php
+++ b/app/i18n/el/conf.php
@@ -102,7 +102,7 @@ return array(
 			'order' => 'Sort by date',	// TODO
 			'search' => 'Expression',	// TODO
 			'state' => 'State',	// TODO
-			'tags' => 'Display by tag',	// TODO
+			'tags' => 'Display by label',	// TODO
 			'type' => 'Type',	// TODO
 		),
 		'get_all' => 'Display all articles',	// TODO

--- a/app/i18n/el/feedback.php
+++ b/app/i18n/el/feedback.php
@@ -115,9 +115,9 @@ return array(
 		'purge_completed' => 'Purge completed (%d articles deleted)',	// TODO
 	),
 	'tag' => array(
-		'created' => 'Tag “%s” has been created.',	// TODO
-		'name_exists' => 'Tag name already exists.',	// TODO
-		'renamed' => 'Tag “%s” has been renamed to “%s”.',	// TODO
+		'created' => 'Label “%s” has been created.',	// TODO
+		'name_exists' => 'Label name already exists.',	// TODO
+		'renamed' => 'Label “%s” has been renamed to “%s”.',	// TODO
 	),
 	'update' => array(
 		'can_apply' => 'FreshRSS will now be updated to the <strong>version %s</strong>.',	// TODO

--- a/app/i18n/en-us/conf.php
+++ b/app/i18n/en-us/conf.php
@@ -102,7 +102,7 @@ return array(
 			'order' => 'Sort by date',	// IGNORE
 			'search' => 'Expression',	// IGNORE
 			'state' => 'State',	// IGNORE
-			'tags' => 'Display by tag',	// IGNORE
+			'tags' => 'Display by label',	// IGNORE
 			'type' => 'Type',	// IGNORE
 		),
 		'get_all' => 'Display all articles',	// IGNORE

--- a/app/i18n/en-us/feedback.php
+++ b/app/i18n/en-us/feedback.php
@@ -115,9 +115,9 @@ return array(
 		'purge_completed' => 'Purge completed (%d articles deleted)',	// IGNORE
 	),
 	'tag' => array(
-		'created' => 'Tag “%s” has been created.',	// IGNORE
-		'name_exists' => 'Tag name already exists.',	// IGNORE
-		'renamed' => 'Tag “%s” has been renamed to “%s”.',	// IGNORE
+		'created' => 'Label “%s” has been created.',	// IGNORE
+		'name_exists' => 'Label name already exists.',	// IGNORE
+		'renamed' => 'Label “%s” has been renamed to “%s”.',	// IGNORE
 	),
 	'update' => array(
 		'can_apply' => 'FreshRSS will now be updated to the <strong>version %s</strong>.',	// IGNORE

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -102,7 +102,7 @@ return array(
 			'order' => 'Sort by date',
 			'search' => 'Expression',
 			'state' => 'State',
-			'tags' => 'Display by tag',
+			'tags' => 'Display by label',
 			'type' => 'Type',
 		),
 		'get_all' => 'Display all articles',

--- a/app/i18n/en/feedback.php
+++ b/app/i18n/en/feedback.php
@@ -115,9 +115,9 @@ return array(
 		'purge_completed' => 'Purge completed (%d articles deleted)',
 	),
 	'tag' => array(
-		'created' => 'Tag “%s” has been created.',
-		'name_exists' => 'Tag name already exists.',
-		'renamed' => 'Tag “%s” has been renamed to “%s”.',
+		'created' => 'Label “%s” has been created.',
+		'name_exists' => 'Label name already exists.',
+		'renamed' => 'Label “%s” has been renamed to “%s”.',
 	),
 	'update' => array(
 		'can_apply' => 'FreshRSS will now be updated to the <strong>version %s</strong>.',

--- a/app/i18n/he/conf.php
+++ b/app/i18n/he/conf.php
@@ -102,7 +102,7 @@ return array(
 			'order' => 'Sort by date',	// TODO
 			'search' => 'Expression',	// TODO
 			'state' => 'State',	// TODO
-			'tags' => 'Display by tag',	// TODO
+			'tags' => 'Display by label',	// TODO
 			'type' => 'Type',	// TODO
 		),
 		'get_all' => 'הצגת כל המאמרים',

--- a/app/i18n/he/feedback.php
+++ b/app/i18n/he/feedback.php
@@ -115,9 +115,9 @@ return array(
 		'purge_completed' => 'הניקוי הושלם (%d מאמרים נמחקו)',
 	),
 	'tag' => array(
-		'created' => 'Tag “%s” has been created.',	// TODO
-		'name_exists' => 'Tag name already exists.',	// TODO
-		'renamed' => 'Tag “%s” has been renamed to “%s”.',	// TODO
+		'created' => 'Label “%s” has been created.',	// TODO
+		'name_exists' => 'Label name already exists.',	// TODO
+		'renamed' => 'Label “%s” has been renamed to “%s”.',	// TODO
 	),
 	'update' => array(
 		'can_apply' => 'FreshRSS will be now updated to the <strong>version %s</strong>.',

--- a/app/i18n/id/conf.php
+++ b/app/i18n/id/conf.php
@@ -102,7 +102,7 @@ return array(
 			'order' => 'Sort by date',	// TODO
 			'search' => 'Expression',	// TODO
 			'state' => 'State',	// TODO
-			'tags' => 'Display by tag',	// TODO
+			'tags' => 'Display by label',	// TODO
 			'type' => 'Type',	// TODO
 		),
 		'get_all' => 'Display all articles',	// TODO

--- a/app/i18n/id/feedback.php
+++ b/app/i18n/id/feedback.php
@@ -115,9 +115,9 @@ return array(
 		'purge_completed' => 'Purge completed (%d articles deleted)',	// TODO
 	),
 	'tag' => array(
-		'created' => 'Tag “%s”has been created.',	// DIRTY
-		'name_exists' => 'Tag name already exists.',	// TODO
-		'renamed' => 'Tag “%s”has been renamed to “%s”.',	// DIRTY
+		'created' => 'Label “%s”has been created.',	// DIRTY
+		'name_exists' => 'Label name already exists.',	// TODO
+		'renamed' => 'Label “%s”has been renamed to “%s”.',	// DIRTY
 	),
 	'update' => array(
 		'can_apply' => 'FreshRSS will now be updated to the <strong>version %s</strong>.',	// TODO

--- a/app/i18n/it/conf.php
+++ b/app/i18n/it/conf.php
@@ -102,7 +102,7 @@ return array(
 			'order' => 'Ordina per data',
 			'search' => 'Espressione',
 			'state' => 'Stato',
-			'tags' => 'Mostra per tag',
+			'tags' => 'Mostra per tag',	// DIRTY
 			'type' => 'Tipo',
 		),
 		'get_all' => 'Mostra tutti gli articoli',

--- a/app/i18n/it/feedback.php
+++ b/app/i18n/it/feedback.php
@@ -115,9 +115,9 @@ return array(
 		'purge_completed' => 'Svecchiamento completato (%d articoli cancellati)',
 	),
 	'tag' => array(
-		'created' => 'Il Tag “%s” è stato creato.',
-		'name_exists' => 'Il nome del tag è già presente.',
-		'renamed' => 'Il Tag “%s” è stato rinominato in “%s”.',
+		'created' => 'Il Tag “%s” è stato creato.',	// DIRTY
+		'name_exists' => 'Il nome del tag è già presente.',	// DIRTY
+		'renamed' => 'Il Tag “%s” è stato rinominato in “%s”.',	// DIRTY
 	),
 	'update' => array(
 		'can_apply' => 'FreshRSS verrà aggiornato alla <strong>versione %s</strong>.',

--- a/app/i18n/nl/conf.php
+++ b/app/i18n/nl/conf.php
@@ -102,7 +102,7 @@ return array(
 			'order' => 'Sorteren op datum',
 			'search' => 'Expressie',
 			'state' => 'Status',
-			'tags' => 'Weergeven op tag',	// DIRTY
+			'tags' => 'Weergeven op label',
 			'type' => 'Type',	// IGNORE
 		),
 		'get_all' => 'Toon alle artikelen',

--- a/app/i18n/nl/conf.php
+++ b/app/i18n/nl/conf.php
@@ -102,7 +102,7 @@ return array(
 			'order' => 'Sorteren op datum',
 			'search' => 'Expressie',
 			'state' => 'Status',
-			'tags' => 'Weergeven op tag',
+			'tags' => 'Weergeven op tag',	// DIRTY
 			'type' => 'Type',	// IGNORE
 		),
 		'get_all' => 'Toon alle artikelen',

--- a/app/i18n/nl/feedback.php
+++ b/app/i18n/nl/feedback.php
@@ -115,9 +115,9 @@ return array(
 		'purge_completed' => 'Opschonen klaar (%d artikelen verwijderd)',
 	),
 	'tag' => array(
-		'created' => 'Tag „%s” is aangemaakt.',
-		'name_exists' => 'Tagnaam bestaat al.',
-		'renamed' => 'Tag „%s” hernoemd naar „%s”.',
+		'created' => 'Tag „%s” is aangemaakt.',	// DIRTY
+		'name_exists' => 'Tagnaam bestaat al.',	// DIRTY
+		'renamed' => 'Tag „%s” hernoemd naar „%s”.',	// DIRTY
 	),
 	'update' => array(
 		'can_apply' => 'FreshRSS word nu vernieud naar <strong>versie %s</strong>.',

--- a/app/i18n/nl/feedback.php
+++ b/app/i18n/nl/feedback.php
@@ -115,9 +115,9 @@ return array(
 		'purge_completed' => 'Opschonen klaar (%d artikelen verwijderd)',
 	),
 	'tag' => array(
-		'created' => 'Tag „%s” is aangemaakt.',	// DIRTY
-		'name_exists' => 'Tagnaam bestaat al.',	// DIRTY
-		'renamed' => 'Tag „%s” hernoemd naar „%s”.',	// DIRTY
+		'created' => 'Label „%s” aangemaakt.',
+		'name_exists' => 'Label bestaat al.',
+		'renamed' => 'Label „%s” hernoemd naar „%s”.',
 	),
 	'update' => array(
 		'can_apply' => 'FreshRSS word nu vernieud naar <strong>versie %s</strong>.',

--- a/app/i18n/pt-br/conf.php
+++ b/app/i18n/pt-br/conf.php
@@ -102,7 +102,7 @@ return array(
 			'order' => 'Ordenar por data',
 			'search' => 'Expressão',
 			'state' => 'Estado',
-			'tags' => 'Exibir por tag',
+			'tags' => 'Exibir por tag',	// DIRTY
 			'type' => 'Tipo',
 		),
 		'get_all' => 'Mostrar todos os artigos',

--- a/app/i18n/pt-br/feedback.php
+++ b/app/i18n/pt-br/feedback.php
@@ -115,9 +115,9 @@ return array(
 		'purge_completed' => 'Limpeza completa (%d artigos deletados)',
 	),
 	'tag' => array(
-		'created' => 'A Tag “%s” foi criada.',
-		'name_exists' => 'O nome da tag já existe.',
-		'renamed' => 'A Tag “%s” foi renomeada para “%s”.',
+		'created' => 'A Tag “%s” foi criada.',	// DIRTY
+		'name_exists' => 'O nome da tag já existe.',	// DIRTY
+		'renamed' => 'A Tag “%s” foi renomeada para “%s”.',	// DIRTY
 	),
 	'update' => array(
 		'can_apply' => 'O FreshRSS será atualizado para a <strong>versão %s</strong>.',


### PR DESCRIPTION
Before:
When a label is created the notification calls it a "tag".
![grafik](https://user-images.githubusercontent.com/1645099/197580167-cdd288bb-33da-434d-9f81-920b10cdef33.png)

Edit user queries:
![grafik](https://user-images.githubusercontent.com/1645099/197581250-29e15a54-dbab-4538-9038-f16b7dd9f536.png)


Changes proposed in this pull request:
* English i18n: "label" -> "tag"
* German: improved
* some other languages: commented the line as `// DIRTY`

How to test the feature manually:

1. check how it is called in the language:
2. go to "Label management" (`./p/i/?c=tag`)

1. Create a new label
3. see the notification

1. Create/edit a user query
2. see the filter list

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested