### PR TITLE
Alternative dark: improve border color of notification

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -38,7 +38,7 @@
 	--alert-error-border-color: #912621;
 
 	--notification-border-color: #eeb;
-	--notification-good-border-color: #0044cb;
+	--notification-good-border-color: #0062b7;
 	--notification-bad-background-color: #fdd;
 	--notification-bad-font-color: #912621;
 	--notification-bad-border-color: #ecc;

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -38,7 +38,7 @@
 	--alert-error-border-color: #912621;
 
 	--notification-border-color: #eeb;
-	--notification-good-border-color: #0044cb;
+	--notification-good-border-color: #0062b7;
 	--notification-bad-background-color: #fdd;
 	--notification-bad-font-color: #912621;
 	--notification-bad-border-color: #ecc;


### PR DESCRIPTION
See https://github.com/FreshRSS/FreshRSS/discussions/5205#discussioncomment-5296474

Changes proposed in this pull request:

- use the blue color as it is already used for other variables


How to test the feature manually:

1. use `Alternative dark` theme
2. do something, that opens a notification, f.e. switch on/off a extension
3. see the border color of the notification

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
