### PR TITLE
fixed: box layout for global view

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -1017,11 +1017,6 @@ kbd {
 	text-shadow: none;
 }
 
-.box.category .item.feed {
-	padding: 2px 10px;
-	font-size: 0.8rem;
-}
-
 /*=== Slider */
 #slider {
 	background: var(--background-color-dark);

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -1017,11 +1017,6 @@ kbd {
 	text-shadow: none;
 }
 
-.box.category .item.feed {
-	padding: 2px 10px;
-	font-size: 0.8rem;
-}
-
 /*=== Slider */
 #slider {
 	background: var(--background-color-dark);

--- a/p/themes/Ansum/_global-view.scss
+++ b/p/themes/Ansum/_global-view.scss
@@ -40,12 +40,7 @@
 		}
 
 		.box-content {
-			padding-bottom: 0.5rem;
-
 			.item.feed {
-				padding: 0.5rem 1.5rem;
-				font-size: 1rem;
-
 				a {
 					color: variables.$main-font-color;
 					font-weight: 400;

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -462,7 +462,7 @@ form th {
 	box-shadow: inset -1px -11px 8px rgba(0, 0, 0, 0.2);
 }
 .tree .tree-folder .tree-folder-title {
-	padding: 1rem 1rem;
+	padding: 1rem;
 	background: #fbf9f6;
 	position: relative;
 	font-size: 0.85rem;
@@ -1070,13 +1070,6 @@ main.prompt {
 }
 #stream .box.category .box-title a.title:hover {
 	color: #ca7227;
-}
-#stream .box.category .box-content {
-	padding-bottom: 0.5rem;
-}
-#stream .box.category .box-content .item.feed {
-	padding: 0.5rem 1.5rem;
-	font-size: 1rem;
 }
 #stream .box.category .box-content .item.feed a {
 	color: #363330;

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -462,7 +462,7 @@ form th {
 	box-shadow: inset 1px -11px 8px rgba(0, 0, 0, 0.2);
 }
 .tree .tree-folder .tree-folder-title {
-	padding: 1rem 1rem;
+	padding: 1rem;
 	background: #fbf9f6;
 	position: relative;
 	font-size: 0.85rem;
@@ -1070,13 +1070,6 @@ main.prompt {
 }
 #stream .box.category .box-title a.title:hover {
 	color: #ca7227;
-}
-#stream .box.category .box-content {
-	padding-bottom: 0.5rem;
-}
-#stream .box.category .box-content .item.feed {
-	padding: 0.5rem 1.5rem;
-	font-size: 1rem;
 }
 #stream .box.category .box-content .item.feed a {
 	color: #363330;

--- a/p/themes/BlueLagoon/BlueLagoon.css
+++ b/p/themes/BlueLagoon/BlueLagoon.css
@@ -1057,11 +1057,6 @@ a.btn {
 	font-weight: bold;
 }
 
-.box.category .item.feed {
-	padding: 2px 10px;
-	font-size: 0.8rem;
-}
-
 .box.category .item.feed:not(.empty):not(.error) .item-title {
 	color: #222;
 }

--- a/p/themes/BlueLagoon/BlueLagoon.rtl.css
+++ b/p/themes/BlueLagoon/BlueLagoon.rtl.css
@@ -1057,11 +1057,6 @@ a.btn {
 	font-weight: bold;
 }
 
-.box.category .item.feed {
-	padding: 2px 10px;
-	font-size: 0.8rem;
-}
-
 .box.category .item.feed:not(.empty):not(.error) .item-title {
 	color: #222;
 }

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -934,11 +934,6 @@ a.btn {
 	text-shadow: none;
 }
 
-.box.category .item.feed {
-	padding: 2px 10px;
-	font-size: 0.8rem;
-}
-
 /*=== Panel */
 #panel {
 	background: #1c1c1c;

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -934,11 +934,6 @@ a.btn {
 	text-shadow: none;
 }
 
-.box.category .item.feed {
-	padding: 2px 10px;
-	font-size: 0.8rem;
-}
-
 /*=== Panel */
 #panel {
 	background: #1c1c1c;

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -951,11 +951,6 @@ a.btn {
 	text-shadow: none;
 }
 
-.box.category .item.feed {
-	padding: 2px 10px;
-	font-size: 0.8rem;
-}
-
 /*=== DIVERS */
 /*===========*/
 .aside.aside_feed .nav-form input,

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -951,11 +951,6 @@ a.btn {
 	text-shadow: none;
 }
 
-.box.category .item.feed {
-	padding: 2px 10px;
-	font-size: 0.8rem;
-}
-
 /*=== DIVERS */
 /*===========*/
 .aside.aside_feed .nav-form input,

