### PR TITLE
Revert auto mark as read same titles for existing articles

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -483,11 +483,6 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 								Minz_ExtensionManager::callHook('entry_auto_unread', $entry, 'updated_article');
 							}
 
-							$entry->applyFilterActions($titlesAsRead);
-							if ($readWhenSameTitleInFeed > 0) {
-								$titlesAsRead[$entry->title()] = true;
-							}
-
 							$entry = Minz_ExtensionManager::callHook('entry_before_insert', $entry);
 							if (!($entry instanceof FreshRSS_Entry)) {
 								// An extension has returned a null value, there is nothing to insert.


### PR DESCRIPTION
Partial revert of https://github.com/FreshRSS/FreshRSS/pull/5505
We should not apply the "*auto mark as read* rule based on existing titles" for updated articles, because the match would most of the time be on that same article's title.
