### PR TITLE
Fix: scroll bar color in dark mode

### DIFF
--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -4,10 +4,12 @@
 ?>
 <!DOCTYPE html>
 <html lang="<?= FreshRSS_Context::$user_conf->language ?>" xml:lang="<?= FreshRSS_Context::$user_conf->language ?>"<?php
+$class = '';
 if (_t('gen.dir') === 'rtl') {
-	echo ' dir="rtl" class="rtl"';
+	echo ' dir="rtl"';
+	$class = 'rtl ';
 }
-?>>
+?> class="<?= $class ?><?= (FreshRSS_Context::$user_conf->darkMode === 'no') ? '' : 'darkMode_' . FreshRSS_Context::$user_conf->darkMode ?>">
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
@@ -53,7 +55,7 @@ if (_t('gen.dir') === 'rtl') {
 		<meta name="robots" content="noindex,nofollow" />
 <?php } ?>
 	</head>
-	<body class="<?= Minz_Request::actionName() ?><?= (FreshRSS_Context::$user_conf->darkMode === 'no') ? '' : ' darkMode_' . FreshRSS_Context::$user_conf->darkMode ?>">
+	<body class="<?= Minz_Request::actionName() ?>">
 <?php
 	if (!Minz_Request::paramBoolean('ajax')) {
 		flush();

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -1182,7 +1182,7 @@ a.btn-attention:hover {
 }
 
 @media screen and (prefers-color-scheme: dark) {
-	:root .darkMode_auto {
+	:root.darkMode_auto {
 		--frss-background-color: #000;
 		--frss-background-color-middle: #222;
 		--frss-border-color: #444;

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -1182,7 +1182,7 @@ a.btn-attention:hover {
 }
 
 @media screen and (prefers-color-scheme: dark) {
-	:root .darkMode_auto {
+	:root.darkMode_auto {
 		--frss-background-color: #000;
 		--frss-background-color-middle: #222;
 		--frss-border-color: #444;


### PR DESCRIPTION
Before: 
the main window scroll bar is in light colors in dark mode
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/b789763f-5cd2-47f8-bd3a-bee06da06b34)

After:
scroll bar has dark colors
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/4e0f6a6f-702c-4674-9bbf-97d1b46eaf0e)


Root of this issue:
The main scroll bar use the background color of the `<html>` tag and not of `<body>`. So the `darkMode_auto` CSS class had to move from `<body>` to `<html>`


How to test the feature manually:
The issue was found in Mozilla Firefox

1. use theme `Origine`
2. set the `auto dark mode` to "auto
3. see the scroll bar

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested