### PR TITLE
Lazy load logo on install, logo on header and theme thumbs in config slide

### DIFF
--- a/app/install.php
+++ b/app/install.php
@@ -445,7 +445,7 @@ function printStep1() {
 	<?php } else { ?>
 	<p class="alert alert-error"><?= _t('install.action.fix_errors_before') ?></p>
 	<a id="actualize" class="btn" href="./index.php?step=1" title="<?= _t('install.check.reload') ?>">
-		<img class="icon" src="../themes/icons/refresh.svg" alt="🔃" />
+		<img class="icon" src="../themes/icons/refresh.svg" alt="🔃" loading="lazy" />
 	</a>
 	<?php } ?>
 <?php
@@ -676,7 +676,7 @@ if (_t('gen.dir') === 'rtl') {
 	<div class="item title">
 		<div id="logo-wrapper">
 			<a href="./">
-				<img class="logo" src="../themes/icons/FreshRSS-logo.svg" alt="">
+				<img class="logo" src="../themes/icons/FreshRSS-logo.svg" alt="" loading="lazy">
 			</a>
 		</div>
 	</div>

--- a/app/layout/header.phtml
+++ b/app/layout/header.phtml
@@ -2,7 +2,7 @@
 	<div class="item title">
 		<a href="<?= _url('index', 'index') ?>">
 			<?php if (FreshRSS_Context::$system_conf->logo_html == '') { ?>
-				<img class="logo" src="<?= _i('FreshRSS-logo', FreshRSS_Themes::ICON_URL) ?>" alt="FreshRSS" />
+				<img class="logo" src="<?= _i('FreshRSS-logo', FreshRSS_Themes::ICON_URL) ?>" alt="FreshRSS" loading="lazy" />
 			<?php
 				} else {
 					echo FreshRSS_Context::$system_conf->logo_html;
@@ -18,7 +18,7 @@
 				<input type="search" name="search" id="search" class="extend"
 					value="<?= htmlspecialchars(htmlspecialchars_decode(FreshRSS_Context::$search, ENT_QUOTES), ENT_COMPAT, 'UTF-8') ?>"
 					placeholder="<?= _t('gen.menu.search') ?>" />
-				
+
 				<?php $param_a = Minz_Request::actionName(); ?>
 				<?php if (in_array($param_a, ['normal', 'global', 'reader'])) { ?>
 				<input type="hidden" name="a" value="<?= $param_a ?>" />
@@ -83,7 +83,7 @@
 				</li>
 				<?php if (FreshRSS_Auth::hasAccess('admin')) { ?>
 				<li class="item dropdown-section">
-					<div class="dropdown-section-title">	
+					<div class="dropdown-section-title">
 						<?= _t('gen.menu.admin') ?>
 					</div>
 					<ul>
@@ -98,7 +98,7 @@
 					</ul>
 				</li>
 				<?php } ?>
-				
+
 				<li class="item dropdown-section">
 					<ul>
 						<li class="item"><a href="<?= _url('index', 'logs') ?>"><?= _t('gen.menu.logs') ?></a></li>

--- a/app/layout/simple.phtml
+++ b/app/layout/simple.phtml
@@ -31,7 +31,7 @@
 		<div class="item title">
 			<a href="<?= _url('index', 'index') ?>">
 				<?php if (FreshRSS_Context::$system_conf->logo_html == '') { ?>
-					<img class="logo" src="<?= _i('FreshRSS-logo', FreshRSS_Themes::ICON_URL) ?>" alt="FreshRSS" />
+					<img class="logo" src="<?= _i('FreshRSS-logo', FreshRSS_Themes::ICON_URL) ?>" alt="FreshRSS" loading="lazy" />
 				<?php
 					} else {
 						echo FreshRSS_Context::$system_conf->logo_html;

--- a/app/views/configure/display.phtml
+++ b/app/views/configure/display.phtml
@@ -60,7 +60,7 @@
 							data-leave-validation="<?= (FreshRSS_Context::$user_conf->theme === $theme['id']) ? 1 : 0 ?>" />
 						<li class="slide-container">
 							<div class="slide">
-								<img src="<?= Minz_Url::display('/themes/' . $theme['id'] . '/thumbs/original.png') ?>" />
+								<img src="<?= Minz_Url::display('/themes/' . $theme['id'] . '/thumbs/original.png') ?>" loading="lazy" />
 							</div>
 							<div class="nav">
 								<?php if ($i !== 1) {?>

--- a/p/index.html
+++ b/p/index.html
@@ -14,6 +14,6 @@
 
 <body>
 <h1><a href="i/">FreshRSS</a></h1>
-<p><a href="i/"><img class="logo" width="25%" src="themes/icons/icon.svg" alt="⊚" loading="lazy"/></a></p>
+<p><a href="i/"><img class="logo" width="25%" src="themes/icons/icon.svg" alt="⊚" loading="lazy" /></a></p>
 </body>
 </html>

--- a/p/index.html
+++ b/p/index.html
@@ -14,6 +14,6 @@
 
 <body>
 <h1><a href="i/">FreshRSS</a></h1>
-<p><a href="i/"><img class="logo" width="25%" src="themes/icons/icon.svg" alt="⊚" /></a></p>
+<p><a href="i/"><img class="logo" width="25%" src="themes/icons/icon.svg" alt="⊚" loading="lazy"/></a></p>
 </body>
 </html>


### PR DESCRIPTION
closes **Partialy** #2371

Changes proposed in this pull request:

- Lazy load logo on install
- Fill the `alt` attribute of logo on install
- Lazy load logo on header
- Lazy load theme thumbs in config slide 

How to test the feature manually:

1. After reseting all project cache, open project url, you will be on installation page.
2. Inspect element, and verify the  FreshRSS logo `alt` attribute and `loading` attribute
3. After installation, inspect element and verify the  FreshRSS logo (on header) `loading` attribute
4. Go to Configuration / Display
5. Inspect element and verify theme thumbs image `loading` attribute

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
