### PR TITLE
Link configuration to proper parameter

### DIFF
--- a/lib/Minz/Extension.php
+++ b/lib/Minz/Extension.php
@@ -231,10 +231,10 @@ abstract class Minz_Extension {
 	/** @param 'system'|'user' $type */
 	private function isExtensionConfigured(string $type): bool {
 		switch ($type) {
-			case 'system':
+			case 'user':
 				$conf = FreshRSS_Context::$user_conf;
 				break;
-			case 'user':
+			case 'system':
 				$conf = FreshRSS_Context::$system_conf;
 				break;
 		}


### PR DESCRIPTION
Before, the system configuration was linked to the user parameter while the user configuration was linked to the system parameter. This was an issue when trying to retrieve some kind of configuration value in an extension. Now, the configurations are properly linked to their parameters.

Changes proposed in this pull request:

- fix extension configuration parameters

How to test the feature manually:

1. check that parameters from an extension can be retrieved properly

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
