### PR TITLE
Add OIDC_X_FORWARDED_HEADERS environment variable (fixes #5516)

### DIFF
--- a/Docker/FreshRSS.Apache.conf
+++ b/Docker/FreshRSS.Apache.conf
@@ -41,6 +41,10 @@ TraceEnable Off
 	<IfDefine !Test_${VStart}OIDC_SCOPES${VEnd}>
 		OIDCScope "${OIDC_SCOPES}"
 	</IfDefine>
+	Define "Test_${OIDC_X_FORWARDED_HEADERS}"
+	<IfDefine !Test_${VStart}OIDC_X_FORWARDED_HEADERS${VEnd}>
+		OIDCXForwardedHeaders ${OIDC_X_FORWARDED_HEADERS}
+	</IfDefine>
 
 	OIDCRefreshAccessTokenBeforeExpiry 30
 </IfDefine>

--- a/docs/en/admins/16_OpenID-Connect.md
+++ b/docs/en/admins/16_OpenID-Connect.md
@@ -22,7 +22,7 @@ OIDC support in Docker is activated by the presence of a non-empty non-zero `OID
 * `OIDC_CLIENT_CRYPTO_KEY`: An opaque key used for internal encryption.
 * `OIDC_REMOTE_USER_CLAIM`: The claim to use as the username within FreshRSS. Defaults to `preferred_username`. Depending on what you choose here, and your identity provider, you’ll need to adjust the scopes you request so that this claim will be accessible. Refer to your identity provider’s documentation.
 * `OIDC_SCOPES`: The OIDC scopes to request. Defaults to `openid`. As mentioned previously, make sure the scopes you pick contain whatever `OIDC_REMOTE_USER_CLAIM` you chose.
-* `OIDC_X_FORWARDED_HEADERS`: Optional. Use when running FreshRSS behind a reverse proxy, so the OIDC module can determine what hostname, port and protocol were used to access FreshRSS. Must be one or more of `Forwarded`, `X-Forwarded-Host`, `X-Forwarded-Port` or `X-Forwarded-Proto` (separate multiple values with a space). See [mod_auth_openidc's documentation for details](https://github.com/OpenIDC/mod_auth_openidc/blob/72c9f479c2d228477ff0a9518964f61879c83fb6/auth_openidc.conf#L1041-L1048).
+* `OIDC_X_FORWARDED_HEADERS`: Optional. Use when running FreshRSS is behind a reverse proxy, so the OIDC module can determine what hostname, port and protocol were used to access FreshRSS. Must be one or more of `Forwarded`, `X-Forwarded-Host`, `X-Forwarded-Port` or `X-Forwarded-Proto` (separate multiple values with a space). See [mod_auth_openidc’s documentation for details](https://github.com/OpenIDC/mod_auth_openidc/blob/72c9f479c2d228477ff0a9518964f61879c83fb6/auth_openidc.conf#L1041-L1048).
 
 You may add additional custom configuration in a new `./FreshRSS/p/i/.htaccess` file.
 

--- a/docs/en/admins/16_OpenID-Connect.md
+++ b/docs/en/admins/16_OpenID-Connect.md
@@ -22,7 +22,7 @@ OIDC support in Docker is activated by the presence of a non-empty non-zero `OID
 * `OIDC_CLIENT_CRYPTO_KEY`: An opaque key used for internal encryption.
 * `OIDC_REMOTE_USER_CLAIM`: The claim to use as the username within FreshRSS. Defaults to `preferred_username`. Depending on what you choose here, and your identity provider, you’ll need to adjust the scopes you request so that this claim will be accessible. Refer to your identity provider’s documentation.
 * `OIDC_SCOPES`: The OIDC scopes to request. Defaults to `openid`. As mentioned previously, make sure the scopes you pick contain whatever `OIDC_REMOTE_USER_CLAIM` you chose.
-* `OIDC_X_FORWARDED_HEADERS`: Optional. Use when running FreshRSS behind a reverse proxy, so the OIDC module can determine what hostname, port and protocol were used to access FreshRSS. Must be one or more of `Forwarded`, `X-Forwarded-Host`, `X-Forwarded-Port` or `X-Forwarded-Proto` (separate multiple values with a space).
+* `OIDC_X_FORWARDED_HEADERS`: Optional. Use when running FreshRSS behind a reverse proxy, so the OIDC module can determine what hostname, port and protocol were used to access FreshRSS. Must be one or more of `Forwarded`, `X-Forwarded-Host`, `X-Forwarded-Port` or `X-Forwarded-Proto` (separate multiple values with a space). See [mod_auth_openidc's documentation for details](https://github.com/OpenIDC/mod_auth_openidc/blob/72c9f479c2d228477ff0a9518964f61879c83fb6/auth_openidc.conf#L1041-L1048).
 
 You may add additional custom configuration in a new `./FreshRSS/p/i/.htaccess` file.
 

--- a/docs/en/admins/16_OpenID-Connect.md
+++ b/docs/en/admins/16_OpenID-Connect.md
@@ -22,6 +22,7 @@ OIDC support in Docker is activated by the presence of a non-empty non-zero `OID
 * `OIDC_CLIENT_CRYPTO_KEY`: An opaque key used for internal encryption.
 * `OIDC_REMOTE_USER_CLAIM`: The claim to use as the username within FreshRSS. Defaults to `preferred_username`. Depending on what you choose here, and your identity provider, you’ll need to adjust the scopes you request so that this claim will be accessible. Refer to your identity provider’s documentation.
 * `OIDC_SCOPES`: The OIDC scopes to request. Defaults to `openid`. As mentioned previously, make sure the scopes you pick contain whatever `OIDC_REMOTE_USER_CLAIM` you chose.
+* `OIDC_X_FORWARDED_HEADERS`: Optional. Use when running FreshRSS behind a reverse proxy, so the OIDC module can determine what hostname, port and protocol were used to access FreshRSS. Must be one or more of `Forwarded`, `X-Forwarded-Host`, `X-Forwarded-Port` or `X-Forwarded-Proto` (separate multiple values with a space).
 
 You may add additional custom configuration in a new `./FreshRSS/p/i/.htaccess` file.
 


### PR DESCRIPTION
The mod_auth_oidc needs an additional directive (`OIDCXForwardedHeaders`) in case FreshRSS is running behind a reverse proxy, so it knows what host, protocol and port were used to access it. This information is then used in the `redirect_uri` when directing the user agent (browser) to the identity provider for authentication.

Please note that, if you are running FreshRSS behind a reverse proxy that handles TLS, you may need to update your identity provider's configuration so it accepts `https://...` as a `redirect_uri`.

Closes #5516