### PR TITLE
Feedback when tag with same name as new category exists

### DIFF
--- a/app/Controllers/categoryController.php
+++ b/app/Controllers/categoryController.php
@@ -28,6 +28,8 @@ class FreshRSS_category_Controller extends FreshRSS_ActionController {
 	 */
 	public function createAction() {
 		$catDAO = FreshRSS_Factory::createCategoryDao();
+		$tagDAO = FreshRSS_Factory::createTagDao();
+
 		$url_redirect = array('c' => 'subscription', 'a' => 'add');
 
 		$limits = FreshRSS_Context::$system_conf->limits;
@@ -49,6 +51,10 @@ class FreshRSS_category_Controller extends FreshRSS_ActionController {
 
 			if ($catDAO->searchByName($cat->name()) != null) {
 				Minz_Request::bad(_t('feedback.sub.category.name_exists'), $url_redirect);
+			}
+
+			if ($tagDAO->searchByName($cat->name()) != null) {
+				Minz_Request::bad(_t('feedback.tag.name_exists', $cat->name()), $url_redirect);
 			}
 
 			$opml_url = checkUrl(Minz_Request::param('opml_url', ''));


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds a check for an existing label with the same name when creating a category.
- When such a label exists, show the string "Label name already exists." that's already used when creating labels

How to test the feature manually:

1. create a new label
2. try to create a new category with the same name

Pull request checklist:

- [X] clear commit messages
- [X] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
