### PR TITLE
fixed: search landing page

### DIFF
--- a/app/layout/header.phtml
+++ b/app/layout/header.phtml
@@ -18,6 +18,11 @@
 				<input type="search" name="search" id="search" class="extend"
 					value="<?= htmlspecialchars(htmlspecialchars_decode(FreshRSS_Context::$search, ENT_QUOTES), ENT_COMPAT, 'UTF-8') ?>"
 					placeholder="<?= _t('gen.menu.search') ?>" />
+				
+				<?php $param_a = Minz_Request::actionName(); ?>
+				<?php if (in_array($param_a, ['normal', 'global', 'reader'])) { ?>
+				<input type="hidden" name="a" value="<?= $param_a ?>" />
+				<?php } ?>
 
 				<?php $get = Minz_Request::param('get', ''); ?>
 				<?php if ($get != '') { ?>

--- a/app/layout/nav_menu.phtml
+++ b/app/layout/nav_menu.phtml
@@ -190,6 +190,11 @@
 			<input type="search" name="search" class="extend" value="<?php
 				echo htmlspecialchars(htmlspecialchars_decode(FreshRSS_Context::$search, ENT_QUOTES), ENT_COMPAT, 'UTF-8'); ?>" placeholder="<?= _t('index.menu.search_short') ?>" />
 
+			<?php $param_a = Minz_Request::actionName(); ?>
+			<?php if (in_array($param_a, ['normal', 'global', 'reader'])) { ?>
+			<input type="hidden" name="a" value="<?= $param_a ?>" />
+			<?php } ?>
+			
 			<?php $get = Minz_Request::param('get', ''); ?>
 			<?php if($get != '') { ?>
 			<input type="hidden" name="get" value="<?= $get ?>" />


### PR DESCRIPTION
Before:
Executing the text search: the result will be displayed always in the default view

After:
The result will be displayed in the current view, if it is a view, else it will displayed in the default view

Changes proposed in this pull request:

- phtml

How to test the feature manually:

1. use the text search
2. the result will be displayed in the current view (or in the default view)


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
