### PR TITLE
Better i18n string for feed submenu for mark as read

### DIFF
--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -174,7 +174,7 @@
 			<button class="read_all as-link <?= $confirm ?>"
 				form="mark-read-aside"
 				formaction="<?= _url('entry', 'read', 'get', 'f_------') ?>"
-				type="submit"><?= _t('gen.action.mark_read') ?></button>
+				type="submit"><?= _t('index.menu.mark_feed_read') ?></button>
 		</li>
 		<?php } ?>
 	</ul>

--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -168,7 +168,7 @@
 		}
 		?>
 		<li class="item"><a class="configure open-slider" href="<?= $url ?>"><?= _t('gen.action.manage') ?></a></li>
-		<li class="item"><a href="<?= _url('feed', 'actualize', 'id', '------') ?>"><?= _t('gen.action.actualize') ?></a></li>
+		<li class="item"><a href="<?= _url('feed', 'actualize', 'id', '------') ?>"><?= _t('index.menu.mark_feed_read') ?></a></li>
 		<li class="item">
 			<?php $confirm = FreshRSS_Context::$user_conf->reading_confirm ? 'confirm" disabled="disabled' : ''; ?>
 			<button class="read_all as-link <?= $confirm ?>"

--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -168,7 +168,7 @@
 		}
 		?>
 		<li class="item"><a class="configure open-slider" href="<?= $url ?>"><?= _t('gen.action.manage') ?></a></li>
-		<li class="item"><a href="<?= _url('feed', 'actualize', 'id', '------') ?>"><?= _t('index.menu.mark_feed_read') ?></a></li>
+		<li class="item"><a href="<?= _url('feed', 'actualize', 'id', '------') ?>"><?= _t('gen.action.actualize') ?></a></li>
 		<li class="item">
 			<?php $confirm = FreshRSS_Context::$user_conf->reading_confirm ? 'confirm" disabled="disabled' : ''; ?>
 			<button class="read_all as-link <?= $confirm ?>"


### PR DESCRIPTION
If a feed is selected there is a "Mark feed as read" string.

![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/fc999bcf-83cf-4df0-a88d-386e205dce47)

Before:
in the feed navigation sub menu there is a "mark as read" string
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/8ddbf6db-84a1-4ffd-91a9-4d0a02e4e53b)

After:
Use the string "Mark feed as read" here
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/be1c7afd-0b06-4740-a627-1ba1875182ab)

