### PR TITLE
fixed: margins in feed navigation bar

### DIFF
--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -30,15 +30,14 @@
 	<ul id="sidebar" class="tree scrollbar-thin">
 		<li class="tree-folder category all<?= FreshRSS_Context::isCurrentGet('a') ? ' active' : '' ?>">
 			<div class="tree-folder-title">
-				<?= _i('all') ?> <a class="title" data-unread="<?= format_number(FreshRSS_Context::$total_unread) ?>" href="<?=
+				<?= _i('all') ?><a class="title" data-unread="<?= format_number(FreshRSS_Context::$total_unread) ?>" href="<?=
 					_url('index', $actual_view) . $state_filter_manual ?>"><?= _t('index.menu.main_stream') ?></a>
 			</div>
 		</li>
 
 		<li class="tree-folder category favorites<?= FreshRSS_Context::isCurrentGet('s') ? ' active' : '' ?>">
 			<div class="tree-folder-title">
-				<?= _i('starred') ?>
-				<a class="title" data-unread="<?= format_number(FreshRSS_Context::$total_starred['unread']) ?>" href="<?= _url('index', $actual_view, 'get', 's') . $state_filter_manual ?>">
+				<?= _i('starred') ?><a class="title" data-unread="<?= format_number(FreshRSS_Context::$total_starred['unread']) ?>" href="<?= _url('index', $actual_view, 'get', 's') . $state_filter_manual ?>">
 					<?= _t('index.menu.favorites', format_number(FreshRSS_Context::$total_starred['all'])) ?>
 				</a>
 			</div>
@@ -50,8 +49,7 @@
 		?>
 		<li id="tags" class="tree-folder category tags<?= $t_active ? ' active' : '' ?>" data-unread="<?= format_number($this->nbUnreadTags) ?>">
 			<div class="tree-folder-title">
-				<a class="dropdown-toggle" href="#"><?= _i($t_show ? 'up' : 'down') ?></a>
-				<a class="title" data-unread="<?= format_number($this->nbUnreadTags) ?>" href="<?= _url('index', $actual_view, 'get', 'T') . $state_filter_manual ?>"><?= _t('index.menu.tags') ?></a>
+				<a class="dropdown-toggle" href="#"><?= _i($t_show ? 'up' : 'down') ?></a><a class="title" data-unread="<?= format_number($this->nbUnreadTags) ?>" href="<?= _url('index', $actual_view, 'get', 'T') . $state_filter_manual ?>"><?= _t('index.menu.tags') ?></a>
 			</div>
 			<ul class="tree-folder-items<?= $t_show ? ' active' : '' ?>">
 				<?php
@@ -87,8 +85,7 @@
 		<li id="c_<?= $cat->id() ?>" class="tree-folder category<?= $c_active ? ' active' : '' ?>"<?=
 			null === $position ? '' : " data-position='$position'" ?> data-unread="<?= $cat->nbNotRead() ?>">
 			<div class="tree-folder-title">
-				<a class="dropdown-toggle" href="#"><?= _i($c_show ? 'up' : 'down') ?></a>
-				<a class="title<?= $cat->hasFeedsWithError() ? ' error' : '' ?>" data-unread="<?=
+				<a class="dropdown-toggle" href="#"><?= _i($c_show ? 'up' : 'down') ?></a><a class="title<?= $cat->hasFeedsWithError() ? ' error' : '' ?>" data-unread="<?=
 					format_number($cat->nbNotRead()) ?>" href="<?= _url('index', $actual_view, 'get', 'c_' . $cat->id()) . $state_filter_manual ?>"><?=
 						$cat->name()
 					?><?php if ($cat->kind() == FreshRSS_Category::KIND_DYNAMIC_OPML) { echo _i('opml-dyn'); } ?></a>
