### PR TITLE
fix: Text overflow in article summary

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1241,6 +1241,7 @@ a.website:hover .favicon {
 	color: var(--frss-font-color-grey-dark);
 	font-size: 0.9rem;
 	font-weight: normal;
+	overflow: hidden;
 	text-overflow: ellipsis;
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1241,6 +1241,7 @@ a.website:hover .favicon {
 	color: var(--frss-font-color-grey-dark);
 	font-size: 0.9rem;
 	font-weight: normal;
+	overflow: hidden;
 	text-overflow: ellipsis;
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;


### PR DESCRIPTION
Closes #4901

Before:
![grafik](https://user-images.githubusercontent.com/1645099/205743984-3c7a7222-8c46-4881-9352-3a05e8c02991.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/205743927-158dc662-a2cd-4b15-9c4e-fdecee144518.png)


Changes proposed in this pull request:

- CSS: add `overflow: hidden`


How to test the feature manually:

1. activate "summary" in normal view
2. see the text

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested