### PR TITLE
Improved: show Terms of Service in config menu

### DIFF
--- a/app/Controllers/authController.php
+++ b/app/Controllers/authController.php
@@ -239,7 +239,7 @@ class FreshRSS_auth_Controller extends FreshRSS_ActionController {
 			Minz_Error::error(403);
 		}
 
-		$this->view->show_tos_checkbox = file_exists(join_path(DATA_PATH, 'tos.html'));
+		$this->view->show_tos_checkbox = file_exists(TOS_FILENAME);
 		$this->view->show_email_field = FreshRSS_Context::$system_conf->force_email_validation;
 		$this->view->preferred_language = Minz_Translate::getLanguage(null, Minz_Request::getPreferredLanguages(), FreshRSS_Context::$system_conf->language);
 		FreshRSS_View::prependTitle(_t('gen.auth.registration.title') . ' · ');

--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -282,10 +282,10 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 	}
 
 	/**
-	 * This action displays the EULA page of FreshRSS.
+	 * This action displays the EULA/TOS (Terms of Service) page of FreshRSS.
 	 * This page is enabled only if admin created a data/tos.html file.
 	 * The content of the page is the content of data/tos.html.
-	 * It returns 404 if there is no EULA.
+	 * It returns 404 if there is no EULA/TOS.
 	 */
 	public function tosAction() {
 		$terms_of_service = file_get_contents(TOS_FILENAME);

--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -288,7 +288,7 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 	 * It returns 404 if there is no EULA.
 	 */
 	public function tosAction() {
-		$terms_of_service = file_get_contents(join_path(DATA_PATH, 'tos.html'));
+		$terms_of_service = file_get_contents(TOS_FILENAME);
 		if (!$terms_of_service) {
 			Minz_Error::error(404);
 		}

--- a/app/Controllers/userController.php
+++ b/app/Controllers/userController.php
@@ -318,7 +318,7 @@ class FreshRSS_user_Controller extends FreshRSS_ActionController {
 				);
 			}
 
-			$tos_enabled = file_exists(join_path(DATA_PATH, 'tos.html'));
+			$tos_enabled = file_exists(TOS_FILENAME);
 			$accept_tos = Minz_Request::param('accept_tos', false);
 
 			if ($system_conf->force_email_validation && empty($email)) {

--- a/app/i18n/cz/admin.php
+++ b/app/i18n/cz/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// TODO
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
 		),
 	),
 	'update' => array(

--- a/app/i18n/cz/admin.php
+++ b/app/i18n/cz/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => 'Registrační formulář uživatele',
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// TODO
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+		),
 	),
 	'update' => array(
 		'_' => 'Aktualizace systému',

--- a/app/i18n/de/admin.php
+++ b/app/i18n/de/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => 'Benutzer-Registrierungsformular',
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// TODO
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+		),
 	),
 	'update' => array(
 		'_' => 'System aktualisieren',

--- a/app/i18n/de/admin.php
+++ b/app/i18n/de/admin.php
@@ -184,9 +184,9 @@ return array(
 			'title' => 'Benutzer-Registrierungsformular',
 		),
 		'tos' => array(
-			'disabled' => 'is not given',	// TODO
-			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
+			'disabled' => 'sind nicht aktiviert',
+			'enabled' => '<a href="./?a=tos">sind aktiv</a>',
+			'help' => 'So werden die <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">Nutzungsbedingungen aktiviert</a>',
 		),
 	),
 	'update' => array(

--- a/app/i18n/de/admin.php
+++ b/app/i18n/de/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// TODO
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
 		),
 	),
 	'update' => array(

--- a/app/i18n/el/admin.php
+++ b/app/i18n/el/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => 'Φόρμα εγγραφής χρήστη',
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// TODO
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+		),
 	),
 	'update' => array(
 		'_' => 'Ενημέρωση συστήματος',

--- a/app/i18n/el/admin.php
+++ b/app/i18n/el/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// TODO
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
 		),
 	),
 	'update' => array(

--- a/app/i18n/en-us/admin.php
+++ b/app/i18n/en-us/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => 'User registration form',	// IGNORE
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// IGNORE
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// IGNORE
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// IGNORE
+		),
 	),
 	'update' => array(
 		'_' => 'Update system',	// IGNORE

--- a/app/i18n/en-us/admin.php
+++ b/app/i18n/en-us/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// IGNORE
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// IGNORE
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// IGNORE
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// IGNORE
 		),
 	),
 	'update' => array(

--- a/app/i18n/en/admin.php
+++ b/app/i18n/en/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// TODO
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
 		),
 	),
 	'update' => array(

--- a/app/i18n/en/admin.php
+++ b/app/i18n/en/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => 'User registration form',
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// TODO
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+		),
 	),
 	'update' => array(
 		'_' => 'Update system',

--- a/app/i18n/es/admin.php
+++ b/app/i18n/es/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// TODO
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
 		),
 	),
 	'update' => array(

--- a/app/i18n/es/admin.php
+++ b/app/i18n/es/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => 'Formulario de registro del usuario',
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// TODO
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+		),
 	),
 	'update' => array(
 		'_' => 'Actualizar sistema',

--- a/app/i18n/fr/admin.php
+++ b/app/i18n/fr/admin.php
@@ -184,9 +184,9 @@ return array(
 			'title' => 'Formulaire d’inscription utilisateur',
 		),
 		'tos' => array(
-			'disabled' => 'is not given',	// TODO
-			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
+			'disabled' => 'non renseigné',
+			'enabled' => '<a href="./?a=tos">activées</a>',
+			'help' => 'Comment <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">activer les conditions d’utilisation</a>',
 		),
 	),
 	'update' => array(

--- a/app/i18n/fr/admin.php
+++ b/app/i18n/fr/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// TODO
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
 		),
 	),
 	'update' => array(

--- a/app/i18n/fr/admin.php
+++ b/app/i18n/fr/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => 'Formulaire d’inscription utilisateur',
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// TODO
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+		),
 	),
 	'update' => array(
 		'_' => 'Système de mise à jour',

--- a/app/i18n/he/admin.php
+++ b/app/i18n/he/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// TODO
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
 		),
 	),
 	'update' => array(

--- a/app/i18n/he/admin.php
+++ b/app/i18n/he/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => 'User registration form',	// TODO
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// TODO
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+		),
 	),
 	'update' => array(
 		'_' => 'מערכת העדכון',

--- a/app/i18n/id/admin.php
+++ b/app/i18n/id/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => 'Formulir Pendaftaran Pengguna',
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// TODO
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+		),
 	),
 	'update' => array(
 		'_' => 'Update system',	// TODO

--- a/app/i18n/id/admin.php
+++ b/app/i18n/id/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// TODO
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
 		),
 	),
 	'update' => array(

--- a/app/i18n/it/admin.php
+++ b/app/i18n/it/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => 'Form di registrazione utente',
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// TODO
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+		),
 	),
 	'update' => array(
 		'_' => 'Aggiornamento sistema',

--- a/app/i18n/it/admin.php
+++ b/app/i18n/it/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// TODO
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
 		),
 	),
 	'update' => array(

--- a/app/i18n/ja/admin.php
+++ b/app/i18n/ja/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => 'ユーザー登録',
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// TODO
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+		),
 	),
 	'update' => array(
 		'_' => 'システムアップデート',

--- a/app/i18n/ja/admin.php
+++ b/app/i18n/ja/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// TODO
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
 		),
 	),
 	'update' => array(

--- a/app/i18n/ko/admin.php
+++ b/app/i18n/ko/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// TODO
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
 		),
 	),
 	'update' => array(

--- a/app/i18n/ko/admin.php
+++ b/app/i18n/ko/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => '사용자 회원가입 양식',
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// TODO
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+		),
 	),
 	'update' => array(
 		'_' => '업데이트',

--- a/app/i18n/nl/admin.php
+++ b/app/i18n/nl/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => 'Gebruikersregistratieformulier',
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// TODO
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+		),
 	),
 	'update' => array(
 		'_' => 'Versie controle',

--- a/app/i18n/nl/admin.php
+++ b/app/i18n/nl/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// TODO
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
 		),
 	),
 	'update' => array(

--- a/app/i18n/oc/admin.php
+++ b/app/i18n/oc/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// TODO
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
 		),
 	),
 	'update' => array(

--- a/app/i18n/oc/admin.php
+++ b/app/i18n/oc/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => 'Formulari d’inscripcion utilizaire',
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// TODO
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+		),
 	),
 	'update' => array(
 		'_' => 'Sistèma de mesa a jorn',

--- a/app/i18n/pl/admin.php
+++ b/app/i18n/pl/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// TODO
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
 		),
 	),
 	'update' => array(

--- a/app/i18n/pl/admin.php
+++ b/app/i18n/pl/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => 'Formularz rejestracji użytkowników',
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// TODO
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+		),
 	),
 	'update' => array(
 		'_' => 'Aktualizacja',

--- a/app/i18n/pt-br/admin.php
+++ b/app/i18n/pt-br/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => 'Formulário de Cadastro de Usuário',
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// TODO
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+		),
 	),
 	'update' => array(
 		'_' => 'Atualização do sistema',

--- a/app/i18n/pt-br/admin.php
+++ b/app/i18n/pt-br/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// TODO
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
 		),
 	),
 	'update' => array(

--- a/app/i18n/ru/admin.php
+++ b/app/i18n/ru/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => 'Форма регистрации пользователей',
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// TODO
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+		),
 	),
 	'update' => array(
 		'_' => 'Обновление системы',

--- a/app/i18n/ru/admin.php
+++ b/app/i18n/ru/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// TODO
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
 		),
 	),
 	'update' => array(

--- a/app/i18n/sk/admin.php
+++ b/app/i18n/sk/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => 'Registračný formulár používateľa',
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// TODO
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+		),
 	),
 	'update' => array(
 		'_' => 'Aktualizácia systému',

--- a/app/i18n/sk/admin.php
+++ b/app/i18n/sk/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// TODO
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
 		),
 	),
 	'update' => array(

--- a/app/i18n/tr/admin.php
+++ b/app/i18n/tr/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// TODO
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
 		),
 	),
 	'update' => array(

--- a/app/i18n/tr/admin.php
+++ b/app/i18n/tr/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => 'Kullanıcı kayıt formu',
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// TODO
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+		),
 	),
 	'update' => array(
 		'_' => 'Sistem güncelleme',

--- a/app/i18n/zh-cn/admin.php
+++ b/app/i18n/zh-cn/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// TODO
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
 		),
 	),
 	'update' => array(

--- a/app/i18n/zh-cn/admin.php
+++ b/app/i18n/zh-cn/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => '用户注册表单',
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// TODO
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+		),
 	),
 	'update' => array(
 		'_' => '更新系统',

--- a/app/i18n/zh-tw/admin.php
+++ b/app/i18n/zh-tw/admin.php
@@ -183,6 +183,11 @@ return array(
 			),
 			'title' => '使用者註冊表單',
 		),
