### PR TITLE
fix: Fix the "Show all articles" option

### DIFF
--- a/app/Models/Context.php
+++ b/app/Models/Context.php
@@ -208,7 +208,9 @@ final class FreshRSS_Context {
 		self::$state = Minz_Request::paramInt('state') ?: self::$user_conf->default_state;
 		$state_forced_by_user = Minz_Request::paramString('state') !== '';
 		if (!$state_forced_by_user && !self::isStateEnabled(FreshRSS_Entry::STATE_READ)) {
-			if (self::$user_conf->default_view === 'adaptive' && self::$get_unread <= 0) {
+			if (self::$user_conf->default_view === 'all') {
+				self::$state |= FreshRSS_Entry::STATE_ALL;
+			} elseif (self::$user_conf->default_view === 'adaptive' && self::$get_unread <= 0) {
 				self::$state |= FreshRSS_Entry::STATE_READ;
 			}
 			if (self::$user_conf->show_fav_unread &&


### PR DESCRIPTION
Closes https://github.com/FreshRSS/FreshRSS/issues/5579

Changes proposed in this pull request:

- Add `FreshRSS_Entry::STATE_ALL` to the current state when `default_view === 'all'`

I'm not too sure about this patch. I've checked and it was working fine in 1.21, but this code didn't change that much between these two versions. So it seems the issue was introduced elsewhere.

How to test the feature manually:

1. Go to Configuration > Reading
2. Choose "Show all articles" for the option "Articles to display"
3. Go to the main stream
4. Check that read and unread articles are displayed

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] ~~unit tests written (optional if too hard)~~
- [x] ~~documentation updated~~

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
