### PR TITLE
fix: Allow to access logs when update is disabled

### DIFF
--- a/app/layout/aside_configure.phtml
+++ b/app/layout/aside_configure.phtml
@@ -82,10 +82,10 @@ function get_logout_url(): string {
 				<li class="item<?= Minz_Request::controllerName() === 'update' && Minz_Request::actionName() === 'index' ? ' active' : '' ?>">
 					<a href="<?= _url('update', 'index') ?>"><?= _t('gen.menu.update') ?></a>
 				</li>
+				<?php } ?>
 				<li class="item<?= Minz_Request::actionName() === 'logs' ? ' active' : '' ?>">
 					<a href="<?= _url('index', 'logs') ?>"><?= _t('gen.menu.logs') ?></a>
 				</li>
-				<?php } ?>
 				<?= Minz_ExtensionManager::callHook('menu_admin_entry') ?>
 			</ul>
 		</li>


### PR DESCRIPTION
Changes proposed in this pull request:

- Move the logs link out of the `if !FreshRSS_Context::$system_conf->disable_update` condition in the aside_configure menu

How to test the feature manually:

1. set `disable_update` to `true` in `data/config.php`
2. check that the logs are accessible in the "Administration" menu

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] ~~unit tests written (optional if too hard)~~
- [x] ~~documentation updated~~

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
