### PR TITLE
fix: #5000

### DIFF
--- a/app/views/configure/display.phtml
+++ b/app/views/configure/display.phtml
@@ -99,8 +99,8 @@
 			<label class="group-name" for="darkMode"><?= _t('conf.display.darkMode') ?></label>
 			<div class="group-controls">
 				<select name="darkMode" id="darkMode" data-leave-validation="<?= FreshRSS_Context::$user_conf->darkMode ?>">
-					<option value="no"<?php FreshRSS_Context::$user_conf->darkMode === 'no' ? ' selected' : '' ?>>No</option>
-					<option value="auto"<?php FreshRSS_Context::$user_conf->darkMode === 'auto' ? ' selected' : '' ?>>Auto</option>
+					<option value="no"<?= FreshRSS_Context::$user_conf->darkMode === 'no' ? ' selected' : '' ?>>No</option>
+					<option value="auto"<?= FreshRSS_Context::$user_conf->darkMode === 'auto' ? ' selected' : '' ?>>Auto</option>
 				</select>
 			</div>
 		</div>


### PR DESCRIPTION
Closes #5000

I invested more than 1 hour to find this stupid mistake.......

Changes proposed in this pull request:

- `<?=` instead of `<?php`


How to test the feature manually:

1. go to config "display"
2. switch the dark mode config to `auto`
3. save it
4. the setting keep `auto`

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested