### PR TITLE
Make header logo take the whole height

### DIFF
--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -394,13 +394,18 @@ a.btn {
 }
 
 .header > .item {
-	padding: 10px;
 	vertical-align: middle;
 	text-align: center;
 }
 
 .header > .item.title {
 	width: 230px;
+}
+
+.header .item.title a {
+	padding: 1rem;
+	display: block;
+	height: 100%;
 }
 
 .header > .item.title h1 {


### PR DESCRIPTION
Changes proposed in this pull request:

- CSS to make header logo take the whole height
- Having big buttons is always nice, it prevents misclicks
- ![Screenshot_20221127_182002](https://user-images.githubusercontent.com/22097904/204150266-ab6f646e-ce2d-4cdc-bc47-73ad9bd46329.png)
