### PR TITLE
Fix favicon fetching while using proxies

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -211,3 +211,4 @@ People are sorted by name so please keep this order.
 * [Yamakuni](https://github.com/Yamakuni): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Yamakuni), [Web](https://ofanch.me/)
 * [yzqzss|一座桥在水上](https://github.com/yzqzss): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:yzqzss), [Web](https://blog.othing.xyz/)
 * [Zhiyuan Zheng](https://github.com/zhzy0077): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:zhzy0077)
+* [Ilias Vrachnis](https://github.com/vrachnis): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:vrachnis)

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -80,6 +80,7 @@ People are sorted by name so please keep this order.
 * [hoilc](https://github.com/hoilc): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:hoilc)
 * [ibiruai](https://github.com/ibiruai): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:ibiruai)
 * [id-konstantin-stepanov](https://github.com/id-konstantin-stepanov): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:id-konstantin-stepanov)
+* [Ilias Vrachnis](https://github.com/vrachnis): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:vrachnis)
 * [Jake Mannens](https://github.com/jakem72360): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:jakem72360)
 * [Jamie Slome](https://github.com/JamieSlome): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:JamieSlome), [Web](https://418sec.com/)
 * [Jan Lukas Gernert](https://github.com/jangernert): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:jangernert)
@@ -211,4 +212,3 @@ People are sorted by name so please keep this order.
 * [Yamakuni](https://github.com/Yamakuni): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Yamakuni), [Web](https://ofanch.me/)
 * [yzqzss|一座桥在水上](https://github.com/yzqzss): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:yzqzss), [Web](https://blog.othing.xyz/)
 * [Zhiyuan Zheng](https://github.com/zhzy0077): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:zhzy0077)
-* [Ilias Vrachnis](https://github.com/vrachnis): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:vrachnis)

--- a/lib/favicons.php
+++ b/lib/favicons.php
@@ -28,16 +28,11 @@ function isImgMime(string $content): bool {
 function downloadHttp(string &$url, array $curlOptions = []): string {
 	syslog(LOG_INFO, 'FreshRSS Favicon GET ' . $url);
 	$url = checkUrl($url);
-	if (!$url) {
+	if ($url == false) {
 		return '';
 	}
 	/** @var CurlHandle $ch */
 	$ch = curl_init($url);
-	FreshRSS_Context::initSystem();
-	$system_conf = FreshRSS_Context::$system_conf;
-	if (isset($system_conf)) {
-		curl_setopt_array($ch, $system_conf->curl_options);
-	}
 	curl_setopt_array($ch, [
 			CURLOPT_RETURNTRANSFER => true,
 			CURLOPT_TIMEOUT => 15,
@@ -46,9 +41,19 @@ function downloadHttp(string &$url, array $curlOptions = []): string {
 			CURLOPT_FOLLOWLOCATION => true,
 			CURLOPT_ENCODING => '',	//Enable all encodings
 		]);
+
+	FreshRSS_Context::initSystem();
+	$system_conf = FreshRSS_Context::$system_conf;
+	if (isset($system_conf)) {
+		curl_setopt_array($ch, $system_conf->curl_options);
+	}
+
 	curl_setopt_array($ch, $curlOptions);
-	/** @var string $response */
+
 	$response = curl_exec($ch);
+	if (!is_string($response)) {
+		$response = '';
+	}
 	$info = curl_getinfo($ch);
 	curl_close($ch);
 	if (!empty($info['url'])) {

--- a/lib/favicons.php
+++ b/lib/favicons.php
@@ -33,6 +33,11 @@ function downloadHttp(string &$url, array $curlOptions = []): string {
 	}
 	/** @var CurlHandle $ch */
 	$ch = curl_init($url);
+	FreshRSS_Context::initSystem();
+	$system_conf = FreshRSS_Context::$system_conf;
+	if (isset($system_conf)) {
+		curl_setopt_array($ch, $system_conf->curl_options);
+	}
 	curl_setopt_array($ch, [
 			CURLOPT_RETURNTRANSFER => true,
 			CURLOPT_TIMEOUT => 15,


### PR DESCRIPTION
Closes #4951

Changes proposed in this pull request:

- If curl_options are defined in config.php, those settings should be respected while fetching favicons.

How to test the feature manually:

1. Define `curl_options` in `config.php`. The following example will work if privoxy is running on the same host as FreshRSS.
```php
  'curl_options' => 
  array (
                  CURLOPT_PROXYTYPE => CURLPROXY_HTTP,
                  CURLOPT_PROXY => 'localhost',
                  CURLOPT_PROXYPORT => 8118,
                  CURLOPT_RETURNTRANSFER => true,
  ),
```
2. Try to add a new feed.
3. The feed's icon is requested through the proxy as indicated by the proxy's log file.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
