### PR TITLE
Minz i18n safer vsprintf

### DIFF
--- a/lib/Minz/Translate.php
+++ b/lib/Minz/Translate.php
@@ -232,7 +232,7 @@ class Minz_Translate {
 		}
 
 		// Get the facultative arguments to replace i18n variables.
-		return vsprintf($translation_value, $args);
+		return empty($args) ? $translation_value : vsprintf($translation_value, $args);
 	}
 
 	/**


### PR DESCRIPTION
Fix bug introduced by https://github.com/FreshRSS/FreshRSS/pull/4807 though only for the French i18n, which has some `%` signs in the URL, making `vsprintf` to crash.

Only use `vsprintf` when we call the translation with some parameters, otherwise skip it (probably faster as well).

```
Warning: vsprintf(): Too few arguments in /var/www/FreshRSS/lib/Minz/Translate.php on line 235
```

But with PHP 8.2+, fatal error:

```
PHP Fatal error:  Uncaught ValueError: The arguments array must contain 2 items, 0 given
```
