### PR TITLE
Avoid a warning on non-numeric TRUSTED_PROXY en var

### DIFF
--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -12,7 +12,7 @@ if [ -n "$LISTEN" ]; then
 fi
 
 if [ -n "$TRUSTED_PROXY" ]; then
-	if [[ "$TRUSTED_PROXY" == 0 ]]; then
+	if [ "$TRUSTED_PROXY" == "0" ]; then
 		# Disable RemoteIPHeader and RemoteIPTrustedProxy
 		find /etc/apache2/ -type f -name FreshRSS.Apache.conf -exec sed -r -i "/^\s*RemoteIP.*$/s/^/#/" {} \;
 	else

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -12,7 +12,7 @@ if [ -n "$LISTEN" ]; then
 fi
 
 if [ -n "$TRUSTED_PROXY" ]; then
-	if [ "$TRUSTED_PROXY" == "0" ]; then
+	if [ "$TRUSTED_PROXY" = "0" ]; then
 		# Disable RemoteIPHeader and RemoteIPTrustedProxy
 		find /etc/apache2/ -type f -name FreshRSS.Apache.conf -exec sed -r -i "/^\s*RemoteIP.*$/s/^/#/" {} \;
 	else

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -12,7 +12,7 @@ if [ -n "$LISTEN" ]; then
 fi
 
 if [ -n "$TRUSTED_PROXY" ]; then
-	if [ "$TRUSTED_PROXY" -eq 0 ]; then
+	if [[ "$TRUSTED_PROXY" == 0 ]]; then
 		# Disable RemoteIPHeader and RemoteIPTrustedProxy
 		find /etc/apache2/ -type f -name FreshRSS.Apache.conf -exec sed -r -i "/^\s*RemoteIP.*$/s/^/#/" {} \;
 	else


### PR DESCRIPTION
Fixes #5732

Changes proposed in this pull request:

- use a double-bracket syntax, that does not complain when TRUSTED_PROXY env var is not numeric

How to test the feature manually: follow the steps from #5732

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated