### PR TITLE
fix: Pafat theme: aside navigation bar: icons

### DIFF
--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -452,8 +452,17 @@ a.btn {
 	text-decoration: none;
 }
 
+.item.feed.error .item-title::before {
+	font-size: 1rem;
+	font-weight: normal;
+	line-height: 1;
+}
+
 .tree-folder-title .title.error::before {
-	color: #fff;
+	color: #f0ad4e;
+	font-size: 1.2rem;
+	font-weight: normal;
+	line-height: 1;
 }
 
 .tree-folder-title .title .icon {

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -452,6 +452,14 @@ a.btn {
 	text-decoration: none;
 }
 
+.tree-folder-title .title.error::before {
+	color: #fff;
+}
+
+.tree-folder-title .title .icon {
+	filter: brightness(2.5);
+}
+
 .tree-folder.active .tree-folder-title {
 	background: #39b3d7;
 	font-weight: bold;

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -452,8 +452,17 @@ a.btn {
 	text-decoration: none;
 }
 
+.item.feed.error .item-title::before {
+	font-size: 1rem;
+	font-weight: normal;
+	line-height: 1;
+}
+
 .tree-folder-title .title.error::before {
-	color: #fff;
+	color: #f0ad4e;
+	font-size: 1.2rem;
+	font-weight: normal;
+	line-height: 1;
 }
 
 .tree-folder-title .title .icon {

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -452,6 +452,14 @@ a.btn {
 	text-decoration: none;
 }
 
+.tree-folder-title .title.error::before {
+	color: #fff;
+}
+
+.tree-folder-title .title .icon {
+	filter: brightness(2.5);
+}
+
 .tree-folder.active .tree-folder-title {
 	background: #39b3d7;
 	font-weight: bold;


### PR DESCRIPTION
After:
Warning icon and dyn. OPML logo are now in white. It is better readable
![grafik](https://user-images.githubusercontent.com/1645099/199842234-ee70e06b-5d2c-4e54-8693-46256140c37e.png)


Changes proposed in this pull request:

- CSS


How to test the feature manually:

1. use Pafat theme
2. warning icon: an error feed is needed
3. dyn. OPML logo: a category with dyn. OPML is needed

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
