### PR TITLE
Automatic trusted_sources during install

### DIFF
--- a/app/Controllers/authController.php
+++ b/app/Controllers/authController.php
@@ -75,7 +75,7 @@ class FreshRSS_auth_Controller extends FreshRSS_ActionController {
 				break;
 			case 'http_auth':
 				Minz_Error::error(403, array('error' => array(_t('feedback.access.denied'),
-						' [HTTP Remote-User=' . htmlspecialchars(httpAuthUser(), ENT_NOQUOTES, 'UTF-8') .
+						' [HTTP Remote-User=' . htmlspecialchars(httpAuthUser(false), ENT_NOQUOTES, 'UTF-8') .
 						' ; Remote IP address=' . ($_SERVER['REMOTE_ADDR'] ?? '') . ']'
 					)), false);
 				break;

--- a/app/Controllers/userController.php
+++ b/app/Controllers/userController.php
@@ -212,7 +212,7 @@ class FreshRSS_user_Controller extends FreshRSS_ActionController {
 	}
 
 	/** @param array<string,mixed> $userConfigOverride */
-	public static function createUser(string $new_user_name, string $email, string $passwordPlain,
+	public static function createUser(string $new_user_name, ?string $email, string $passwordPlain,
 		array $userConfigOverride = [], bool $insertDefaultFeeds = true): bool {
 		$userConfig = [];
 

--- a/app/Models/Auth.php
+++ b/app/Models/Auth.php
@@ -73,8 +73,9 @@ class FreshRSS_Auth {
 			$login_ok = FreshRSS_UserDAO::exists($current_user);
 			if (!$login_ok && FreshRSS_Context::$system_conf->http_auth_auto_register) {
 				$email = null;
-				if (!empty(FreshRSS_Context::$system_conf->http_auth_auto_register_email_field)) {
-					$email = (string)($_SERVER[FreshRSS_Context::$system_conf->http_auth_auto_register_email_field] ?? null);
+				if (FreshRSS_Context::$system_conf->http_auth_auto_register_email_field !== '' &&
+					isset($_SERVER[FreshRSS_Context::$system_conf->http_auth_auto_register_email_field])) {
+					$email = (string)($_SERVER[FreshRSS_Context::$system_conf->http_auth_auto_register_email_field]);
 				}
 				$language = Minz_Translate::getLanguage(null, Minz_Request::getPreferredLanguages(), FreshRSS_Context::$system_conf->language);
 				Minz_Translate::init($language);

--- a/app/Models/Auth.php
+++ b/app/Models/Auth.php
@@ -75,7 +75,7 @@ class FreshRSS_Auth {
 				$email = null;
 				if (FreshRSS_Context::$system_conf->http_auth_auto_register_email_field !== '' &&
 					isset($_SERVER[FreshRSS_Context::$system_conf->http_auth_auto_register_email_field])) {
-					$email = (string)($_SERVER[FreshRSS_Context::$system_conf->http_auth_auto_register_email_field]);
+					$email = (string)$_SERVER[FreshRSS_Context::$system_conf->http_auth_auto_register_email_field];
 				}
 				$language = Minz_Translate::getLanguage(null, Minz_Request::getPreferredLanguages(), FreshRSS_Context::$system_conf->language);
 				Minz_Translate::init($language);

--- a/app/Models/Auth.php
+++ b/app/Models/Auth.php
@@ -73,9 +73,8 @@ class FreshRSS_Auth {
 			$login_ok = FreshRSS_UserDAO::exists($current_user);
 			if (!$login_ok && FreshRSS_Context::$system_conf->http_auth_auto_register) {
 				$email = null;
-				if (FreshRSS_Context::$system_conf->http_auth_auto_register_email_field !== '' &&
-					isset($_SERVER[FreshRSS_Context::$system_conf->http_auth_auto_register_email_field])) {
-					$email = $_SERVER[FreshRSS_Context::$system_conf->http_auth_auto_register_email_field];
+				if (!empty(FreshRSS_Context::$system_conf->http_auth_auto_register_email_field)) {
+					$email = (string)($_SERVER[FreshRSS_Context::$system_conf->http_auth_auto_register_email_field] ?? null);
 				}
 				$language = Minz_Translate::getLanguage(null, Minz_Request::getPreferredLanguages(), FreshRSS_Context::$system_conf->language);
 				Minz_Translate::init($language);

--- a/app/Models/SystemConfiguration.php
+++ b/app/Models/SystemConfiguration.php
@@ -7,7 +7,7 @@
  * @property-read bool $allow_robots
  * @property bool $api_enabled
  * @property string $archiving
- * @property string $auth_type
+ * @property 'form'|'http_auth'|'none' $auth_type
  * @property string $auto_update_url
  * @property-read array<int,mixed> $curl_options
  * @property string $default_user
@@ -23,7 +23,7 @@
  * @property-read string $salt
  * @property-read bool $simplepie_syslog_enabled
  * @property bool $unsafe_autologin_enabled
- * @property-read array<string> $trusted_sources
+ * @property array<string> $trusted_sources
  */
 final class FreshRSS_SystemConfiguration extends Minz_Configuration {
 

--- a/app/install.php
+++ b/app/install.php
@@ -149,6 +149,10 @@ function saveStep2(): void {
 		if (Minz_Session::param('auth_type') != '') {
 			$config_array['auth_type'] = Minz_Session::param('auth_type');
 		}
+		if (Minz_Session::param('auth_type') === 'http_auth' && !empty($_SERVER['REMOTE_ADDR'])) {
+			// Trust by default the remote IP address (e.g. proxy) used during install to provide remote user name
+			$config_array['trusted_sources'] = $_SERVER['REMOTE_ADDR'];
+		}
 
 		$customConfigPath = DATA_PATH . '/config.custom.php';
 		if (file_exists($customConfigPath)) {
@@ -591,7 +595,7 @@ function printStep3(): void {
 			<div class="group-controls">
 				<input type="text" id="default_user" name="default_user" autocomplete="username" required="required" size="16"
 					pattern="<?= FreshRSS_user_Controller::USERNAME_PATTERN ?>" value="<?= isset($_SESSION['default_user']) ? $_SESSION['default_user'] : '' ?>"
-					placeholder="<?= httpAuthUser() == '' ? 'alice' : httpAuthUser() ?>" tabindex="1" />
+					placeholder="<?= httpAuthUser(false) == '' ? 'alice' : httpAuthUser(false) ?>" tabindex="1" />
 				<p class="help"><?= _i('help') ?> <?= _t('install.default_user.max_char') ?></p>
 			</div>
 		</div>
@@ -603,7 +607,8 @@ function printStep3(): void {
 					<option value="form"<?= $auth_type === 'form' || (no_auth($auth_type) && cryptAvailable()) ? ' selected="selected"' : '',
 						cryptAvailable() ? '' : ' disabled="disabled"' ?>><?= _t('install.auth.form') ?></option>
 					<option value="http_auth"<?= $auth_type === 'http_auth' ? ' selected="selected"' : '',
-						httpAuthUser() == '' ? ' disabled="disabled"' : '' ?>><?= _t('install.auth.http') ?>(REMOTE_USER = '<?= httpAuthUser() ?>')</option>
+						httpAuthUser(false) == '' ? ' disabled="disabled"' : '' ?>>
+							<?= _t('install.auth.http') ?>(REMOTE_USER = '<?= httpAuthUser(false) ?>')</option>
 					<option value="none"<?= $auth_type === 'none' || (no_auth($auth_type) && !cryptAvailable()) ? ' selected="selected"' : ''
 						?>><?= _t('install.auth.none') ?></option>
 				</select>

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -634,13 +634,22 @@ function ipToBits(string $ip): string {
  */
 function checkCIDR(string $ip, string $range): bool {
 	$binary_ip = ipToBits($ip);
-	list($subnet, $mask_bits) = explode('/', $range);
-	$mask_bits = intval($mask_bits);
+	$split = explode('/', $range);
+
+	$subnet = $split[0] ?? '';
+	if ($subnet == '') {
+		return false;
+	}
 	$binary_subnet = ipToBits($subnet);
+
+	$mask_bits = $split[1] ?? '';
+	$mask_bits = intval($mask_bits);
+	if ($mask_bits == 0) {
+		$mask_bits = null;
+	}
 
 	$ip_net_bits = substr($binary_ip, 0, $mask_bits);
 	$subnet_bits = substr($binary_subnet, 0, $mask_bits);
-
 	return $ip_net_bits === $subnet_bits;
 }
 
@@ -665,14 +674,14 @@ function checkTrustedIP(): bool {
 	return false;
 }
 
-function httpAuthUser(bool $onlyTrustedIp = true): string {
+function httpAuthUser(bool $onlyTrusted = true): string {
 	if (!empty($_SERVER['REMOTE_USER'])) {
 		return $_SERVER['REMOTE_USER'];
 	}
 	if (!empty($_SERVER['REDIRECT_REMOTE_USER'])) {
 		return $_SERVER['REDIRECT_REMOTE_USER'];
 	}
-	if (!$onlyTrustedIp || checkTrustedIP()) {
+	if (!$onlyTrusted || checkTrustedIP()) {
 		if (!empty($_SERVER['HTTP_REMOTE_USER'])) {
 			return $_SERVER['HTTP_REMOTE_USER'];
 		}

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -644,7 +644,7 @@ function checkCIDR(string $ip, string $range): bool {
 
 	$mask_bits = $split[1] ?? '';
 	$mask_bits = intval($mask_bits);
-	if ($mask_bits == 0) {
+	if ($mask_bits === 0) {
 		$mask_bits = null;
 	}
 

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -643,7 +643,7 @@ function checkCIDR(string $ip, string $range): bool {
 	$binary_subnet = ipToBits($subnet);
 
 	$mask_bits = $split[1] ?? '';
-	$mask_bits = intval($mask_bits);
+	$mask_bits = (int)$mask_bits;
 	if ($mask_bits === 0) {
 		$mask_bits = null;
 	}


### PR DESCRIPTION
Fix https://github.com/FreshRSS/FreshRSS/issues/5357
Fix also the fact that http_auth was broken during install.
And make the `checkCIDR()` robust when using IP addresses without a range suffix (was previously generating warnings).