### PR TITLE
i18n fix percent_of_total

### DIFF
--- a/app/i18n/cz/admin.php
+++ b/app/i18n/cz/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => 'Všechny kanály',
 		'no_idle' => 'Nejsou žádné nečinné kanály!',
 		'number_entries' => '%d článků',
-		'percent_of_total' => '%% ze všech',
+		'percent_of_total' => '% ze všech',
 		'repartition' => 'Přerozdělení článků',
 		'status_favorites' => 'Oblíbené',
 		'status_read' => 'Přečtené',

--- a/app/i18n/de/admin.php
+++ b/app/i18n/de/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => 'Haupt-Feeds',
 		'no_idle' => 'Es gibt keinen inaktiven Feed!',
 		'number_entries' => '%d Artikel',
-		'percent_of_total' => '%% Gesamt',
+		'percent_of_total' => '% Gesamt',
 		'repartition' => 'Artikel-Verteilung',
 		'status_favorites' => 'Favoriten',
 		'status_read' => 'Gelesen',

--- a/app/i18n/el/admin.php
+++ b/app/i18n/el/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => 'Κύρια ροή',
 		'no_idle' => 'Δεν υπάρχουν αδρανείς τροφοδοσίες!',
 		'number_entries' => '%d άρθρα',
-		'percent_of_total' => '%% εκ του συνόλου',
+		'percent_of_total' => '% εκ του συνόλου',
 		'repartition' => 'Articles repartition',	// TODO
 		'status_favorites' => 'Αγαπημένα',
 		'status_read' => 'Ανάγνωση',

--- a/app/i18n/en-us/admin.php
+++ b/app/i18n/en-us/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => 'Main stream',	// IGNORE
 		'no_idle' => 'There are no idle feeds!',	// IGNORE
 		'number_entries' => '%d articles',	// IGNORE
-		'percent_of_total' => '%% of total',	// IGNORE
+		'percent_of_total' => '% of total',	// IGNORE
 		'repartition' => 'Articles repartition',	// IGNORE
 		'status_favorites' => 'Favorites',
 		'status_read' => 'Read',	// IGNORE

--- a/app/i18n/en/admin.php
+++ b/app/i18n/en/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => 'Main stream',
 		'no_idle' => 'There are no idle feeds!',
 		'number_entries' => '%d articles',
-		'percent_of_total' => '%% of total',
+		'percent_of_total' => '% of total',
 		'repartition' => 'Articles repartition',
 		'status_favorites' => 'Favourites',
 		'status_read' => 'Read',

--- a/app/i18n/es/admin.php
+++ b/app/i18n/es/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => 'Salida principal',
 		'no_idle' => 'No hay fuentes inactivas',
 		'number_entries' => '%d artículos',
-		'percent_of_total' => '%% del total',
+		'percent_of_total' => '% del total',
 		'repartition' => 'Reprto de artículos',
 		'status_favorites' => 'Favoritos',
 		'status_read' => 'Leídos',

--- a/app/i18n/fr/admin.php
+++ b/app/i18n/fr/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => 'Flux principal',
 		'no_idle' => 'Il n’y a aucun flux inactif !',
 		'number_entries' => '%d articles',	// IGNORE
-		'percent_of_total' => '%% du total',
+		'percent_of_total' => '% du total',
 		'repartition' => 'Répartition des articles',
 		'status_favorites' => 'favoris',
 		'status_read' => 'lus',

--- a/app/i18n/he/admin.php
+++ b/app/i18n/he/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => 'הזנה ראשית',
 		'no_idle' => 'אין הזנות מובטלות!',
 		'number_entries' => '%d מאמרים',
-		'percent_of_total' => '%% מסך הכל',
+		'percent_of_total' => '% מסך הכל',
 		'repartition' => 'חלוקת המאמרים',
 		'status_favorites' => 'מועדפים',
 		'status_read' => 'נקרא',

--- a/app/i18n/id/admin.php
+++ b/app/i18n/id/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => 'Aliran utama',
 		'no_idle' => 'Tidak ada idle feed!',
 		'number_entries' => '%d artikel',
-		'percent_of_total' => '%% dari total',
+		'percent_of_total' => '% dari total',
 		'repartition' => 'Mengembalikan artikel',
 		'status_favorites' => 'Favorites',
 		'status_read' => 'Read',	// TODO

--- a/app/i18n/it/admin.php
+++ b/app/i18n/it/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => 'Flusso principale',
 		'no_idle' => 'Non ci sono feed non aggiornati',
 		'number_entries' => '%d articoli',
-		'percent_of_total' => '%% del totale',
+		'percent_of_total' => '% del totale',
 		'repartition' => 'Ripartizione articoli',
 		'status_favorites' => 'Preferiti',
 		'status_read' => 'Letti',

--- a/app/i18n/ja/admin.php
+++ b/app/i18n/ja/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => '主なストリーム',
 		'no_idle' => '未使用のフィードはありません!',
 		'number_entries' => '%d 記事',
