### PR TITLE
Fix: broken HTML

### DIFF
--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -466,7 +466,7 @@
 				</div>
 			</div>
 			<div class="form-group">
-				<label class="group-name" for="xPathItemTimeFormat"><small>
+				<label class="group-name" for="xPathItemTimeFormat">
 					<?= _t('sub.feed.kind.html_xpath.item_timeFormat') ?></label>
 				<div class="group-controls">
 					<textarea class="w100" name="xPathItemTimeFormat" id="xPathItemTimeFormat" rows="2" cols="64" spellcheck="false"


### PR DESCRIPTION
an open `<small>` without a `</small>`.

It is not necessary there

Changes proposed in this pull request:

- .phtml


How to test the feature manually:

1. edit a feed in the subscription menu
2. see (XPath) `Custom date/time format` input


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
