### PR TITLE
Fixed Spanish translation typo

### DIFF
--- a/app/i18n/es/sub.php
+++ b/app/i18n/es/sub.php
@@ -188,7 +188,7 @@ return array(
 		'label_management' => 'Gestión de etiquetas',
 		'stats' => array(
 			'idle' => 'Fuentes inactivas',
-			'main' => 'Estadísticas principañes',
+			'main' => 'Estadísticas principales',
 			'repartition' => 'Reparto de artículos',
 		),
 		'subscription_management' => 'Administración de suscripciones',


### PR DESCRIPTION
Hello, I just found this little typo when using my FreshRSS instance, here's the correct spelling.