### PR TITLE
TOS in footer

### DIFF
--- a/app/views/auth/formLogin.phtml
+++ b/app/views/auth/formLogin.phtml
@@ -3,7 +3,9 @@
 	<h1><?= _t('gen.auth.login') ?></h1>
 
 	<?php if (!max_registrations_reached()) { ?>
-		<a href="<?= _url('auth', 'register') ?>"><?= _t('gen.auth.registration.ask') ?></a>
+		<div class="link-registration">
+			<a href="<?= _url('auth', 'register') ?>"><?= _t('gen.auth.registration.ask') ?></a>
+		</div>
 	<?php } ?>
 
 	<form id="crypto-form" method="post" action="<?= _url('auth', 'login') ?>">
@@ -39,6 +41,11 @@
 			</button>
 		</div>
 	</form>
-
-	<p><a href="<?= _url('index', 'about') ?>"><?= _t('gen.freshrss.about') ?></a></p>
 </main>
+
+<footer class="main-footer">
+	<a href="<?= _url('index', 'about') ?>"><?= _t('gen.freshrss.about') ?></a>
+	<?php if (file_exists(TOS_FILENAME)) { ?>
+		| <a href="<?= _url('index', 'tos') ?>"><?= _t('index.tos.title')?></a>
+	<?php } ?>
+</footer>

--- a/app/views/auth/register.phtml
+++ b/app/views/auth/register.phtml
@@ -77,6 +77,11 @@
 			<a href="<?= _url('index', 'index') ?>"><?= _t('gen.action.cancel') ?></a>
 		</div>
 	</form>
-
-	<p><a href="<?= _url('index', 'about') ?>"><?= _t('gen.freshrss.about') ?></a></p>
 </main>
+
+<footer class="main-footer">
+	<a href="<?= _url('index', 'about') ?>"><?= _t('gen.freshrss.about') ?></a>
+	<?php if (file_exists(TOS_FILENAME)) { ?>
+		| <a href="<?= _url('index', 'tos') ?>"><?= _t('index.tos.title')?></a>
+	<?php } ?>
+</footer>

--- a/app/views/index/about.phtml
+++ b/app/views/index/about.phtml
@@ -45,3 +45,11 @@
 	<h2><?= _t('index.about.credits') ?></h2>
 	<p><?= _t('index.about.credits_content') ?></p>
 </main>
+
+<?php if (!FreshRSS_Auth::hasAccess()) { ?>
+<footer class="main-footer">
+	<?php if (file_exists(TOS_FILENAME)) { ?>
+		<a href="<?= _url('index', 'tos') ?>"><?= _t('index.tos.title')?></a>
+	<?php } ?>
+</footer>
+<?php } ?>

--- a/app/views/index/tos.phtml
+++ b/app/views/index/tos.phtml
@@ -27,3 +27,9 @@
 	<h1><?= _t('index.tos.title')?></h1>
 	<?= $this->terms_of_service ?>
 </main>
+
+<?php if (!FreshRSS_Auth::hasAccess()) { ?>
+<footer class="main-footer">
+	<a href="<?= _url('index', 'about') ?>"><?= _t('gen.freshrss.about') ?></a>
+</footer>
+<?php } ?>

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -63,11 +63,22 @@ html, body {
 }
 
 main.prompt {
-	margin: 3rem auto;
+	margin: 3rem auto 0;
 	padding: 2rem;
 	max-width: 400px;
 	min-width: 300px;
 	width: 33%;
+	text-align: center;
+}
+
+main.prompt .link-registration {
+	padding: 1rem 0 0;
+	margin-bottom: 3rem;
+}
+
+footer.main-footer {
+	margin: 0 2rem 2rem;
+	padding: 1rem;
 	text-align: center;
 }
 
@@ -367,7 +378,6 @@ td.numeric {
 
 .prompt form {
 	margin-top: 2rem;
-	margin-bottom: 3rem;
 	text-align: left;
 }
 

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -63,11 +63,22 @@ html, body {
 }
 
 main.prompt {
-	margin: 3rem auto;
+	margin: 3rem auto 0;
 	padding: 2rem;
 	max-width: 400px;
 	min-width: 300px;
 	width: 33%;
+	text-align: center;
+}
+
+main.prompt .link-registration {
+	padding: 1rem 0 0;
+	margin-bottom: 3rem;
+}
+
+footer.main-footer {
+	margin: 0 2rem 2rem;
+	padding: 1rem;
 	text-align: center;
 }
 
@@ -367,7 +378,6 @@ td.numeric {
 
 .prompt form {
 	margin-top: 2rem;
-	margin-bottom: 3rem;
 	text-align: right;
 }
 


### PR DESCRIPTION
Ref #5189
Follow up of #5215

Changes proposed in this pull request:

Add the link to the Terms of Service to:

1) Login screen
![grafik](https://user-images.githubusercontent.com/1645099/226750104-8a0e0f82-6517-496b-80bc-a3216fca1e0a.png)

2) Registration form
![grafik](https://user-images.githubusercontent.com/1645099/226750178-78b445a9-7439-4539-af06-9156e14cb1ea.png)


3) add the "about FreshRSS" link to the TOS page to keep the sites consistent and having a `<footer>`
![grafik](https://user-images.githubusercontent.com/1645099/226750143-cff320ac-c35e-4b9a-b0cb-7515c7e6a39d.png)




How to test the feature manually:

1. create data/tos.html
2. see the screens


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
