### PR TITLE
fix: Fix check of existing usernames in cli scripts

### DIFF
--- a/cli/create-user.php
+++ b/cli/create-user.php
@@ -10,7 +10,7 @@ if (!FreshRSS_user_Controller::checkUsername($username)) {
 }
 
 $usernames = listUsers();
-if (preg_grep("/^$username$/i", $usernames) !== false) {
+if (preg_grep("/^$username$/i", $usernames)) {
 	fail('FreshRSS warning: username already exists “' . $username . '”', EXIT_CODE_ALREADY_EXISTS);
 }
 

--- a/cli/delete-user.php
+++ b/cli/delete-user.php
@@ -19,7 +19,7 @@ if (!FreshRSS_user_Controller::checkUsername($username)) {
 }
 
 $usernames = listUsers();
-if (preg_grep("/^$username$/i", $usernames) === false) {
+if (!preg_grep("/^$username$/i", $usernames)) {
 	fail('FreshRSS error: username not found “' . $username . '”');
 }
 


### PR DESCRIPTION
Regression introduced in 7f9594b8c7d7799f2e5f89328bd5981410db8cf0

Reference: https://github.com/FreshRSS/FreshRSS/pull/5501

Changes proposed in this pull request:

- test return value of `preg_grep` to be either `false` or empty array in `create-user.php` and `delete-user.php` scripts

How to test the feature manually:

1. create a user that doesn't exist (e.g. `cli/create-user.php --user foo --password 'mysecret'`) → check it works
2. delete a user that doesn't exist (e.g. `cli/delete-user.php --user bar`) → check it fails with the message `FreshRSS error: username not found “bar”`

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
