### PR TITLE
fix: article header: alignment of favicon/tags

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1330,8 +1330,9 @@ a.website:hover .favicon {
 }
 
 .content > header .tags .icon,
+.content > header .website .favicon,
 .content > footer .tags .icon {
-	padding: 0 1rem 0 0;
+	margin: 0 0.5rem 0 0;
 	line-height: 1.5;
 }
 

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1330,8 +1330,9 @@ a.website:hover .favicon {
 }
 
 .content > header .tags .icon,
+.content > header .website .favicon,
 .content > footer .tags .icon {
-	padding: 0 0 0 1rem;
+	margin: 0 0 0 0.5rem;
 	line-height: 1.5;
 }
 


### PR DESCRIPTION
Align favicon and tags icon

Before:
![grafik](https://user-images.githubusercontent.com/1645099/204866352-59494694-d2f2-4e2a-bcbf-5a9e62ebe55b.png)


After:
![grafik](https://user-images.githubusercontent.com/1645099/204866303-bb5f79cd-7daf-45b7-a952-f506b4733790.png)


Changes proposed in this pull request:

- frss.css


How to test the feature manually:

1. open an article and see the favicon


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested