### PR TITLE
OPML export fix empty attributes

### DIFF
--- a/app/views/helpers/export/opml.phtml
+++ b/app/views/helpers/export/opml.phtml
@@ -59,6 +59,9 @@ function feedsToOutlines(array $feeds, bool $excludeMutedFeeds = false): array {
 			$outline['frss:cssFullContentFilter'] = $feed->attributes('path_entries_filter');
 		}
 
+		// Remove null attributes
+		$outline = array_filter($outline, static function (?string $value) { return $value !== null; });
+
 		$outlines[] = $outline;
 	}
 


### PR DESCRIPTION
Fix:
> Deprecated:  DOMElement::setAttributeNS(): Passing null to parameter #3 ($value) of type string is deprecated in /var/www/FreshRSS/lib/marienfressinaud/lib_opml/src/LibOpml/LibOpml.php on line 680
