### PR TITLE
improved: Pafat theme aside bar

### DIFF
--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -429,15 +429,18 @@ a.btn {
 	margin: 10px 0;
 }
 
+.tree-folder {
+	padding: 0.25rem 0.5rem;
+}
+
 .tree-folder-title {
-	margin: 5px;
 	padding: 0.125rem 0.5rem;
 	background: #5bc0de;
 	color: #fff;
 	font-size: 0.9rem;
 	border-top: 1px solid transparent;
 	border-bottom: 1px solid transparent;
-	border-radius: 5px;
+	border-radius: 0.25rem;
 	position: relative;
 	line-height: 2rem;
 }
@@ -459,10 +462,19 @@ a.btn {
 	border-bottom: 1px solid #666;
 }
 
-.tree-folder-items > .item {
-	padding: 0 10px;
+.aside_feed .configure-feeds .btn {
+	padding: 0.125rem 0.75rem;
+}
+
+
+.aside_feed .tree-folder-items > .item.feed {
+	padding: 0 0.5rem;
 	line-height: 2.5rem;
 	font-size: 0.8rem;
+}
+
+.aside .feed .item-title:not([data-unread="0"])::after {
+	right: 0.5rem;
 }
 
 .tree-folder-items > .item.active {
@@ -546,6 +558,10 @@ a.signin {
 .aside.aside_feed .feed .item-title:not([data-unread="0"])::after {
 	background-color: #5bc0de;
 	color: white;
+}
+
+.aside.aside_feed .tree-folder.category.active .feed .item-title:not([data-unread="0"])::after {
+	background-color: #39b3d7;
 }
 
 .aside.aside_feed .category .title:not([data-unread="0"])::after {

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -429,15 +429,18 @@ a.btn {
 	margin: 10px 0;
 }
 
+.tree-folder {
+	padding: 0.25rem 0.5rem;
+}
+
 .tree-folder-title {
-	margin: 5px;
 	padding: 0.125rem 0.5rem;
 	background: #5bc0de;
 	color: #fff;
 	font-size: 0.9rem;
 	border-top: 1px solid transparent;
 	border-bottom: 1px solid transparent;
-	border-radius: 5px;
+	border-radius: 0.25rem;
 	position: relative;
 	line-height: 2rem;
 }
@@ -459,10 +462,19 @@ a.btn {
 	border-bottom: 1px solid #666;
 }
 
-.tree-folder-items > .item {
-	padding: 0 10px;
+.aside_feed .configure-feeds .btn {
+	padding: 0.125rem 0.75rem;
+}
+
+
+.aside_feed .tree-folder-items > .item.feed {
+	padding: 0 0.5rem;
 	line-height: 2.5rem;
 	font-size: 0.8rem;
+}
+
+.aside .feed .item-title:not([data-unread="0"])::after {
+	left: 0.5rem;
 }
 
 .tree-folder-items > .item.active {
@@ -546,6 +558,10 @@ a.signin {
 .aside.aside_feed .feed .item-title:not([data-unread="0"])::after {
 	background-color: #5bc0de;
 	color: white;
+}
+
+.aside.aside_feed .tree-folder.category.active .feed .item-title:not([data-unread="0"])::after {
+	background-color: #39b3d7;
 }
 
 .aside.aside_feed .category .title:not([data-unread="0"])::after {

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1836,7 +1836,7 @@ input:checked + .slide-container .properties {
 
 .feed .item-title:not([data-unread="0"]) {
 	font-weight: bold;
-	width: calc(100% - 80px);
+	width: calc(100% - 5.5rem);
 }
 
 .state_unread .category:not(.active)[data-unread="0"],

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1836,7 +1836,7 @@ input:checked + .slide-container .properties {
 
 .feed .item-title:not([data-unread="0"]) {
 	font-weight: bold;
-	width: calc(100% - 80px);
+	width: calc(100% - 5.5rem);
 }
 
 .state_unread .category:not(.active)[data-unread="0"],


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/1645099/198880374-e597609a-6ea3-43cf-aab4-eed81a5014f3.png)


After:
1 + 2: same space between the blocks
3: a bit more space around the button's text
![grafik](https://user-images.githubusercontent.com/1645099/198880385-e250dcbe-17cb-42ff-b3cb-f34c5df679ee.png)


Before:
![grafik](https://user-images.githubusercontent.com/1645099/198880395-8df85ff8-8aa6-40ba-941b-f8be82d41f2b.png)


After:
1: if active category then the unread counter has the same darker blue like the category
2: if category is not active than it has the same (lighter) blue like the category
3: text cut improved
![grafik](https://user-images.githubusercontent.com/1645099/198880401-39001881-3b67-44cc-861f-d9bb4e95a945.png)



Changes proposed in this pull request:

- CSS


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
