### PR TITLE
Fix MySQL bug

### DIFF
--- a/app/SQL/install.sql.mysql.php
+++ b/app/SQL/install.sql.mysql.php
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS `_feed` (
 	`kind` SMALLINT DEFAULT 0,	-- 1.20.0
 	`category` INT DEFAULT 0,	-- 1.20.0
 	`name` VARCHAR(191) NOT NULL,
-	`website` VARCHAR(32768) CHARACTER SET latin1 COLLATE latin1_bin,
+	`website` TEXT CHARACTER SET latin1 COLLATE latin1_bin,
 	`description` TEXT,
 	`lastUpdate` INT(11) DEFAULT 0,	-- Until year 2038
 	`priority` TINYINT(2) NOT NULL DEFAULT 10,


### PR DESCRIPTION
#fix https://github.com/FreshRSS/FreshRSS/issues/5128
MySQL cannot have multiple VARCHAR(x) whose total length is higher than 65535 in the same table.

> ERROR 1118 (42000): Row size too large. The maximum row size for the used table type, not counting BLOBs, is 65535. This includes storage overhead, check the manual. You have to change some columns to TEXT or BLOBs

Regression from https://github.com/FreshRSS/FreshRSS/pull/5038