### PR TITLE
fix: Current Flux in Origine theme

### DIFF
--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -839,17 +839,17 @@ a:hover .icon {
 	border-left: 2px solid transparent;
 }
 
+.flux.current {
+	background-color: var(--background-color-light);
+	border-left: 2px solid var(--contrast-border-color-active);
+}
+
 .flux .flux_header:hover {
 	background-color: var(--background-color-hover) !important;
 }
 
 .flux .flux_header:not(.current):hover .item.title {
 	background: inherit;
-}
-
-.flux.current .flux_header {
-	background-color: var(--background-color-light);
-	border-left: 2px solid var(--contrast-border-color-active);
 }
 
 .flux.not_read {

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -839,17 +839,17 @@ a:hover .icon {
 	border-right: 2px solid transparent;
 }
 
+.flux.current {
+	background-color: var(--background-color-light);
+	border-right: 2px solid var(--contrast-border-color-active);
+}
+
 .flux .flux_header:hover {
 	background-color: var(--background-color-hover) !important;
 }
 
 .flux .flux_header:not(.current):hover .item.title {
 	background: inherit;
-}
-
-.flux.current .flux_header {
-	background-color: var(--background-color-light);
-	border-right: 2px solid var(--contrast-border-color-active);
 }
 
 .flux.not_read {


### PR DESCRIPTION
Regression from #4693 Origine theme

Before:
Border for current article is not the same border like the other borders
![grafik](https://user-images.githubusercontent.com/1645099/203651747-dc557552-21cd-4b28-9353-e7d5ce7b93f4.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/203651884-77b8feb5-bd7d-4633-b277-90f31eebdb17.png)


Changes proposed in this pull request:

- CSS


How to test the feature manually:

1. use the Origine theme
2. open a article in normal view
3. see the left border


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