+		'tos' => array(
+			'disabled' => 'is not given',	// TODO
+			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+		),
 	),
 	'update' => array(
 		'_' => '更新系統',

--- a/app/i18n/zh-tw/admin.php
+++ b/app/i18n/zh-tw/admin.php
@@ -186,7 +186,7 @@ return array(
 		'tos' => array(
 			'disabled' => 'is not given',	// TODO
 			'enabled' => '<a href="./?a=tos">is enabled</a>',	// TODO
-			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_target">enable the Terms of Service</a>',	// TODO
+			'help' => 'How to <a href="https://freshrss.github.io/FreshRSS/en/admins/12_User_management.html#enable-terms-of-service-tos" target="_blank">enable the Terms of Service</a>',	// TODO
 		),
 	),
 	'update' => array(

--- a/app/layout/aside_configure.phtml
+++ b/app/layout/aside_configure.phtml
@@ -84,6 +84,11 @@
 				<li class="item<?= Minz_Request::actionName() === 'about' ? ' active' : '' ?>">
 					<a href="<?= _url('index', 'about') ?>"><?= _t('gen.menu.about') ?></a>
 				</li>
+				<?php if (file_exists(TOS_FILENAME)) { ?>
+					<li class="item">
+						<a href="<?= _url('index', 'tos') ?>"><?= _t('index.tos.title')?></a>
+					</li>
+				<?php } ?>
 			</ul>
 		</li>
 	</ul>

--- a/app/layout/header.phtml
+++ b/app/layout/header.phtml
@@ -103,6 +103,11 @@
 					<ul>
 						<li class="item"><a href="<?= _url('index', 'logs') ?>"><?= _t('gen.menu.logs') ?></a></li>
 						<li class="item"><a href="<?= _url('index', 'about') ?>"><?= _t('gen.menu.about') ?></a></li>
+						<?php if (file_exists(TOS_FILENAME)) { ?>
+							<li class="item">
+								<a href="<?= _url('index', 'tos') ?>"><?= _t('index.tos.title')?></a>
+							</li>
+						<?php } ?>
 						<?= Minz_ExtensionManager::callHook('menu_other_entry') ?>
 					</ul>
 				</li>

--- a/app/views/configure/system.phtml
+++ b/app/views/configure/system.phtml
@@ -84,6 +84,19 @@
 		</div>
 
 		<div class="form-group">
+			<label class="group-name"><?= _t('index.tos.title') ?></label>
+			<div class="group-controls">
+				<?php if (file_exists(TOS_FILENAME)) { ?>
+					<?= _t('admin.system.tos.enabled') ?>
+					<?php
+				} else { ?>
+					<?= _t('admin.system.tos.disabled') ?>
+					<p class="help"><?= _i('help') ?> <?= _t('admin.system.tos.help') ?></p>
+				<?php } ?>
+			</div>
+		</div>
+
+		<div class="form-group">
 			<div class="group-controls">
 				<label class="checkbox" for="force-email-validation">
 					<input

--- a/app/views/index/about.phtml
+++ b/app/views/index/about.phtml
@@ -5,7 +5,7 @@
 	}
 ?>
 
-<main class="post content">
+<main class="post content<?= !FreshRSS_Auth::hasAccess() ? ' centered' : ''?>">
 	<?php if (FreshRSS_Auth::hasAccess()) {?>
 	<div class="link-back-wrapper">
 		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>

--- a/app/views/index/tos.phtml
+++ b/app/views/index/tos.phtml
@@ -10,5 +10,6 @@
 		</a>
 	<?php } ?>
 
+	<h1><?= _t('index.tos.title')?></h1>
 	<?= $this->terms_of_service ?>
 </main>

--- a/app/views/index/tos.phtml
+++ b/app/views/index/tos.phtml
@@ -5,7 +5,7 @@
 	}
 ?>
 