--- a/p/themes/Mapco/_global-view.scss
+++ b/p/themes/Mapco/_global-view.scss
@@ -40,12 +40,7 @@
 		}
 
 		.box-content {
-			padding-bottom: 0.5rem;
-
 			.item.feed {
-				padding: 0.5rem 1.5rem;
-				font-size: 1rem;
-
 				a {
 					color: variables.$main-font-color;
 					font-weight: 400;

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -1089,13 +1089,6 @@ main.prompt {
 #stream .box.category .box-title a.title:hover {
 	color: #36c;
 }
-#stream .box.category .box-content {
-	padding-bottom: 0.5rem;
-}
-#stream .box.category .box-content .item.feed {
-	padding: 0.5rem 1.5rem;
-	font-size: 1rem;
-}
 #stream .box.category .box-content .item.feed a {
 	color: #303136;
 	font-weight: 400;

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -1089,13 +1089,6 @@ main.prompt {
 #stream .box.category .box-title a.title:hover {
 	color: #36c;
 }
-#stream .box.category .box-content {
-	padding-bottom: 0.5rem;
-}
-#stream .box.category .box-content .item.feed {
-	padding: 0.5rem 1.5rem;
-	font-size: 1rem;
-}
 #stream .box.category .box-content .item.feed a {
 	color: #303136;
 	font-weight: 400;

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -1080,11 +1080,6 @@ input.extend {
 	text-shadow: none;
 }
 
-.box.category .item.feed {
-	padding: 2px 10px;
-	font-size: 0.8rem;
-}
-
 #panel {
 	background-color: var(--bg);
 }

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -1080,11 +1080,6 @@ input.extend {
 	text-shadow: none;
 }
 
-.box.category .item.feed {
-	padding: 2px 10px;
-	font-size: 0.8rem;
-}
-
 #panel {
 	background-color: var(--bg);
 }

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -1057,11 +1057,6 @@ a:hover .icon {
 	text-shadow: none;
 }
 
-.box.category .item.feed {
-	padding: 2px 10px;
-	font-size: 0.8rem;
-}
-
 /*=== DIVERS */
 /*===========*/
 .aside.aside_feed .nav-form input,

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -1057,11 +1057,6 @@ a:hover .icon {
 	text-shadow: none;
 }
 
-.box.category .item.feed {
-	padding: 2px 10px;
-	font-size: 0.8rem;
-}
-
 /*=== DIVERS */
 /*===========*/
 .aside.aside_feed .nav-form input,

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -934,11 +934,6 @@ a.signin {
 	line-height: 1.6rem;
 }
 
-.box.category .item.feed {
-	padding: 2px 10px;
-	font-size: 0.8rem;
-}
-
 /*=== DIVERS */
 /*===========*/
 .aside.aside_feed .nav-form input,

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -934,11 +934,6 @@ a.signin {
 	line-height: 1.6rem;
 }
 
-.box.category .item.feed {
-	padding: 2px 10px;
-	font-size: 0.8rem;
-}
-
 /*=== DIVERS */
 /*===========*/
 .aside.aside_feed .nav-form input,

--- a/p/themes/Screwdriver/screwdriver.css
+++ b/p/themes/Screwdriver/screwdriver.css
@@ -1037,11 +1037,6 @@ a.btn {
 	font-weight: bold;
 }
 
-.box.category .item.feed {
-	padding: 2px 10px;
-	font-size: 0.8rem;
-}
-
 .box.category .item.feed:not(.empty):not(.error) .item-title {
 	color: #222;
 }

--- a/p/themes/Screwdriver/screwdriver.rtl.css
+++ b/p/themes/Screwdriver/screwdriver.rtl.css
@@ -1037,11 +1037,6 @@ a.btn {
 	font-weight: bold;
 }
 
-.box.category .item.feed {
-	padding: 2px 10px;
-	font-size: 0.8rem;
-}
-
 .box.category .item.feed:not(.empty):not(.error) .item-title {
 	color: #222;
 }

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -537,10 +537,6 @@ form th {
 	font-weight: bold;
 	text-shadow: none;
 }
-.box.category .item.feed {
-	padding: 2px 10px;
-	font-size: 0.8rem;
-}
 .box.visible-semi {
 	border-style: solid;
 }

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -537,10 +537,6 @@ form th {
 	font-weight: bold;
 	text-shadow: none;
 }
-.box.category .item.feed {
-	padding: 2px 10px;
-	font-size: 0.8rem;
-}
 .box.visible-semi {
 	border-style: solid;
 }

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -695,11 +695,6 @@ form {
 			font-weight: bold;
 			text-shadow: none;
 		}
-
-		.item.feed {
-			padding: 2px 10px;
-			font-size: 0.8rem;
-		}
 	}
 
 	&.visible-semi {

--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -752,11 +752,6 @@ a.btn {
 	text-shadow: none;
 }
 
-.box.category .item.feed {
-	padding: 2px 10px;
-	font-size: 0.8rem;
-}
-
 /*=== DIVERS */
 /*===========*/
 .aside.aside_feed .nav-form input,

--- a/p/themes/base-theme/base.rtl.css
+++ b/p/themes/base-theme/base.rtl.css
@@ -752,11 +752,6 @@ a.btn {
 	text-shadow: none;
 }
 
-.box.category .item.feed {
-	padding: 2px 10px;
-	font-size: 0.8rem;
-}
-
 /*=== DIVERS */
 /*===========*/
 .aside.aside_feed .nav-form input,


### PR DESCRIPTION
Use the same `.box` layout for global view as in subscription management (same `font-size`, same `padding`).

Changes proposed in this pull request:

- (S)CSS

How to test the feature manually:

1. see the boxes in subscription management
2. see the boxes in global view


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested