### PR TITLE
fix: Lemmy sharing service parameter

### DIFF
--- a/app/shares.php
+++ b/app/shares.php
@@ -94,7 +94,7 @@ return array(
 		'method' => 'GET',
 	),
 	'lemmy' => array(
-		'url' => '~URL~/create_post?url=~LINK~&name=~TITLE~',
+		'url' => '~URL~/create_post?url=~LINK~&title=~TITLE~',
 		'transform' => array('rawurlencode'),
 		'help' => 'https://join-lemmy.org/',
 		'form' => 'advanced',


### PR DESCRIPTION
Closes #5018

Changes proposed in this pull request:

- `name` parameter changed to `title`


How to test the feature manually:

use the Lemmy sharing service

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
