### PR TITLE
Fix macOS feed title meta-click behavior

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -50,6 +50,7 @@ People are sorted by name so please keep this order.
 * [Damstre](https://github.com/Damstre): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Damstre)
 * [danc](https://github.com/danc): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:danc), [Web](http://tintouli.free.fr/)
 * [Daniel Lo Nigro](https://github.com/Daniel15): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Daniel15), [Web](https://d.sb/)
+* [David Lynch](https://github.com/kemayo): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:kemayo), [Web](http://davidlynch.org/)
 * [David Souza](https://github.com/araujo0205): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:araujo0205), [Web](http://davidsouza.tech/)
 * [Dennis Cheng](https://github.com/den13501): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:den13501)
 * [Django Janny](https://github.com/keltroth): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:keltroth)

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1059,8 +1059,8 @@ function init_stream(stream) {
 		}
 
 		el = ev.target.closest('.item.title > a');
-		if (el) {	// Allow default control-click behaviour such as open in background-tab
-			return ev.ctrlKey;
+		if (el) {	// Allow default control/command-click behaviour such as open in background-tab
+			return ev.ctrlKey || ev.metaKey;
 		}
 
 		el = ev.target.closest('.flux .content .text a');


### PR DESCRIPTION
Changes proposed in this pull request:

- On macOS, command-clicking the feed item's title should open the URL in a new tab, just as ctrl-clicking them on another OS would

How to test the feature manually:

1. Using macOS, command-click the link in a feed item's title
2. Using another OS, verify that this hasn't interfered with ctrl-clicking the feed item's title

Pull request checklist:

- [X] clear commit messages
- [X] code manually tested
- [ ] unit tests written (optional if too hard)
-- Pure JS change, not unit-testable without major additions to the project
- [X] documentation updated
-- No documentation affected, but I did update the relevant comment in the JS file...