### PR TITLE
Global view: reduce overhead

### DIFF
--- a/p/scripts/global_view.js
+++ b/p/scripts/global_view.js
@@ -12,7 +12,7 @@ function load_panel(link) {
 	panel_loading = true;
 
 	const req = new XMLHttpRequest();
-	req.open('GET', link, true);
+	req.open('GET', link + '&ajax=1', true);
 	req.responseType = 'document';
 	req.onload = function (e) {
 		if (this.status != 200) {


### PR DESCRIPTION
Global view: 

Before:
if you open a feed it will load the full normal view via JavaScript and will display only the main part.

After:
`&ajax=1` added to the Ajax call. So only the feed stream will be loaded

How to test the feature manually:

1. go to global view
2. open a feed
3. check the response of the Ajax call (only the feed stream will be received)

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested