### PR TITLE
fix long transactions blocking mysql

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -433,6 +433,9 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 				/** @var array<string,bool> */
 				$newGuids = [];
 
+
+				$transactionStartTime = microtime(true);
+
 				// Add entries in database if possible.
 				/** @var FreshRSS_Entry $entry */
 				foreach ($entries as $entry) {
@@ -505,6 +508,12 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 							$feed->incPendingUnread();
 						}
 						$nb_new_articles++;
+					}
+
+					// check transactionStartTime >= 3s
+					if ((microtime(true) - $transactionStartTime)>= 3 && $entryDAO->inTransaction()) {
+						$entryDAO->commit();
+						$transactionStartTime = microtime(true);
 					}
 				}
 				$entryDAO->updateLastSeen($feed->id(), array_keys($newGuids), $mtime);


### PR DESCRIPTION
Changes proposed in this pull request:
- The long transaction with more than 3 second is submitted automatically.

How to test the feature manually:

1. Add a time-consuming operation in the hook entry_before_insert
2. Import a feed with 3000+ articles
3. Use the command show processlist; to check the database for blocked operations.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
