### PR TITLE
defined('CLEANCACHE_HOURS')

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -57,3 +57,6 @@ defined('EXTENSIONS_PATH') or define('EXTENSIONS_PATH', FRESHRSS_PATH . '/extens
 
 //Directory used for feed mutex with *.freshrss.lock files. Must be writable.
 defined('TMP_PATH') or define('TMP_PATH', sys_get_temp_dir());
+
+//clean the chacke after x hours (720 hours = 30 days)
+defined('CLEANCACHE_HOURS') or define('CLEANCACHE_HOURS', 720);

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -434,7 +434,7 @@ function httpGet(string $url, string $cachePath, string $type = 'html', array $a
 	}
 
 	if (mt_rand(0, 30) === 1) {	// Remove old entries once in a while
-		cleanCache();
+		cleanCache(CLEANCACHE_HOURS);
 	}
 
 	if (FreshRSS_Context::$system_conf->simplepie_syslog_enabled) {


### PR DESCRIPTION
Closes #4627

now it is possible to config the cache via `./constants.local.php`
```
<?php
	define('CLEANCACHE_HOURS', 240);
```

default: `720` hours

Changes proposed in this pull request:

- introduce the constant `CLEANCACHE_HOURS`


How to test the feature manually:

1. check the content of the folder `./data/cache`
2. create `./constants.local.php` and set the hours
3. go to the frontend and reload the page (it would help to comment out the condition `if (mt_rand(0, 30) === 1)` in `lib/lib_rss.php`)
4. old cache files are deleted in `./data/cache`

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
