### PR TITLE
Docker: Add DATA_PATH to cron env

### DIFF
--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -21,6 +21,7 @@ if [ -n "$CRON_MIN" ]; then
 		echo "export COPY_LOG_TO_SYSLOG=$COPY_LOG_TO_SYSLOG"
 		echo "export COPY_SYSLOG_TO_STDERR=$COPY_SYSLOG_TO_STDERR"
 		echo "export FRESHRSS_ENV=$FRESHRSS_ENV"
+		echo "export DATA_PATH=$DATA_PATH"
 	) >/var/www/FreshRSS/Docker/env.txt
 	sed </etc/crontab.freshrss.default \
 		-r "s#^[^ ]+ #$CRON_MIN #" | crontab -


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds `$DATA_PATH` to the cron environment

This fixes automatic feed updating with non-standard data paths.

How to test the feature manually:

1. Set a non-standard `DATA_PATH` and enable automatic feed updating with `CRON_MIN`
2. `cat /tmp/FreshRSS.log`
3. See successful result instead of `Failed requirements!`

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
