### PR TITLE
fix: group-controls min-width

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -402,7 +402,7 @@ td.numeric {
 }
 
 .form-group .group-controls {
-	min-width: 250px;
+	min-width: 200px;
 	margin: 0 0 0 220px;
 	overflow-x: auto;
 }

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -402,7 +402,7 @@ td.numeric {
 }
 
 .form-group .group-controls {
-	min-width: 250px;
+	min-width: 200px;
 	margin: 0 220px 0 0;
 	overflow-x: auto;
 }


### PR DESCRIPTION
Window with: around 840px (there is the break point between "desktop view" and "mobile view"

Before:
![grafik](https://user-images.githubusercontent.com/1645099/218268093-f6b1da41-4673-4e44-9f2f-c928463c4918.png)


After:
![grafik](https://user-images.githubusercontent.com/1645099/218268123-b9f431dc-c06a-430d-a5aa-6a6bed35e00d.png)


Changes proposed in this pull request:

- CSS in `frss.css`


How to test the feature manually:

1. go to f.e. label management
2. change the width of the window to about 845px
3. see the text inputs

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested