### PR TITLE
improved: background colors for dark mode of Origine theme

### DIFF
--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -1190,13 +1190,13 @@ a:hover .icon {
 		--background-color-light: #111;
 		--background-color-light-shadowed: #191919;
 		--background-color-grey: #1f1f1f;
-		--background-color-hover: #222;
+		--background-color-hover: #212227;
 
-		--unread-article-background-color: #201f1e;
-		--unread-article-background-color-hover: #1a1918;
+		--unread-article-background-color: #1b1817;
+		--unread-article-background-color-hover: #292422;
 		--unread-article-border-color: #ff5300;
 		--favorite-article-background-color: #24221d;
-		--favorite-article-background-color-hover: #1d1b17;
+		--favorite-article-background-color-hover: #302d26;
 		--favorite-article-border-color: #ffc300;
 
 		--contrast-background-color: #0084cc;

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -1190,13 +1190,13 @@ a:hover .icon {
 		--background-color-light: #111;
 		--background-color-light-shadowed: #191919;
 		--background-color-grey: #1f1f1f;
-		--background-color-hover: #222;
+		--background-color-hover: #212227;
 
-		--unread-article-background-color: #201f1e;
-		--unread-article-background-color-hover: #1a1918;
+		--unread-article-background-color: #1b1817;
+		--unread-article-background-color-hover: #292422;
 		--unread-article-border-color: #ff5300;
 		--favorite-article-background-color: #24221d;
-		--favorite-article-background-color-hover: #1d1b17;
+		--favorite-article-background-color-hover: #302d26;
 		--favorite-article-border-color: #ffc300;
 
 		--contrast-background-color: #0084cc;


### PR DESCRIPTION
Improved background colors for dark mode of Origine theme

How to test the feature manually:

1. use Origine theme
2. enable auto dark mode
3. see in normal view the lines and hover it with the mouse

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
