### PR TITLE
Docker Alpine time zone

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,9 @@ FROM alpine:3.17
 
 ENV TZ UTC
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+RUN apk add --no-cache tzdata && \
+	ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 RUN apk add --no-cache \
 	apache2 php-apache2 \
 	php php-curl php-gmp php-intl php-mbstring php-xml php-zip \

--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -2,6 +2,9 @@ FROM alpine:3.17
 
 ENV TZ UTC
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+RUN apk add --no-cache tzdata && \
+	ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 RUN apk add --no-cache \
 	apache2 php-apache2 \
 	php php-curl php-gmp php-intl php-mbstring php-xml php-zip \


### PR DESCRIPTION
Allow setting the timezone with a `TZ` environment variable in our Alpine-based Docker images just like for our Debian-based Docker images. See https://github.com/FreshRSS/FreshRSS/discussions/4898#discussioncomment-4245991