### PR TITLE
Allow choosing the OIDC remote user claim and scopes to request from the identity provider

### DIFF
--- a/Docker/FreshRSS.Apache.conf
+++ b/Docker/FreshRSS.Apache.conf
@@ -10,6 +10,8 @@ AllowEncodedSlashes On
 ServerTokens OS
 TraceEnable Off
 
+# Workaround to be able to check whether an environment variable is set
+# See: https://serverfault.com/questions/1022233/using-ifdefine-with-environment-variables/1022234#1022234
 Define VStart "${"
 Define VEnd "}"
 

--- a/Docker/FreshRSS.Apache.conf
+++ b/Docker/FreshRSS.Apache.conf
@@ -10,6 +10,9 @@ AllowEncodedSlashes On
 ServerTokens OS
 TraceEnable Off
 
+Define VStart "${"
+Define VEnd "}"
+
 <IfDefine OIDC_ENABLED>
 	<IfModule !auth_openidc_module>
 		Error "The auth_openidc_module is not available. Install it or unset environment variable OIDC_ENABLED."
@@ -22,8 +25,20 @@ TraceEnable Off
 	OIDCRedirectURI /i/oidc/
 	OIDCCryptoPassphrase ${OIDC_CLIENT_CRYPTO_KEY}
 
-	OIDCRemoteUserClaim preferred_username
-	OIDCScope "openid"
+	Define "Test_${OIDC_REMOTE_USER_CLAIM}"
+	<IfDefine Test_${VStart}OIDC_REMOTE_USER_CLAIM${VEnd}>
+		OIDCRemoteUserClaim preferred_username
+	</IfDefine>
+	<IfDefine !Test_${VStart}OIDC_REMOTE_USER_CLAIM${VEnd}>
+		OIDCRemoteUserClaim "${OIDC_REMOTE_USER_CLAIM}"
+	</IfDefine>
+	Define "Test_${OIDC_SCOPES}"
+	<IfDefine Test_${VStart}OIDC_SCOPES${VEnd}>
+		OIDCScope openid
+	</IfDefine>
+	<IfDefine !Test_${VStart}OIDC_SCOPES${VEnd}>
+		OIDCScope "${OIDC_SCOPES}"
+	</IfDefine>
 
 	OIDCRefreshAccessTokenBeforeExpiry 30
 </IfDefine>

--- a/Docker/FreshRSS.Apache.conf
+++ b/Docker/FreshRSS.Apache.conf
@@ -10,15 +10,15 @@ AllowEncodedSlashes On
 ServerTokens OS
 TraceEnable Off
 
-# Workaround to be able to check whether an environment variable is set
-# See: https://serverfault.com/questions/1022233/using-ifdefine-with-environment-variables/1022234#1022234
-Define VStart "${"
-Define VEnd "}"
-
 <IfDefine OIDC_ENABLED>
 	<IfModule !auth_openidc_module>
 		Error "The auth_openidc_module is not available. Install it or unset environment variable OIDC_ENABLED."
 	</IfModule>
+
+	# Workaround to be able to check whether an environment variable is set
+	# See: https://serverfault.com/questions/1022233/using-ifdefine-with-environment-variables/1022234#1022234
+	Define VStart "${"
+	Define VEnd "}"
 
 	OIDCProviderMetadataURL ${OIDC_PROVIDER_METADATA_URL}
 	OIDCClientID ${OIDC_CLIENT_ID}

--- a/docs/en/admins/16_OpenID-Connect.md
+++ b/docs/en/admins/16_OpenID-Connect.md
@@ -20,6 +20,8 @@ OIDC support in Docker is activated by the presence of a non-empty non-zero `OID
 * `OIDC_CLIENT_ID`: The OIDC client id from your issuer.
 * `OIDC_CLIENT_SECRET`: The OIDC client secret issuer.
 * `OIDC_CLIENT_CRYPTO_KEY`: An opaque key used for internal encryption.
+* `OIDC_REMOTE_USER_CLAIM`: The claim to use as the username within FreshRSS. Defaults to `preferred_username`. Depending on what you choose here, and your identity provider, you'll need to adjust the scopes you request so that this claim will be accessible. Refer to your identity provider's documentation.
+* `OIDC_SCOPES`: The OIDC scopes to request. Defaults to `openid`. As mentioned previously, make sure the scopes you pick contain whatever `OIDC_REMOTE_USER_CLAIM` you chose.
 
 You may add additional custom configuration in a new `./FreshRSS/p/i/.htaccess` file.
 

--- a/docs/en/admins/16_OpenID-Connect.md
+++ b/docs/en/admins/16_OpenID-Connect.md
@@ -20,7 +20,7 @@ OIDC support in Docker is activated by the presence of a non-empty non-zero `OID
 * `OIDC_CLIENT_ID`: The OIDC client id from your issuer.
 * `OIDC_CLIENT_SECRET`: The OIDC client secret issuer.
 * `OIDC_CLIENT_CRYPTO_KEY`: An opaque key used for internal encryption.
-* `OIDC_REMOTE_USER_CLAIM`: The claim to use as the username within FreshRSS. Defaults to `preferred_username`. Depending on what you choose here, and your identity provider, you'll need to adjust the scopes you request so that this claim will be accessible. Refer to your identity provider's documentation.
+* `OIDC_REMOTE_USER_CLAIM`: The claim to use as the username within FreshRSS. Defaults to `preferred_username`. Depending on what you choose here, and your identity provider, you’ll need to adjust the scopes you request so that this claim will be accessible. Refer to your identity provider’s documentation.
 * `OIDC_SCOPES`: The OIDC scopes to request. Defaults to `openid`. As mentioned previously, make sure the scopes you pick contain whatever `OIDC_REMOTE_USER_CLAIM` you chose.
 
 You may add additional custom configuration in a new `./FreshRSS/p/i/.htaccess` file.


### PR DESCRIPTION
Changes proposed in this pull request:

- Allow setting the `OIDC_SCOPES` environment variable to control what scopes to request from the OIDC identity provider. This defaults to `openid`.
- Allow setting the `OIDC_REMOTE_USER_CLAIM` environment to control what claim to use as the username. This defaults to `preferred_username`.
- Document these environment variables.

How to test the feature manually:

1. I personally needed this to integrate with Authentik, so configure that, create an OIDC provider and an application.
2. Configure a FreshRSS Debian docker container (I used `Docker/Dockerfile`) to use Authentik as the OIDC identity provider. Use the following environment variables besides the ones needed to get OIDC in FreshRSS:
   - `OIDC_SCOPES=openid profile` (`profile` is required to get the `preferred_username` claim)
4. Open the FreshRSS instance. You should be redirected to Authentik to login, then go back to FreshRSS and be asked to setup the new instance. If it doesn't work, you'll be greeted with some error page. If it works, you can setup the instance.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated
