### PR TITLE
Better handling of special chars in searches

### DIFF
--- a/app/Models/BooleanSearch.php
+++ b/app/Models/BooleanSearch.php
@@ -165,7 +165,7 @@ class FreshRSS_BooleanSearch {
 				$i++;
 				while ($i < $length) {
 					$c = $input[$i];
-					$backslashed = $i >= 1 ? $input[$i - 1] === '\\' : false;
+					$backslashed = $input[$i - 1] === '\\';
 					if ($c === '(' && !$backslashed) {
 						// One nested level deeper
 						$parentheses++;

--- a/app/Models/BooleanSearch.php
+++ b/app/Models/BooleanSearch.php
@@ -118,8 +118,9 @@ class FreshRSS_BooleanSearch {
 		$nextOperator = 'AND';
 		while ($i < $length) {
 			$c = $input[$i];
+			$backslashed = $i >= 1 ? $input[$i - 1] === '\\' : false;
 
-			if ($c === '(') {
+			if ($c === '(' && !$backslashed) {
 				$hasParenthesis = true;
 
 				$before = trim($before);
@@ -164,11 +165,12 @@ class FreshRSS_BooleanSearch {
 				$i++;
 				while ($i < $length) {
 					$c = $input[$i];
-					if ($c === '(') {
+					$backslashed = $i >= 1 ? $input[$i - 1] === '\\' : false;
+					if ($c === '(' && !$backslashed) {
 						// One nested level deeper
 						$parentheses++;
 						$sub .= $c;
-					} elseif ($c === ')') {
+					} elseif ($c === ')' && !$backslashed) {
 						$parentheses--;
 						if ($parentheses === 0) {
 							// Found the matching closing parenthesis

--- a/app/Models/Search.php
+++ b/app/Models/Search.php
@@ -201,6 +201,13 @@ class FreshRSS_Search {
 		return $value;
 	}
 
+	private static function escapeCharacters($value) {
+		if (is_array($value)) {
+			return array_map('self::escapeCharacters', $value);
+		}
+		return addcslashes($value, '%_');
+	}
+
 	/**
 	 * Parse the search string to find entry (article) IDs.
 	 */
@@ -330,6 +337,7 @@ class FreshRSS_Search {
 				$names_array = explode(',', $names_list);
 				$names_array = self::removeEmptyValues($names_array);
 				if (!empty($names_array)) {
+					$names_array = self::escapeCharacters($names_array);
 					$this->label_names[] = $names_array;
 				}
 			}
@@ -356,6 +364,7 @@ class FreshRSS_Search {
 				$names_array = explode(',', $names_list);
 				$names_array = self::removeEmptyValues($names_array);
 				if (!empty($names_array)) {
+					$names_array = self::escapeCharacters($names_array);
 					$this->not_label_names[] = $names_array;
 				}
 			}
@@ -377,6 +386,7 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->intitle = self::removeEmptyValues($this->intitle);
+		$this->intitle = self::escapeCharacters($this->intitle);
 		return $input;
 	}
 
@@ -390,6 +400,7 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->not_intitle = self::removeEmptyValues($this->not_intitle);
+		$this->not_intitle = self::escapeCharacters($this->not_intitle);
 		return $input;
 	}
 
@@ -408,6 +419,7 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->author = self::removeEmptyValues($this->author);
+		$this->author = self::escapeCharacters($this->author);
 		return $input;
 	}
 
@@ -421,6 +433,7 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->not_author = self::removeEmptyValues($this->not_author);
+		$this->not_author = self::escapeCharacters($this->not_author);
 		return $input;
 	}
 
@@ -434,6 +447,7 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->inurl = self::removeEmptyValues($this->inurl);
+		$this->inurl = self::escapeCharacters($this->inurl);
 		return $input;
 	}
 
@@ -443,6 +457,7 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->not_inurl = self::removeEmptyValues($this->not_inurl);
+		$this->not_inurl = self::escapeCharacters($this->not_inurl);
 		return $input;
 	}
 
@@ -455,6 +470,7 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 			$dates = self::removeEmptyValues($matches['search']);
 			if (!empty($dates[0])) {
+				$dates = self::escapeCharacters($dates);
 				list($this->min_date, $this->max_date) = parseDateInterval($dates[0]);
 			}
 		}
@@ -466,6 +482,7 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 			$dates = self::removeEmptyValues($matches['search']);
 			if (!empty($dates[0])) {
+				$dates = self::escapeCharacters($dates);
 				list($this->not_min_date, $this->not_max_date) = parseDateInterval($dates[0]);
 			}
 		}
@@ -482,6 +499,7 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 			$dates = self::removeEmptyValues($matches['search']);
 			if (!empty($dates[0])) {
+				$dates = self::escapeCharacters($dates);
 				list($this->min_pubdate, $this->max_pubdate) = parseDateInterval($dates[0]);
 			}
 		}
@@ -493,6 +511,7 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 			$dates = self::removeEmptyValues($matches['search']);
 			if (!empty($dates[0])) {
+				$dates = self::escapeCharacters($dates);
 				list($this->not_min_pubdate, $this->not_max_pubdate) = parseDateInterval($dates[0]);
 			}
 		}
@@ -511,6 +530,7 @@ class FreshRSS_Search {
 		}
 		$this->tags = self::removeEmptyValues($this->tags);
 		$this->tags = self::decodeSpaces($this->tags);
+		$this->tags = self::escapeCharacters($this->tags);
 		return $input;
 	}
 
@@ -521,6 +541,7 @@ class FreshRSS_Search {
 		}
 		$this->not_tags = self::removeEmptyValues($this->not_tags);
 		$this->not_tags = self::decodeSpaces($this->not_tags);
+		$this->not_tags = self::escapeCharacters($this->not_tags);
 		return $input;
 	}
 
