### PR TITLE
fix: Adark theme: line-height

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -709,6 +709,10 @@ kbd {
 	border-top: 1px solid var(--border-color-dark);
 }
 
+.day span {
+	line-height: 1.5;
+}
+
 #new-article + .day {
 	border-top: none;
 }

--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -80,13 +80,11 @@ textarea {
 }
 
 input, select, textarea {
-	padding: 5px;
+	padding: 7px;
 	background: var(--background-color-light);
 	color: var(--font-color-middle);
 	border: 1px solid var(--border-color-middle);
 	border-radius: 3px;
-	min-height: 25px;
-	line-height: 25px;
 	vertical-align: middle;
 }
 
@@ -95,10 +93,6 @@ select:hover,
 textarea:hover,
 label:hover {
 	color: var(--font-color-light);
-}
-
-select {
-	padding: 10px 0px 9px;
 }
 
 option {
@@ -215,7 +209,7 @@ form th {
 	border-radius: 3px;
 	min-height: 37px;
 	min-width: 15px;
-	line-height: 25px;
+	line-height: 1.7;
 	vertical-align: middle;
 	cursor: pointer;
 	overflow: hidden;
@@ -223,7 +217,6 @@ form th {
 
 a.btn {
 	min-height: 25px;
-	line-height: 25px;
 }
 
 .btn:hover {
@@ -291,8 +284,7 @@ a.btn {
 /*=== Navigation */
 .nav-list .nav-header,
 .nav-list .item {
-	height: 2.5em;
-	line-height: 2.5em;
+	line-height: 2.5;
 	color: var(--font-color-light);
 	font-size: 0.9rem;
 }
@@ -374,7 +366,7 @@ a.btn {
 .dropdown-menu > .item > span,
 .dropdown-menu > .item > .as-link {
 	padding: 0 22px;
-	line-height: 2.5em;
+	line-height: 2.5;
 	font-size: 0.8rem;
 }
 
@@ -477,7 +469,7 @@ kbd {
 
 .box .box-content .item {
 	font-size: 0.9rem;
-	line-height: 2.5em;
+	line-height: 2.5;
 }
 
 /*=== Tree */
@@ -489,7 +481,7 @@ kbd {
 	position: relative;
 	padding: 0 10px;
 	background: var(--background-color-light);
-	line-height: 2.5rem;
+	line-height: 2.5;
 	font-size: 1rem;
 }
 
@@ -533,7 +525,7 @@ kbd {
 
 .tree-folder-items > .item {
 	padding: 0 10px;
-	line-height: 2.5rem;
+	line-height: 3.1;
 	font-size: 0.8rem;
 }
 
@@ -598,7 +590,7 @@ kbd {
 /*=== Aside main page (categories) */
 .aside_feed .category .title:not([data-unread="0"])::after {
 	padding: 0 10px;
-	line-height: 1.5rem;
+	line-height: 1.5;
 }
 
 .aside.aside_feed .category .title:not([data-unread="0"])::after,
@@ -697,7 +689,7 @@ kbd {
 }
 
 #new-article > a {
-	line-height: 3em;
+	padding: 0.75rem;
 	color: var(--font-color-light);
 	font-weight: bold;
 }
@@ -711,7 +703,7 @@ kbd {
 .day {
 	padding: 0 10px;
 	font-weight: bold;
-	line-height: 3em;
+	line-height: 3;
 	background: var(--background-color-dark);
 	color: var(--font-color-light);
 	border-top: 1px solid var(--border-color-dark);
@@ -921,11 +913,11 @@ kbd {
 
 .notification a.close {
 	padding: 0 15px;
-	line-height: 3em;
+	line-height: 3;
 }
 
 .notification#actualizeProgress {
-	line-height: 2em;
+	line-height: 2;
 }
 
 /*=== "Load more" part */
@@ -950,7 +942,7 @@ kbd {
 	margin: 0;
 	background: var(--background-color-light);
 	text-align: center;
-	line-height: 3em;
+	line-height: 3;
 	table-layout: fixed;
 }
 

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -709,6 +709,10 @@ kbd {
 	border-top: 1px solid var(--border-color-dark);
 }
 
+.day span {
+	line-height: 1.5;
+}
+
 #new-article + .day {
 	border-top: none;
 }

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -80,13 +80,11 @@ textarea {
 }
 
 input, select, textarea {
-	padding: 5px;
+	padding: 7px;
 	background: var(--background-color-light);
 	color: var(--font-color-middle);
 	border: 1px solid var(--border-color-middle);
 	border-radius: 3px;
-	min-height: 25px;
-	line-height: 25px;
 	vertical-align: middle;
 }
 
@@ -95,10 +93,6 @@ select:hover,
 textarea:hover,
 label:hover {
 	color: var(--font-color-light);
-}
-
-select {
-	padding: 10px 0px 9px;
 }
 
 option {
@@ -215,7 +209,7 @@ form th {
 	border-radius: 3px;
 	min-height: 37px;
 	min-width: 15px;
-	line-height: 25px;
+	line-height: 1.7;
 	vertical-align: middle;
 	cursor: pointer;
 	overflow: hidden;
@@ -223,7 +217,6 @@ form th {
 
 a.btn {
 	min-height: 25px;
-	line-height: 25px;
 }
 
 .btn:hover {
@@ -291,8 +284,7 @@ a.btn {
 /*=== Navigation */
 .nav-list .nav-header,
 .nav-list .item {
-	height: 2.5em;
-	line-height: 2.5em;
+	line-height: 2.5;
 	color: var(--font-color-light);
 	font-size: 0.9rem;
 }
@@ -374,7 +366,7 @@ a.btn {
 .dropdown-menu > .item > span,
 .dropdown-menu > .item > .as-link {
 	padding: 0 22px;
-	line-height: 2.5em;
+	line-height: 2.5;
 	font-size: 0.8rem;
 }
 
@@ -477,7 +469,7 @@ kbd {
 
 .box .box-content .item {
 	font-size: 0.9rem;
-	line-height: 2.5em;
+	line-height: 2.5;
 }
 
 /*=== Tree */
@@ -489,7 +481,7 @@ kbd {
 	position: relative;
 	padding: 0 10px;
 	background: var(--background-color-light);
-	line-height: 2.5rem;
+	line-height: 2.5;
 	font-size: 1rem;
 }
 
@@ -533,7 +525,7 @@ kbd {
 
 .tree-folder-items > .item {
 	padding: 0 10px;
-	line-height: 2.5rem;
+	line-height: 3.1;
 	font-size: 0.8rem;
 }
 
@@ -598,7 +590,7 @@ kbd {
 /*=== Aside main page (categories) */
 .aside_feed .category .title:not([data-unread="0"])::after {
 	padding: 0 10px;
-	line-height: 1.5rem;
+	line-height: 1.5;
 }
 
 .aside.aside_feed .category .title:not([data-unread="0"])::after,
@@ -697,7 +689,7 @@ kbd {
 }
 
 #new-article > a {
-	line-height: 3em;
+	padding: 0.75rem;
 	color: var(--font-color-light);
 	font-weight: bold;
 }
@@ -711,7 +703,7 @@ kbd {
 .day {
 	padding: 0 10px;
 	font-weight: bold;
-	line-height: 3em;
+	line-height: 3;
 	background: var(--background-color-dark);
 	color: var(--font-color-light);
 	border-top: 1px solid var(--border-color-dark);
@@ -921,11 +913,11 @@ kbd {
 
 .notification a.close {
 	padding: 0 15px;
-	line-height: 3em;
+	line-height: 3;
 }
 
 .notification#actualizeProgress {
-	line-height: 2em;
+	line-height: 2;
 }
 
 /*=== "Load more" part */
@@ -950,7 +942,7 @@ kbd {
 	margin: 0;
 	background: var(--background-color-light);
 	text-align: center;
-	line-height: 3em;
+	line-height: 3;
 	table-layout: fixed;
 }
 


### PR DESCRIPTION
Follow up of https://github.com/FreshRSS/FreshRSS/issues/3733. This PR is for Alternative Dark theme

It improves also a bit the input styles. Now it looks a bit more beautiful:

Before:
![grafik](https://user-images.githubusercontent.com/1645099/199050886-96e0b107-81b0-488a-b31f-2c69dfdea906.png)


After:
![grafik](https://user-images.githubusercontent.com/1645099/199050836-0a61b569-bd21-49b1-9c1c-76ce9ac97afc.png)


Changes proposed in this pull request:

- CSS: `line-height` without units


How to test the feature manually:

1. use Alternative Dark theme


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
