### PR TITLE
Improve markAsReadUponGone

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -531,7 +531,10 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 
 			$feedDAO->updateLastUpdate($feed->id(), false, $mtime);
 			$needFeedCacheRefresh |= ($feed->keepMaxUnread() != false);
-			$needFeedCacheRefresh |= ($feed->markAsReadUponGone() != false);
+			if (!$simplePiePush) {
+				// Do not call for WebSub events, as we do not know the list of articles still on the upstream feed.
+				$needFeedCacheRefresh |= ($feed->markAsReadUponGone() != false);
+			}
 			if ($needFeedCacheRefresh) {
 				$feedDAO->updateCachedValues($feed->id());
 			}

--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -492,7 +492,7 @@ SQL;
 	 * Remember to call updateCachedValues() after calling this function
 	 * @return int|false number of lines affected or false in case of error
 	 */
-	public function markAsReadUponGone() {
+	public function markAsReadUponGone(int $id) {
 		//Double SELECT for MySQL workaround ERROR 1093 (HY000)
 		$sql = <<<'SQL'
 UPDATE `_entry` SET is_read=1

--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -496,20 +496,18 @@ SQL;
 		//Double SELECT for MySQL workaround ERROR 1093 (HY000)
 		$sql = <<<'SQL'
 UPDATE `_entry` SET is_read=1
-WHERE id_feed=:id_feed1 AND is_read=0 AND (
-	`lastSeen` < (SELECT e3.maxlastseen FROM (
-		SELECT MAX(e2.`lastSeen`) AS maxlastseen FROM `_entry` e2 WHERE e2.id_feed = :id_feed2
-	) e3)
-	OR `lastSeen` < (SELECT f3.lastcorrectupdate FROM (
-		SELECT `lastUpdate` - (ttl * 2) AS lastcorrectupdate FROM `_feed` WHERE id = :id_feed3 AND error = 0
-	) f3)
+WHERE id_feed=:id_feed AND is_read=0 AND (
+	`lastSeen` < (SELECT s1.maxlastseen FROM (
+		SELECT MAX(e2.`lastSeen`) AS maxlastseen FROM `_entry` e2 WHERE e2.id_feed = id_feed
+	) s1)
+	OR `lastSeen` < (SELECT s2.lastcorrectupdate FROM (
+		SELECT f2.`lastUpdate` - (f2.ttl * 2) AS lastcorrectupdate FROM `_feed` f2 WHERE f2.id = id_feed AND f2.error = 0
+	) s2)
 )
 SQL;
 
 		if (($stm = $this->pdo->prepare($sql)) &&
-			$stm->bindParam(':id_feed1', $id, PDO::PARAM_INT) &&
-			$stm->bindParam(':id_feed2', $id, PDO::PARAM_INT) &&
-			$stm->bindParam(':id_feed3', $id, PDO::PARAM_INT) &&
+			$stm->bindParam(':id_feed', $id, PDO::PARAM_INT) &&
 			$stm->execute()) {
 			return $stm->rowCount();
 		} else {

--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -69,7 +69,7 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo {
 		);
 
 		if ($stm && $stm->execute($values)) {
-			return $this->pdo->lastInsertId('`_feed_id_seq`');
+			return (int)($this->pdo->lastInsertId('`_feed_id_seq`'));
 		} else {
 			$info = $stm == null ? $this->pdo->errorInfo() : $stm->errorInfo();
 			if ($this->autoUpdateDb($info)) {
@@ -355,7 +355,7 @@ SQL;
 	}
 
 	/**
-	 * Use $defaultCacheDuration == -1 to return all feeds, without filtering them by TTL.
+	 * @param int $defaultCacheDuration Use -1 to return all feeds, without filtering them by TTL.
 	 * @return array<FreshRSS_Feed>
 	 */
 	public function listFeedsOrderUpdate(int $defaultCacheDuration = 3600, int $limit = 0): array {
@@ -497,11 +497,11 @@ SQL;
 		$sql = <<<'SQL'
 UPDATE `_entry` SET is_read=1
 WHERE id_feed=:id_feed1 AND is_read=0 AND (
-	`lastSeen` < (SELECT s1.maxlastseen FROM (
+	`lastSeen` + 60 < (SELECT s1.maxlastseen FROM (
 		SELECT MAX(e2.`lastSeen`) AS maxlastseen FROM `_entry` e2 WHERE e2.id_feed = :id_feed2
 	) s1)
-	OR `lastSeen` < (SELECT s2.lastcorrectupdate FROM (
-		SELECT f2.`lastUpdate` - (f2.ttl * 2) AS lastcorrectupdate FROM `_feed` f2 WHERE f2.id = :id_feed3 AND f2.error = 0
+	OR `lastSeen` + 60 < (SELECT s2.lastcorrectupdate FROM (
+		SELECT f2.`lastUpdate` AS lastcorrectupdate FROM `_feed` f2 WHERE f2.id = :id_feed3 AND f2.error = 0
 	) s2)
 )
 SQL;

--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -496,18 +496,20 @@ SQL;
 		//Double SELECT for MySQL workaround ERROR 1093 (HY000)
 		$sql = <<<'SQL'
 UPDATE `_entry` SET is_read=1
-WHERE id_feed=:id_feed AND is_read=0 AND (
+WHERE id_feed=:id_feed1 AND is_read=0 AND (
 	`lastSeen` < (SELECT s1.maxlastseen FROM (
-		SELECT MAX(e2.`lastSeen`) AS maxlastseen FROM `_entry` e2 WHERE e2.id_feed = id_feed
+		SELECT MAX(e2.`lastSeen`) AS maxlastseen FROM `_entry` e2 WHERE e2.id_feed = :id_feed2
 	) s1)
 	OR `lastSeen` < (SELECT s2.lastcorrectupdate FROM (
-		SELECT f2.`lastUpdate` - (f2.ttl * 2) AS lastcorrectupdate FROM `_feed` f2 WHERE f2.id = id_feed AND f2.error = 0
+		SELECT f2.`lastUpdate` - (f2.ttl * 2) AS lastcorrectupdate FROM `_feed` f2 WHERE f2.id = :id_feed3 AND f2.error = 0
 	) s2)
 )
 SQL;
 
 		if (($stm = $this->pdo->prepare($sql)) &&
-			$stm->bindParam(':id_feed', $id, PDO::PARAM_INT) &&
+			$stm->bindParam(':id_feed1', $id, PDO::PARAM_INT) &&
+			$stm->bindParam(':id_feed2', $id, PDO::PARAM_INT) &&
+			$stm->bindParam(':id_feed3', $id, PDO::PARAM_INT) &&
 			$stm->execute()) {
 			return $stm->rowCount();
 		} else {


### PR DESCRIPTION
Fix case  when the upstream feed has zero article, then old articles would never be automatically marked as read with the "mark as read when gone" policy, which was only based on the timestamp of new articles from the upstream feed.

Fix also bugs in the case of WebSub, and in the case of feeds with invalid (duplicate) GUIDs
