### PR TITLE
Fix OpenID Connect crash on ARM

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -36,6 +36,7 @@ LABEL \
 	org.opencontainers.image.version="$FRESHRSS_VERSION"
 
 RUN a2dismod -f alias autoindex negotiation status && \
+	a2dismod auth_openidc && \
 	a2enmod deflate expires headers mime remoteip setenvif && \
 	a2disconf '*' && \
 	a2dissite '*' && \

--- a/Docker/Dockerfile-QEMU-ARM
+++ b/Docker/Dockerfile-QEMU-ARM
@@ -42,6 +42,7 @@ LABEL \
 	org.opencontainers.image.version="$FRESHRSS_VERSION"
 
 RUN a2dismod -f alias autoindex negotiation status && \
+	a2dismod auth_openidc && \
 	a2enmod deflate expires headers mime remoteip setenvif && \
 	a2disconf '*' && \
 	a2dissite '*' && \

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -11,6 +11,10 @@ if [ -n "$LISTEN" ]; then
 	find /etc/apache2/ -type f -name FreshRSS.Apache.conf -exec sed -r -i "\\#^Listen#s#^.*#Listen $LISTEN#" {} \;
 fi
 
+if [ -n "$OIDC_ENABLED" ] && [ "$OIDC_ENABLED" -ne 0 ]; then
+	a2enmod auth_openidc
+fi
+
 if [ -n "$CRON_MIN" ]; then
 	(
 		echo "export TZ=$TZ"


### PR DESCRIPTION
Only enable the Apache auth_openidc module when actually used
Fix https://github.com/FreshRSS/FreshRSS/issues/5460
Follow-up of https://github.com/FreshRSS/FreshRSS/pull/5351
