### PR TITLE
Docker Alpine 3.17

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM alpine:3.17
 
 ENV TZ UTC
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,8 +18,7 @@ RUN rm -f /etc/apache2/conf.d/languages.conf /etc/apache2/conf.d/info.conf \
 	sed -r -i "/^\s*(CustomLog|ErrorLog|Listen) /s/^/#/" \
 		/etc/apache2/httpd.conf
 
-RUN addgroup developer && \
-	adduser --ingroup developer --disabled-password developer && \
+RUN adduser --ingroup www-data --disabled-password developer && \
 	echo "developer ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/developer
 
 ENV COPY_LOG_TO_SYSLOG On

--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM alpine:3.17
 
 ENV TZ UTC
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]


### PR DESCRIPTION
Update alternative Docker image to Alpine 3.17 with PHP 8.1.12 (and still Apache 2.4.54) https://alpinelinux.org/posts/Alpine-3.17.0-released.html
