### PR TITLE
SimplePie use single constant for default HTTP Accept header

### DIFF
--- a/lib/SimplePie/SimplePie.php
+++ b/lib/SimplePie/SimplePie.php
@@ -1690,7 +1690,7 @@ class SimplePie
 				else
 				{
 					$headers = array(
-						'Accept' => 'application/atom+xml, application/rss+xml, application/rdf+xml;q=0.9, application/xml;q=0.8, text/xml;q=0.8, text/html;q=0.7, unknown/unknown;q=0.1, application/unknown;q=0.1, */*;q=0.1',
+						'Accept' => SimplePie_File::DEFAULT_HTTP_ACCEPT,
 					);
 					if (isset($this->data['headers']['last-modified']))
 					{
@@ -1754,7 +1754,7 @@ class SimplePie
 			else
 			{
 				$headers = array(
-					'Accept' => 'application/atom+xml, application/rss+xml, application/rdf+xml;q=0.9, application/xml;q=0.8, text/xml;q=0.8, text/html;q=0.7, unknown/unknown;q=0.1, application/unknown;q=0.1, */*;q=0.1',
+					'Accept' => SimplePie_File::DEFAULT_HTTP_ACCEPT,
 				);
 				$file = $this->registry->create('File', array($this->feed_url, $this->timeout, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options, $this->syslog_enabled));
 			}

--- a/lib/SimplePie/SimplePie.php
+++ b/lib/SimplePie/SimplePie.php
@@ -418,6 +418,12 @@ define('SIMPLEPIE_FILE_SOURCE_FILE_GET_CONTENTS', 16);
  */
 class SimplePie
 {
+
+	/**
+	 * @internal Default value of the HTTP Accept header when fetching/locating feeds
+	 */
+	public const DEFAULT_HTTP_ACCEPT_HEADER = 'application/atom+xml, application/rss+xml, application/rdf+xml;q=0.9, application/xml;q=0.8, text/xml;q=0.8, text/html;q=0.7, unknown/unknown;q=0.1, application/unknown;q=0.1, */*;q=0.1';
+
 	/**
 	 * @var array Raw data
 	 * @access private
@@ -1690,7 +1696,7 @@ class SimplePie
 				else
 				{
 					$headers = array(
-						'Accept' => SimplePie_File::DEFAULT_HTTP_ACCEPT,
+						'Accept' => SimplePie::DEFAULT_HTTP_ACCEPT_HEADER,
 					);
 					if (isset($this->data['headers']['last-modified']))
 					{
@@ -1754,7 +1760,7 @@ class SimplePie
 			else
 			{
 				$headers = array(
-					'Accept' => SimplePie_File::DEFAULT_HTTP_ACCEPT,
+					'Accept' => SimplePie::DEFAULT_HTTP_ACCEPT_HEADER,
 				);
 				$file = $this->registry->create('File', array($this->feed_url, $this->timeout, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options, $this->syslog_enabled));
 			}

--- a/lib/SimplePie/SimplePie/File.php
+++ b/lib/SimplePie/SimplePie/File.php
@@ -54,9 +54,6 @@
  */
 class SimplePie_File
 {
-
-	const DEFAULT_HTTP_ACCEPT = 'application/atom+xml, application/rss+xml, application/rdf+xml;q=0.9, application/xml;q=0.8, text/xml;q=0.8, text/html;q=0.7, unknown/unknown;q=0.1, application/unknown;q=0.1, */*;q=0.1';
-
 	var $url;
 	var $useragent;
 	var $success = true;

--- a/lib/SimplePie/SimplePie/File.php
+++ b/lib/SimplePie/SimplePie/File.php
@@ -55,7 +55,7 @@
 class SimplePie_File
 {
 
-	const DEFAULT_HTTP_ACCEPT = 'application/atom+xml, application/rss+xml, application/rdf+xml;q=0.9, application/xml;q=0.8, text/xml;q=0.7, text/html;q=0.6, text/plain;q=0.5, application/octet-stream;q=0.1';
+	const DEFAULT_HTTP_ACCEPT = 'application/atom+xml, application/rss+xml, application/rdf+xml;q=0.9, application/xml;q=0.8, text/xml;q=0.8, text/html;q=0.7, unknown/unknown;q=0.1, application/unknown;q=0.1, */*;q=0.1';
 
 	var $url;
 	var $useragent;

--- a/lib/SimplePie/SimplePie/File.php
+++ b/lib/SimplePie/SimplePie/File.php
@@ -54,6 +54,9 @@
  */
 class SimplePie_File
 {
+
+	const DEFAULT_HTTP_ACCEPT = 'application/atom+xml, application/rss+xml, application/rdf+xml;q=0.9, application/xml;q=0.8, text/xml;q=0.8, text/html;q=0.7, unknown/unknown;q=0.1, application/unknown;q=0.1, */*;q=0.1';
+
 	var $url;
 	var $useragent;
 	var $success = true;

--- a/lib/SimplePie/SimplePie/File.php
+++ b/lib/SimplePie/SimplePie/File.php
@@ -55,7 +55,7 @@
 class SimplePie_File
 {
 
-	const DEFAULT_HTTP_ACCEPT = 'application/atom+xml, application/rss+xml, application/rdf+xml;q=0.9, application/xml;q=0.8, text/xml;q=0.8, text/html;q=0.7, unknown/unknown;q=0.1, application/unknown;q=0.1, */*;q=0.1';
+	const DEFAULT_HTTP_ACCEPT = 'application/atom+xml, application/rss+xml, application/rdf+xml;q=0.9, application/xml;q=0.8, text/xml;q=0.7, text/html;q=0.6, text/plain;q=0.5, application/octet-stream;q=0.1';
 
 	var $url;
 	var $useragent;

--- a/lib/SimplePie/SimplePie/Locator.php
+++ b/lib/SimplePie/SimplePie/Locator.php
@@ -256,7 +256,7 @@ class SimplePie_Locator
 				{
 					$this->checked_feeds++;
 					$headers = array(
-						'Accept' => 'application/atom+xml, application/rss+xml, application/rdf+xml;q=0.9, application/xml;q=0.8, text/xml;q=0.8, text/html;q=0.7, unknown/unknown;q=0.1, application/unknown;q=0.1, */*;q=0.1',
+						'Accept' => SimplePie_File::DEFAULT_HTTP_ACCEPT,
 					);
 					$feed = $this->registry->create('File', array($href, $this->timeout, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options));
 					if ($feed->success && ($feed->method & SIMPLEPIE_FILE_SOURCE_REMOTE === 0 || ($feed->status_code === 200 || $feed->status_code > 206 && $feed->status_code < 300)) && $this->is_feed($feed, true))
@@ -386,7 +386,7 @@ class SimplePie_Locator
 				$this->checked_feeds++;
 
 				$headers = array(
-					'Accept' => 'application/atom+xml, application/rss+xml, application/rdf+xml;q=0.9, application/xml;q=0.8, text/xml;q=0.8, text/html;q=0.7, unknown/unknown;q=0.1, application/unknown;q=0.1, */*;q=0.1',
+					'Accept' => SimplePie_File::DEFAULT_HTTP_ACCEPT,
 				);
 				$feed = $this->registry->create('File', array($value, $this->timeout, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options));
 				if ($feed->success && ($feed->method & SIMPLEPIE_FILE_SOURCE_REMOTE === 0 || ($feed->status_code === 200 || $feed->status_code > 206 && $feed->status_code < 300)) && $this->is_feed($feed))
@@ -414,9 +414,9 @@ class SimplePie_Locator
 			{
 				$this->checked_feeds++;
 				$headers = array(
-					'Accept' => 'application/atom+xml, application/rss+xml, application/rdf+xml;q=0.9, application/xml;q=0.8, text/xml;q=0.8, text/html;q=0.7, unknown/unknown;q=0.1, application/unknown;q=0.1, */*;q=0.1',
+					'Accept' => SimplePie_File::DEFAULT_HTTP_ACCEPT,
 				);
-				$feed = $this->registry->create('File', array($value, $this->timeout, 5, null, $this->useragent, $this->force_fsockopen, $this->curl_options));
+				$feed = $this->registry->create('File', array($value, $this->timeout, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options));
 				if ($feed->success && ($feed->method & SIMPLEPIE_FILE_SOURCE_REMOTE === 0 || ($feed->status_code === 200 || $feed->status_code > 206 && $feed->status_code < 300)) && $this->is_feed($feed))
 				{
 					return array($feed);

--- a/lib/SimplePie/SimplePie/Locator.php
+++ b/lib/SimplePie/SimplePie/Locator.php
@@ -256,7 +256,7 @@ class SimplePie_Locator
 				{
 					$this->checked_feeds++;
 					$headers = array(
-						'Accept' => SimplePie_File::DEFAULT_HTTP_ACCEPT,
+						'Accept' => SimplePie::DEFAULT_HTTP_ACCEPT_HEADER,
 					);
 					$feed = $this->registry->create('File', array($href, $this->timeout, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options));
 					if ($feed->success && ($feed->method & SIMPLEPIE_FILE_SOURCE_REMOTE === 0 || ($feed->status_code === 200 || $feed->status_code > 206 && $feed->status_code < 300)) && $this->is_feed($feed, true))
@@ -386,7 +386,7 @@ class SimplePie_Locator
 				$this->checked_feeds++;
 
 				$headers = array(
-					'Accept' => SimplePie_File::DEFAULT_HTTP_ACCEPT,
+					'Accept' => SimplePie::DEFAULT_HTTP_ACCEPT_HEADER,
 				);
 				$feed = $this->registry->create('File', array($value, $this->timeout, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options));
 				if ($feed->success && ($feed->method & SIMPLEPIE_FILE_SOURCE_REMOTE === 0 || ($feed->status_code === 200 || $feed->status_code > 206 && $feed->status_code < 300)) && $this->is_feed($feed))
@@ -414,7 +414,7 @@ class SimplePie_Locator
 			{
 				$this->checked_feeds++;
 				$headers = array(
-					'Accept' => SimplePie_File::DEFAULT_HTTP_ACCEPT,
+					'Accept' => SimplePie::DEFAULT_HTTP_ACCEPT_HEADER,
 				);
 				$feed = $this->registry->create('File', array($value, $this->timeout, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options));
 				if ($feed->success && ($feed->method & SIMPLEPIE_FILE_SOURCE_REMOTE === 0 || ($feed->status_code === 200 || $feed->status_code > 206 && $feed->status_code < 300)) && $this->is_feed($feed))


### PR DESCRIPTION
Follow-up of https://github.com/simplepie/simplepie/commit/5d966b9f64a6034f89b019152d7cad9059f8819f
* Use single constant for default SimplePie HTTP Accept
* Missing headers in `SimplePie_Locator::body()`

~~Fix https://github.com/FreshRSS/FreshRSS/pull/5079#issuecomment-1421619176~~
~~The `*/*` breaks Mastodon content negotiation~~