### PR TITLE
docs: fix formating

### DIFF
--- a/docs/fr/developers/01_First_steps.md
+++ b/docs/fr/developers/01_First_steps.md
@@ -57,7 +57,7 @@ Vous pouvez arrêter les conteneurs en tapant <kbd>Control</kbd> + <kbd>c</kbd> 
 make stop
 ```
 
-Si la configuration vous intéresse, les commandes `make' sont définies dans
+Si la configuration vous intéresse, les commandes `make` sont définies dans
 le fichier [`Makefile`](/Makefile).
 
 Si vous avez besoin d’utiliser une image Docker identifiée par un tag


### PR DESCRIPTION
Changes proposed in this pull request:

Fix markdown formating by replacing apostrophe by a backtick.

Before the fix:
![image](https://user-images.githubusercontent.com/5607440/209985352-34952f2d-894b-4d12-b5fd-70be7c80266b.png)

How to test the feature manually:

1. Go to https://github.com/sad270/FreshRSS/blob/patch-1/docs/fr/developers/01_First_steps.md ( If for any reason you read this after the merge and I have deleted the branch you can go to https://github.com/FreshRSS/FreshRSS/blob/edge/docs/fr/developers/01_First_steps.md )

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
