### PR TITLE
Improved: implement CSS variable --frss-padding-flux-items

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -38,6 +38,8 @@
 
 	--frss-loading-image: url("loader.gif");
 
+	--frss-padding-flux-items: 0.75rem;
+
 	line-height: 1.5;
 }
 
@@ -1129,15 +1131,20 @@ input[type="search"] {
 	line-height: 1.5rem;
 }
 
+.flux .flux_header .item.manage .item-element,
+.flux .flux_header .item.website .item-element,
+.flux .flux_header .item.link .item-element {
+	padding-left: var(--frss-padding-flux-items);
+	padding-right: var(--frss-padding-flux-items);
+}
+
 .flux .item.manage,
 .flux .item.link {
-	width: 40px;
-	text-align: center;
+	width: calc(1rem + 2 * var(--frss-padding-flux-items));
 }
 
 .flux .item.website {
 	width: 200px;
-	padding-right: 10px;
 }
 
 .website a:hover .favicon,

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1917,6 +1917,10 @@ input:checked + .slide-container .properties {
 /*===========*/
 
 @media (max-width: 840px) {
+	:root {
+		--frss-padding-flux-items: 0.5rem;
+	}
+
 	.flux_header .item.website span,
 	.item.date, .day .date,
 	.dropdown-menu > .no-mobile,

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1917,6 +1917,10 @@ input:checked + .slide-container .properties {
 /*===========*/
 
 @media (max-width: 840px) {
+	:root {
+		--frss-padding-flux-items: 0.5rem;
+	}
+
 	.flux_header .item.website span,
 	.item.date, .day .date,
 	.dropdown-menu > .no-mobile,

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -38,6 +38,8 @@
 
 	--frss-loading-image: url("loader.gif");
 
+	--frss-padding-flux-items: 0.75rem;
+
 	line-height: 1.5;
 }
 
@@ -1129,15 +1131,20 @@ input[type="search"] {
 	line-height: 1.5rem;
 }
 
+.flux .flux_header .item.manage .item-element,
+.flux .flux_header .item.website .item-element,
+.flux .flux_header .item.link .item-element {
+	padding-right: var(--frss-padding-flux-items);
+	padding-left: var(--frss-padding-flux-items);
+}
+
 .flux .item.manage,
 .flux .item.link {
-	width: 40px;
-	text-align: center;
+	width: calc(1rem + 2 * var(--frss-padding-flux-items));
 }
 
 .flux .item.website {
 	width: 200px;
-	padding-left: 10px;
 }
 
 .website a:hover .favicon,


### PR DESCRIPTION
Ref #4776

The space around the icons is now adjustable via the CSS variable `--frss-padding-flux-items`. If you want to have tighter columns, now you can adjust it easily. Default: `0.75rem`
![grafik](https://user-images.githubusercontent.com/1645099/198854093-7ab03a5d-96a2-489e-ac7b-23b286e4f240.png)

In mobile view the padding is now `0.5rem` to have it a bit compacter

Changes proposed in this pull request:

- CSS


How to test the feature manually:

1. see the screen shot

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested