### PR TITLE
Exclude .git folder

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 *.min.js
+.git/
 extensions/
 node_modules/
 p/scripts/vendor/

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,3 +1,4 @@
+.git/
 node_modules/
 p/scripts/bcrypt.min.js
 p/scripts/vendor/

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,3 +1,4 @@
+.git/
 lib/phpgt/
 lib/phpmailer/
 node_modules/

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,3 +1,4 @@
+.git/
 extensions/
 node_modules/
 p/scripts/vendor/

--- a/.typos.toml
+++ b/.typos.toml
@@ -13,6 +13,7 @@ extend-exclude = [
 	"*.po",
 	"*.pot",
 	"*.rtl.css",
+	".git/",
 	"app/i18n/cz/",
 	"app/i18n/de/",
 	"app/i18n/es/",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,6 +3,7 @@
 	<description>Created with the PHP Coding Standard Generator. https://edorian.github.com/php-coding-standard-generator/</description>
 	<arg name="extensions" value="php,phtml,css,js"/>
 	<arg name="tab-width" value="4"/>
+	<exclude-pattern>./.git/</exclude-pattern>
 	<exclude-pattern>./lib/SimplePie/</exclude-pattern>
 	<exclude-pattern>./lib/phpgt/</exclude-pattern>
 	<exclude-pattern>./lib/phpmailer/</exclude-pattern>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,7 @@ parameters:
 	paths:
 		- .
 	excludePaths:
+		- .git/*
 		- lib/phpmailer/*
 		- lib/SimplePie/*
 		- node_modules/*


### PR DESCRIPTION
Some tests were searching in the .git/ folder, leading to some errors. Example

```
phpcs . -s

FILE: /home/alex/GitHub/FreshRSS/.git/logs/refs/remotes/mathContao/css-notification-frss.css
--------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
--------------------------------------------------------------------------------------------------
 1 | WARNING | File appears to be minified and cannot be processed
   |         | (Internal.Tokenizer.Exception)
--------------------------------------------------------------------------------------------------
```
