### PR TITLE
chmod +x extensions

### DIFF
--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -58,6 +58,8 @@ if [ -n "$FRESHRSS_USER" ]; then
 fi
 
 chown -R :www-data .
-chmod -R g+r . && chmod -R g+w ./data/
+chmod -R g+r .
+chmod -R g+w ./data/
+chmod g+x ./extensions/
 
 exec "$@"


### PR DESCRIPTION
To ease adding custom extensions such as in
https://github.com/FreshRSS/Extensions/issues/37#issuecomment-1363474585

Note: `+x` is needed on a folder to be able to list the sub-folders (extensions). We are not doing a `+x` on files.

See also https://github.com/FreshRSS/FreshRSS/issues/3599