### PR TITLE
Apache TraceEnable Off

### DIFF
--- a/Docker/FreshRSS.Apache.conf
+++ b/Docker/FreshRSS.Apache.conf
@@ -8,6 +8,7 @@ CustomLog /dev/stdout combined_proxy
 ErrorLog /dev/stderr
 AllowEncodedSlashes On
 ServerTokens OS
+TraceEnable Off
 
 <Directory />
 	AllowOverride None


### PR DESCRIPTION
I have just received an e-mail with a security concern.
Although most likely an obsolete concern (old browsers with Java applets), and the Apache team saying that there is no problem, let's disable the TRACE method by default in our Docker images until we hear anybody actually wanting this feature.

* https://httpd.apache.org/docs/current/mod/core.html#traceenable
* https://owasp.org/www-community/attacks/Cross_Site_Tracing
