### PR TITLE
Update lib_opml to v0.5.1

### DIFF
--- a/lib/composer.json
+++ b/lib/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=7.2.0",
-        "marienfressinaud/lib_opml": "0.5.0",
+        "marienfressinaud/lib_opml": "0.5.1",
         "phpgt/cssxpath": "dev-master#4fbe420aba3d9e729940107ded4236a835a1a132",
         "phpmailer/phpmailer": "6.6.0"
     },

--- a/lib/marienfressinaud/lib_opml/CHANGELOG.md
+++ b/lib/marienfressinaud/lib_opml/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog of lib\_opml
 
+## 2023-03-10 - v0.5.1
+
+- fix: Handle case where OPML is loaded but empty
+- misc: Fix installation of Composer on the CI
+- misc: Force timezone to UTC in tests
+
 ## 2022-07-25 - v0.5.0
 
 - BREAKING CHANGE: Reverse parameters in `libopml_render()`

--- a/lib/marienfressinaud/lib_opml/src/LibOpml/LibOpml.php
+++ b/lib/marienfressinaud/lib_opml/src/LibOpml/LibOpml.php
@@ -153,7 +153,7 @@ class LibOpml
             $result = false;
         }
 
-        if (!$result) {
+        if (!$result || !$dom->documentElement) {
             throw new Exception('OPML string is not valid XML');
         }
 


### PR DESCRIPTION
Closes https://github.com/FreshRSS/FreshRSS/issues/5179

Changes proposed in this pull request:

- Update lib_opml to v0.5.1 which handles empty DOM (i.e. no `documentElement`)

How to test the feature manually:

1. I don't know, I wasn't able to reproduce the bug :shrug: 

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
