### PR TITLE
fix: Swage theme

### DIFF
--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -60,7 +60,7 @@ select:invalid {
 	font-size: 0.9rem;
 }
 
-.dropdown-menu > .item > a,
+.dropdown-menu > .item a,
 .dropdown-menu > .item > span,
 .dropdown-menu > .item > .as-link,
 .dropdown-menu > .item button, .dropdown-menu > .item {
@@ -203,6 +203,7 @@ form th {
 }
 .form-group .group-name {
 	padding: 10px 0;
+	text-align: right;
 }
 .form-group .group-controls {
 	min-height: 25px;
@@ -911,6 +912,7 @@ a.signin {
 	}
 	.form-group .group-name {
 		padding-bottom: 0;
+		text-align: left;
 	}
 	.dropdown {
 		position: relative;

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -60,7 +60,7 @@ select:invalid {
 	font-size: 0.9rem;
 }
 
-.dropdown-menu > .item > a,
+.dropdown-menu > .item a,
 .dropdown-menu > .item > span,
 .dropdown-menu > .item > .as-link,
 .dropdown-menu > .item button, .dropdown-menu > .item {
@@ -203,6 +203,7 @@ form th {
 }
 .form-group .group-name {
 	padding: 10px 0;
+	text-align: left;
 }
 .form-group .group-controls {
 	min-height: 25px;
@@ -911,6 +912,7 @@ a.signin {
 	}
 	.form-group .group-name {
 		padding-bottom: 0;
+		text-align: right;
 	}
 	.dropdown {
 		position: relative;

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -439,7 +439,7 @@ form {
 			@extend %dropdown;
 			padding: 0 0 0 0.5rem;
 
-			> a,
+			a,
 			> span,
 			> .as-link,
 			button {


### PR DESCRIPTION
Regression #4922
+ SCSS compiled that brings `text-align` lines (back?) to CSS files (to be honest: I have no clue why this lines were missed in the CSS files)

Changes proposed in this pull request:

- (S)CSS

Before:
![grafik](https://user-images.githubusercontent.com/1645099/206866176-537a2e91-e8f0-473b-ab5b-cde60961b927.png)


After:
![grafik](https://user-images.githubusercontent.com/1645099/206866141-b3ba653d-4611-430a-84ae-caeb158c89e4.png)


How to test the feature manually:

1. use Swage theme
2. open the config menu
3. see the menu items

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested