### PR TITLE
Use the correct font file for Lato in bold

### DIFF
--- a/p/themes/Mapco/_fonts.scss
+++ b/p/themes/Mapco/_fonts.scss
@@ -19,7 +19,7 @@
 	font-style: normal;
 	font-stretch: normal;
 	font-weight: 700;
-	src: url("../fonts/LatoLatin-Regular.woff") format("woff");
+	src: url("../fonts/LatoLatin-Bold.woff") format("woff");
 }
 
 @font-face {

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -17,7 +17,7 @@
 	font-style: normal;
 	font-stretch: normal;
 	font-weight: 700;
-	src: url("../fonts/LatoLatin-Regular.woff") format("woff");
+	src: url("../fonts/LatoLatin-Bold.woff") format("woff");
 }
 @font-face {
 	font-family: "lato";

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -17,7 +17,7 @@
 	font-style: normal;
 	font-stretch: normal;
 	font-weight: 700;
-	src: url("../fonts/LatoLatin-Regular.woff") format("woff");
+	src: url("../fonts/LatoLatin-Bold.woff") format("woff");
 }
 @font-face {
 	font-family: "lato";


### PR DESCRIPTION
Closes #4849

Changes proposed in this pull request:

- Use LatoLatin-Regular.woff for Lato with `font-weight: bold`

How to test the feature manually:

1. Pull the branch
2. Launch FreshRSS from the branch
3. Set Mapco as the theme
4. The title of unread articles should be rendered in bold

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
