### PR TITLE
fix: add sharing method

### DIFF
--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -216,7 +216,8 @@ form th {
 }
 
 .stick .btn:first-child,
-.stick input:first-child {
+.stick input:first-child,
+.stick select:first-child {
 	border-radius: 3px 0 0 3px;
 }
 
@@ -233,6 +234,7 @@ form th {
 .stick .btn + input,
 .stick .btn + .dropdown > .btn,
 .stick input + .btn,
+.stick select + .btn,
 .stick input + input,
 .stick input + .dropdown > .btn,
 .stick .dropdown + .btn,

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -216,7 +216,8 @@ form th {
 }
 
 .stick .btn:first-child,
-.stick input:first-child {
+.stick input:first-child,
+.stick select:first-child {
 	border-radius: 0 3px 3px 0;
 }
 
@@ -233,6 +234,7 @@ form th {
 .stick .btn + input,
 .stick .btn + .dropdown > .btn,
 .stick input + .btn,
+.stick select + .btn,
 .stick input + input,
 .stick input + .dropdown > .btn,
 .stick .dropdown + .btn,

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -219,6 +219,10 @@ input, select, textarea {
 	box-sizing: border-box;
 }
 
+select {
+	min-width: 6em;
+}
+
 input.w50,
 select.w50,
 textarea.w50 {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -219,6 +219,10 @@ input, select, textarea {
 	box-sizing: border-box;
 }
 
+select {
+	min-width: 6em;
+}
+
 input.w50,
 select.w50,
 textarea.w50 {


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/1645099/218281452-50982490-6759-4ad8-af66-11a261dc88e3.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/218281457-de760d42-b30a-435e-830c-da23db7bdfff.png)

Little improvement in Origine theme:
Before:
![grafik](https://user-images.githubusercontent.com/1645099/218281726-1732dd40-537b-4aed-8d9e-bb1775f76220.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/218281734-f30a68d6-b763-4c97-96ba-e0c9090c0df9.png)



Changes proposed in this pull request:

- CSS: `frss.css` and `origine.css`

How to test the feature manually:

1. use `Origine` theme
2. go to `sharing`
3. scroll down to the `add sharing method` section
4. change the width to 845px

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
