### PR TITLE
Fix dev container Apache logs

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -13,6 +13,8 @@ or as [GitHub Codespaces](https://github.com/features/codespaces) simply in a We
 A test instance of FreshRSS is automatically started as visible from the *Ports* tab: check the *Local Address* column, and click on the *Open in browser* 🌐 icon.
 It runs the FreshRSS code that you are currently editing.
 
+Apache logs can be seen in `/var/log/apache2/access.log` and `/var/log/apache2/error.log`.
+
 ## Software tests
 
 Running the tests can be done directly from the built-in terminal, e.g.:

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -9,4 +9,4 @@ cp ./Docker/*.Apache.conf /etc/apache2/conf.d/
 chown -R developer:www-data /home/developer/freshrss-data
 chmod -R g+rwX /home/developer/freshrss-data
 
-httpd
+httpd -c 'ErrorLog "/var/log/apache2/error.log"' -c 'CustomLog "/var/log/apache2/access.log" combined_proxy'


### PR DESCRIPTION
Apache logs were not available from the dev container.
Quick fix while waiting for a better integrated solution (e.g. coming in output window) - contributions welcome.
