### PR TITLE
fix:  Ansum and Mapco: icons_as_emojis 

### DIFF
--- a/p/themes/Ansum/_components.scss
+++ b/p/themes/Ansum/_components.scss
@@ -57,6 +57,11 @@
 			font-size: 1rem;
 			line-height: 2.5em;
 
+			span.icon {
+				padding: 0 0.25rem !important;
+				line-height: 1;
+			}
+
 			&:not(.addItem):hover {
 				background: variables.$main-first;
 				color: variables.$white;

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -258,6 +258,10 @@ form th {
 	font-size: 1rem;
 	line-height: 2.5em;
 }
+.dropdown-menu .item a span.icon, .dropdown-menu .item span span.icon, .dropdown-menu .item .as-link span.icon {
+	padding: 0 0.25rem !important;
+	line-height: 1;
+}
 .dropdown-menu .item a:not(.addItem):hover, .dropdown-menu .item span:not(.addItem):hover, .dropdown-menu .item .as-link:not(.addItem):hover {
 	background: #ca7227;
 	color: #fff;

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -258,6 +258,10 @@ form th {
 	font-size: 1rem;
 	line-height: 2.5em;
 }
+.dropdown-menu .item a span.icon, .dropdown-menu .item span span.icon, .dropdown-menu .item .as-link span.icon {
+	padding: 0 0.25rem !important;
+	line-height: 1;
+}
 .dropdown-menu .item a:not(.addItem):hover, .dropdown-menu .item span:not(.addItem):hover, .dropdown-menu .item .as-link:not(.addItem):hover {
 	background: #ca7227;
 	color: #fff;

--- a/p/themes/Mapco/_components.scss
+++ b/p/themes/Mapco/_components.scss
@@ -57,6 +57,11 @@
 			font-size: 1rem;
 			line-height: 2.5em;
 
+			span.icon {
+				padding: 0 0.25rem !important;
+				line-height: 1;
+			}
+
 			&:not(.addItem):hover {
 				background: variables.$main-first;
 				color: variables.$white;

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -257,6 +257,10 @@ form th {
 	font-size: 1rem;
 	line-height: 2.5em;
 }
+.dropdown-menu .item a span.icon, .dropdown-menu .item span span.icon, .dropdown-menu .item .as-link span.icon {
+	padding: 0 0.25rem !important;
+	line-height: 1;
+}
 .dropdown-menu .item a:not(.addItem):hover, .dropdown-menu .item span:not(.addItem):hover, .dropdown-menu .item .as-link:not(.addItem):hover {
 	background: #36c;
 	color: #fff;

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -257,6 +257,10 @@ form th {
 	font-size: 1rem;
 	line-height: 2.5em;
 }
+.dropdown-menu .item a span.icon, .dropdown-menu .item span span.icon, .dropdown-menu .item .as-link span.icon {
+	padding: 0 0.25rem !important;
+	line-height: 1;
+}
 .dropdown-menu .item a:not(.addItem):hover, .dropdown-menu .item span:not(.addItem):hover, .dropdown-menu .item .as-link:not(.addItem):hover {
 	background: #36c;
 	color: #fff;


### PR DESCRIPTION
Closes #4965

After:
![grafik](https://user-images.githubusercontent.com/1645099/209849777-cea33529-c79e-4473-bb42-e39f62b38074.png)


Changes proposed in this pull request:

- (S)CSS for Ansum and Mapco


How to test the feature manually:

1. config.php `'icons_as_emojis' => false,`
2. mobile view
3. use Ansum or Mapco theme
4. open config menu
5. hover over the logout line

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested