### PR TITLE
fix: notification box in mobile view

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2169,6 +2169,7 @@ input:checked + .slide-container .properties {
 	}
 
 	.notification {
+		padding: 0.75rem;
 		top: 0;
 		left: 0;
 		right: 0;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2169,6 +2169,7 @@ input:checked + .slide-container .properties {
 	}
 
 	.notification {
+		padding: 0.75rem;
 		top: 0;
 		right: 0;
 		left: 0;


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/1645099/209719971-82729864-3274-41d6-ae2b-638482ccc9d8.png)



After:
![grafik](https://user-images.githubusercontent.com/1645099/209719561-7271a29a-259c-43c9-abc5-773150838195.png)


Changes proposed in this pull request:

- CSS in `frss.rss`


How to test the feature manually:

1. mobile view
2. create a notification (f.e. save a setting)
3. see the text in the notification text box and it alignment to left and right

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
