### PR TITLE
Docker quiet Apache a2enmod

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -35,12 +35,12 @@ LABEL \
 	org.opencontainers.image.vendor="FreshRSS" \
 	org.opencontainers.image.version="$FRESHRSS_VERSION"
 
-RUN a2dismod -f alias autoindex negotiation status && \
-	a2dismod auth_openidc && \
-	a2enmod deflate expires headers mime remoteip setenvif && \
-	a2disconf '*' && \
-	a2dissite '*' && \
-	a2ensite 'FreshRSS*'
+RUN a2dismod -q -f alias autoindex negotiation status && \
+	a2dismod -q auth_openidc && \
+	a2enmod -q deflate expires headers mime remoteip setenvif && \
+	a2disconf -q '*' && \
+	a2dissite -q '*' && \
+	a2ensite -q 'FreshRSS*'
 
 RUN sed -r -i "/^\s*(CustomLog|ErrorLog|Listen) /s/^/#/" /etc/apache2/apache2.conf && \
 	sed -r -i "/^\s*Listen /s/^/#/" /etc/apache2/ports.conf && \

--- a/Docker/Dockerfile-QEMU-ARM
+++ b/Docker/Dockerfile-QEMU-ARM
@@ -41,12 +41,12 @@ LABEL \
 	org.opencontainers.image.vendor="FreshRSS" \
 	org.opencontainers.image.version="$FRESHRSS_VERSION"
 
-RUN a2dismod -f alias autoindex negotiation status && \
-	a2dismod auth_openidc && \
-	a2enmod deflate expires headers mime remoteip setenvif && \
-	a2disconf '*' && \
-	a2dissite '*' && \
-	a2ensite 'FreshRSS*'
+RUN a2dismod -q -f alias autoindex negotiation status && \
+	a2dismod -q auth_openidc && \
+	a2enmod -q deflate expires headers mime remoteip setenvif && \
+	a2disconf -q '*' && \
+	a2dissite -q '*' && \
+	a2ensite -q 'FreshRSS*'
 
 RUN sed -r -i "/^\s*(CustomLog|ErrorLog|Listen) /s/^/#/" /etc/apache2/apache2.conf && \
 	sed -r -i "/^\s*Listen /s/^/#/" /etc/apache2/ports.conf && \

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -12,7 +12,7 @@ if [ -n "$LISTEN" ]; then
 fi
 
 if [ -n "$OIDC_ENABLED" ] && [ "$OIDC_ENABLED" -ne 0 ]; then
-	a2enmod auth_openidc
+	a2enmod -q auth_openidc
 fi
 
 if [ -n "$CRON_MIN" ]; then


### PR DESCRIPTION
Quiet output for a2enmod, a2dismod, a2disconf, a2dissite, a2ensite to avoid many messages like the following, which are not even relevant because Apache is not yet started at this stage:

```
To activate the new configuration, you need to run:
  systemctl restart apache2
```

Related to https://github.com/FreshRSS/FreshRSS/pull/5463
