### PR TITLE
fix: Thumbnails background

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1212,8 +1212,12 @@ a.website:hover .favicon {
 
 .flux .item.thumbnail {
 	line-height: 0;
-	padding: 0.75rem;
+	padding: var(--frss-padding-top-bottom) var(--frss-padding-flux-items);
 	height: 80px;
+}
+
+.flux .item.thumbnail .item-element{
+	padding: 0;
 }
 
 .flux .item.thumbnail.small {

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1216,7 +1216,7 @@ a.website:hover .favicon {
 	height: 80px;
 }
 
-.flux .item.thumbnail .item-element{
+.flux .item.thumbnail .item-element {
 	padding: 0;
 }
 

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1212,8 +1212,12 @@ a.website:hover .favicon {
 
 .flux .item.thumbnail {
 	line-height: 0;
-	padding: 0.75rem;
+	padding: var(--frss-padding-top-bottom) var(--frss-padding-flux-items);
 	height: 80px;
+}
+
+.flux .item.thumbnail .item-element{
+	padding: 0;
 }
 
 .flux .item.thumbnail.small {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1216,7 +1216,7 @@ a.website:hover .favicon {
 	height: 80px;
 }
 
-.flux .item.thumbnail .item-element{
+.flux .item.thumbnail .item-element {
 	padding: 0;
 }
 


### PR DESCRIPTION
Closes #5048

Before:
![grafik](https://user-images.githubusercontent.com/1645099/215563748-de1db922-74b2-482f-aa7f-f0a82807dd99.png)


After:
![grafik](https://user-images.githubusercontent.com/1645099/215563791-c1bbb9fd-dbf1-4476-8dcd-c8a336afeb96.png)


Changes proposed in this pull request:

- CSS


How to test the feature manually:

1. enable the thumbnails
2. see the thumnails column


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
