### PR TITLE
Fix error handling when updating URL

### DIFF
--- a/app/Controllers/subscriptionController.php
+++ b/app/Controllers/subscriptionController.php
@@ -256,7 +256,7 @@ class FreshRSS_subscription_Controller extends FreshRSS_ActionController {
 					$url_redirect = array('c' => 'subscription', 'params' => array('id' => $id));
 			}
 
-			if ($feedDAO->updateFeed($id, $values) !== false) {
+			if ($values['url'] != '' && $feedDAO->updateFeed($id, $values) !== false) {
 				$feed->_categoryId($values['category']);
 				// update url and website values for faviconPrepare
 				$feed->_url($values['url'], false);
@@ -265,6 +265,9 @@ class FreshRSS_subscription_Controller extends FreshRSS_ActionController {
 
 				Minz_Request::good(_t('feedback.sub.feed.updated'), $url_redirect);
 			} else {
+				if ($values['url'] == '') {
+					Minz_Log::warning('Invalid feed URL!');
+				}
 				Minz_Request::bad(_t('feedback.sub.feed.error'), $url_redirect);
 			}
 		}

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -259,13 +259,14 @@ class FreshRSS_Feed extends Minz_Model {
 	}
 	public function _url(string $value, bool $validate = true) {
 		$this->hash = '';
+		$url = $value;
 		if ($validate) {
-			$value = checkUrl($value);
+			$url = checkUrl($url);
 		}
-		if ($value == '') {
+		if ($url == '') {
 			throw new FreshRSS_BadUrl_Exception($value);
 		}
-		$this->url = $value;
+		$this->url = $url;
 	}
 	public function _kind(int $value) {
 		$this->kind = $value;

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -845,7 +845,7 @@ function errorMessageInfo($errorTitle, $error = '') {
 	$details = '';
 	// Prevent empty tags by checking if error isn not empty first
 	if ($error) {
-		$error = htmlspecialchars($error, ENT_NOQUOTES, 'UTF-8');
+		$error = htmlspecialchars($error, ENT_NOQUOTES, 'UTF-8') . "\n";
 
 		// First line is the main message, other lines are the details
 		list($message, $details) = explode("\n", $error, 2);


### PR DESCRIPTION
Fix 3 related errors handling when updating the feed URL with an invalid URL. Previously leading to unclear 500 page with additional PHP errors.