-<main class="post content">
+<main class="post content<?= !FreshRSS_Auth::hasAccess() ? ' centered' : ''?>">
 	<?php if (FreshRSS_Auth::hasAccess()) {?>
 		<div class="link-back-wrapper">
 			<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>

--- a/app/views/index/tos.phtml
+++ b/app/views/index/tos.phtml
@@ -1,13 +1,27 @@
-<?php /** @var FreshRSS_View $this */ ?>
+<?php
+	/** @var FreshRSS_View $this */
+	if (FreshRSS_Auth::hasAccess()) {
+		$this->partial('aside_configure');
+	}
+?>
+
 <main class="post content">
-	<?php if ($this->can_register) { ?>
-		<a href="<?= _url('auth', 'register') ?>">
-			<?= _t('gen.action.back') ?>
-		</a>
+	<?php if (FreshRSS_Auth::hasAccess()) {?>
+		<div class="link-back-wrapper">
+			<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
+		</div>
+	<?php } elseif ($this->can_register) { ?>
+		<div class="link-back-wrapper">
+			<a href="<?= _url('auth', 'register') ?>">
+				<?= _t('gen.action.back') ?>
+			</a>
+		</div>
 	<?php } else { ?>
-		<a href="<?= _url('index', 'index') ?>">
-			<?= _t('gen.action.back') ?>
-		</a>
+		<div class="link-back-wrapper">
+			<a href="<?= _url('index', 'index') ?>">
+				<?= _t('gen.action.back') ?>
+			</a>
+		</div>
 	<?php } ?>
 
 	<h1><?= _t('index.tos.title')?></h1>

--- a/constants.php
+++ b/constants.php
@@ -59,5 +59,5 @@ defined('EXTENSIONS_PATH') or define('EXTENSIONS_PATH', FRESHRSS_PATH . '/extens
 //Directory used for feed mutex with *.freshrss.lock files. Must be writable.
 defined('TMP_PATH') or define('TMP_PATH', sys_get_temp_dir());
 
-//clean the chacke after x hours (720 hours = 30 days)
+//clean the cache after x hours (720 hours = 30 days)
 defined('CLEANCACHE_HOURS') or define('CLEANCACHE_HOURS', 720);

--- a/constants.php
+++ b/constants.php
@@ -46,6 +46,7 @@ defined('USERS_PATH') or define('USERS_PATH', DATA_PATH . '/users');
 defined('LOG_FILENAME') or define('LOG_FILENAME', 'log.txt');
 defined('ADMIN_LOG') or define('ADMIN_LOG', USERS_PATH . '/_/' . LOG_FILENAME);
 defined('API_LOG') or define('API_LOG', USERS_PATH . '/_/log_api.txt');
+defined('TOS_FILENAME') or define('TOS_FILENAME', DATA_PATH . '/tos.html');
 defined('CACHE_PATH') or define('CACHE_PATH', DATA_PATH . '/cache');
 defined('PSHB_LOG') or define('PSHB_LOG', USERS_PATH . '/_/log_pshb.txt');
 defined('PSHB_PATH') or define('PSHB_PATH', DATA_PATH . '/PubSubHubbub');

--- a/data/tos.example.html
+++ b/data/tos.example.html
@@ -1,4 +1,4 @@
-<h1>Terms of Service</h1>
+<!-- <h1>Terms of Service</h1> -->
 
 <h2>Article 1: Lorem ipsum</h2>
 

--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -621,20 +621,6 @@ kbd {
 	left: 2px;
 }
 
-/*=== Configuration pages */
-.post {
-	padding: 10px 50px;
-	font-size: 0.9em;
-}
-
-.post form {
-	margin: 10px 0;
-}
-
-.post.content {
-	max-width: 550px;
-}
-
 .slides {
 	border-color: var(--border-color-middle);
 }

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -621,20 +621,6 @@ kbd {
 	right: 2px;
 }
 
-/*=== Configuration pages */
-.post {
-	padding: 10px 50px;
-	font-size: 0.9em;
-}
-
-.post form {
-	margin: 10px 0;
-}
-
-.post.content {
-	max-width: 550px;
-}
-
 .slides {
 	border-color: var(--border-color-middle);
 }

--- a/p/themes/Ansum/_configuration.scss
+++ b/p/themes/Ansum/_configuration.scss
@@ -2,16 +2,7 @@
 
 /*=== Configuration pages */
 .post {
-	padding: 1rem 2rem;
 	font-size: 1rem;
-
-	form {
-		margin: 1rem 0;
-	}
-
-	&.content {
-		max-width: 550px;
-	}
 
 	h1, h2 {
 		color: variables.$main-font-color;

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -1102,14 +1102,7 @@ main.prompt {
 
 /*=== Configuration pages */
 .post {
-	padding: 1rem 2rem;
 	font-size: 1rem;
-}
-.post form {
-	margin: 1rem 0;
-}
-.post.content {
-	max-width: 550px;
 }
 .post h1, .post h2 {
 	color: #363330;
@@ -1312,3 +1305,5 @@ a, button.as-link {
 	outline: none;
 	color: #ca7227;
 }
+
+/*# sourceMappingURL=ansum.css.map */

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -1102,14 +1102,7 @@ main.prompt {
 
 /*=== Configuration pages */
 .post {
-	padding: 1rem 2rem;
 	font-size: 1rem;
-}
-.post form {
-	margin: 1rem 0;
-}
-.post.content {
-	max-width: 550px;
 }
 .post h1, .post h2 {
 	color: #363330;

--- a/p/themes/BlueLagoon/BlueLagoon.css
+++ b/p/themes/BlueLagoon/BlueLagoon.css
@@ -660,20 +660,6 @@ a.btn {
 	border-radius: 3px;
 }
 
-/*=== Configuration pages */
-.post {
-	padding: 10px 50px;
-	font-size: 0.9em;
-}
-
-.post form {
-	margin: 10px 0;
-}
-
-.post.content {
-	max-width: 550px;
-}
-
 /*=== Prompt (centered) */
 .prompt .form-group {
 	margin-bottom: 1rem;

--- a/p/themes/BlueLagoon/BlueLagoon.rtl.css
+++ b/p/themes/BlueLagoon/BlueLagoon.rtl.css
@@ -660,20 +660,6 @@ a.btn {
 	border-radius: 3px;
 }
 
-/*=== Configuration pages */
-.post {
-	padding: 10px 50px;
-	font-size: 0.9em;
-}
-
-.post form {
-	margin: 10px 0;
-}
-
-.post.content {
-	max-width: 550px;
-}
-
 /*=== Prompt (centered) */
 .prompt .form-group {
 	margin-bottom: 1rem;

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -612,20 +612,6 @@ a.btn {
 	background-color: #111;
 }
 
-/*=== Configuration pages */
-.post {
-	padding: 10px 50px;
-	font-size: 0.9em;
-}
-
-.post form {
-	margin: 10px 0;
-}
-
-.post.content {
-	max-width: 550px;
-}
-
 /*=== Prompt (centered) */
 .prompt .form-group {
 	margin-bottom: 1rem;

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -612,20 +612,6 @@ a.btn {
 	background-color: #111;
 }
 
-/*=== Configuration pages */
-.post {
-	padding: 10px 50px;
-	font-size: 0.9em;
-}
-
-.post form {
-	margin: 10px 0;
-}
-
-.post.content {
-	max-width: 550px;
-}
-
 /*=== Prompt (centered) */
 .prompt .form-group {
 	margin-bottom: 1rem;

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -617,20 +617,6 @@ a.btn {
 	border-radius: 3px;
 }
 
-/*=== Configuration pages */
-.post {
-	padding: 10px 50px;
-	font-size: 0.9em;
-}
-
-.post form {
-	margin: 10px 0;
-}
-
-.post.content {
-	max-width: 550px;
-}
-
 /*=== Prompt (centered) */
 .prompt .form-group {
 	margin-bottom: 1rem;

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -617,20 +617,6 @@ a.btn {
 	border-radius: 3px;
 }
 
-/*=== Configuration pages */
-.post {
-	padding: 10px 50px;
-	font-size: 0.9em;
-}
-
-.post form {
-	margin: 10px 0;
-}
-
-.post.content {
-	max-width: 550px;
-}
-
 /*=== Prompt (centered) */
 .prompt .form-group {
 	margin-bottom: 1rem;

--- a/p/themes/Mapco/_configuration.scss
+++ b/p/themes/Mapco/_configuration.scss
@@ -2,16 +2,7 @@
 
 /*=== Configuration pages */
 .post {
-	padding: 1rem 2rem;
 	font-size: 1rem;
-
-	form {
-		margin: 1rem 0;
-	}
-
-	&.content {
-		max-width: 550px;
-	}
 
 	h1, h2 {
 		color: variables.$main-font-color;

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -1116,14 +1116,7 @@ main.prompt {
 
 /*=== Configuration pages */
 .post {
-	padding: 1rem 2rem;
 	font-size: 1rem;
-}
-.post form {
-	margin: 1rem 0;
-}
-.post.content {
-	max-width: 550px;
 }
 .post h1, .post h2 {
 	color: #303136;

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -1116,14 +1116,7 @@ main.prompt {
 
 /*=== Configuration pages */
 .post {
-	padding: 1rem 2rem;
 	font-size: 1rem;
-}
-.post form {
-	margin: 1rem 0;
-}
-.post.content {
-	max-width: 550px;
 }
 .post h1, .post h2 {
 	color: #303136;

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -914,21 +914,6 @@ option {
 	left: 2px;
 }
 
-
-/*=== Configuration pages */
-.post {
-	padding: 10px 50px;
-	font-size: 0.9em;
-}
-
-.post form {
-	margin: 10px 0;
-}
-
-.post.content {
-	max-width: 550px;
-}
-
 /*=== Prompt (centered) */
 .prompt input {
 	margin: 5px auto;

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -914,21 +914,6 @@ option {
 	right: 2px;
 }
 
-
-/*=== Configuration pages */
-.post {
-	padding: 10px 50px;
-	font-size: 0.9em;
-}
-
-.post form {
-	margin: 10px 0;
-}
-
-.post.content {
-	max-width: 550px;
-}
-
 /*=== Prompt (centered) */
 .prompt input {
 	margin: 5px auto;

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -738,20 +738,6 @@ a.btn-attention:hover {
 	left: 2px;
 }
 
-/*=== Configuration pages */
-.post {
-	padding: 10px 50px;
-	font-size: 0.9em;
-}
-
-.post form {
-	margin: 10px 0;
-}
-
-.post.content {
-	max-width: 550px;
-}
-
 /*=== Prompt (centered) */
 .prompt .form-group {
 	margin-bottom: 1rem;

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -738,20 +738,6 @@ a.btn-attention:hover {
 	right: 2px;
 }
 
-/*=== Configuration pages */
-.post {
-	padding: 10px 50px;
-	font-size: 0.9em;
-}
-
-.post form {
-	margin: 10px 0;
-}
-
-.post.content {
-	max-width: 550px;
-}
-
 /*=== Prompt (centered) */
 .prompt .form-group {
 	margin-bottom: 1rem;

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -714,20 +714,6 @@ a.signin {
 	filter: brightness(3);
 }
 
-/*=== Configuration pages */
-.post {
-	padding: 10px 50px;
-	font-size: 0.9em;
-}
-
-.post form {
-	margin: 10px 0;
-}
-
-.post.content {
-	max-width: 550px;
-}
-
 /*=== Prompt (centered) */
 .prompt .form-group {
 	margin-bottom: 1rem;

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -714,20 +714,6 @@ a.signin {
 	filter: brightness(3);
 }
 
-/*=== Configuration pages */
-.post {
-	padding: 10px 50px;
-	font-size: 0.9em;
-}
-
-.post form {
-	margin: 10px 0;
-}
-
-.post.content {
-	max-width: 550px;
-}
-
 /*=== Prompt (centered) */
 .prompt .form-group {
 	margin-bottom: 1rem;

--- a/p/themes/Screwdriver/screwdriver.css
+++ b/p/themes/Screwdriver/screwdriver.css
@@ -635,20 +635,6 @@ a.btn {
 	border-radius: 3px;
 }
 
-/*=== Configuration pages */
-.post {
-	padding: 10px 50px;
-	font-size: 0.9em;
-}
-
-.post form {
-	margin: 10px 0;
-}
-
-.post.content {
-	max-width: 550px;
-}
-
 /*=== Prompt (centered) */
 .prompt {
 	text-shadow: 0 1px rgba(255,255,255,0.08);

--- a/p/themes/Screwdriver/screwdriver.rtl.css
+++ b/p/themes/Screwdriver/screwdriver.rtl.css
@@ -635,20 +635,6 @@ a.btn {
 	border-radius: 3px;
 }
 
-/*=== Configuration pages */
-.post {
-	padding: 10px 50px;
-	font-size: 0.9em;
-}
-
-.post form {
-	margin: 10px 0;
-}
-
-.post.content {
-	max-width: 550px;
-}
-
 /*=== Prompt (centered) */
 .prompt {
 	text-shadow: 0 1px rgba(255,255,255,0.08);

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -673,18 +673,11 @@ form th {
 }
 
 .post {
-	padding: 10px 50px;
 	font-size: 0.9em;
 }
 .post input.long {
 	height: 33px;
 	margin-top: 0px;
-}
-.post form {
-	margin: 10px 0;
-}
-.post.content {
-	max-width: 550px;
 }
 
 .prompt input {
@@ -1174,11 +1167,9 @@ button.as-link {
 	left: 0;
 	right: auto;
 }
-
 #nav_menu_actions ul.dropdown-menu::after {
 	display: none;
 }
-
 #nav_menu_actions .dropdown.only-mobile {
 	display: initial !important;
 }
@@ -1194,5 +1185,3 @@ button.as-link {
 #slider label {
 	min-height: initial;
 }
-
-/*# sourceMappingURL=swage.css.map */

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -673,18 +673,11 @@ form th {
 }
 
 .post {
-	padding: 10px 50px;
 	font-size: 0.9em;
 }
 .post input.long {
 	height: 33px;
 	margin-top: 0px;
-}
-.post form {
-	margin: 10px 0;
-}
-.post.content {
-	max-width: 550px;
 }
 
 .prompt input {
@@ -1174,11 +1167,9 @@ button.as-link {
 	right: 0;
 	left: auto;
 }
-
 #nav_menu_actions ul.dropdown-menu::after {
 	display: none;
 }
-
 #nav_menu_actions .dropdown.only-mobile {
 	display: initial !important;
 }

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -872,7 +872,6 @@ form {
 }
 
 .post {
-	padding: 10px 50px;
 	font-size: 0.9em;
 
 	input {
@@ -880,14 +879,6 @@ form {
 			height: 33px;
 			margin-top: 0px;
 		}
-	}
-
-	form {
-		margin: 10px 0;
-	}
-
-	&.content {
-		max-width: 550px;
 	}
 }
 

--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -461,20 +461,6 @@ a.btn {
 	border-radius: 3px;
 }
 
-/*=== Configuration pages */
-.post {
-	padding: 10px 50px;
-	font-size: 0.9em;
-}
-
-.post form {
-	margin: 10px 0;
-}
-
-.post.content {
-	max-width: 550px;
-}
-
 /*=== Prompt (centered) */
 .prompt {
 	text-align: center;

--- a/p/themes/base-theme/base.rtl.css
+++ b/p/themes/base-theme/base.rtl.css
@@ -461,20 +461,6 @@ a.btn {
 	border-radius: 3px;
 }
 
-/*=== Configuration pages */
-.post {
-	padding: 10px 50px;
-	font-size: 0.9em;
-}
-
-.post form {
-	margin: 10px 0;
-}
-
-.post.content {
-	max-width: 550px;
-}
-
 /*=== Prompt (centered) */
 .prompt {
 	text-align: center;

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1759,6 +1759,20 @@ html.slider-active {
 	background-position: center;
 }
 
+/*=== Configuration pages */
+.post {
+	padding: 1rem 2rem;
+	font-size: 0.9em;
+}
+
+.post form {
+	margin: 1rem 0;
+}
+
+.post.content.centered {
+	max-width: 550px;
+}
+
 /*=== SLIDESHOW */
 /*==============*/
 .slides {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1759,6 +1759,20 @@ html.slider-active {
 	background-position: center;
 }
 
+/*=== Configuration pages */
+.post {
+	padding: 1rem 2rem;
+	font-size: 0.9em;
+}
+
+.post form {
+	margin: 1rem 0;
+}
+
+.post.content.centered {
+	max-width: 550px;
+}
+
 /*=== SLIDESHOW */
 /*==============*/
 .slides {


### PR DESCRIPTION
Ref #5189

Changes proposed in this pull request:

Before:
logged in users cannot read the Terms of Service, if enabled

After:
if TOS (Terms of Service) is set, it is readable in config menu
![grafik](https://user-images.githubusercontent.com/1645099/226207807-b2ab03e7-ea4a-48f7-897a-3b6967132edf.png)


Before:
No information about TOS for admins

After:
Information about TOS given in System Configuration.
TOS not given:
![grafik](https://user-images.githubusercontent.com/1645099/226207938-c9aee5f8-3808-4c15-a10c-ad4c3e05fa1d.png)

TOS given:
![grafik](https://user-images.githubusercontent.com/1645099/226207885-dc8f5158-9e7c-4e48-9cf5-648e7ead1fe5.png)


Technical changes: 
- introduced `TOS_FILENAME` as constant, that points to the `tos.html`
- CSS: moved some standard CSS lines from themes into `frss.css`
- `tos.html`/`tos.example.html`: `<h1>` headline is not needed anymore in the html file. It is now included by default on the page, that displays the TOS

How to test the feature manually:

1. enable/disable the TOS
2. look into the config menu
3. read the TOS

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
