### PR TITLE
fix: dyn. OPML icon

### DIFF
--- a/app/Models/Themes.php
+++ b/app/Models/Themes.php
@@ -144,9 +144,9 @@ class FreshRSS_Themes extends Minz_Model {
 		}
 
 		if ($type == self::ICON_DEFAULT) {
-			if ((FreshRSS_Context::$user_conf && FreshRSS_Context::$user_conf->icons_as_emojis) ||
+			if ((FreshRSS_Context::$user_conf && FreshRSS_Context::$user_conf->icons_as_emojis)
 				// default to emoji alternate for some icons
-				in_array($name, [ 'opml-dyn' ])) {
+				) {
 				$type = self::ICON_EMOJI;
 			} else {
 				$type = self::ICON_IMG;

--- a/app/views/subscription/index.phtml
+++ b/app/views/subscription/index.phtml
@@ -35,8 +35,7 @@
 		<div class="box">
 			<div class="box-title">
 				<a class="configure open-slider" href="<?= _url('subscription', 'category', 'id', $cat->id()) ?>" data-cat-position="<?= $cat->attributes('position') ?>"><?= _i('configure') ?></a>
-				<h2><?= $cat->name() ?></h2>
-				<?php if ($cat->kind() == FreshRSS_Category::KIND_DYNAMIC_OPML) { echo _i('opml-dyn'); } ?>
+				<h2><?= $cat->name() ?><?php if ($cat->kind() == FreshRSS_Category::KIND_DYNAMIC_OPML) { echo " " . _i('opml-dyn'); } ?></h2>
 			</div>
 			<ul class="box-content drop-zone scrollbar-thin" dropzone="move" data-cat-id="<?= $cat->id() ?>">
 				<?php

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -98,6 +98,12 @@ h2 {
 	line-height: 1.5;
 }
 
+h2 .icon,
+legend .icon {
+	height: 0.8em;
+	vertical-align: baseline;
+}
+
 h3 {
 	margin: 0.5rem 0 0.25rem;
 	font-size: 1.2rem;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -98,6 +98,12 @@ h2 {
 	line-height: 1.5;
 }
 
+h2 .icon,
+legend .icon {
+	height: 0.8em;
+	vertical-align: baseline;
+}
+
 h3 {
 	margin: 0.5rem 0 0.25rem;
 	font-size: 1.2rem;


### PR DESCRIPTION
Closes #4683

After:
![grafik](https://user-images.githubusercontent.com/1645099/199823854-efba4de0-ad62-4ee7-a6f3-0cbbb1028d1a.png)

![grafik](https://user-images.githubusercontent.com/1645099/199823941-d0a1247b-46a4-4e79-8652-1ba600c78c8e.png)

![grafik](https://user-images.githubusercontent.com/1645099/199824077-5487a8ce-1e95-419b-ae46-558c71bbc95f.png)


Changes proposed in this pull request:

- CSS
- revert the exception for the icon


How to test the feature manually:

see screenshots

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
