### PR TITLE
Improved: Theme slider for mobile

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2346,6 +2346,10 @@ input:checked + .slide-container .properties {
 	.stat.half {
 		grid-column: 1 / span 2;
 	}
+
+	.slide + .nav label {
+		opacity: 0.5;
+	}
 }
 
 /*=== PRINTER */

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2346,6 +2346,10 @@ input:checked + .slide-container .properties {
 	.stat.half {
 		grid-column: 1 / span 2;
 	}
+
+	.slide + .nav label {
+		opacity: 0.5;
+	}
 }
 
 /*=== PRINTER */


### PR DESCRIPTION
Before:
In mobile view the arrows (left/right) are not visible. On touch there is (almost) no `:hover` so the user cannot see the left/right navigation buttons
![grafik](https://user-images.githubusercontent.com/1645099/230898218-58cd903f-b731-4068-ba9b-a833a05fe971.png)

After:
The arrows are shown in the mobile view in the same style like hovering with the mouse cursor over the slider.
![grafik](https://user-images.githubusercontent.com/1645099/230898384-508c85d5-be66-41a6-9fbc-2cccc5b38233.png)


Changes proposed in this pull request:

- CSS

How to test the feature manually:

1. go to `Display` config
2. use it in mobile view (small screen)
3. see the arrows that are displayed

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
