### PR TITLE
Use RemoteIPInternalProxy directive of remoteip Apache module

### DIFF
--- a/Docker/FreshRSS.Apache.conf
+++ b/Docker/FreshRSS.Apache.conf
@@ -11,7 +11,7 @@ ErrorLog /dev/stderr
 	# Can be disabled by setting the TRUSTED_PROXY environment variable to 0:
 	RemoteIPHeader X-Forwarded-For
 	# Can be overridden by the TRUSTED_PROXY environment variable:
-	RemoteIPTrustedProxy 10.0.0.1/8 172.16.0.1/12 192.168.0.1/16
+	RemoteIPInternalProxy 10.0.0.1/8 172.16.0.1/12 192.168.0.1/16
 </IfModule>
 
 LogFormat "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined_proxy

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -329,7 +329,7 @@ services:
       LISTEN: 0.0.0.0:80
       # Optional parameter, remove for automatic settings, set to 0 to disable,
       # or (if you use a proxy) to a space-separated list of trusted IP ranges
-      # compatible with https://httpd.apache.org/docs/current/mod/mod_remoteip.html#remoteiptrustedproxy
+      # compatible with https://httpd.apache.org/docs/current/mod/mod_remoteip.html#remoteipinternalproxy
       # This impacts which IP address is logged (X-Forwarded-For or REMOTE_ADDR).
       # This also impacts external authentication methods;
       # see https://freshrss.github.io/FreshRSS/en/admins/09_AccessControl.html

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -13,11 +13,11 @@ fi
 
 if [ -n "$TRUSTED_PROXY" ]; then
 	if [ "$TRUSTED_PROXY" -eq 0 ]; then
-		# Disable RemoteIPHeader and RemoteIPTrustedProxy
+		# Disable RemoteIPHeader and RemoteIPInternalProxy
 		find /etc/apache2/ -type f -name FreshRSS.Apache.conf -exec sed -r -i "/^\s*RemoteIP.*$/s/^/#/" {} \;
 	else
-		# Custom list for RemoteIPTrustedProxy
-		find /etc/apache2/ -type f -name FreshRSS.Apache.conf -exec sed -r -i "\\#^\s*RemoteIPTrustedProxy#s#^.*#\tRemoteIPTrustedProxy $TRUSTED_PROXY#" {} \;
+		# Custom list for RemoteIPInternalProxy
+		find /etc/apache2/ -type f -name FreshRSS.Apache.conf -exec sed -r -i "\\#^\s*RemoteIPInternalProxy#s#^.*#\tRemoteIPInternalProxy $TRUSTED_PROXY#" {} \;
 	fi
 fi
 

--- a/docs/en/admins/09_AccessControl.md
+++ b/docs/en/admins/09_AccessControl.md
@@ -30,7 +30,7 @@ To enable this feature, you need to add the IP range (in CIDR notation) of your 
 To allow only one IPv4, you can use a `/32` like this: `trusted_sources => [ '192.168.1.10/32' ]`.
 Likewise to allow only one IPv6, you can use a `/128` like this: `trusted_sources => [ '::1/128' ]`.
 
-You may alternatively pass a `TRUSTED_PROXY` environment variable in a format compatible with [Apache’s `mod_remoteip` `RemoteIPTrustedProxy`](https://httpd.apache.org/docs/current/mod/mod_remoteip.html#remoteiptrustedproxy).
+You may alternatively pass a `TRUSTED_PROXY` environment variable in a format compatible with [Apache’s `mod_remoteip` `RemoteIPInternalProxy`](https://httpd.apache.org/docs/current/mod/mod_remoteip.html#remoteipinternalproxy).
 
 > ☠️ WARNING: FreshRSS will trust any IP configured in the `trusted_sources` option, if your proxy isn’t properly secured, an attacker could simply attach this header and get admin access.
 


### PR DESCRIPTION
instead of RemoteIPTrustedProxy directive

To allow internal IPs to be trusted: for internal clients, and also for the case of chained internal reverse-proxies

Fixes #5726

Changes proposed in this pull request:

- replace RemoteIPTrustedProxy directive by RemoteIPInternalProxy in Apache configuration

How to test the feature manually:

Follow test-case of #5726

Pull request checklist:

- [x] clear commit messages
- [ ] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
