### PR TITLE
Fix remember opened categories

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -777,8 +777,10 @@ function rememberOpenCategory(category_id, isOpen) {
 
 function openCategory(category_id) {
 	const category_element = document.getElementById(category_id);
+	if (!category_element) return;
 	category_element.querySelector('.tree-folder-items').classList.add('active');
 	const img = category_element.querySelector('a.dropdown-toggle img');
+	if (!img) return;
 	img.src = img.src.replace('/icons/down.', '/icons/up.');
 	img.alt = '🔼';
 }


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/4826 Was crashing if a category did not exist anymore
