### PR TITLE
Increase time limit import OPML

### DIFF
--- a/app/Services/ImportService.php
+++ b/app/Services/ImportService.php
@@ -36,6 +36,7 @@ class FreshRSS_Import_Service {
 	 * @param boolean $dry_run true to not create categories and feeds in database.
 	 */
 	public function importOpml(string $opml_file, $forced_category = null, $dry_run = false) {
+		@set_time_limit(300);
 		$this->lastStatus = true;
 		$opml_array = array();
 		try {


### PR DESCRIPTION
Importing an OPML file can take a long time.
While waiting for a better way to customize, let's give it more time, like other slow functions
