### PR TITLE
Fix markAsReadUponGone

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -400,6 +400,7 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 			}
 
 			$isNewFeed = $feed->lastUpdate() <= 0;
+			$feedIsUnchanged = false;
 
 			try {
 				if ($simplePiePush) {
@@ -416,6 +417,10 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 					}
 				} else {
 					$simplePie = $feed->load(false, $isNewFeed);
+					if ($simplePie === null) {
+						// Feed is cached and unchanged
+						$feedIsUnchanged = true;
+					}
 				}
 				$newGuids = $simplePie === null ? [] : $feed->loadGuids($simplePie);
 				$entries = $simplePie === null ? [] : $feed->loadEntries($simplePie);
@@ -525,6 +530,12 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 					}
 				}
 				$entryDAO->updateLastSeen($feed->id(), array_keys($newGuids), $mtime);
+			} elseif ($feedIsUnchanged) {
+				// Feed cache was unchanged, so mark as seen the same entries as last time
+				if (!$entryDAO->inTransaction()) {
+					$entryDAO->beginTransaction();
+				}
+				$entryDAO->updateLastSeenUnchanged($feed->id(), $mtime);
 			}
 			unset($entries);
 


### PR DESCRIPTION
Fix regression from https://github.com/FreshRSS/FreshRSS/pull/5315
which indroduced a bug for cached feeds.
We now update the `lastSeen` property of entries to account for the fact that they are unchanged but still existing.
