### PR TITLE
Flat theme: un-deprecate

### DIFF
--- a/docs/en/users/05_Configuration.md
+++ b/docs/en/users/05_Configuration.md
@@ -22,7 +22,7 @@ There’s no accounting for tastes, which is why FreshRSS offers 13 official the
 | Blue Lagoon     |Mister aiR | No longer supported. Will be removed with FreshRSS V1.22.0 |
 | Dark | AD | |
 | Dark pink | Miicat_47 | |
-| Flat design | Marien Fressinaud | No longer supported. Will be removed with FreshRSS V1.22.0 |
+| Flat design | Marien Fressinaud | |
 | Mapco | Thomas Guesnon  | |
 | Nord theme | joelchrono12 | |
 | Origine | Marien Fressinaud | (default theme) |

--- a/p/themes/Flat/metadata.json
+++ b/p/themes/Flat/metadata.json
@@ -4,6 +4,5 @@
   "description": "Thème plat pour FreshRSS",
   "version": 0.2,
   "files": ["_frss.css", "flat.css"],
-  "deprecated": true,
 	"theme-color": "#34495e"
 }


### PR DESCRIPTION
Based on #4295 there is a demand for the `Flat` theme. So I deleted the flag that marked it as `deprecated`.
Follow up of #4807

Changes proposed in this pull request:

- `metadata.json` of Flat theme
- documentation


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
