### PR TITLE
fixed: Global view - Stick the article to the top when opened

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -447,9 +447,7 @@ function toggleContent(new_active, old_active, skipping) {
 			// when skipping, this feels more natural if it’s not so near the top
 			new_pos -= document.body.clientHeight / 4;
 		}
-		if (relative_move) {
-			new_pos += box_to_move.scrollTop;
-		}
+
 		box_to_move.scrollTop = new_pos;
 	}
 


### PR DESCRIPTION
Closes #5073
Ref #2336

Changes proposed in this pull request:

- Javascript main.js


How to test the feature manually:

enable `Display `-> `Stick the article to the top when opened `

1. go to global view
2. open/close articles
3. the article sticks to the top

same behavior, when `Reading` -> `Show articles unfolded by default ` is enabled (Ref #2336)

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
