### PR TITLE
Fix "server cannot write in /var/www/FreshRSS/p/api"

### DIFF
--- a/cli/access-permissions.sh
+++ b/cli/access-permissions.sh
@@ -14,8 +14,8 @@ fi
 # Based on group access
 chown -R :www-data .
 
-# Read files, and directory traversal
-chmod -R g+rX .
+# Read files, write files, and directory traversal
+chmod -R g+rwX .
 
 # Write access
 mkdir -p ./data/users/_/


### PR DESCRIPTION
Changes proposed in this pull request:

- Fixes "server cannot write in /var/www/FreshRSS/p/api" error in logs when using Docker/Podman.

How to test the feature manually:

1. Build a new Docker image from the Dockerfile in the repository.
2. Setup a FreshRSS Docker/Podman instance as per the manual.
3. Install an extension (e.g. TTRSS API) by extracting the archive into the `freshrss_extensions` Docker volume.
4. Restart the container.
5. Open the web UI (via reverse proxy or what have you) and try to enable the extension in Settings > Extensions > System Extensions by flipping the switch for the extension.
6. Check the logs. If the logs say "server cannot write in /var/www/FreshRSS/p/api", then the test has failed.

Pull request checklist:

- [X] clear commit messages
- [X] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

No documentation seems to need to be updated for this change.

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
