### PR TITLE
Help needed: $test2 does not work

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -20,6 +20,7 @@ class FreshRSS_Entry extends Minz_Model {
 	private $title;
 	private $authors;
 	private $content;
+	private $content_enclosures = [];
 	private $link;
 	private $date;
 	private $date_added = 0; //In microseconds
@@ -52,6 +53,8 @@ class FreshRSS_Entry extends Minz_Model {
 		$this->_title($title);
 		$this->_authors($authors);
 		$this->_content($content);
+		$test = ["cons","truct"];
+		$this->_content_enclosures($test);
 		$this->_link($link);
 		$this->_date($pubdate);
 		$this->_isRead($is_read);
@@ -118,6 +121,9 @@ class FreshRSS_Entry extends Minz_Model {
 	}
 	public function content(): string {
 		return $this->content;
+	}
+	public function content_enclosures(): array {
+		return $this->content_enclosures;
 	}
 
 	/** @return array<array<string,string>> */
@@ -317,6 +323,11 @@ class FreshRSS_Entry extends Minz_Model {
 	public function _content(string $value) {
 		$this->hash = '';
 		$this->content = $value;
+	}
+
+	public function _content_enclosures($value) {
+		$this->hash = '';
+		$this->content_enclosures = $value;
 	}
 	public function _link(string $value) {
 		$this->hash = '';

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -586,6 +586,8 @@ class FreshRSS_Feed extends Minz_Model {
 			);
 			$entry->_tags($tags);
 			$entry->_feed($this);
+			$test2 = ["lo","ad","Ent","ry"];
+			$entry->_content_enclosures($test2);
 			$entry->hash();	//Must be computed before loading full content
 			$entry->loadCompleteContent();	// Optionally load full content for truncated feeds
 

--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -164,6 +164,7 @@ $today = @strtotime('today');
 				<div class="text"><?php
 					echo $lazyload && $hidePosts ? lazyimg($this->entry->content()) : $this->entry->content();
 				?></div>
+				<?= print_r($this->entry->content_enclosures()); ?>
 				<?php
 				$display_authors_date = FreshRSS_Context::$user_conf->show_author_date === 'f' || FreshRSS_Context::$user_conf->show_author_date === 'b';
 				$display_tags = FreshRSS_Context::$user_conf->show_tags === 'f' || FreshRSS_Context::$user_conf->show_tags === 'b';


### PR DESCRIPTION
I need your help:

My general goal: I want to improve the enclosures, that HTML is set in `Feed->loadEntries()` but it would make sense to have the HTML in `normal.phtml`.

I added `FreshRSS_Entry->content_enclosure` and it setter `_content_enclosures()` and getter `content_enclosures()`.

The issue: with $test (in the constructor) it works, but $test2 (in loadEntries()) it does not work,

How to test:
1. open an article with an enclosure.
2. see the `print_r()` output

It is now:
![grafik](https://user-images.githubusercontent.com/1645099/207446802-efb7f137-2f88-4051-a48e-96a54bb891dd.png)

Expected behaviour:
`Array ( [0] => lo [1] => ad [2] => Ent [3] => ry ) 1 `

Any help?