-		'percent_of_total' => '%% 総計',
+		'percent_of_total' => '% 総計',
 		'repartition' => '記事の仕切り',
 		'status_favorites' => 'お気に入り',
 		'status_read' => '既読',

--- a/app/i18n/ko/admin.php
+++ b/app/i18n/ko/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => '메인 스트림',
 		'no_idle' => '유휴 피드가 없습니다!',
 		'number_entries' => '%d 개의 글',
-		'percent_of_total' => '전체에서의 비율 (%%)',
+		'percent_of_total' => '전체에서의 비율 (%)',
 		'repartition' => '글 분류',
 		'status_favorites' => '즐겨찾기',
 		'status_read' => '읽음',

--- a/app/i18n/nl/admin.php
+++ b/app/i18n/nl/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => 'Overzicht',
 		'no_idle' => 'Er is geen gepauzeerde feed!',
 		'number_entries' => '%d artikelen',
-		'percent_of_total' => '%% van totaal',
+		'percent_of_total' => '% van totaal',
 		'repartition' => 'Artikelverdeling',
 		'status_favorites' => 'Favorieten',
 		'status_read' => 'Gelezen',

--- a/app/i18n/oc/admin.php
+++ b/app/i18n/oc/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => 'Flux màger',
 		'no_idle' => 'I a pas cap d’article inactiu !',
 		'number_entries' => '%d articles',	// IGNORE
-		'percent_of_total' => '%% del total',
+		'percent_of_total' => '% del total',
 		'repartition' => 'Reparticion dels articles',
 		'status_favorites' => 'Favorits',
 		'status_read' => 'Legit',

--- a/app/i18n/pl/admin.php
+++ b/app/i18n/pl/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => 'Kanał główny',
 		'no_idle' => 'Brak bezczynnych kanałów!',
 		'number_entries' => '%d wiadomości',
-		'percent_of_total' => '%% wszystkich',
+		'percent_of_total' => '% wszystkich',
 		'repartition' => 'Podział wiadomości',
 		'status_favorites' => 'Ulubione',
 		'status_read' => 'Przeczytane',

--- a/app/i18n/pt-br/admin.php
+++ b/app/i18n/pt-br/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => 'Stream principal',
 		'no_idle' => 'Não há nenhum feed inativo!',
 		'number_entries' => '%d artigos',
-		'percent_of_total' => '%% do total',
+		'percent_of_total' => '% do total',
 		'repartition' => 'Repartição de artigos',
 		'status_favorites' => 'Favoritos',
 		'status_read' => 'Lido',

--- a/app/i18n/ru/admin.php
+++ b/app/i18n/ru/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => 'Основной поток',
 		'no_idle' => 'Нет неактивных лент!',
 		'number_entries' => 'статей: %d',
-		'percent_of_total' => '%% от всего',
+		'percent_of_total' => '% от всего',
 		'repartition' => 'Распределение статей',
 		'status_favorites' => 'В избранном',
 		'status_read' => 'Прочитано',

--- a/app/i18n/sk/admin.php
+++ b/app/i18n/sk/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => 'Všetky kanály',
 		'no_idle' => 'Žiadne neaktívne kanály!',
 		'number_entries' => 'Počet článkov: %d',
-		'percent_of_total' => 'Z celkového počtu: %%',
+		'percent_of_total' => 'Z celkového počtu: %',
 		'repartition' => 'Rozdelenie článkov',
 		'status_favorites' => 'Obľúbené',
 		'status_read' => 'Prečítané',

--- a/app/i18n/tr/admin.php
+++ b/app/i18n/tr/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => 'Ana akış',
 		'no_idle' => 'Boşta akış yok!',
 		'number_entries' => '%d makale',
-		'percent_of_total' => '%% toplamın yüzdesi',
+		'percent_of_total' => '% toplamın yüzdesi',
 		'repartition' => 'Makale dağılımı',
 		'status_favorites' => 'Favoriler',
 		'status_read' => 'Okunmuş',

--- a/app/i18n/zh-cn/admin.php
+++ b/app/i18n/zh-cn/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => '首页',
 		'no_idle' => '订阅源近期皆有更新！',
 		'number_entries' => '%d 篇文章',
-		'percent_of_total' => '%%',
+		'percent_of_total' => '%',
 		'repartition' => '文章分布',
 		'status_favorites' => '收藏',
 		'status_read' => '已读',

--- a/app/i18n/zh-tw/admin.php
+++ b/app/i18n/zh-tw/admin.php
@@ -147,7 +147,7 @@ return array(
 		'main_stream' => '首頁',
 		'no_idle' => '訂閱源近期皆有更新！',
 		'number_entries' => '%d 篇文章',
-		'percent_of_total' => '%%',
+		'percent_of_total' => '%',
 		'repartition' => '文章分布',
 		'status_favorites' => '收藏',
 		'status_read' => '已讀',


### PR DESCRIPTION
Fix double `%%` (escaping not needed anymore for strings not using an sprintf construction since https://github.com/FreshRSS/FreshRSS/pull/5022)

![image](https://user-images.githubusercontent.com/1008324/227918486-3f9bc92a-5503-4fc1-b5ba-057791c1f6dc.png)
