### PR TITLE
 Improved: Dark mode of Origine (Improve #5229)

### DIFF
--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -1265,17 +1265,17 @@ a.btn-attention:hover {
 		--form-element-invalid-box-shadow-color-inset: none;
 	}
 
-	:root .darkMode_auto .btn {
+	:root .darkMode_auto .nav_menu .btn {
 		color: #777;
 	}
 
-	:root .darkMode_auto .btn:hover {
+	:root .darkMode_auto .nav_menu .btn:hover {
 		color: var(--font-color-grey);
 	}
 
-	:root .darkMode_auto .btn.active,
-	:root .darkMode_auto .btn:active,
-	:root .darkMode_auto .dropdown-target:target ~ .btn.dropdown-toggle {
+	:root .darkMode_auto .nav_menu .btn.active,
+	:root .darkMode_auto .nav_menu .btn:active,
+	:root .darkMode_auto .nav_menu .dropdown-target:target ~ .btn.dropdown-toggle {
 		background: var(--border-color);
 	}
 

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -1265,17 +1265,17 @@ a.btn-attention:hover {
 		--form-element-invalid-box-shadow-color-inset: none;
 	}
 
-	:root .darkMode_auto .btn {
+	:root .darkMode_auto .nav_menu .btn {
 		color: #777;
 	}
 
-	:root .darkMode_auto .btn:hover {
+	:root .darkMode_auto .nav_menu .btn:hover {
 		color: var(--font-color-grey);
 	}
 
-	:root .darkMode_auto .btn.active,
-	:root .darkMode_auto .btn:active,
-	:root .darkMode_auto .dropdown-target:target ~ .btn.dropdown-toggle {
+	:root .darkMode_auto .nav_menu .btn.active,
+	:root .darkMode_auto .nav_menu .btn:active,
+	:root .darkMode_auto .nav_menu .dropdown-target:target ~ .btn.dropdown-toggle {
 		background: var(--border-color);
 	}
 


### PR DESCRIPTION
Ref #5229

Before:
#5229 had some side effects. It made the font color of all buttons grey:

![grafik](https://user-images.githubusercontent.com/1645099/231300883-49f2d5c4-3f9a-470f-9ea3-84bfab307049.png)

After:
![grafik](https://user-images.githubusercontent.com/1645099/231300963-90ece6db-e396-4ce1-98e0-cbd0b02e5a48.png)


Changes proposed in this pull request:

- Origine.css


How to test the feature manually:

1. use Origine theme
2. enable the dark mode
3. see the buttons

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
