### PR TITLE
fix: over flowing table that destroy the layout

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -123,8 +123,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 	border: 1px solid var(--border-color-dark);
 }
 

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -123,8 +123,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 	border: 1px solid var(--border-color-dark);
 }
 

--- a/p/themes/Ansum/_tables.scss
+++ b/p/themes/Ansum/_tables.scss
@@ -5,8 +5,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 	border: 1px solid variables.$grey-medium-light;
 }
 

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -201,8 +201,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 	border: 1px solid #e4d8cc;
 }
 

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -201,8 +201,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 	border: 1px solid #e4d8cc;
 }
 

--- a/p/themes/BlueLagoon/BlueLagoon.css
+++ b/p/themes/BlueLagoon/BlueLagoon.css
@@ -75,8 +75,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 	border: 1px solid #ddd;
 }
 

--- a/p/themes/BlueLagoon/BlueLagoon.rtl.css
+++ b/p/themes/BlueLagoon/BlueLagoon.rtl.css
@@ -75,8 +75,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 	border: 1px solid #ddd;
 }
 

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -87,8 +87,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 	border: 1px solid #333;
 }
 

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -87,8 +87,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 	border: 1px solid #333;
 }
 

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -79,8 +79,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 	border: 1px solid #ddd;
 }
 

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -79,8 +79,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 	border: 1px solid #ddd;
 }
 

--- a/p/themes/Mapco/_tables.scss
+++ b/p/themes/Mapco/_tables.scss
@@ -5,8 +5,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 	border: 1px solid variables.$grey-medium-light;
 }
 

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -200,8 +200,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 	border: 1px solid #d5d8db;
 }
 

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -200,8 +200,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 	border: 1px solid #d5d8db;
 }
 

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -95,10 +95,6 @@ button.as-link[disabled] {
 }
 
 /*=== Tables */
-tr, th, td {
-	padding: 0.5em;
-}
-
 form td,
 form th {
 	font-weight: normal;

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -95,10 +95,6 @@ button.as-link[disabled] {
 }
 
 /*=== Tables */
-tr, th, td {
-	padding: 0.5em;
-}
-
 form td,
 form th {
 	font-weight: normal;

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -156,8 +156,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 	border: 1px solid var(--border-color);
 }
 

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -156,8 +156,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 	border: 1px solid var(--border-color);
 }
 

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -69,8 +69,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 	border: 1px solid #ddd;
 }
 

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -69,8 +69,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 	border: 1px solid #ddd;
 }
 

--- a/p/themes/Screwdriver/screwdriver.css
+++ b/p/themes/Screwdriver/screwdriver.css
@@ -73,8 +73,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 	border: 1px solid #ddd;
 }
 

--- a/p/themes/Screwdriver/screwdriver.rtl.css
+++ b/p/themes/Screwdriver/screwdriver.rtl.css
@@ -73,8 +73,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 	border: 1px solid #ddd;
 }
 

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -162,10 +162,8 @@ table {
 	border-collapse: collapse;
 }
 
-tr,
 td,
 th {
-	padding: 0.5em;
 	border: 1px solid var(--color-border-light-darker);
 }
 

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -162,10 +162,8 @@ table {
 	border-collapse: collapse;
 }
 
-tr,
 td,
 th {
-	padding: 0.5em;
 	border: 1px solid var(--color-border-light-darker);
 }
 

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -202,10 +202,8 @@ table {
 	border-collapse: collapse;
 }
 
-tr,
 td,
 th {
-	padding: 0.5em;
 	border: 1px solid var(--color-border-light-darker);
 }
 

--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -61,8 +61,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 }
 
 th {

--- a/p/themes/base-theme/base.rtl.css
+++ b/p/themes/base-theme/base.rtl.css
@@ -61,8 +61,7 @@ table {
 	border-collapse: collapse;
 }
 
-tr, th, td {
-	padding: 0.5em;
+th, td {
 }
 
 th {

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -334,7 +334,12 @@ button.as-link[disabled] {
 }
 
 table {
+	margin: 0.5rem 0;
 	max-width: 100%;
+}
+
+th, td {
+	padding: 0.5rem;
 }
 
 th.numeric,
@@ -1281,6 +1286,7 @@ a.website:hover .favicon {
 	padding: 0.75rem;
 	line-height: 1.5;
 	word-wrap: break-word;
+	overflow: auto;
 }
 
 .content.large {
@@ -2131,6 +2137,14 @@ input:checked + .slide-container .properties {
 
 	.reader .flux .content {
 		padding: 1rem;
+	}
+
+	table {
+		font-size: 0.9rem;
+	}
+
+	th, td {
+		padding: 0.25rem;
 	}
 
 	.notification {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -334,7 +334,12 @@ button.as-link[disabled] {
 }
 
 table {
+	margin: 0.5rem 0;
 	max-width: 100%;
+}
+
+th, td {
+	padding: 0.5rem;
 }
 
 th.numeric,
@@ -1281,6 +1286,7 @@ a.website:hover .favicon {
 	padding: 0.75rem;
 	line-height: 1.5;
 	word-wrap: break-word;
+	overflow: auto;
 }
 
 .content.large {
@@ -2131,6 +2137,14 @@ input:checked + .slide-container .properties {
 
 	.reader .flux .content {
 		padding: 1rem;
+	}
+
+	table {
+		font-size: 0.9rem;
+	}
+
+	th, td {
+		padding: 0.25rem;
 	}
 
 	.notification {


### PR DESCRIPTION
Closes #3129
Related https://github.com/FreshRSS/FreshRSS/pull/3819#issuecomment-910744111

Changes proposed in this pull request:

- (S)CSS

Before:
on tiny screens large tables could destroy the layout while over floating the border and stretch the whole layout.

The large, over floating table:
![grafik](https://user-images.githubusercontent.com/1645099/202853209-6f0507b1-71b8-444d-889c-178803690f08.png)

The whole Layout is broken:
![grafik](https://user-images.githubusercontent.com/1645099/202853568-ee21a4e2-bee5-4516-8692-118cc98fba9c.png)



After:
Table overflows, but does not shift the layout. In mobile view the font-size is a bit smaller (`0.9.rem`) than in normal view (`1rem`)
![grafik](https://user-images.githubusercontent.com/1645099/202853337-0342e794-a67c-4d68-8fcb-c27ec1b848ab.png)

The article with the over floating table is scrollable but has no effect on other articles. So the main layout will to be destroyed.
![grafik](https://user-images.githubusercontent.com/1645099/202853516-4626795f-abd7-48cd-9f66-6412c0538488.png)


![grafik](https://user-images.githubusercontent.com/1645099/202853581-071f57a1-9dd3-4955-af07-9dffbe4b4cde.png)




How to test the feature manually:

1. use a small screen
2. have a article with table that is wider than the screen
3. scroll the overflowing article


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
