### PR TITLE
tec: Make FreshRSS_Share::register public

### DIFF
--- a/app/Models/Share.php
+++ b/app/Models/Share.php
@@ -15,7 +15,7 @@ class FreshRSS_Share {
 	 * @param array{'type':string,'url':string,'transform'?:array<callable>|array<string,array<callable>>,'field'?:string,'help'?:string,'form'?:'simple'|'advanced',
 	 *	'method'?:'GET'|'POST','HTMLtag'?:'button','deprecated'?:bool} $share_options is an array defining the share option.
 	 */
-	private static function register(array $share_options): void {
+	public static function register(array $share_options): void {
 		$type = $share_options['type'];
 		if (isset(self::$list_sharing[$type])) {
 			return;


### PR DESCRIPTION
I don't know why the visibility of this method has changed, but it's essential to register custom shares as extensions.

Changes proposed in this pull request:

- Change `FreshRSS_Share::register` method visibility back to `public`

How to test the feature manually:

N/A

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] ~~unit tests written (optional if too hard)~~
- [x] ~~documentation updated~~

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
