### PR TITLE
fix: Swage theme dropdown triangle

### DIFF
--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -1158,10 +1158,16 @@ button.as-link {
 	left: 0;
 	right: auto;
 }
+#nav_menu_actions ul.dropdown-menu::after {
+	display: none;
+}
 
 #nav_menu_read_all ul.dropdown-menu {
 	right: 0;
 	left: auto;
+}
+#nav_menu_read_all ul.dropdown-menu::after {
+	display: none;
 }
 
 #slider label {

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -1158,10 +1158,16 @@ button.as-link {
 	right: 0;
 	left: auto;
 }
+#nav_menu_actions ul.dropdown-menu::after {
+	display: none;
+}
 
 #nav_menu_read_all ul.dropdown-menu {
 	left: 0;
 	right: auto;
+}
+#nav_menu_read_all ul.dropdown-menu::after {
+	display: none;
 }
 
 #slider label {

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -1481,6 +1481,10 @@ button.as-link {
 	ul.dropdown-menu {
 		left: 0;
 		right: auto;
+
+		&::after {
+			display: none;
+		}
 	}
 }
 
@@ -1488,6 +1492,10 @@ button.as-link {
 	ul.dropdown-menu {
 		right: 0;
 		left: auto;
+
+		&::after {
+			display: none;
+		}
 	}
 }
 


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/1645099/213870174-2cbc6e4a-85a6-4acc-a8ec-66bfd458aca4.png)

![grafik](https://user-images.githubusercontent.com/1645099/213870182-744d61bd-7653-4f13-9a99-002a46dee4aa.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/213870184-298be43a-803c-462d-be5d-97c3acfcdc91.png)

![grafik](https://user-images.githubusercontent.com/1645099/213870187-7964b2ba-0cb4-4c5a-ab93-ab8826fbc995.png)


Changes proposed in this pull request:

- (S)CSS

How to test the feature manually:

1. use Swage theme
2. open the dropdown menus in the navigation bar

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
