### PR TITLE
Improved: Theme selector

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1846,7 +1846,7 @@ html.slider-active {
 	position: absolute;
 }
 
-.theme-preview-list .preview:hover + .nav label {
+.theme-preview-list .preview + .nav label {
 	opacity: 0.5;
 }
 
@@ -2380,10 +2380,6 @@ html.slider-active {
 
 	.stat.half {
 		grid-column: 1 / span 2;
-	}
-
-	.theme-preview-list .preview + .nav label {
-		opacity: 0.5;
 	}
 }
 

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1846,7 +1846,7 @@ html.slider-active {
 	position: absolute;
 }
 
-.theme-preview-list .preview:hover + .nav label {
+.theme-preview-list .preview + .nav label {
 	opacity: 0.5;
 }
 
@@ -2380,10 +2380,6 @@ html.slider-active {
 
 	.stat.half {
 		grid-column: 1 / span 2;
-	}
-
-	.theme-preview-list .preview + .nav label {
-		opacity: 0.5;
 	}
 }
 


### PR DESCRIPTION
Closes #5556

Before:
Arrows will be shown when hovering.

After:
Arrows will always been shown.

![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/8bbd6253-645a-4e07-902a-2f93ec282517)


Changes proposed in this pull request:

- frss.css


How to test the feature manually:

1. go to config -> display
2. see the arrows on the theme preview


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
