### PR TITLE
Incorrect url for articles in feed

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -211,3 +211,4 @@ People are sorted by name so please keep this order.
 * [Yamakuni](https://github.com/Yamakuni): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Yamakuni), [Web](https://ofanch.me/)
 * [yzqzss|一座桥在水上](https://github.com/yzqzss): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:yzqzss), [Web](https://blog.othing.xyz/)
 * [Zhiyuan Zheng](https://github.com/zhzy0077): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:zhzy0077)
+* [Jimish Gamit](https://github.com/gjimish): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:gjimish)

--- a/lib/SimplePie/SimplePie/Item.php
+++ b/lib/SimplePie/SimplePie/Item.php
@@ -1022,7 +1022,18 @@ class SimplePie_Item
 			}
 			if ($links = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'link'))
 			{
-				$this->data['links']['alternate'][] = $this->sanitize($links[0]['data'], SIMPLEPIE_CONSTRUCT_IRI, $this->get_base($links[0]));
+				if (!empty($links[0]['data']))
+				{
+					$this->data['links']['alternate'][] = $this->sanitize($links[0]['data'], SIMPLEPIE_CONSTRUCT_IRI, $this->get_base($links[0]));
+				}
+				else
+				{
+					if (isset($links[0]['attribs']['']['href']))
+					{
+						$link_rel = (isset($links[0]['attribs']['']['rel'])) ? $links[0]['attribs']['']['rel'] : 'alternate';
+						$this->data['links'][$link_rel][] = $this->sanitize($links[0]['attribs']['']['href'], SIMPLEPIE_CONSTRUCT_IRI, $this->get_base($links[0]));
+					}
+				}
 			}
 			if ($links = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'guid'))
 			{


### PR DESCRIPTION
Closes #5323

Changes proposed in this pull request:

- Get article URI from `attribs`

How to test the feature manually:

1. Subscribe [theatlantic.com](https://www.theatlantic.com/feed/all/) feed.
2. Instead of an image, each article's title should redirect you to the appropriate url.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
