### PR TITLE
[docs] Fix typos on the word 'scrape' and its variations

### DIFF
--- a/docs/en/users/02_First_steps.md
+++ b/docs/en/users/02_First_steps.md
@@ -26,4 +26,4 @@ Now that you’ve mastered basic use, it’s time to configure FreshRSS to impro
 * [Add some extensions](https://github.com/FreshRSS/Extensions)
 * [Frequently asked questions](07_Frequently_Asked_Questions.md)
 
-FreshRSS has a built-in engine that [scraps a website to create an own feed](11_website_scraping.md).
+FreshRSS has a built-in engine that [scrapes a website to create an own feed](11_website_scraping.md).

--- a/docs/en/users/11_website_scraping.md
+++ b/docs/en/users/11_website_scraping.md
@@ -15,7 +15,7 @@ Firefox: the built-in “inspect” tool may be used to help create a valid XPat
 Select the node in the HTML, right click with your mouse and chose “Copy” and “XPath”.
 The XPath is stored in your clipboard now.
 
-## Tipps & tricks
+## Tips & tricks
 
 - [Timezone of date](https://github.com/FreshRSS/FreshRSS/discussions/5483)
 

--- a/docs/en/users/11_website_scraping.md
+++ b/docs/en/users/11_website_scraping.md
@@ -1,11 +1,11 @@
 # Website scraping
 
-FreshRSS has a built-in [Web scrapping](https://en.wikipedia.org/wiki/Web_scraping) engine that generates a feed from websites that have no RSS/Atom feed published.
+FreshRSS has a built-in [Web scraping](https://en.wikipedia.org/wiki/Web_scraping) engine that generates a feed from websites that have no RSS/Atom feed published.
 
 ## How to add
 
 Go to “Subscription Management” where a new feed can be added.
-Change the “Type of feed source” to “HTML + XPath (Web scrapping)”.
+Change the “Type of feed source” to “HTML + XPath (Web scraping)”.
 An additional list of text boxes to configure the web scraping.
 [XPath 1.0](https://www.w3.org/TR/xpath-10/) is used as traversing language.
 


### PR DESCRIPTION
Very simple change to the English documentation