### PR TITLE
fix: Swage theme

### DIFF
--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -572,6 +572,7 @@ form th {
 	height: auto;
 }
 .header > .item {
+	padding: 0;
 	vertical-align: middle;
 }
 .header > .item.title {
@@ -724,6 +725,7 @@ form th {
 }
 
 .nav_menu {
+	padding: 0;
 	width: 100%;
 	font-size: 0;
 	background-color: var(--color-background-nav);

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -572,6 +572,7 @@ form th {
 	height: auto;
 }
 .header > .item {
+	padding: 0;
 	vertical-align: middle;
 }
 .header > .item.title {
@@ -724,6 +725,7 @@ form th {
 }
 
 .nav_menu {
+	padding: 0;
 	width: 100%;
 	font-size: 0;
 	background-color: var(--color-background-nav);

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -727,6 +727,7 @@ form {
 	height: auto;
 
 	> .item {
+		padding: 0;
 		vertical-align: middle;
 
 		&.title {
@@ -933,6 +934,7 @@ form {
 
 
 .nav_menu {
+	padding: 0;
 	width: 100%;
 	font-size: 0;
 	background-color: var(--color-background-nav);


### PR DESCRIPTION
Regression from #4794

Before:
![grafik](https://user-images.githubusercontent.com/1645099/202874357-3e2940f4-9f82-4f68-9000-14b64fd8aab0.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/202874370-e890866d-a0e1-448d-bf2a-8ed7be2aa67d.png)


Changes proposed in this pull request:

- fixed the navigation/button bar in Swage theme


How to test the feature manually:

1. use Swage theme
2. check the navigation/button bar


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
