### PR TITLE
add oidc callback URL and hints for Authelia to docs

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -30,6 +30,7 @@ People are sorted by name so please keep this order.
 * [ASMfreaK](https://github.com/ASMfreaK): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:ASMfreaK)
 * [Axel Leroy](https://github.com/axeleroy): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:axeleroy), [Web](https://axel.leroy.sh/)
 * [azlux](https://github.com/azlux): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:azlux), [Web](https://azlux.fr/)
+* [Balázs Keresztury](https://github.com/belidzs/): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:belidzs), [Web](https://keresztury.com/)
 * [Bartosz Taudul](https://github.com/wolfpld): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:wolfpld), [Web](https://wolf.nereid.pl/)
 * [Benjamin Bouvier](https://github.com/bnjbvr): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:bnjbvr), [Web](https://benj.me/)
 * [bluewhale235](https://github.com/BuleWhale): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:BuleWhale)

--- a/docs/en/admins/16_OpenID-Connect.md
+++ b/docs/en/admins/16_OpenID-Connect.md
@@ -7,6 +7,8 @@ This is one of the [access control methods](09_AccessControl.md) supported by Fr
 OIDC support is provided by [mod_auth_openidc](https://github.com/OpenIDC/mod_auth_openidc).
 Additional documentation can be found in that project.
 
+The callback URL is `https://<your-domain>/i/oidc/`.
+
 ## Using Docker
 
 OIDC support in Docker is activated by the presence of a non-empty non-zero `OIDC_ENABLED` environment variable.
@@ -21,7 +23,7 @@ OIDC support in Docker is activated by the presence of a non-empty non-zero `OID
 * `OIDC_CLIENT_SECRET`: The OIDC client secret issuer.
 * `OIDC_CLIENT_CRYPTO_KEY`: An opaque key used for internal encryption.
 * `OIDC_REMOTE_USER_CLAIM`: The claim to use as the username within FreshRSS. Defaults to `preferred_username`. Depending on what you choose here, and your identity provider, you’ll need to adjust the scopes you request so that this claim will be accessible. Refer to your identity provider’s documentation.
-* `OIDC_SCOPES`: The OIDC scopes to request. Defaults to `openid`. As mentioned previously, make sure the scopes you pick contain whatever `OIDC_REMOTE_USER_CLAIM` you chose.
+* `OIDC_SCOPES`: The OIDC scopes to request separated by an empty space. Defaults to `openid`. As mentioned previously, make sure the scopes you pick contain whatever `OIDC_REMOTE_USER_CLAIM` you chose. For example, Authelia would require setting this value to `openid profile` to make `preferred_username` accessible.
 * `OIDC_X_FORWARDED_HEADERS`: Optional. Use when running FreshRSS is behind a reverse proxy, so the OIDC module can determine what hostname, port and protocol were used to access FreshRSS. Must be one or more of `Forwarded`, `X-Forwarded-Host`, `X-Forwarded-Port` or `X-Forwarded-Proto` (separate multiple values with a space). See [mod_auth_openidc’s documentation for details](https://github.com/OpenIDC/mod_auth_openidc/blob/72c9f479c2d228477ff0a9518964f61879c83fb6/auth_openidc.conf#L1041-L1048).
 
 You may add additional custom configuration in a new `./FreshRSS/p/i/.htaccess` file.
@@ -36,4 +38,4 @@ After being properly configured, OIDC support can be activated in FreshRSS.
 
 During a new FreshRSS install, the **HTTP Authentication Method** must be picked.
 
-After install, the method can be changed in *Administration > Authentication*.
+After install, the method can be changed in *Administration > Authentication*. Note that this option will be greyed out if Apache is unable to read the `REMOTE_USER` variable.


### PR DESCRIPTION
Closes #5645

Changes proposed in this pull request:

- add oidc callback URL to docs
- add hints for using Authelia to docs
- add hints on greyed out configuration parameter

How to test the feature manually:

N/A

Pull request checklist:

- [x] clear commit messages
- [ ] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
