### PR TITLE
fix: Theme "Dark": text of theme slider

### DIFF
--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -947,6 +947,10 @@ a.btn {
 	border-left: 1px solid #666;
 }
 
+.properties {
+	color: #111;
+}
+
 /*=== DIVERS */
 /*===========*/
 .aside.aside_feed .nav-form input,

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -947,6 +947,10 @@ a.btn {
 	border-right: 1px solid #666;
 }
 
+.properties {
+	color: #111;
+}
+
 /*=== DIVERS */
 /*===========*/
 .aside.aside_feed .nav-form input,


### PR DESCRIPTION
Theme: dark (not alternative dark)

Before:
![grafik](https://user-images.githubusercontent.com/1645099/199324023-682818e5-b76f-411a-bad0-7936e799e1d2.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/199324100-ca7118c6-5d84-4168-bef7-e1bbafda7c7e.png)


Changes proposed in this pull request:

- CSS


How to test the feature manually:

1. see the text on the theme slider


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
