### PR TITLE
Improved: share to clipboard improved with animation and icon

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1089,6 +1089,9 @@ function init_stream(stream) {
 		el = ev.target.closest('.item.share > button[data-type="clipboard"]');
 		if (el && navigator.clipboard) {	// Clipboard
 			navigator.clipboard.writeText(el.dataset.url);
+			el.classList.remove('ok');
+			void el.offsetWidth; // it does nothwing, but it is needed. See hack: https://css-tricks.com/restart-css-animation/
+			el.classList.add('ok');
 			return false;
 		}
 

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1090,7 +1090,7 @@ function init_stream(stream) {
 		if (el && navigator.clipboard) {	// Clipboard
 			navigator.clipboard.writeText(el.dataset.url);
 			el.classList.remove('ok');
-			void el.offsetWidth; // it does nothwing, but it is needed. See hack: https://css-tricks.com/restart-css-animation/
+			el.dataset.foo = el.offsetWidth; // it does nothing, but it is needed. See https://github.com/FreshRSS/FreshRSS/pull/5295
 			el.classList.add('ok');
 			return false;
 		}

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1914,8 +1914,8 @@ input:checked + .slide-container .properties {
 	opacity: 0;
 	transition: all 0.6s;
 	left: 0px;
-	height: 1rem;
 	width: 100%;
+	height: 1rem;
 }
 
 .item.share button:active::after {
@@ -1930,15 +1930,14 @@ input:checked + .slide-container .properties {
 	left: 0.5rem;
 	animation-duration: 10s;
 	animation-fill-mode: both;
-}
-
-.item.share button.ok::before {
 	animation-name: easeOut;
 }
 
 @keyframes easeOut {
 	0% {opacity: 1;}
+
 	80% {opacity: 1;}
+
 	100% {opacity: 0;}
 }
 

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1901,6 +1901,47 @@ input:checked + .slide-container .properties {
 	color: var(--frss-font-color-error);
 }
 
+.item.share button {
+	position: relative;
+}
+
+.item.share button::after {
+	content: "";
+	background: var(--frss-background-color-transparent);
+	display: inline-block;
+	position: absolute;
+	padding-top: 1rem;
+	opacity: 0;
+	transition: all 0.6s;
+	left: 0px;
+	height: 1rem;
+	width: 100%;
+}
+
+.item.share button:active::after {
+	opacity: 1;
+	width: 0;
+	transition: 0s
+}
+
+.item.share button.ok::before {
+	content: "✓";
+	position: absolute;
+	left: 0.5rem;
+	animation-duration: 10s;
+	animation-fill-mode: both;
+}
+
+.item.share button.ok::before {
+	animation-name: easeOut;
+}
+
+@keyframes easeOut {
+	0% {opacity: 1;}
+	80% {opacity: 1;}
+	100% {opacity: 0;}
+}
+
 .deprecated {
 	font-weight: bold;
 }

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1914,8 +1914,8 @@ input:checked + .slide-container .properties {
 	opacity: 0;
 	transition: all 0.6s;
 	right: 0px;
-	height: 1rem;
 	width: 100%;
+	height: 1rem;
 }
 
 .item.share button:active::after {
@@ -1930,15 +1930,14 @@ input:checked + .slide-container .properties {
 	right: 0.5rem;
 	animation-duration: 10s;
 	animation-fill-mode: both;
-}
-
-.item.share button.ok::before {
 	animation-name: easeOut;
 }
 
 @keyframes easeOut {
 	0% {opacity: 1;}
+
 	80% {opacity: 1;}
+
 	100% {opacity: 0;}
 }
 

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1901,6 +1901,47 @@ input:checked + .slide-container .properties {
 	color: var(--frss-font-color-error);
 }
 
+.item.share button {
+	position: relative;
+}
+
+.item.share button::after {
+	content: "";
+	background: var(--frss-background-color-transparent);
+	display: inline-block;
+	position: absolute;
+	padding-top: 1rem;
+	opacity: 0;
+	transition: all 0.6s;
+	right: 0px;
+	height: 1rem;
+	width: 100%;
+}
+
+.item.share button:active::after {
+	opacity: 1;
+	width: 0;
+	transition: 0s
+}
+
+.item.share button.ok::before {
+	content: "✓";
+	position: absolute;
+	right: 0.5rem;
+	animation-duration: 10s;
+	animation-fill-mode: both;
+}
+
+.item.share button.ok::before {
+	animation-name: easeOut;
+}
+
+@keyframes easeOut {
+	0% {opacity: 1;}
+	80% {opacity: 1;}
+	100% {opacity: 0;}
+}
+
 .deprecated {
 	font-weight: bold;
 }


### PR DESCRIPTION
Sharing Service `Clipboard`

Before:
User clicks on the `Clipboard` and there is no visual feedback.
![grafik](https://user-images.githubusercontent.com/1645099/231747447-1acc14e4-04b5-4817-948a-232e125b699f.png)


After:
Click on `Clipboard`:
- a background animatoin runs from left to right side (it is not so good visible in the gif)
- a checkmark icon is set, that easeout after 10 seconds
![clipboard](https://user-images.githubusercontent.com/1645099/231748627-9908c802-57d9-4e8b-94cf-9da74d14ca6f.gif)


Notice:
Only the Clipboard is animated, because only this sharing service does not open another service as click feedback.

Changes proposed in this pull request:

- JS and CSS


How to test the feature manually:

1. add `Clipboard` to the sharing service list
2. share an article via click on `Clipboard`
3. see the animation and checkmark

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
