### PR TITLE
fix: Ansum/Mapco theme: updating notification

### DIFF
--- a/p/themes/Ansum/_layout.scss
+++ b/p/themes/Ansum/_layout.scss
@@ -358,6 +358,10 @@ main.prompt {
 		br {
 			display: none;
 		}
+
+		.title {
+			margin: 0 2rem;
+		}
 	}
 }
 

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -937,6 +937,9 @@ main.prompt {
 .notification#actualizeProgress br {
 	display: none;
 }
+.notification#actualizeProgress .title {
+	margin: 0 2rem;
+}
 
 /*=== Navigation menu (for articles) */
 #nav_entries {

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -937,6 +937,9 @@ main.prompt {
 .notification#actualizeProgress br {
 	display: none;
 }
+.notification#actualizeProgress .title {
+	margin: 0 2rem;
+}
 
 /*=== Navigation menu (for articles) */
 #nav_entries {

--- a/p/themes/Mapco/_layout.scss
+++ b/p/themes/Mapco/_layout.scss
@@ -371,6 +371,10 @@ main.prompt {
 		br {
 			display: none;
 		}
+
+		.title {
+			margin: 0 2rem;
+		}
 	}
 }
 

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -954,6 +954,9 @@ main.prompt {
 .notification#actualizeProgress br {
 	display: none;
 }
+.notification#actualizeProgress .title {
+	margin: 0 2rem;
+}
 
 /*=== Navigation menu (for articles) */
 #nav_entries {

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -954,6 +954,9 @@ main.prompt {
 .notification#actualizeProgress br {
 	display: none;
 }
+.notification#actualizeProgress .title {
+	margin: 0 2rem;
+}
 
 /*=== Navigation menu (for articles) */
 #nav_entries {


### PR DESCRIPTION
Closes #4990

After:
![grafik](https://user-images.githubusercontent.com/1645099/211221668-289226c0-b141-4ede-bc3d-c3ec7a1eb173.png)


Changes proposed in this pull request:

- (S)CSS for Ansum + Mapco theme


How to test the feature manually:

1. use Ansum/Mapco Theme
2. update the feeds
3. see the notification box

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
