### PR TITLE
Improve: open "manage feed" with Ctrl in a new tab

### DIFF
--- a/p/scripts/extra.js
+++ b/p/scripts/extra.js
@@ -145,6 +145,9 @@ function init_archiving(parent) {
 const freshrssSliderLoadEvent = new Event('freshrss:slider-load');
 
 function open_slider_listener(ev) {
+	if (ev.ctrlKey || ev.shiftKey) {
+		return;
+	}
 	const a = ev.target.closest('.open-slider');
 	if (a) {
 		if (!context.ajax_loading) {


### PR DESCRIPTION
Closes #4977

Fix provided by @Frenzie 

Changes proposed in this pull request:

- JS


How to test the feature manually:

1. Press CTRL key and click on "manage"
2. it will open the feed settings in a new tab


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
