### PR TITLE
fix: jump to next button: div -> span

### DIFF
--- a/app/views/helpers/stream-footer.phtml
+++ b/app/views/helpers/stream-footer.phtml
@@ -37,9 +37,9 @@ if ($hasAccess) { ?>
 			formaction="<?= Minz_Url::display($url_mark_read) ?>"
 			type="submit">
 			<span class="bigTick">✓</span><br />
-			<span class="markAllRead"><?= _t('gen.stream.mark_all_read') ?></span>
+			<span class="markAllRead"><?= _t('gen.stream.mark_all_read') ?></span><br />
 			<?php if (FreshRSS_Context::$user_conf->onread_jump_next) { ?>
-				<div class="jumpNext"><?= _t('conf.reading.jump_next') ?></div>
+				<span class="jumpNext"><?= _t('conf.reading.jump_next') ?></span>
 			<?php } ?>
 		</button>
 	<?php } else { ?>


### PR DESCRIPTION
Closes #5202
Ref: #4681

Changes proposed in this pull request:

- `<div>` -> `<span>`, because `<div>` is not allowed in `<button>` (see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button)

How to test the feature manually:

1. check the read-all-button in normal view


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
