### PR TITLE
fix: Close button for slider in Origine theme

### DIFF
--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -1132,7 +1132,8 @@ a:hover .icon {
 
 	.aside .toggle_aside,
 	#panel .close,
-	.dropdown-menu .toggle_aside {
+	.dropdown-menu .toggle_aside,
+	#slider .toggle_aside {
 		background-color: var(--background-color-light-shadowed);
 		border-bottom: 1px solid var(--border-color);
 	}

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -1132,7 +1132,8 @@ a:hover .icon {
 
 	.aside .toggle_aside,
 	#panel .close,
-	.dropdown-menu .toggle_aside {
+	.dropdown-menu .toggle_aside,
+	#slider .toggle_aside {
 		background-color: var(--background-color-light-shadowed);
 		border-bottom: 1px solid var(--border-color);
 	}


### PR DESCRIPTION
Before: 
Close button has not the same stile everywhere in Origine theme
![grafik](https://user-images.githubusercontent.com/1645099/201498503-7c248b9f-11bf-4636-8dae-e8ca2f04a262.png)

How it should look like:
![grafik](https://user-images.githubusercontent.com/1645099/201498514-391c1fff-36d4-4ec7-9bfb-173281d0de98.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/201498519-a79819f1-31eb-4f6c-ac92-5ead93cf7ee4.png)



Changes proposed in this pull request:

- CSS


How to test the feature manually:

1. open slider in mobile view (f.e. config a category)
2. see the close button


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
