### PR TITLE
Improved: Origine Compact theme

### DIFF
--- a/p/themes/Origine-compact/origine-compact.css
+++ b/p/themes/Origine-compact/origine-compact.css
@@ -6,12 +6,6 @@
 	--frss-padding-top-bottom: 0.125rem;
 }
 
-input, select, textarea {
-	padding: 3px 5px 2px 5px;
-	min-height: 25px;
-	line-height: 2;
-}
-
 /*=== COMPONENTS */
 /*===============*/
 /*=== Forms */
@@ -58,24 +52,19 @@ a.btn,
 /*=== STRUCTURE */
 /*===============*/
 /*=== Header */
-.header .item.configure .btn,
-.header .item.search .btn {
-	min-height: 18px;
-	padding: 4px 10px;
-	line-height: 1.4;
+.header {
+	/* search bar and config button height = 2.1rem */
+	height: calc(2.1rem + 2 * var(--frss-padding-top-bottom));
 }
 
 .header > .item.title .logo {
+	/* logo is smaller than needed */
 	height: 1.5rem;
-}
-
-.header > .item.search input {
-	padding: 1px 5px;
 }
 
 /*=== Body */
 #global {
-	height: calc(100vh - (calc(1.5rem + 2 * var(--frss-padding-top-bottom))))
+	height: calc(100vh - (calc(2.1rem + 2 * var(--frss-padding-top-bottom))))
 }
 
 /*=== Aside main page (categories) */

--- a/p/themes/Origine-compact/origine-compact.rtl.css
+++ b/p/themes/Origine-compact/origine-compact.rtl.css
@@ -6,12 +6,6 @@
 	--frss-padding-top-bottom: 0.125rem;
 }
 
-input, select, textarea {
-	padding: 3px 5px 2px 5px;
-	min-height: 25px;
-	line-height: 2;
-}
-
 /*=== COMPONENTS */
 /*===============*/
 /*=== Forms */
@@ -58,24 +52,19 @@ a.btn,
 /*=== STRUCTURE */
 /*===============*/
 /*=== Header */
-.header .item.configure .btn,
-.header .item.search .btn {
-	min-height: 18px;
-	padding: 4px 10px;
-	line-height: 1.4;
+.header {
+	/* search bar and config button height = 2.1rem */
+	height: calc(2.1rem + 2 * var(--frss-padding-top-bottom));
 }
 
 .header > .item.title .logo {
+	/* logo is smaller than needed */
 	height: 1.5rem;
-}
-
-.header > .item.search input {
-	padding: 1px 5px;
 }
 
 /*=== Body */
 #global {
-	height: calc(100vh - (calc(1.5rem + 2 * var(--frss-padding-top-bottom))))
+	height: calc(100vh - (calc(2.1rem + 2 * var(--frss-padding-top-bottom))))
 }
 
 /*=== Aside main page (categories) */

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -118,7 +118,6 @@ h3 {
 /*=== Paragraphs */
 p {
 	margin: 1rem 0 0.5rem;
-	font-size: 1rem;
 }
 
 p.help, .prompt p.help {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -118,7 +118,6 @@ h3 {
 /*=== Paragraphs */
 p {
 	margin: 1rem 0 0.5rem;
-	font-size: 1rem;
 }
 
 p.help, .prompt p.help {


### PR DESCRIPTION
Cleanup CSS code for Origine Compact theme. Now it uses more the Origine theme code base

Changes proposed in this pull request:

- CSS


How to test the feature manually:

1. use Origine Compact theme


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
