### PR TITLE
Fix TagDAO for SQLite

### DIFF
--- a/app/Models/TagDAO.php
+++ b/app/Models/TagDAO.php
@@ -212,11 +212,13 @@ SQL;
 
 	public function searchById(int $id): ?FreshRSS_Tag {
 		$res = $this->fetchAssoc('SELECT * FROM `_tag` WHERE id=:id', [':id' => $id]);
+		/** @var array<array{'id':int,'name':string,'attributes'?:string}>|null $res */
 		return $res === null ? null : self::daoToTag($res)[0] ?? null;
 	}
 
 	public function searchByName(string $name): ?FreshRSS_Tag {
 		$res = $this->fetchAssoc('SELECT * FROM `_tag` WHERE name=:name', [':name' => $name]);
+		/** @var array<array{'id':int,'name':string,'attributes'?:string}>|null $res */
 		return $res === null ? null : self::daoToTag($res)[0] ?? null;
 	}
 
@@ -237,7 +239,8 @@ SQL;
 
 		$stm = $this->pdo->query($sql);
 		if ($stm !== false) {
-			return self::daoToTag($stm->fetchAll(PDO::FETCH_ASSOC));
+			$res = $stm->fetchAll(PDO::FETCH_ASSOC) ?: [];
+			return self::daoToTag($res);
 		} else {
 			$info = $this->pdo->errorInfo();
 			if ($this->autoUpdateDb($info)) {
@@ -440,13 +443,13 @@ SQL;
 	}
 
 	/**
-	 * @param iterable<array<string,int|string|null>> $listDAO
+	 * @param iterable<array{'id':int,'name':string,'attributes'?:string}> $listDAO
 	 * @return array<FreshRSS_Tag>
 	 */
 	private static function daoToTag(iterable $listDAO): array {
 		$list = [];
 		foreach ($listDAO as $dao) {
-			if (empty($dao['id']) || !is_int($dao['id']) || empty($dao['name']) || !is_string($dao['name'])) {
+			if (empty($dao['id']) || empty($dao['name'])) {
 				continue;
 			}
 			$tag = new FreshRSS_Tag($dao['name']);


### PR DESCRIPTION
The list of tags was empty when using SQLite.
I have just realised that SQLite PDO driver returns int columns as string (at least in my test with PHP 7.4.33) so there was a type bug.
We might have other bugs of this type for SQLite...
