### PR TITLE
Add archive.org as sharing service

### DIFF
--- a/app/i18n/cz/gen.php
+++ b/app/i18n/cz/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Známé základní stránky',
+		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Schránka',

--- a/app/i18n/de/gen.php
+++ b/app/i18n/de/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known-Seite (https://withknown.com)',
+		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Zwischenablage',

--- a/app/i18n/el/gen.php
+++ b/app/i18n/el/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known based sites',	// TODO
+		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// TODO
 		'blogotext' => 'Blogotext',	// TODO
 		'clipboard' => 'Clipboard',	// TODO

--- a/app/i18n/en-us/gen.php
+++ b/app/i18n/en-us/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known based sites',	// IGNORE
+		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Clipboard',	// IGNORE

--- a/app/i18n/en/gen.php
+++ b/app/i18n/en/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known based sites',
+		'archiveORG' => 'archive.org',
 		'archivePH' => 'archive.ph',
 		'blogotext' => 'Blogotext',
 		'clipboard' => 'Clipboard',

--- a/app/i18n/es/gen.php
+++ b/app/i18n/es/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Sitios basados en conocidos',
+		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Portapapeles',

--- a/app/i18n/fr/gen.php
+++ b/app/i18n/fr/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Sites basés sur Known',
+		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Presse-papier',

--- a/app/i18n/he/gen.php
+++ b/app/i18n/he/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known based sites',	// TODO
+		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Clipboard',	// TODO

--- a/app/i18n/id/gen.php
+++ b/app/i18n/id/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known based sites',	// TODO
+		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// TODO
 		'blogotext' => 'Blogotext',	// TODO
 		'clipboard' => 'Clipboard',	// TODO

--- a/app/i18n/it/gen.php
+++ b/app/i18n/it/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Siti basati su Known',
+		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Appunti',

--- a/app/i18n/ja/gen.php
+++ b/app/i18n/ja/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'よく使われるサイト',
+		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'クリップボード',

--- a/app/i18n/ko/gen.php
+++ b/app/i18n/ko/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known based sites',	// IGNORE
+		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => '클립보드',

--- a/app/i18n/nl/gen.php
+++ b/app/i18n/nl/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known-gebaseerde sites',
+		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Klembord',

--- a/app/i18n/oc/gen.php
+++ b/app/i18n/oc/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Sites basats sus Known',
+		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Quicha-papiers.',

--- a/app/i18n/pl/gen.php
+++ b/app/i18n/pl/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Strony bazujące na usłudze Known',
+		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Schowek',

--- a/app/i18n/pt-br/gen.php
+++ b/app/i18n/pt-br/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Sites no Known',
+		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Área de transferência',

--- a/app/i18n/ru/gen.php
+++ b/app/i18n/ru/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Сайты на Known',
+		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Буфер обмена',

--- a/app/i18n/sk/gen.php
+++ b/app/i18n/sk/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Stránky založené na Known',
+		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Schránka',

--- a/app/i18n/tr/gen.php
+++ b/app/i18n/tr/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Bilinen siteler',
+		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => 'Kopyala',

--- a/app/i18n/zh-cn/gen.php
+++ b/app/i18n/zh-cn/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => '基于 Known 的站点',
+		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => '剪贴板',

--- a/app/i18n/zh-tw/gen.php
+++ b/app/i18n/zh-tw/gen.php
@@ -192,6 +192,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => '基於 Known 的站點',
+		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'blogotext' => 'Blogotext',	// IGNORE
 		'clipboard' => '剪貼板',

--- a/app/shares.php
+++ b/app/shares.php
@@ -26,6 +26,13 @@
  */
 
 return array(
+	'archiveORG' => array(
+		'url' => 'https://web.archive.org/save/~LINK~',
+		'transform' => array(),
+		'help' => 'https://web.archive.org',
+		'form' => 'simple',
+		'method' => 'GET',
+	),
 	'archivePH' => array(
 		'url' => 'https://archive.ph/submit/?url=~LINK~',
 		'transform' => array(),


### PR DESCRIPTION
Changes proposed in this pull request:

- add archive.org as sharing service

How to test the feature manually:

1. share an article.
2. wait ten seconds. (The waiting time will be longer when the Internet Archive is overloaded)
3. automatically redirect to the snapshot URL.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated