### PR TITLE
docs: fix nginx configuration

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -488,7 +488,7 @@ server {
 	}
 
 	location /freshrss/ {
-		proxy_pass http://freshrss;
+		proxy_pass http://freshrss/;
 		add_header X-Frame-Options SAMEORIGIN;
 		add_header X-XSS-Protection "1; mode=block";
 		proxy_redirect off;


### PR DESCRIPTION
Update nginx configuration in `Hosted in a subdirectory type.`

Closes #5193

Changes proposed in this pull request:

- Change proxy_pass 

As-Is
`proxy_pass http://freshrss;`
To-Be
`proxy_pass http://freshrss/;`

