### PR TITLE
Update .gitignore: ignore the directory data.back

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /bin/
 /node_modules/
 /vendor/
-/data.backup/
+/data.back/
 /constants.local.php
 
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /bin/
 /node_modules/
 /vendor/
+/data.backup/
 /constants.local.php
 
 .vscode/


### PR DESCRIPTION
While an update the `./data` directory is backed-up into `./data.back`.
It is not needed for git, while `./data.backup` could store gigabytes of data (because of the `cache `directory)
