### PR TITLE
Remove obsolete TTL migration code

### DIFF
--- a/app/Controllers/statsController.php
+++ b/app/Controllers/statsController.php
@@ -32,10 +32,7 @@ class FreshRSS_stats_Controller extends FreshRSS_ActionController {
 		]);
 
 		$catDAO = FreshRSS_Factory::createCategoryDao();
-		$feedDAO = FreshRSS_Factory::createFeedDao();
-
 		$catDAO->checkDefault();
-		$feedDAO->updateTTL();
 		$this->view->categories = $catDAO->listSortedCategories(false) ?: [];
 		$this->view->default_category = $catDAO->getDefault();
 

--- a/app/Controllers/subscriptionController.php
+++ b/app/Controllers/subscriptionController.php
@@ -15,10 +15,7 @@ class FreshRSS_subscription_Controller extends FreshRSS_ActionController {
 		}
 
 		$catDAO = FreshRSS_Factory::createCategoryDao();
-		$feedDAO = FreshRSS_Factory::createFeedDao();
-
 		$catDAO->checkDefault();
-		$feedDAO->updateTTL();
 		$this->view->categories = $catDAO->listSortedCategories(false, true) ?: [];
 		$this->view->default_category = $catDAO->getDefault();
 


### PR DESCRIPTION
Remove `updateTTL` function used to help migration to 5+ year-old FreshRSS 1.10 and FreshRSS 0.7.3 https://github.com/FreshRSS/FreshRSS/pull/1750
This function contributed to locking the database https://github.com/FreshRSS/FreshRSS/pull/5574
Subset of https://github.com/FreshRSS/FreshRSS/pull/3558
