### PR TITLE
Fix parenthesis escaping bug

### DIFF
--- a/app/Models/BooleanSearch.php
+++ b/app/Models/BooleanSearch.php
@@ -233,7 +233,7 @@ class FreshRSS_BooleanSearch {
 
 	private function parseOrSegments(string $input): void {
 		$input = trim($input);
-		if ($input == '') {
+		if ($input === '') {
 			return;
 		}
 		$splits = preg_split('/\b(OR)\b/i', $input, -1, PREG_SPLIT_DELIM_CAPTURE) ?: [];

--- a/app/Models/Search.php
+++ b/app/Models/Search.php
@@ -73,6 +73,7 @@ class FreshRSS_Search {
 
 	public function __construct(string $input) {
 		$input = self::cleanSearch($input);
+		$input = self::unescape($input);
 		$this->raw_input = $input;
 
 		$input = $this->parseNotEntryIds($input);
@@ -661,5 +662,10 @@ class FreshRSS_Search {
 			return '';
 		}
 		return trim($input);
+	}
+
+	/** Remove escaping backslashes for parenthesis logic */
+	private static function unescape(string $input): string {
+		return str_replace(['\\(', '\\)'], ['(', ')'], $input);
 	}
 }

--- a/tests/app/Models/SearchTest.php
+++ b/tests/app/Models/SearchTest.php
@@ -330,8 +330,8 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 			[
 				'intitle:"\\(test\\)"',
 				'(e.title LIKE ? )',
-				['%\\(test\\)%'],
-			]
+				['%(test)%'],
+			],
 		];
 	}
 }


### PR DESCRIPTION
fix https://github.com/FreshRSS/FreshRSS/issues/5632
In the SQL search, parentheses should not be escaped. Escaped parenthesis in the SQL search were tolerated by PostgreSQL but not by SQLite.
This also broke the auto-mark-as-read using escaped parentheses.