### PR TITLE
Linkding share now passes title #5432

### DIFF
--- a/app/shares.php
+++ b/app/shares.php
@@ -117,7 +117,7 @@ return [
 		'method' => 'GET',
 	],
 	'linkding' => [
-		'url' => '~URL~/bookmarks/new?url=~LINK~&auto_close',
+		'url' => '~URL~/bookmarks/new?url=~LINK~&title=~TITLE~&auto_close',
 		'transform' => ['rawurlencode'],
 		'help' => 'https://github.com/sissbruecker/linkding/blob/master/docs/how-to.md',
 		'form' => 'advanced',


### PR DESCRIPTION
Closes #5432 

Changes proposed in this pull request:

- The Linkding share will now pass the site title

How to test the feature manually:

1. Create Linkding share option
2. Share an article
3. Note the &title=.... in the path

Note: While the PR to add title support to Linkding has been merged, it hasn't yet been added to a release. If this change were released before that change nothing would change in the short term; the title parameter would simply be ignored. Once the Linkding change is released then the title would start to be populated.

Pull request checklist:

- [X] clear commit messages
- [X] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
