### PR TITLE
fix: .icon height

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -728,8 +728,7 @@ input[type="checkbox"]:focus-visible {
 .icon {
 	display: inline-block;
 	max-width: none;
-	width: 1rem;
-	height: inherit;
+	height: 1rem;
 	vertical-align: middle;
 	line-height: 1;
 }

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -728,8 +728,7 @@ input[type="checkbox"]:focus-visible {
 .icon {
 	display: inline-block;
 	max-width: none;
-	width: 1rem;
-	height: inherit;
+	height: 1rem;
 	vertical-align: middle;
 	line-height: 1;
 }


### PR DESCRIPTION
Regression from #4711

Visible in Pafat theme:
![grafik](https://user-images.githubusercontent.com/1645099/198894991-28904469-6c73-43c3-af20-054cdea3fd73.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/198895006-f5a0f332-12ee-480e-a4d3-5404d0a6d0dd.png)



Pull request checklist:

- [x] clear commit messages
- [x] code manually tested