@@ -556,6 +577,7 @@ class FreshRSS_Search {
 		} else {
 			$this->search = explode(' ', $input);
 		}
+		$this->search = self::escapeCharacters($this->search);
 		return $input;
 	}
 
@@ -577,6 +599,7 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->not_search = self::removeEmptyValues($this->not_search);
+		$this->not_search = self::escapeCharacters($this->not_search);
 		return $input;
 	}
 

--- a/app/Models/Search.php
+++ b/app/Models/Search.php
@@ -201,13 +201,6 @@ class FreshRSS_Search {
 		return $value;
 	}
 
-	private static function escapeCharacters($value) {
-		if (is_array($value)) {
-			return array_map('self::escapeCharacters', $value);
-		}
-		return addcslashes($value, '%_');
-	}
-
 	/**
 	 * Parse the search string to find entry (article) IDs.
 	 */
@@ -337,7 +330,6 @@ class FreshRSS_Search {
 				$names_array = explode(',', $names_list);
 				$names_array = self::removeEmptyValues($names_array);
 				if (!empty($names_array)) {
-					$names_array = self::escapeCharacters($names_array);
 					$this->label_names[] = $names_array;
 				}
 			}
@@ -364,7 +356,6 @@ class FreshRSS_Search {
 				$names_array = explode(',', $names_list);
 				$names_array = self::removeEmptyValues($names_array);
 				if (!empty($names_array)) {
-					$names_array = self::escapeCharacters($names_array);
 					$this->not_label_names[] = $names_array;
 				}
 			}
@@ -386,7 +377,6 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->intitle = self::removeEmptyValues($this->intitle);
-		$this->intitle = self::escapeCharacters($this->intitle);
 		return $input;
 	}
 
@@ -400,7 +390,6 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->not_intitle = self::removeEmptyValues($this->not_intitle);
-		$this->not_intitle = self::escapeCharacters($this->not_intitle);
 		return $input;
 	}
 
@@ -419,7 +408,6 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->author = self::removeEmptyValues($this->author);
-		$this->author = self::escapeCharacters($this->author);
 		return $input;
 	}
 
@@ -433,7 +421,6 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->not_author = self::removeEmptyValues($this->not_author);
-		$this->not_author = self::escapeCharacters($this->not_author);
 		return $input;
 	}
 
@@ -447,7 +434,6 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->inurl = self::removeEmptyValues($this->inurl);
-		$this->inurl = self::escapeCharacters($this->inurl);
 		return $input;
 	}
 
@@ -457,7 +443,6 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->not_inurl = self::removeEmptyValues($this->not_inurl);
-		$this->not_inurl = self::escapeCharacters($this->not_inurl);
 		return $input;
 	}
 
@@ -470,7 +455,6 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 			$dates = self::removeEmptyValues($matches['search']);
 			if (!empty($dates[0])) {
-				$dates = self::escapeCharacters($dates);
 				list($this->min_date, $this->max_date) = parseDateInterval($dates[0]);
 			}
 		}
@@ -482,7 +466,6 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 			$dates = self::removeEmptyValues($matches['search']);
 			if (!empty($dates[0])) {
-				$dates = self::escapeCharacters($dates);
 				list($this->not_min_date, $this->not_max_date) = parseDateInterval($dates[0]);
 			}
 		}
@@ -499,7 +482,6 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 			$dates = self::removeEmptyValues($matches['search']);
 			if (!empty($dates[0])) {
-				$dates = self::escapeCharacters($dates);
 				list($this->min_pubdate, $this->max_pubdate) = parseDateInterval($dates[0]);
 			}
 		}
@@ -511,7 +493,6 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 			$dates = self::removeEmptyValues($matches['search']);
 			if (!empty($dates[0])) {
-				$dates = self::escapeCharacters($dates);
 				list($this->not_min_pubdate, $this->not_max_pubdate) = parseDateInterval($dates[0]);
 			}
 		}
@@ -530,7 +511,6 @@ class FreshRSS_Search {
 		}
 		$this->tags = self::removeEmptyValues($this->tags);
 		$this->tags = self::decodeSpaces($this->tags);
