### PR TITLE
Fix: dropdowns' overflow

### DIFF
--- a/app/views/index/reader.phtml
+++ b/app/views/index/reader.phtml
@@ -87,8 +87,8 @@ $MAX_TAGS_DISPLAYED = FreshRSS_Context::$user_conf->show_tags_max;
 								if (!empty($remainingTags)) { // more than 7 tags: show dropdown menu ?>
 									<li class="item tag">
 										<div class="dropdown">
-											<div id="dropdown-tags2-<?= $this->entry->id() ?>" class="dropdown-target"></div>
-											<a class="dropdown-toggle" href="#dropdown-tags2-<?= $this->entry->id() ?>"><?= _i('down') ?></a>
+											<div id="dropdown-tags-<?= $this->entry->id() ?>" class="dropdown-target"></div>
+											<a class="dropdown-toggle" href="#dropdown-tags-<?= $this->entry->id() ?>"><?= _i('down') ?></a>
 											<ul class="dropdown-menu">
 												<li class="dropdown-header"><?= _t('index.tag.related') ?></li>
 												<?php

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1302,22 +1302,34 @@ a.website:hover .favicon {
 .content {
 	min-height: 20rem;
 	margin: auto;
-	padding: 0.75rem;
 	line-height: 1.5;
 	word-wrap: break-word;
-	overflow: auto;
+}
+
+.content .text {
+	overflow-x: auto;
+}
+
+.content .text div {
+	overflow-x: auto;
+}
+
+.content header,
+.content .text,
+.content footer {
+	padding: 0 3rem;
 }
 
 .content.large {
-	max-width: 1000px;
+	max-width: 1100px;
 }
 
 .content.medium {
-	max-width: 800px;
+	max-width: 900px;
 }
 
 .content.thin {
-	max-width: 550px;
+	max-width: 650px;
 }
 
 .content .article-header-topline {
@@ -1331,14 +1343,13 @@ a.website:hover .favicon {
 }
 
 .content > footer {
-	margin: 2rem 0 2rem;
 	padding-top: 1rem;
-	border-top: 2px solid var(--frss-border-color);
 	clear: both;
 }
 
 .content > footer .subtitle {
-	padding-bottom: 1rem;
+	padding: 2rem 0 1rem;
+	border-top: 2px solid var(--frss-border-color);
 }
 
 .content > header .tags,
@@ -1980,7 +1991,7 @@ input:checked + .slide-container .properties {
 }
 
 .reader .flux .content {
-	padding: 3rem;
+	padding: 3rem 0;
 	background-color: var(--frss-background-color);
 	border: 1px solid var(--frss-border-color);
 }
@@ -2096,7 +2107,7 @@ input:checked + .slide-container .properties {
 	}
 
 	.dropdown-target:target ~ .dropdown-toggle:not(.btn) ~ .dropdown-menu {
-		margin-top: 0;
+		margin-top: 10px;
 	}
 
 	.configure .dropdown .dropdown-menu {
@@ -2187,7 +2198,9 @@ input:checked + .slide-container .properties {
 		top: 0;
 	}
 
-	.reader .flux .content {
+	.content header,
+	.content .text,
+	.content footer {
 		padding: 1rem;
 	}
 

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1320,6 +1320,14 @@ a.website:hover .favicon {
 	padding: 0 3rem;
 }
 
+.content header {
+	padding-top: calc(2 * var(--frss-padding-top-bottom));
+}
+
+.content footer {
+	padding-bottom: calc(2 * var(--frss-padding-top-bottom));
+}
+
 .content.large {
 	max-width: 1100px;
 }

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1302,22 +1302,31 @@ a.website:hover .favicon {
 .content {
 	min-height: 20rem;
 	margin: auto;
-	padding: 0.75rem;
+	padding: 2rem 0.75rem;
 	line-height: 1.5;
 	word-wrap: break-word;
+}
+
+.content .text {
 	overflow: auto;
 }
 
+.content header,
+.content .text,
+.content footer {
+	padding: 0 3rem;
+}
+
 .content.large {
-	max-width: 1000px;
+	max-width: 1100px;
 }
 
 .content.medium {
-	max-width: 800px;
+	max-width: 900px;
 }
 
 .content.thin {
-	max-width: 550px;
+	max-width: 650px;
 }
 
 .content .article-header-topline {
@@ -1331,14 +1340,13 @@ a.website:hover .favicon {
 }
 
 .content > footer {
-	margin: 2rem 0 2rem;
 	padding-top: 1rem;
-	border-top: 2px solid var(--frss-border-color);
 	clear: both;
 }
 
 .content > footer .subtitle {
-	padding-bottom: 1rem;
+	padding: 2rem 0 1rem;
+	border-top: 2px solid var(--frss-border-color);
 }
 
 .content > header .tags,
@@ -1980,7 +1988,7 @@ input:checked + .slide-container .properties {
 }
 
 .reader .flux .content {
-	padding: 3rem;
+	padding: 3rem 0;
 	background-color: var(--frss-background-color);
 	border: 1px solid var(--frss-border-color);
 }
@@ -2187,8 +2195,10 @@ input:checked + .slide-container .properties {
 		top: 0;
 	}
 
-	.reader .flux .content {
-		padding: 1rem;
+	.content header,
+	.content .text,
+	.content footer {
+		padding: 0 1rem;
 	}
 
 	table {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1302,19 +1302,30 @@ a.website:hover .favicon {
 .content {
 	min-height: 20rem;
 	margin: auto;
-	padding: 2rem 0.75rem;
 	line-height: 1.5;
 	word-wrap: break-word;
 }
 
 .content .text {
-	overflow: auto;
+	overflow-x: auto;
+}
+
+.content .text div {
+	overflow-x: auto;
 }
 
 .content header,
 .content .text,
 .content footer {
 	padding: 0 3rem;
+}
+
+.content header {
+	padding-top: calc(2 * var(--frss-padding-top-bottom));
+}
+
+.content footer {
+	padding-bottom: calc(2 * var(--frss-padding-top-bottom));
 }
 
 .content.large {
@@ -2104,7 +2115,7 @@ input:checked + .slide-container .properties {
 	}
 
 	.dropdown-target:target ~ .dropdown-toggle:not(.btn) ~ .dropdown-menu {
-		margin-top: 0;
+		margin-top: 10px;
 	}
 
 	.configure .dropdown .dropdown-menu {
@@ -2198,7 +2209,7 @@ input:checked + .slide-container .properties {
 	.content header,
 	.content .text,
 	.content footer {
-		padding: 0 1rem;
+		padding: 1rem;
 	}
 
 	table {


### PR DESCRIPTION
Before:
reading view:
(1) and (2) opens the tag list. The tag list is cropped by the article frame
![grafik](https://user-images.githubusercontent.com/1645099/215355780-94a6e97c-d3e4-4522-82a2-607dbebab62b.png)

After:
(1) and (2) will not be cropped anymore
![grafik](https://user-images.githubusercontent.com/1645099/215356138-f4594068-2abe-4602-a6d9-220aee682464.png)

(2) has its own dropdown
![grafik](https://user-images.githubusercontent.com/1645099/215356133-b81ed153-5daa-4a1d-91e9-defdc174c58b.png)


---

That is the PR that causes the cropping: #4872 (it wanted to fix overflowing tables). It is now solved in another way:

(the feed with very wide tables: https://raw.githubusercontent.com/math-GH/testfeed/main/chatgpt-generated-feed.xml )

Before:
if a table overflows
![grafik](https://user-images.githubusercontent.com/1645099/215356543-fe4b1867-7b0b-41ec-926b-049bd98d84b4.png)
the whole article is scrollable, to read the table
![grafik](https://user-images.githubusercontent.com/1645099/215356565-39cf57ac-b10e-4897-a4d3-fb571e8da2fa.png)


After:
if the table is wrapped by a `<div>` the div will be scrollable
![grafik](https://user-images.githubusercontent.com/1645099/215356600-beba09c7-6dea-4560-a5ea-7fa417eaf8f2.png)


---

Additional this issue is fixed:
Before:
normal view: dropdowns in mobile view. The triangle is misplaced:
![grafik](https://user-images.githubusercontent.com/1645099/215356284-6106d40a-61ac-4847-b7d7-12ac275cb092.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/215356367-8c14d24b-1b36-4840-85b8-d0f85aeb8683.png)




Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
