### PR TITLE
Fix feed ordering

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -103,9 +103,7 @@ class FreshRSS_Category extends Minz_Model {
 				$this->hasFeedsWithError |= $feed->inError();
 			}
 
-			usort($this->feeds, function ($a, $b) {
-				return strnatcasecmp($a->name(), $b->name());
-			});
+			$this->sortFeeds();
 		}
 
 		return $this->feeds;
@@ -144,6 +142,7 @@ class FreshRSS_Category extends Minz_Model {
 		}
 
 		$this->feeds = $values;
+		$this->sortFeeds();
 	}
 
 	/**
@@ -155,6 +154,8 @@ class FreshRSS_Category extends Minz_Model {
 			$this->feeds = [];
 		}
 		$this->feeds[] = $feed;
+
+		$this->sortFeeds();
 	}
 
 	public function _attributes($key, $value) {
@@ -244,5 +245,11 @@ class FreshRSS_Category extends Minz_Model {
 		$catDAO->updateLastUpdate($this->id(), !$ok);
 
 		return $ok;
+	}
+
+	private function sortFeeds() {
+		usort($this->feeds, static function ($a, $b) {
+			return strnatcasecmp($a->name(), $b->name());
+		});
 	}
 }

--- a/tests/app/Models/CategoryTest.php
+++ b/tests/app/Models/CategoryTest.php
@@ -30,4 +30,54 @@ class CategoryTest extends PHPUnit\Framework\TestCase {
 		);
 	}
 
+	public function test_feedOrdering() {
+		$feed_1 = $this->getMockBuilder(FreshRSS_Feed::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$feed_1->expects($this->any())
+			->method('name')
+			->willReturn('AAA');
+
+		$feed_2 = $this->getMockBuilder(FreshRSS_Feed::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$feed_2->expects($this->any())
+			->method('name')
+			->willReturn('ZZZ');
+
+		$feed_3 = $this->getMockBuilder(FreshRSS_Feed::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$feed_3->expects($this->any())
+			->method('name')
+			->willReturn('lll');
+
+		$category = new FreshRSS_Category('test', [
+			$feed_1,
+			$feed_2,
+			$feed_3,
+		]);
+		$feeds = $category->feeds();
+
+		$this->assertCount(3, $feeds);
+		$this->assertEquals('AAA', $feeds[0]->name());
+		$this->assertEquals('lll', $feeds[1]->name());
+		$this->assertEquals('ZZZ', $feeds[2]->name());
+
+		$feed_4 = $this->getMockBuilder(FreshRSS_Feed::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$feed_4->expects($this->any())
+			->method('name')
+			->willReturn('BBB');
+
+		$category->addFeed($feed_4);
+		$feeds = $category->feeds();
+
+		$this->assertCount(4, $feeds);
+		$this->assertEquals('AAA', $feeds[0]->name());
+		$this->assertEquals('BBB', $feeds[1]->name());
+		$this->assertEquals('lll', $feeds[2]->name());
+		$this->assertEquals('ZZZ', $feeds[3]->name());
+	}
 }


### PR DESCRIPTION
Closes #4790

Changes proposed in this pull request:

- sort feeds in category in a consistent manner.

How to test the feature manually:

1. Check the feed order within a category in the subscription page
2. Validate that the order is the same in normal view
3. Validate that the order is the same in global view

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).

Before, the feeds were not ordered every time there was a change in the category feed list. This behavior was causing discrepancies in the displayed list. Now, the feeds are ordered every time there is a change in the category feed list.