### PR TITLE
Dev Container extensions syntax update

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,19 +4,23 @@
 	"build": {
 		"dockerfile": "Dockerfile"
 	},
-	"extensions": [
-		"bmewburn.vscode-intelephense-client",
-		"DavidAnson.vscode-markdownlint",
-		"dbaeumer.vscode-eslint",
-		"eamodio.gitlens",
-		"EditorConfig.EditorConfig",
-		"foxundermoon.shell-format",
-		"mrmlnc.vscode-apache",
-		"ms-azuretools.vscode-docker",
-		"redhat.vscode-yaml",
-		"timonwong.shellcheck",
-		"ValeryanM.vscode-phpsab"
-	],
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"bmewburn.vscode-intelephense-client",
+				"DavidAnson.vscode-markdownlint",
+				"dbaeumer.vscode-eslint",
+				"eamodio.gitlens",
+				"EditorConfig.EditorConfig",
+				"foxundermoon.shell-format",
+				"mrmlnc.vscode-apache",
+				"ms-azuretools.vscode-docker",
+				"redhat.vscode-yaml",
+				"timonwong.shellcheck",
+				"ValeryanM.vscode-phpsab"
+			]
+		}
+	},
 	"forwardPorts": [
 		8080
 	],


### PR DESCRIPTION
The JSON syntax has changed for specifying extensions
https://containers.dev/supporting
