### PR TITLE
Fix cache refresh

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -385,10 +385,14 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 			}
 			if ($simplePiePush === null && $feed_id === 0 && (time() <= $feed->lastUpdate() + $ttl)) {
 				//Too early to refresh from source, but check whether the feed was updated by another user
-				if ($mtime <= 0 || $feed->lastUpdate() >= $mtime) {
+				$ε = 10;	// negligible offset errors in seconds
+				if ($mtime <= 0 ||
+					$feed->lastUpdate() + $ε >= $mtime ||
+					time() + $ε >= $mtime + FreshRSS_Context::$system_conf->limits['cache_duration']) {	// is cache still valid?
 					continue;	//Nothing newer from other users
 				}
-				Minz_Log::debug('Feed ' . $feed->url(false) . ' was updated at ' . date('c', $mtime) . ' by another user; will take advantage of the newer cache.');
+				Minz_Log::debug('Feed ' . $feed->url(false) . ' was updated at ' . date('c', $feed->lastUpdate()) .
+					', and at ' . date('c', $mtime) . ' by another user; take advantage of newer cache.');
 			}
 
 			if (!$feed->lock()) {

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -859,7 +859,9 @@ class FreshRSS_Feed extends Minz_Model {
 
 	/** @return int|false */
 	public function cacheModifiedTime() {
-		return @filemtime(FreshRSS_Feed::cacheFilename($this->url, $this->attributes(), $this->kind));
+		$filename = FreshRSS_Feed::cacheFilename($this->url, $this->attributes(), $this->kind);
+		clearstatcache(true, $filename);
+		return @filemtime($filename);
 	}
 
 	public function lock(): bool {


### PR DESCRIPTION
Improvement of https://github.com/FreshRSS/FreshRSS/pull/4422

The main problem was due to `touch()` not automatically clearing the file status cache, and requiring a call to `clearstatcache()`. Example:

```
php > touch('/tmp/touch.txt');
php > echo date('c', filemtime('/tmp/touch.txt'));
2023-08-03T17:27:43+02:00
php > touch('/tmp/touch.txt');
php > echo date('c', filemtime('/tmp/touch.txt'));
2023-08-03T17:27:43+02:00
php > clearstatcache(true, '/tmp/touch.txt');
php > echo date('c', filemtime('/tmp/touch.txt'));
2023-08-03T17:28:21+02:00
```
