### PR TITLE
fix: background color of <pre>

### DIFF
--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -899,9 +899,8 @@ a:hover .icon {
 	margin: 10px auto;
 	padding: 10px 20px;
 	overflow: auto;
-	background-color: var(--font-color);
-	color: var(--font-color-light);
 	font-size: 0.9rem;
+	border: 1px solid var(--border-color);
 	border-radius: 3px;
 }
 
@@ -911,12 +910,6 @@ a:hover .icon {
 	color: var(--error-feed-color);
 	border: 1px solid var(--border-color);
 	border-radius: 3px;
-}
-
-.content pre code {
-	background-color: transparent;
-	color: var(--font-color-light);
-	border: none;
 }
 
 .content blockquote {

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -899,9 +899,8 @@ a:hover .icon {
 	margin: 10px auto;
 	padding: 10px 20px;
 	overflow: auto;
-	background-color: var(--font-color);
-	color: var(--font-color-light);
 	font-size: 0.9rem;
+	border: 1px solid var(--border-color);
 	border-radius: 3px;
 }
 
@@ -911,12 +910,6 @@ a:hover .icon {
 	color: var(--error-feed-color);
 	border: 1px solid var(--border-color);
 	border-radius: 3px;
-}
-
-.content pre code {
-	background-color: transparent;
-	color: var(--font-color-light);
-	border: none;
 }
 
 .content blockquote {


### PR DESCRIPTION
Closes #5587

Changes proposed in this pull request:

- `<pre>` has now background color anymore (deleted the black background)


How to test the feature manually:

1. open a feed, that has a `<pre>` in content (example see in #5587)

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
