### PR TITLE
Fixed: i18n extensions: 'en' as fallback

### DIFF
--- a/lib/Minz/Translate.php
+++ b/lib/Minz/Translate.php
@@ -126,8 +126,13 @@ class Minz_Translate {
 	private static function loadLang(string $path): void {
 		$lang_path = $path . '/' . self::$lang_name;
 		if (!file_exists($lang_path) || self::$lang_name == '') {
-			// The lang path does not exist, nothing more to do.
-			return;
+			// The lang path does not exist, fallback to English ('en')
+			self::$lang_name = 'en';
+			$lang_path = $path . '/' . self::$lang_name;
+			if (!file_exists($lang_path)) {
+				// English ('en') i18n files not given. Stop here. The keys will shown.
+				return;
+			}
 		}
 
 		$list_i18n_files = array_values(array_diff(

--- a/lib/Minz/Translate.php
+++ b/lib/Minz/Translate.php
@@ -37,7 +37,7 @@ class Minz_Translate {
 	 * Init the translation object.
 	 * @param string $lang_name the lang to show.
 	 */
-	public static function init(?string $lang_name = null): void {
+	public static function init(string $lang_name = ''): void {
 		self::$lang_name = $lang_name;
 		self::$lang_files = array();
 		self::$translates = array();
@@ -125,12 +125,12 @@ class Minz_Translate {
 	 */
 	private static function loadLang(string $path): void {
 		$lang_path = $path . '/' . self::$lang_name;
-		if (!file_exists($lang_path) || self::$lang_name == '') {
+		if (self::$lang_name === '' || !is_dir($lang_path)) {
 			// The lang path does not exist, fallback to English ('en')
 			self::$lang_name = 'en';
 			$lang_path = $path . '/' . self::$lang_name;
-			if (!file_exists($lang_path)) {
-				// English ('en') i18n files not given. Stop here. The keys will shown.
+			if (!is_dir($lang_path)) {
+				// English ('en') i18n files not provided. Stop here. The keys will be shown.
 				return;
 			}
 		}


### PR DESCRIPTION
Closes #5419 and #5425

If users language not provided by the i18n files of the extension then try to fallback to English, if available.



How to test the feature manually:

see #5419

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
