### PR TITLE
improved: delete .nav-list .empty/.error

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -309,24 +309,6 @@ a.btn {
 	text-decoration: none;
 }
 
-.nav-list .item.empty a {
-	color: var(--empty-feed-color);
-}
-
-.nav-list .item.active.empty a {
-	background: var(--empty-feed-color);
-	color: var(--font-color-light);
-}
-
-.nav-list .item.error a {
-	color: var(--font-color-error);
-}
-
-.nav-list .item.active.error a {
-	background: var(--contrast-attention-background-color);
-	color: var(--font-color-light);
-}
-
 .nav-list .nav-header {
 	padding: 0 10px;
 	color: var(--font-color-middle);

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -309,24 +309,6 @@ a.btn {
 	text-decoration: none;
 }
 
-.nav-list .item.empty a {
-	color: var(--empty-feed-color);
-}
-
-.nav-list .item.active.empty a {
-	background: var(--empty-feed-color);
-	color: var(--font-color-light);
-}
-
-.nav-list .item.error a {
-	color: var(--font-color-error);
-}
-
-.nav-list .item.active.error a {
-	background: var(--contrast-attention-background-color);
-	color: var(--font-color-light);
-}
-
 .nav-list .nav-header {
 	padding: 0 10px;
 	color: var(--font-color-middle);

--- a/p/themes/Ansum/_sidebar.scss
+++ b/p/themes/Ansum/_sidebar.scss
@@ -152,27 +152,7 @@
 			@include mixins.transition(all, 0.15s, ease-in-out);
 		}
 
-		.error {
-			a {
-				color: variables.$alert-bg;
-			}
-		}
-
 		&:hover {
-			.error {
-				a {
-					background: variables.$main-first;
-					color: variables.$sid-font-color;
-				}
-			}
-
-			.empty {
-				a {
-					background: variables.$warning-bg;
-					color: variables.$sid-font-color;
-				}
-			}
-
 			a {
 				background: variables.$sid-bg-dark;
 				text-decoration: none;
@@ -183,31 +163,11 @@
 			background: variables.$main-first;
 			color: variables.$white;
 
-			.error {
-				a {
-					background: variables.$main-first;
-					color: variables.$white;
-				}
-			}
-
-			.empty {
-				a {
-					background: variables.$warning-bg;
-					color: variables.$white;
-				}
-			}
-
 			a {
 				background: variables.$main-first;
 				color: variables.$white;
 				text-decoration: none;
 			}
-		}
-	}
-
-	&.empty {
-		a {
-			color: variables.$warning-bg;
 		}
 	}
 

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -566,17 +566,6 @@ form th {
 	color: #363330;
 	transition: all 0.15s ease-in-out;
 }
-.nav-list .item .error a {
-	color: #f5633e;
-}
-.nav-list .item:hover .error a {
-	background: #ca7227;
-	color: #363330;
-}
-.nav-list .item:hover .empty a {
-	background: #f4f762;
-	color: #363330;
-}
 .nav-list .item:hover a {
 	background: #efe3d3;
 	text-decoration: none;
@@ -585,21 +574,10 @@ form th {
 	background: #ca7227;
 	color: #fff;
 }
-.nav-list .item.active .error a {
-	background: #ca7227;
-	color: #fff;
-}
-.nav-list .item.active .empty a {
-	background: #f4f762;
-	color: #fff;
-}
 .nav-list .item.active a {
 	background: #ca7227;
 	color: #fff;
 	text-decoration: none;
-}
-.nav-list.empty a {
-	color: #f4f762;
 }
 .nav-list .nav-header {
 	padding: 0 10px;

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -566,17 +566,6 @@ form th {
 	color: #363330;
 	transition: all 0.15s ease-in-out;
 }
-.nav-list .item .error a {
-	color: #f5633e;
-}
-.nav-list .item:hover .error a {
-	background: #ca7227;
-	color: #363330;
-}
-.nav-list .item:hover .empty a {
-	background: #f4f762;
-	color: #363330;
-}
 .nav-list .item:hover a {
 	background: #efe3d3;
 	text-decoration: none;
@@ -585,21 +574,10 @@ form th {
 	background: #ca7227;
 	color: #fff;
 }
-.nav-list .item.active .error a {
-	background: #ca7227;
-	color: #fff;
-}
-.nav-list .item.active .empty a {
-	background: #f4f762;
-	color: #fff;
-}
 .nav-list .item.active a {
 	background: #ca7227;
 	color: #fff;
 	text-decoration: none;
-}
-.nav-list.empty a {
-	color: #f4f762;
 }
 .nav-list .nav-header {
 	padding: 0 10px;

--- a/p/themes/BlueLagoon/BlueLagoon.css
+++ b/p/themes/BlueLagoon/BlueLagoon.css
@@ -294,25 +294,6 @@ a.btn {
 	text-decoration: none;
 }
 
-.nav-list .item.empty a {
-	color: #f39c12;
-}
-
-.nav-list .item.active.empty a {
-	background: linear-gradient(180deg, #e4992c 0%, #d18114 100%) #e4992c;
-	background: -webkit-linear-gradient(180deg, #e4992c 0%, #d18114 100%);
-	color: #fff;
-}
-
-.nav-list .item.error a {
-	color: #bd362f;
-}
-
-.nav-list .item.active.error a {
-	background: #bd362f;
-	color: #fff;
-}
-
 .nav-list .nav-header {
 	padding: 0 10px;
 	background: transparent;

--- a/p/themes/BlueLagoon/BlueLagoon.rtl.css
+++ b/p/themes/BlueLagoon/BlueLagoon.rtl.css
@@ -294,25 +294,6 @@ a.btn {
 	text-decoration: none;
 }
 
-.nav-list .item.empty a {
-	color: #f39c12;
-}
-
-.nav-list .item.active.empty a {
-	background: linear-gradient(-180deg, #e4992c 0%, #d18114 100%) #e4992c;
-	background: -webkit-linear-gradient(-180deg, #e4992c 0%, #d18114 100%);
-	color: #fff;
-}
-
-.nav-list .item.error a {
-	color: #bd362f;
-}
-
-.nav-list .item.active.error a {
-	background: #bd362f;
-	color: #fff;
-}
-
 .nav-list .nav-header {
 	padding: 0 10px;
 	background: transparent;

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -289,26 +289,6 @@ a.btn {
 	text-decoration: none;
 }
 
-.nav-list .item.empty a {
-	color: #c95;
-}
-
-.nav-list .item:hover.empty a,
-.nav-list .item.active.empty a {
-	background: #c95;
-	color: #fff;
-}
-
-.nav-list .item.error a {
-	color: #a44;
-}
-
-.nav-list .item:hover.error a,
-.nav-list .item.active.error a {
-	background: #a44;
-	color: #fff;
-}
-
 .nav-list .nav-header {
 	padding: 0 10px;
 	font-weight: bold;

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -289,26 +289,6 @@ a.btn {
 	text-decoration: none;
 }
 
-.nav-list .item.empty a {
-	color: #c95;
-}
-
-.nav-list .item:hover.empty a,
-.nav-list .item.active.empty a {
-	background: #c95;
-	color: #fff;
-}
-
-.nav-list .item.error a {
-	color: #a44;
-}
-
-.nav-list .item:hover.error a,
-.nav-list .item.active.error a {
-	background: #a44;
-	color: #fff;
-}
-
 .nav-list .nav-header {
 	padding: 0 10px;
 	font-weight: bold;

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -276,26 +276,6 @@ a.btn {
 	text-decoration: none;
 }
 
-.nav-list .item.empty a {
-	color: #f39c12;
-}
-
-.nav-list .item:hover.empty a,
-.nav-list .item.active.empty a {
-	background: #f39c12;
-	color: #fff;
-}
-
-.nav-list .item.error a {
-	color: #bd362f;
-}
-
-.nav-list .item:hover.error a,
-.nav-list .item.active.error a {
-	background: #bd362f;
-	color: #fff;
-}
-
 .nav-list .nav-header {
 	padding: 0 10px;
 	font-weight: bold;

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -276,26 +276,6 @@ a.btn {
 	text-decoration: none;
 }
 
-.nav-list .item.empty a {
-	color: #f39c12;
-}
-
-.nav-list .item:hover.empty a,
-.nav-list .item.active.empty a {
-	background: #f39c12;
-	color: #fff;
-}
-
-.nav-list .item.error a {
-	color: #bd362f;
-}
-
-.nav-list .item:hover.error a,
-.nav-list .item.active.error a {
-	background: #bd362f;
-	color: #fff;
-}
-
 .nav-list .nav-header {
 	padding: 0 10px;
 	font-weight: bold;

--- a/p/themes/Mapco/_sidebar.scss
+++ b/p/themes/Mapco/_sidebar.scss
@@ -151,27 +151,7 @@
 			@include mixins.transition(all, 0.15s, ease-in-out);
 		}
 
-		.error {
-			a {
-				color: variables.$alert-bg;
-			}
-		}
-
 		&:hover {
-			.error {
-				a {
-					background: variables.$main-first;
-					color: variables.$sid-font-color;
-				}
-			}
-
-			.empty {
-				a {
-					background: variables.$warning-bg;
-					color: variables.$sid-font-color;
-				}
-			}
-
 			a {
 				background: variables.$sid-bg-dark;
 				text-decoration: none;
@@ -182,31 +162,11 @@
 			background: variables.$main-first;
 			color: variables.$white;
 
-			.error {
-				a {
-					background: variables.$main-first;
-					color: variables.$white;
-				}
-			}
-
-			.empty {
-				a {
-					background: variables.$warning-bg;
-					color: variables.$white;
-				}
-			}
-
 			a {
 				background: variables.$main-first;
 				color: variables.$white;
 				text-decoration: none;
 			}
-		}
-	}
-
-	&.empty {
-		a {
-			color: variables.$warning-bg;
 		}
 	}
 

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -580,17 +580,6 @@ form th {
 	color: #ffffff;
 	transition: all 0.15s ease-in-out;
 }
-.nav-list .item .error a {
-	color: #f5633e;
-}
-.nav-list .item:hover .error a {
-	background: #36c;
-	color: #ffffff;
-}
-.nav-list .item:hover .empty a {
-	background: #f4f762;
-	color: #ffffff;
-}
 .nav-list .item:hover a {
 	background: #17181a;
 	text-decoration: none;
@@ -599,21 +588,10 @@ form th {
 	background: #36c;
 	color: #fff;
 }
-.nav-list .item.active .error a {
-	background: #36c;
-	color: #fff;
-}
-.nav-list .item.active .empty a {
-	background: #f4f762;
-	color: #fff;
-}
 .nav-list .item.active a {
 	background: #36c;
 	color: #fff;
 	text-decoration: none;
-}
-.nav-list.empty a {
-	color: #f4f762;
 }
 .nav-list .nav-header {
 	padding: 0 10px;

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -580,17 +580,6 @@ form th {
 	color: #ffffff;
 	transition: all 0.15s ease-in-out;
 }
-.nav-list .item .error a {
-	color: #f5633e;
-}
-.nav-list .item:hover .error a {
-	background: #36c;
-	color: #ffffff;
-}
-.nav-list .item:hover .empty a {
-	background: #f4f762;
-	color: #ffffff;
-}
 .nav-list .item:hover a {
 	background: #17181a;
 	text-decoration: none;
@@ -599,21 +588,10 @@ form th {
 	background: #36c;
 	color: #fff;
 }
-.nav-list .item.active .error a {
-	background: #36c;
-	color: #fff;
-}
-.nav-list .item.active .empty a {
-	background: #f4f762;
-	color: #fff;
-}
 .nav-list .item.active a {
 	background: #36c;
 	color: #fff;
 	text-decoration: none;
-}
-.nav-list.empty a {
-	color: #f4f762;
 }
 .nav-list .nav-header {
 	padding: 0 10px;

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -389,24 +389,6 @@ a:hover .icon {
 	text-decoration: none;
 }
 
-.nav-list .item.empty a {
-	color: var(--empty-feed-color);
-}
-
-.nav-list .item.active.empty a {
-	background-color: var(--empty-feed-color);
-	color: var(--font-color-light);
-}
-
-.nav-list .item.error a {
-	color: var(--error-feed-color);
-}
-
-.nav-list .item.active.error a {
-	background-color: var(--error-feed-color);
-	color: var(--font-color-light);
-}
-
 .nav-list .nav-header {
 	padding: 0 10px;
 	background-color: var(--background-color-grey);

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -389,24 +389,6 @@ a:hover .icon {
 	text-decoration: none;
 }
 
-.nav-list .item.empty a {
-	color: var(--empty-feed-color);
-}
-
-.nav-list .item.active.empty a {
-	background-color: var(--empty-feed-color);
-	color: var(--font-color-light);
-}
-
-.nav-list .item.error a {
-	color: var(--error-feed-color);
-}
-
-.nav-list .item.active.error a {
-	background-color: var(--error-feed-color);
-	color: var(--font-color-light);
-}
-
 .nav-list .nav-header {
 	padding: 0 10px;
 	background-color: var(--background-color-grey);

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -249,24 +249,6 @@ a.btn {
 	text-decoration: none;
 }
 
-.nav-list .item.empty a {
-	color: #f39c12;
-}
-
-.nav-list .item.active.empty a {
-	background: #f39c12;
-	color: #fff;
-}
-
-.nav-list .item.error a {
-	color: #bd362f;
-}
-
-.nav-list .item.active.error a {
-	background: #bd362f;
-	color: #fff;
-}
-
 .nav-list .nav-header {
 	padding: 0 10px;
 	background: #f4f4f4;

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -249,24 +249,6 @@ a.btn {
 	text-decoration: none;
 }
 
-.nav-list .item.empty a {
-	color: #f39c12;
-}
-
-.nav-list .item.active.empty a {
-	background: #f39c12;
-	color: #fff;
-}
-
-.nav-list .item.error a {
-	color: #bd362f;
-}
-
-.nav-list .item.active.error a {
-	background: #bd362f;
-	color: #fff;
-}
-
 .nav-list .nav-header {
 	padding: 0 10px;
 	background: #f4f4f4;

--- a/p/themes/Screwdriver/screwdriver.css
+++ b/p/themes/Screwdriver/screwdriver.css
@@ -298,25 +298,6 @@ a.btn {
 	text-decoration: none;
 }
 
-.nav-list .item.empty a {
-	color: #f39c12;
-}
-
-.nav-list .item.active.empty a {
-	background: linear-gradient(180deg, #e4992c 0%, #d18114 100%) #e4992c;
-	background: -webkit-linear-gradient(180deg, #e4992c 0%, #d18114 100%);
-	color: #fff;
-}
-
-.nav-list .item.error a {
-	color: #bd362f;
-}
-
-.nav-list .item.active.error a {
-	background: #bd362f;
-	color: #fff;
-}
-
 .nav-list .nav-header {
 	padding: 0 10px;
 	background: transparent;

--- a/p/themes/Screwdriver/screwdriver.rtl.css
+++ b/p/themes/Screwdriver/screwdriver.rtl.css
@@ -298,25 +298,6 @@ a.btn {
 	text-decoration: none;
 }
 
-.nav-list .item.empty a {
-	color: #f39c12;
-}
-
-.nav-list .item.active.empty a {
-	background: linear-gradient(-180deg, #e4992c 0%, #d18114 100%) #e4992c;
-	background: -webkit-linear-gradient(-180deg, #e4992c 0%, #d18114 100%);
-	color: #fff;
-}
-
-.nav-list .item.error a {
-	color: #bd362f;
-}
-
-.nav-list .item.active.error a {
-	background: #bd362f;
-	color: #fff;
-}
-
 .nav-list .nav-header {
 	padding: 0 10px;
 	background: transparent;

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -281,24 +281,8 @@ form th {
 .nav-list .item.active a {
 	color: var(--color-text-light);
 }
-.nav-list .item.active.empty a,
-.nav-list .item.active .error a {
-	color: var(--color-text-light);
-}
-.nav-list .item.active.empty a {
-	background-color: var(--color-background-alert);
-}
-.nav-list .item.active.error a {
-	background-color: var(--color-background-bad);
-}
 .nav-list .item > a {
 	padding: 0 1.5rem;
-}
-.nav-list .item.empty a {
-	color: var(--color-text-alert);
-}
-.nav-list .item.error a {
-	color: var(--color-text-bad-lighter);
 }
 .nav-list .item .icon {
 	filter: brightness(3);

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -281,24 +281,8 @@ form th {
 .nav-list .item.active a {
 	color: var(--color-text-light);
 }
-.nav-list .item.active.empty a,
-.nav-list .item.active .error a {
-	color: var(--color-text-light);
-}
-.nav-list .item.active.empty a {
-	background-color: var(--color-background-alert);
-}
-.nav-list .item.active.error a {
-	background-color: var(--color-background-bad);
-}
 .nav-list .item > a {
 	padding: 0 1.5rem;
-}
-.nav-list .item.empty a {
-	color: var(--color-text-alert);
-}
-.nav-list .item.error a {
-	color: var(--color-text-bad-lighter);
 }
 .nav-list .item .icon {
 	filter: brightness(3);

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -365,31 +365,10 @@ form {
 			a {
 				color: var(--color-text-light);
 			}
-
-			&.empty a,
-			.error a {
-				color: var(--color-text-light);
-			}
-
-			&.empty a {
-				background-color: var(--color-background-alert);
-			}
-
-			&.error a {
-				background-color: var(--color-background-bad);
-			}
 		}
 
 		> a {
 			padding: 0 1.5rem;
-		}
-
-		&.empty a {
-			color: var(--color-text-alert);
-		}
-
-		&.error a {
-			color: var(--color-text-bad-lighter);
 		}
 
 		.icon {

--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -199,18 +199,6 @@ a.btn {
 	text-decoration: none;
 }
 
-.nav-list .item.empty a {
-}
-
-.nav-list .item.active.empty a {
-}
-
-.nav-list .item.error a {
-}
-
-.nav-list .item.active.error a {
-}
-
 .nav-list .nav-header {
 	padding: 0 10px;
 	font-weight: bold;

--- a/p/themes/base-theme/base.rtl.css
+++ b/p/themes/base-theme/base.rtl.css
@@ -199,18 +199,6 @@ a.btn {
 	text-decoration: none;
 }
 
-.nav-list .item.empty a {
-}
-
-.nav-list .item.active.empty a {
-}
-
-.nav-list .item.error a {
-}
-
-.nav-list .item.active.error a {
-}
-
 .nav-list .nav-header {
 	padding: 0 10px;
 	font-weight: bold;


### PR DESCRIPTION
If I do not overlook something, then `.nav-list` does not have `.empty` or `.error` as sub-classes anymore
![grafik](https://user-images.githubusercontent.com/1645099/204111142-18942e09-2193-404d-b1f3-c0bdee19ac07.png)

So we can delete the CSS

Changes proposed in this pull request:

- CSS

How to test the feature manually:

1. check the code


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
