### PR TITLE
Fix MySQL UNIX socket support

### DIFF
--- a/lib/Minz/ModelPdo.php
+++ b/lib/Minz/ModelPdo.php
@@ -51,7 +51,13 @@ class Minz_ModelPdo {
 
 		switch ($db['type']) {
 			case 'mysql':
-				$dsn = 'mysql:host=' . (empty($dbServer['host']) ? $db['host'] : $dbServer['host']) . ';charset=utf8mb4';
+				$dsn = 'mysql:';
+				if (empty($dbServer['host'])) {
+					$dsn .= 'unix_socket=' . $db['host'];
+				} else {
+					$dsn .= 'host=' . $dbServer['host'];
+				}
+				$dsn .= ';charset=utf8mb4';
 				if (!empty($db['base'])) {
 					$dsn .= ';dbname=' . $db['base'];
 				}


### PR DESCRIPTION
Changes proposed in this pull request:

- This changes fixes MySQL UNIX socket support as MySQL uses different parameters for passing UNIX socket paths (`unix_socket`) and TCP sockets (`host`) in contrast to PosgreSQL which uses one for both (`host`). See also [PDO_MYSQL DSN](https://www.php.net/manual/en/ref.pdo-mysql.connection.php)  and [PDO_PGSQL DSN](https://www.php.net/manual/en/ref.pdo-pgsql.connection.php).

This has probably been broken since the beginning (https://github.com/FreshRSS/FreshRSS/pull/1889).

How to test the feature manually:

1. Set `$config['db']['type']` to `mysql`
2. Set `$config['db']['host']` to socket path (e.g. `/run/mysqld/mysqld.sock`)
3. Run fails with ` Access to database is denied for `feeds`: SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo for /run/mysqld/mysqld.sock failed: Name or service not known`

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
