### PR TITLE
Increase max HTTP timeout

### DIFF
--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -602,7 +602,7 @@
 		<div class="form-group">
 			<label class="group-name" for="timeout"><?= _t('sub.feed.timeout') ?></label>
 			<div class="group-controls">
-				<input type="number" name="timeout" id="timeout" class="w50" min="3" max="120" value="<?= $this->feed->attributes('timeout') ?>" placeholder="<?= _t('gen.short.by_default') ?>" />
+				<input type="number" name="timeout" id="timeout" class="w50" min="3" max="900" value="<?= $this->feed->attributes('timeout') ?>" placeholder="<?= _t('gen.short.by_default') ?>" />
 			</div>
 		</div>
 

--- a/app/views/subscription/add.phtml
+++ b/app/views/subscription/add.phtml
@@ -237,7 +237,7 @@
 			<div class="form-group">
 				<label class="group-name" for="timeout"><?= _t('sub.feed.timeout') ?></label>
 				<div class="group-controls">
-					<input type="number" name="timeout" id="timeout" min="3" max="120" value="" placeholder="<?= _t('gen.short.by_default') ?>" />
+					<input type="number" name="timeout" id="timeout" min="3" max="900" value="" placeholder="<?= _t('gen.short.by_default') ?>" />
 				</div>
 			</div>
 

--- a/config.default.php
+++ b/config.default.php
@@ -103,7 +103,7 @@ return array(
 		'cache_duration' => 800,
 
 		# SimplePie HTTP request timeout in seconds.
-		'timeout' => 15,
+		'timeout' => 20,
 
 		# If a user has not used FreshRSS for more than x seconds,
 		#	then its feeds are not refreshed anymore.

--- a/docs/en/users/04_Subscriptions.md
+++ b/docs/en/users/04_Subscriptions.md
@@ -5,7 +5,7 @@
 3. Paste the URL in the “Feed URL” field.
 4. (optional): You can select the category for your feed. By default, it will be in “Uncategorized”.
 5. (optional): If the subscription requires credentials, you can enter them in the "HTTP username" and "HTTP password" fields.
-6. (optional): You can set a timeout for the feed request if the feed requires it.
+6. (optional): You can set a timeout for the feed request.
 7. (optional): You can choose to ignore SSL certificate errors (such as with self-signed certificates) by setting "Verify SSL security" to "No". This is not recommended, and it is better to either add the root certificate to the FreshRSS server or to fix the SSL certificate problems on the feed hosting server.
 
 ## Subscription management


### PR DESCRIPTION
* Increase custom maximum HTTP request timeout from 2 minutes to 15 minutes;
    * Reason: I have some feeds generated by RSS Bridge, which can take several minutes.
* Increase default HTTP request timeout from 15 to 20s.
    * Reason: I regularly observe feeds, which are slow to answer.