-		$this->tags = self::escapeCharacters($this->tags);
 		return $input;
 	}
 
@@ -541,7 +521,6 @@ class FreshRSS_Search {
 		}
 		$this->not_tags = self::removeEmptyValues($this->not_tags);
 		$this->not_tags = self::decodeSpaces($this->not_tags);
-		$this->not_tags = self::escapeCharacters($this->not_tags);
 		return $input;
 	}
 
@@ -577,7 +556,6 @@ class FreshRSS_Search {
 		} else {
 			$this->search = explode(' ', $input);
 		}
-		$this->search = self::escapeCharacters($this->search);
 		return $input;
 	}
 
@@ -599,7 +577,6 @@ class FreshRSS_Search {
 			$input = str_replace($matches[0], '', $input);
 		}
 		$this->not_search = self::removeEmptyValues($this->not_search);
-		$this->not_search = self::escapeCharacters($this->not_search);
 		return $input;
 	}
 

--- a/docs/en/users/03_Main_view.md
+++ b/docs/en/users/03_Main_view.md
@@ -247,6 +247,8 @@ Finally, parentheses may be used to express more complex queries, with basic neg
 * `(author:Alice intitle:hello) !(author:Bob intitle:world)`
 * `!(S:1 OR S:2)`
 
+> ℹ️ If you need to search for a parenthesis, it needs to be escaped like `\(` or `\)`
+
 ### By sorting by date
 
 You can change the sort order by clicking the toggle button available in the header.

--- a/docs/fr/users/03_Main_view.md
+++ b/docs/fr/users/03_Main_view.md
@@ -275,3 +275,5 @@ Enfin, les parenthèses peuvent être utilisées pour des expressions plus compl
 * `!((author:Alice intitle:bonjour) OR (author:Bob intitle:monde))`
 * `(author:Alice intitle:bonjour) !(author:Bob intitle:monde)`
 * `!(S:1 OR S:2)`
+
+> ℹ️ Si vous devez chercher une parenthèse, elle doit être *échappée* comme suit : `\(` ou `\)`

--- a/tests/app/Models/SearchTest.php
+++ b/tests/app/Models/SearchTest.php
@@ -284,16 +284,16 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 				array('word6', 'word7'),
 			),
 			array(
-				'wor_d6 intitle:word2 inurl:word3 pubdate:2007-03-01/2008-05-11 #word4 author:wor_d1 #wor_d5 "wor_d7 word8" date:2007-03-01/2008-05-11',
-				array('wor\\_d1'),
+				'word6 intitle:word2 inurl:word3 pubdate:2007-03-01/2008-05-11 #word4 author:word1 #word5 "word7 word8" date:2007-03-01/2008-05-11',
+				array('word1'),
 				strtotime('2007-03-01'),
 				strtotime('2008-05-12') - 1,
 				array('word2'),
 				array('word3'),
 				strtotime('2007-03-01'),
 				strtotime('2008-05-12') - 1,
-				array('word4', 'wor\\_d5'),
-				array('wor\\_d7 word8', 'wor\\_d6'),
+				array('word4', 'word5'),
+				array('word7 word8', 'word6'),
 			),
 		);
 	}

--- a/tests/app/Models/SearchTest.php
+++ b/tests/app/Models/SearchTest.php
@@ -284,16 +284,16 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 				array('word6', 'word7'),
 			),
 			array(
-				'word6 intitle:word2 inurl:word3 pubdate:2007-03-01/2008-05-11 #word4 author:word1 #word5 "word7 word8" date:2007-03-01/2008-05-11',
-				array('word1'),
+				'wor_d6 intitle:word2 inurl:word3 pubdate:2007-03-01/2008-05-11 #word4 author:wor_d1 #wor_d5 "wor_d7 word8" date:2007-03-01/2008-05-11',
+				array('wor\\_d1'),
 				strtotime('2007-03-01'),
 				strtotime('2008-05-12') - 1,
 				array('word2'),
 				array('word3'),
 				strtotime('2007-03-01'),
 				strtotime('2008-05-12') - 1,
-				array('word4', 'word5'),
-				array('word7 word8', 'word6'),
+				array('word4', 'wor\\_d5'),
+				array('wor\\_d7 word8', 'wor\\_d6'),
 			),
 		);
 	}
@@ -339,6 +339,11 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 				'(author:Alice intitle:hello) !(author:Bob intitle:world)',
 				' ((e.author LIKE ? AND e.title LIKE ? )) AND NOT ((e.author LIKE ? AND e.title LIKE ? )) ',
 				['%Alice%', '%hello%', '%Bob%', '%world%'],
+			],
+			[
+				'intitle:"\\(test\\)"',
+				'(e.title LIKE ? )',
+				['%\\(test\\)%'],
 			]
 		];
 	}


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/4987

Allows searching for parentheses with `\(` or `\) ` ~~and a better handing of `_` and `#` which means something special in SQL `LIKE`~~