### PR TITLE
Fix type hints regressions

### DIFF
--- a/app/Controllers/updateController.php
+++ b/app/Controllers/updateController.php
@@ -217,7 +217,7 @@ class FreshRSS_update_Controller extends FreshRSS_ActionController {
 	}
 
 	public function applyAction() {
-		if (Minz_Configuration::get('system')->disable_update || !file_exists(UPDATE_FILENAME) || !touch(FRESHRSS_PATH . '/index.html')) {
+		if (FreshRSS_Context::$system_conf->disable_update || !file_exists(UPDATE_FILENAME) || !touch(FRESHRSS_PATH . '/index.html')) {
 			Minz_Request::forward(array('c' => 'update'), true);
 		}
 

--- a/app/Models/Context.php
+++ b/app/Models/Context.php
@@ -58,12 +58,7 @@ class FreshRSS_Context {
 	public static function initSystem($reload = false) {
 		if ($reload || FreshRSS_Context::$system_conf == null) {
 			//TODO: Keep in session what we need instead of always reloading from disk
-			Minz_Configuration::register('system', DATA_PATH . '/config.php', FRESHRSS_PATH . '/config.default.php');
-			/**
-			 * @var FreshRSS_SystemConfiguration $system_conf
-			 */
-			$system_conf = Minz_Configuration::get('system');
-			FreshRSS_Context::$system_conf = $system_conf;
+			FreshRSS_Context::$system_conf = FreshRSS_SystemConfiguration::init(DATA_PATH . '/config.php', FRESHRSS_PATH . '/config.default.php');
 			// Register the configuration setter for the system configuration
 			$configurationSetter = new FreshRSS_ConfigurationSetter();
 			FreshRSS_Context::$system_conf->_configurationSetter($configurationSetter);
@@ -88,17 +83,12 @@ class FreshRSS_Context {
 			(!$userMustExist || FreshRSS_user_Controller::userExists($username))) {
 			try {
 				//TODO: Keep in session what we need instead of always reloading from disk
-				Minz_Configuration::register('user',
+				FreshRSS_Context::$user_conf = FreshRSS_UserConfiguration::init(
 					USERS_PATH . '/' . $username . '/config.php',
 					FRESHRSS_PATH . '/config-user.default.php',
 					FreshRSS_Context::$system_conf->configurationSetter());
 
 				Minz_Session::_param('currentUser', $username);
-				/**
-				 * @var FreshRSS_UserConfiguration $user_conf
-				 */
-				$user_conf = Minz_Configuration::get('user');
-				FreshRSS_Context::$user_conf = $user_conf;
 			} catch (Exception $ex) {
 				Minz_Log::warning($ex->getMessage(), USERS_PATH . '/_/' . LOG_FILENAME);
 			}

--- a/app/Models/SystemConfiguration.php
+++ b/app/Models/SystemConfiguration.php
@@ -25,6 +25,10 @@
  * @property string $unsafe_autologin_enabled
  * @property-read array<string> $trusted_sources
  */
-class FreshRSS_SystemConfiguration extends Minz_Configuration {
+final class FreshRSS_SystemConfiguration extends Minz_Configuration {
 
+	public static function init($config_filename, $default_filename = null): FreshRSS_SystemConfiguration {
+		parent::register('system', $config_filename, $default_filename);
+		return parent::get('system');
+	}
 }

--- a/app/Models/UserConfiguration.php
+++ b/app/Models/UserConfiguration.php
@@ -66,6 +66,10 @@
  * @property string $view_mode
  * @property array<string,mixed> $volatile
  */
-class FreshRSS_UserConfiguration extends Minz_Configuration {
+final class FreshRSS_UserConfiguration extends Minz_Configuration {
 
+	public static function init($config_filename, $default_filename = null, $configuration_setter = null): FreshRSS_UserConfiguration {
+		parent::register('user', $config_filename, $default_filename, $configuration_setter);
+		return parent::get('user');
+	}
 }

--- a/app/install.php
+++ b/app/install.php
@@ -283,11 +283,7 @@ function freshrss_already_installed() {
 	// A configuration file already exists, we try to load it.
 	$system_conf = null;
 	try {
-		Minz_Configuration::register('system', $conf_path);
-		/**
-		 * @var FreshRSS_SystemConfiguration $system_conf
-		 */
-		$system_conf = Minz_Configuration::get('system');
+		$system_conf = FreshRSS_SystemConfiguration::init($conf_path);
 	} catch (Minz_FileNotExistException $e) {
 		return false;
 	}
@@ -295,7 +291,7 @@ function freshrss_already_installed() {
 	// ok, the global conf exists… but what about default user conf?
 	$current_user = $system_conf->default_user;
 	try {
-		Minz_Configuration::register('user', join_path(USERS_PATH, $current_user, 'config.php'));
+		FreshRSS_UserConfiguration::init(USERS_PATH . '/' . $current_user . '/config.php');
 	} catch (Minz_FileNotExistException $e) {
 		return false;
 	}

--- a/app/layout/aside_configure.phtml
+++ b/app/layout/aside_configure.phtml
@@ -1,8 +1,8 @@
 <nav class="nav nav-list aside" id="aside_feed">
 	<a class="toggle_aside" href="#close"><?= _i('close') ?></a>
-	
+
 	<ul>
-		<li class="nav-header"><?= _t('gen.menu.account') ?>: <?= htmlspecialchars(Minz_Session::param('currentUser', '_'), ENT_NOQUOTES, 'UTF-8')?></li>	
+		<li class="nav-header"><?= _t('gen.menu.account') ?>: <?= htmlspecialchars(Minz_Session::param('currentUser', '_'), ENT_NOQUOTES, 'UTF-8')?></li>
 		<li class="item<?= Minz_Request::controllerName() === 'user' && Minz_Request::actionName() === 'profile' ? ' active' : '' ?>">
 			<a href="<?= _url('user', 'profile') ?>"><?= _t('gen.menu.user_profile') ?></a>
 		</li>
@@ -54,7 +54,7 @@
 		<li class="item<?= Minz_Request::controllerName() === 'update' && Minz_Request::actionName() === 'checkInstall' ? ' active' : '' ?>">
 			<a href="<?= _url('update', 'checkInstall') ?>"><?= _t('gen.menu.check_install') ?></a>
 		</li>
-		<?php if (!Minz_Configuration::get('system')->disable_update) { ?>
+		<?php if (!FreshRSS_Context::$system_conf->disable_update) { ?>
 		<li class="item<?= Minz_Request::controllerName() === 'update' && Minz_Request::actionName() === 'index' ? ' active' : '' ?>">
 			<a href="<?= _url('update', 'index') ?>"><?= _t('gen.menu.update') ?></a>
 		</li>

--- a/app/layout/header.phtml
+++ b/app/layout/header.phtml
@@ -71,7 +71,7 @@
 				<li class="item"><a href="<?= _url('user', 'manage') ?>"><?= _t('gen.menu.user_management') ?></a></li>
 				<li class="item"><a href="<?= _url('auth', 'index') ?>"><?= _t('gen.menu.authentication') ?></a></li>
 				<li class="item"><a href="<?= _url('update', 'checkInstall') ?>"><?= _t('gen.menu.check_install') ?></a></li>
-				<?php if (!Minz_Configuration::get('system')->disable_update) { ?>
+				<?php if (!FreshRSS_Context::$system_conf->disable_update) { ?>
 				<li class="item"><a href="<?= _url('update', 'index') ?>"><?= _t('gen.menu.update') ?></a></li>
 				<?php } ?>
 				<?= Minz_ExtensionManager::callHook('menu_admin_entry') ?>

--- a/lib/Minz/Configuration.php
+++ b/lib/Minz/Configuration.php
@@ -26,7 +26,7 @@ class Minz_Configuration {
 	 * @param object $configuration_setter an optional helper to set values in configuration
 	 */
 	public static function register($namespace, $config_filename, $default_filename = null, $configuration_setter = null) {
-		self::$config_list[$namespace] = new Minz_Configuration(
+		self::$config_list[$namespace] = new static(
 			$namespace, $config_filename, $default_filename, $configuration_setter
 		);
 	}
@@ -51,7 +51,7 @@ class Minz_Configuration {
 	 * Return the configuration related to a given namespace.
 	 *
 	 * @param string $namespace the name of the configuration to get.
-	 * @return Minz_Configuration object
+	 * @return static object
 	 * @throws Minz_ConfigurationNamespaceException if the namespace does not exist.
 	 */
 	public static function get($namespace) {
@@ -117,7 +117,7 @@ class Minz_Configuration {
 	 * @param string $default_filename the file containing default values, null by default.
 	 * @param object $configuration_setter an optional helper to set values in configuration
 	 */
-	private function __construct($namespace, $config_filename, $default_filename = null, $configuration_setter = null) {
+	private final function __construct($namespace, $config_filename, $default_filename = null, $configuration_setter = null) {
 		$this->namespace = $namespace;
 		$this->config_filename = $config_filename;
 		$this->default_filename = $default_filename;


### PR DESCRIPTION
Fix regressions from https://github.com/FreshRSS/FreshRSS/pull/4561 , which added some hard type hints but without ensuring that the code paths would provide strictly identical class types.

Example:

```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to checkToken() must be an instance of FreshRSS_UserConfiguration, instance of Minz_Configuration given, called in /var/www/FreshRSS/p/api/greader.php on line 1091 and defined in /var/www/FreshRSS/p/api/greader.php:223
Stack trace:
#0 /var/www/FreshRSS/p/api/greader.php(1091): checkToken()
#1 {main}
  thrown in /var/www/FreshRSS/p/api/greader.php on line 223
```

I refactored the way we access our configuration to have stricter types, improvement of https://github.com/FreshRSS/FreshRSS/pull/4110
More work could be done to simplify the way we work with configurations.