### PR TITLE
main.js: fix empty window opened when pressing space after page load

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1013,11 +1013,13 @@ function init_shortcuts() {
 			}
 
 			const link_go_website = document.querySelector('.flux.current a.go_website');
-			const newWindow = window.open();
-			if (link_go_website && newWindow) {
-				newWindow.opener = null;
-				newWindow.location = link_go_website.href;
-				ev.preventDefault();
+			if (link_go_website) {
+				const newWindow = window.open();
+				if (newWindow) {
+					newWindow.opener = null;
+					newWindow.location = link_go_website.href;
+					ev.preventDefault();
+				}
 			}
 			return;
 		}


### PR DESCRIPTION
Fixes the following problem:

1. Don't have any article selected (easiest by clicking on "main stream" or a category)
2. Press space
3. A blank window is opened, but since there's no link nothing else happens.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
