### PR TITLE
Add docker-compose instructions for ARM64

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -389,10 +389,11 @@ image: freshrss/freshrss:arm
 ```
 
 If you then get this error message when running `docker compose up`:
-```
-The requested image's platform (linux/arm/v7) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
-```
-... you will also need to specify the platform in the `service` part:
+
+> The requested image's platform (linux/arm/v7) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
+
+… you will also need to specify the platform in the `service` part:
+
 ```yaml
 services:
   freshrss:

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -383,7 +383,7 @@ docker-compose down --remove-orphans --volumes
 
 ### Docker Compose and ARM64
 
-If you're working or want to host on an ARM64 system (such as Apple Silicon (M1/M2)) you'll need to use the `arm` tag in your `docker-compose.yml` file:
+If you’re working or want to host on an ARM64 system (such as Apple Silicon (M1/M2)) you’ll need to use the `arm` tag in your `docker-compose.yml` file:
 ```yaml
 image: freshrss/freshrss:arm
 ```

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -256,7 +256,7 @@ sudo nano /var/lib/docker/volumes/freshrss_data/_data/config.php
 
 ## Docker Compose
 
-First, put variables such as passwords in your `.env` file (see [`example.env`](./freshrss/example.env)):
+First, put variables such as passwords in your `.env` file, which can live where your `docker-compose.yml` should be. See [`example.env`](./freshrss/example.env).
 
 ```ini
 ADMIN_EMAIL=admin@example.net
@@ -380,6 +380,26 @@ docker-compose down --remove-orphans --volumes
 ```
 
 > ℹ️ You can combine it with `-f docker-compose-db.yml` to spin a PostgreSQL database.
+
+### Docker Compose and ARM64
+
+If you're working or want to host on an ARM64 system (such as Apple Silicon (M1/M2)) you'll need to use the `arm` tag in your `docker-compose.yml` file:
+```yaml
+image: freshrss/freshrss:arm
+```
+
+If you then get this error message when running `docker compose up`:
+```
+The requested image's platform (linux/arm/v7) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
+```
+... you will also need to specify the platform in the `service` part:
+```yaml
+services:
+  freshrss:
+    image: freshrss/freshrss:arm
+    platform: linux/arm/v7
+    container_name: freshrss
+ ```
 
 ## Run in production
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Add docker-compose instructions for users on ARM64 machines

How to test the feature manually:

1. Obtain an ARM64 machine, such as a recent Apple Silicon Mac (ok they're not technically ARM64 but they'll do for this).
2. Following the previous instructions for setting up an instance via `docker-compose`, you would get an error regarding the architecture of the image being AMD64 and incompatible. If you corrected this by changing the image to `freshrss/freshrss:arm`, you may then get an error around the image platform being `linux/arm/v7` while the host platform is `linux/arm/v8`
3. By following the updated instructions in this PR you should be able to get FreshRSS working correctly in Docker on an M1/M2/ARM64 host machine.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard) (NOT APPLICABLE)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
