### PR TITLE
SQL: clean old auto-updates

### DIFF
--- a/app/Models/DatabaseDAO.php
+++ b/app/Models/DatabaseDAO.php
@@ -204,27 +204,9 @@ SQL;
 		return $ok;
 	}
 
-	public function ensureCaseInsensitiveGuids(): bool {
-		$ok = true;
-		if ($this->pdo->dbType() === 'mysql') {
-			include(APP_PATH . '/SQL/install.sql.mysql.php');
-
-			$ok = false;
-			try {
-				$ok = $this->pdo->exec($GLOBALS['SQL_UPDATE_GUID_LATIN1_BIN']) !== false;	//FreshRSS 1.12
-			} catch (Exception $e) {
-				$ok = false;
-				Minz_Log::error(__METHOD__ . ' error: ' . $e->getMessage());
-			}
-		}
-		return $ok;
-	}
-
 	public function minorDbMaintenance(): void {
 		$catDAO = FreshRSS_Factory::createCategoryDao();
 		$catDAO->resetDefaultCategoryName();
-
-		$this->ensureCaseInsensitiveGuids();
 	}
 
 	private static function stdError(string $error): bool {

--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -26,26 +26,6 @@ class FreshRSS_EntryDAO extends Minz_ModelPdo {
 		return str_replace('INSERT INTO ', 'INSERT IGNORE INTO ', $sql);
 	}
 
-	//TODO: Move the database auto-updates to DatabaseDAO
-	protected function createEntryTempTable(): bool {
-		$ok = false;
-		$hadTransaction = $this->pdo->inTransaction();
-		if ($hadTransaction) {
-			$this->pdo->commit();
-		}
-		try {
-			require(APP_PATH . '/SQL/install.sql.' . $this->pdo->dbType() . '.php');
-			Minz_Log::warning('SQL CREATE TABLE entrytmp...');
-			$ok = $this->pdo->exec($GLOBALS['SQL_CREATE_TABLE_ENTRYTMP'] . $GLOBALS['SQL_CREATE_INDEX_ENTRY_1']) !== false;
-		} catch (Exception $ex) {
-			Minz_Log::error(__method__ . ' error: ' . $ex->getMessage());
-		}
-		if ($hadTransaction) {
-			$this->pdo->beginTransaction();
-		}
-		return $ok;
-	}
-
 	private function updateToMediumBlob(): bool {
 		if ($this->pdo->dbType() !== 'mysql') {
 			return false;
@@ -94,14 +74,6 @@ SQL;
 					if (stripos($errorLines[0], $column) !== false) {
 						return $this->addColumn($column);
 					}
-				}
-			}
-			if ($errorInfo[0] === FreshRSS_DatabaseDAO::ER_BAD_TABLE_ERROR) {
-				if (stripos($errorInfo[2], 'tag') !== false) {
-					$tagDAO = FreshRSS_Factory::createTagDao();
-					return $tagDAO->createTagTable();	//v1.12.0
-				} elseif (stripos($errorInfo[2], 'entrytmp') !== false) {
-					return $this->createEntryTempTable();	//v1.7.0
 				}
 			}
 		}

--- a/app/Models/EntryDAOPGSQL.php
+++ b/app/Models/EntryDAOPGSQL.php
@@ -29,14 +29,6 @@ class FreshRSS_EntryDAOPGSQL extends FreshRSS_EntryDAOSQLite {
 					}
 				}
 			}
-			if ($errorInfo[0] === FreshRSS_DatabaseDAOPGSQL::UNDEFINED_TABLE) {
-				if (stripos($errorInfo[2], 'tag') !== false) {
-					$tagDAO = FreshRSS_Factory::createTagDao();
-					return $tagDAO->createTagTable();	//v1.12.0
-				} elseif (stripos($errorInfo[2], 'entrytmp') !== false) {
-					return $this->createEntryTempTable();	//v1.7.0
-				}
-			}
 		}
 		return false;
 	}

--- a/app/Models/EntryDAOSQLite.php
+++ b/app/Models/EntryDAOSQLite.php
@@ -32,19 +32,6 @@ class FreshRSS_EntryDAOSQLite extends FreshRSS_EntryDAO {
 				}
 			}
 		}
-		if ($tableInfo = $this->pdo->query("SELECT sql FROM sqlite_master where name='tag'")) {
-			$showCreate = $tableInfo->fetchColumn();
-			if (is_string($showCreate) && stripos($showCreate, 'tag') === false) {
-				$tagDAO = FreshRSS_Factory::createTagDao();
-				return $tagDAO->createTagTable();	//v1.12.0
-			}
-		}
-		if ($tableInfo = $this->pdo->query("SELECT sql FROM sqlite_master where name='entrytmp'")) {
-			$showCreate = $tableInfo->fetchColumn();
-			if (is_string($showCreate) && stripos($showCreate, 'entrytmp') === false) {
-				return $this->createEntryTempTable();	//v1.7.0
-			}
-		}
 		return false;
 	}
 

