### PR TITLE
fix: swage theme: jumping lines

### DIFF
--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -784,7 +784,6 @@ form th {
 .flux:hover:not(.current):hover .item.title,
 .flux .current:not(.current):hover .item.title {
 	background: #fff;
-	top: 0.15rem;
 }
 .flux.favorite:not(.current) {
 	background: #fff6da;

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -784,7 +784,6 @@ form th {
 .flux:hover:not(.current):hover .item.title,
 .flux .current:not(.current):hover .item.title {
 	background: #fff;
-	top: 0.15rem;
 }
 .flux.favorite:not(.current) {
 	background: #fff6da;

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -1015,7 +1015,6 @@ form {
 
 		&:not(.current):hover .item.title {
 			background: $color_hover;
-			top: 0.15rem;
 		}
 	}
 


### PR DESCRIPTION
There was 1 line missed in the SCSS file `swage.scss` that brought back the jumping lines issue.

Changes proposed in this pull request:

- (S)CSS


How to test the feature manually:

1. use Swage theme
2. hover over the lines of the normal view


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested


(Maybe it is just a zombie because of Halloween ;) )