@@ -121,9 +118,8 @@
 		if ($f_active || $nbFeedsTotal < FreshRSS_Context::$user_conf->simplify_over_n_feeds):
 	?><div class="dropdown no-mobile">
 		<div class="dropdown-target"></div><a class="dropdown-toggle" data-fweb="<?= $feed->website() ?>"><?= _i('configure') ?></a><?php /* feed_config_template */ ?>
-	</div>
-	<?php
-			if (FreshRSS_Context::$user_conf->show_favicons) { ?><img class="favicon" src="<?= $feed->favicon() ?>" alt="✇" loading="lazy" /><?php }
+	</div><?php
+			if (FreshRSS_Context::$user_conf->show_favicons) { ?><img class="favicon test" src="<?= $feed->favicon() ?>" alt="✇" loading="lazy" /><?php }
 		endif;
 	?><a class="item-title" data-unread="<?= format_number($feed->nbNotRead()) ?>" href="<?=
 		_url('index', $actual_view, 'get', 'f_' . $feed->id()) . $state_filter_manual ?>"><?= $feed->name() ?></a></li>

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -544,8 +544,8 @@ form th {
 	padding: 0.125rem 0.75rem;
 }
 
-
 .aside_feed .tree-folder-items > .item.feed {
+	padding-left: 0.5rem;
 	font-size: 0.8rem;
 }
 

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -544,8 +544,8 @@ form th {
 	padding: 0.125rem 0.75rem;
 }
 
-
 .aside_feed .tree-folder-items > .item.feed {
+	padding-right: 0.5rem;
 	font-size: 0.8rem;
 }
 

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1105,8 +1105,18 @@ input[type="search"] {
 	width: calc(100% - 75px);
 }
 
-.aside_feed .tree-folder-title .icon {
-	padding: 0 0.25rem;
+.aside_feed .tree-folder.category .tree-folder-title .title.error .icon {
+	margin: 0 0.5rem;
+	padding: 0;
+}
+
+.aside_feed .tree-folder-title .icon,
+.aside_feed .tree-folder-items .feed .icon {
+	padding: 0 0.5rem 0 0;
+}
+
+.aside_feed .tree-folder-items .feed .favicon {
+	padding: 0;
 }
 
 .aside_feed .tree-folder-items .item.feed {
@@ -2315,6 +2325,11 @@ html.slider-active {
 
 	.aside_feed .configure-feeds {
 		margin-top: 10px;
+	}
+
+	.aside_feed .tree-folder-items .feed .favicon {
+		margin: 0;
+		padding: 0 0.5rem 0 0;
 	}
 
 	.flux_header .item.website {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1105,8 +1105,18 @@ input[type="search"] {
 	width: calc(100% - 75px);
 }
 
-.aside_feed .tree-folder-title .icon {
-	padding: 0 0.25rem;
+.aside_feed .tree-folder.category .tree-folder-title .title.error .icon {
+	margin: 0 0.5rem;
+	padding: 0;
+}
+
+.aside_feed .tree-folder-title .icon,
+.aside_feed .tree-folder-items .feed .icon {
+	padding: 0 0 0 0.5rem;
+}
+
+.aside_feed .tree-folder-items .feed .favicon {
+	padding: 0;
 }
 
 .aside_feed .tree-folder-items .item.feed {
@@ -2315,6 +2325,11 @@ html.slider-active {
 
 	.aside_feed .configure-feeds {
 		margin-top: 10px;
+	}
+
+	.aside_feed .tree-folder-items .feed .favicon {
+		margin: 0;
+		padding: 0 0 0 0.5rem;
 	}
 
 	.flux_header .item.website {


### PR DESCRIPTION
Before:
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/7af93714-3b50-49b7-8e0a-6ad47a35f262)


After:
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/0cbd7b45-07e7-495b-b36d-db95ac77bb8e)


Changes proposed in this pull request:

- CSS
- phtml, to delete some unwanted spaces


How to test the feature manually:

1. see the left hand side feed navigation bar


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
