### PR TITLE
Fix warning when tagging entries

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1188,7 +1188,7 @@ function init_stream(stream) {
 				checkboxTag.disabled = true;
 
 				const req = new XMLHttpRequest();
-				req.open('POST', './?c=tag&a=tagEntry', true);
+				req.open('POST', './?c=tag&a=tagEntry&ajax=1', true);
 				req.responseType = 'json';
 				req.onerror = function (e) {
 					checkboxTag.checked = !isChecked;


### PR DESCRIPTION
```
File not found: `/views/tag/tagEntry.phtml`
```

(only visible in *development* mode)


Because we had no view file for this call.
