### PR TITLE
fix: Reader view on mobile screen

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2129,6 +2129,10 @@ input:checked + .slide-container .properties {
 		top: 0;
 	}
 
+	.reader .flux .content {
+		padding: 1rem;
+	}
+
 	.notification {
 		top: 0;
 		left: 0;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2129,6 +2129,10 @@ input:checked + .slide-container .properties {
 		top: 0;
 	}
 
+	.reader .flux .content {
+		padding: 1rem;
+	}
+
 	.notification {
 		top: 0;
 		right: 0;


### PR DESCRIPTION
Closes #4864

Changes proposed in this pull request:

- CSS

How to test the feature manually:

1. use reader view
2. see the articles on a mobile device/small screen
3. see the padding between border and article text

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