--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -10,8 +10,6 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo {
 		try {
 			if ($name === 'kind') {	//v1.20.0
 				return $this->pdo->exec('ALTER TABLE `_feed` ADD COLUMN kind SMALLINT DEFAULT 0') !== false;
-			} elseif ($name === 'attributes') {	//v1.11.0
-				return $this->pdo->exec('ALTER TABLE `_feed` ADD COLUMN attributes TEXT') !== false;
 			}
 		} catch (Exception $e) {
 			Minz_Log::error(__method__ . ' error: ' . $e->getMessage());
@@ -24,7 +22,7 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo {
 		if (isset($errorInfo[0])) {
 			if ($errorInfo[0] === FreshRSS_DatabaseDAO::ER_BAD_FIELD_ERROR || $errorInfo[0] === FreshRSS_DatabaseDAOPGSQL::UNDEFINED_COLUMN) {
 				$errorLines = explode("\n", $errorInfo[2], 2);	// The relevant column name is on the first line, other lines are noise
-				foreach (['attributes', 'kind'] as $column) {
+				foreach (['kind'] as $column) {
 					if (stripos($errorLines[0], $column) !== false) {
 						return $this->addColumn($column);
 					}

--- a/app/Models/TagDAOSQLite.php
+++ b/app/Models/TagDAOSQLite.php
@@ -6,15 +6,4 @@ class FreshRSS_TagDAOSQLite extends FreshRSS_TagDAO {
 		return 'OR IGNORE';
 	}
 
-	/** @param array<string> $errorInfo */
-	protected function autoUpdateDb(array $errorInfo): bool {
-		if ($tableInfo = $this->pdo->query("SELECT sql FROM sqlite_master where name='tag'")) {
-			$showCreate = $tableInfo->fetchColumn();
-			if (is_string($showCreate) && stripos($showCreate, 'tag') === false) {
-				return $this->createTagTable();	//v1.12.0
-			}
-		}
-		return false;
-	}
-
 }

--- a/app/Models/UserDAO.php
+++ b/app/Models/UserDAO.php
@@ -6,7 +6,7 @@ class FreshRSS_UserDAO extends Minz_ModelPdo {
 		require(APP_PATH . '/SQL/install.sql.' . $this->pdo->dbType() . '.php');
 
 		try {
-			$sql = $GLOBALS['SQL_CREATE_TABLES'] . $GLOBALS['SQL_CREATE_TABLE_ENTRYTMP'] . $GLOBALS['SQL_CREATE_TABLE_TAGS'];
+			$sql = $GLOBALS['SQL_CREATE_TABLES'];
 			$ok = $this->pdo->exec($sql) !== false;	//Note: Only exec() can take multiple statements safely.
 		} catch (Exception $e) {
 			$ok = false;

--- a/app/SQL/install.sql.mysql.php
+++ b/app/SQL/install.sql.mysql.php
@@ -66,13 +66,7 @@ CREATE TABLE IF NOT EXISTS `_entry` (
 ENGINE = INNODB;
 
 INSERT IGNORE INTO `_category` (id, name) VALUES(1, "Uncategorized");
-SQL;
 
-$GLOBALS['SQL_CREATE_INDEX_ENTRY_1'] = <<<'SQL'
-CREATE INDEX `entry_feed_read_index` ON `_entry` (`id_feed`,`is_read`);	-- v1.7
-SQL;
-
-$GLOBALS['SQL_CREATE_TABLE_ENTRYTMP'] = <<<'SQL'
 CREATE TABLE IF NOT EXISTS `_entrytmp` (	-- v1.7
 	`id` BIGINT NOT NULL,
 	`guid` VARCHAR(760) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
@@ -94,9 +88,7 @@ CREATE TABLE IF NOT EXISTS `_entrytmp` (	-- v1.7
 	INDEX (`date`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
 ENGINE = INNODB;
-SQL;
 
-$GLOBALS['SQL_CREATE_TABLE_TAGS'] = <<<'SQL'
 CREATE TABLE IF NOT EXISTS `_tag` (	-- v1.12
 	`id` INT NOT NULL AUTO_INCREMENT,
 	`name` VARCHAR(63) NOT NULL,
@@ -119,9 +111,4 @@ SQL;
 
 $GLOBALS['SQL_DROP_TABLES'] = <<<'SQL'
 DROP TABLE IF EXISTS `_entrytag`, `_tag`, `_entrytmp`, `_entry`, `_feed`, `_category`;
-SQL;
-
-$GLOBALS['SQL_UPDATE_GUID_LATIN1_BIN'] = <<<'SQL'
-ALTER TABLE `_entrytmp` MODIFY `guid` VARCHAR(760) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL;	-- v1.12
-ALTER TABLE `_entry` MODIFY `guid` VARCHAR(760) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL;
 SQL;

--- a/app/SQL/install.sql.pgsql.php
+++ b/app/SQL/install.sql.pgsql.php
@@ -62,13 +62,7 @@ INSERT INTO `_category` (id, name)
 	SELECT 1, 'Uncategorized'
 	WHERE NOT EXISTS (SELECT id FROM `_category` WHERE id = 1)
 	RETURNING nextval('`_category_id_seq`');
-SQL;
 
-$GLOBALS['SQL_CREATE_INDEX_ENTRY_1'] = <<<'SQL'
-CREATE INDEX IF NOT EXISTS `_entry_feed_read_index` ON `_entry` ("id_feed","is_read");	-- v1.7
-SQL;
-
-$GLOBALS['SQL_CREATE_TABLE_ENTRYTMP'] = <<<'SQL'
 CREATE TABLE IF NOT EXISTS `_entrytmp` (	-- v1.7
 	"id" BIGINT NOT NULL PRIMARY KEY,
 	"guid" VARCHAR(760) NOT NULL,
@@ -88,9 +82,7 @@ CREATE TABLE IF NOT EXISTS `_entrytmp` (	-- v1.7
 	UNIQUE ("id_feed","guid")
 );
 CREATE INDEX IF NOT EXISTS `_entrytmp_date_index` ON `_entrytmp` ("date");
-SQL;
 
-$GLOBALS['SQL_CREATE_TABLE_TAGS'] = <<<'SQL'
 CREATE TABLE IF NOT EXISTS `_tag` (	-- v1.12
 	"id" SERIAL PRIMARY KEY,
 	"name" VARCHAR(63) UNIQUE NOT NULL,

--- a/app/SQL/install.sql.sqlite.php
+++ b/app/SQL/install.sql.sqlite.php
@@ -61,13 +61,7 @@ CREATE INDEX IF NOT EXISTS entry_lastSeen_index ON `entry`(`lastSeen`);	-- //v1.
 CREATE INDEX IF NOT EXISTS entry_feed_read_index ON `entry`(`id_feed`,`is_read`);	-- v1.7
 
 INSERT OR IGNORE INTO `category` (id, name) VALUES(1, "Uncategorized");
-SQL;
 
-$GLOBALS['SQL_CREATE_INDEX_ENTRY_1'] = <<<'SQL'
-CREATE INDEX IF NOT EXISTS entry_feed_read_index ON `entry`(`id_feed`,`is_read`);	-- v1.7
-SQL;
-
-$GLOBALS['SQL_CREATE_TABLE_ENTRYTMP'] = <<<'SQL'
 CREATE TABLE IF NOT EXISTS `entrytmp` (	-- v1.7
 	`id` BIGINT NOT NULL,
 	`guid` VARCHAR(760) NOT NULL,
@@ -88,9 +82,7 @@ CREATE TABLE IF NOT EXISTS `entrytmp` (	-- v1.7
 	UNIQUE (`id_feed`,`guid`)
 );
 CREATE INDEX IF NOT EXISTS entrytmp_date_index ON `entrytmp`(`date`);
-SQL;
 
-$GLOBALS['SQL_CREATE_TABLE_TAGS'] = <<<'SQL'
 CREATE TABLE IF NOT EXISTS `tag` (	-- v1.12
 	`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
 	`name` VARCHAR(63) NOT NULL,


### PR DESCRIPTION
Should help with some DB lock issues.

Complete https://github.com/FreshRSS/FreshRSS/pull/3558 after https://github.com/FreshRSS/FreshRSS/pull/5625 already cherry-picked from it.

* Removed auto-update of MySQL GUID case sensitivity
https://github.com/FreshRSS/FreshRSS/pull/2078
  * Contributed to a DB lock in https://github.com/FreshRSS/FreshRSS/issues/5008

Also removed the following non-problematic auto-updates, simply because they were older than the above ones (October 2018)
* Auto-create custom labels (1.12.0) https://github.com/FreshRSS/FreshRSS/pull/2027
* Auto-add JSON column for feeds (1.11.0) https://github.com/FreshRSS/FreshRSS/pull/1838
* Auto-create temporary tables (1.7.0) https://github.com/FreshRSS/FreshRSS/pull/1470
