### PR TITLE
Fix: inputs manage feed

### DIFF
--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -519,7 +519,7 @@
 			?>
 			<label class="group-name" for="path_entries_filter"><?= _t('sub.feed.css_path_filter') ?></label>
 			<div class="group-controls">
-				<div class="stick w100">
+				<div class="w100">
 					<input type="text" name="path_entries_filter" id="path_entries_filter" class="w100" value="<?= $path_entries_filter ?>"
 						data-leave-validation="<?= $path_entries_filter ?>" placeholder="<?= _t('gen.short.blank_to_disable') ?>" />
 				</div>

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -208,7 +208,7 @@ label {
 	display: block;
 }
 
-input {
+input:not(.w50,.w100) {
 	max-width: 90%;
 	width: 300px;
 }

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -208,7 +208,7 @@ label {
 	display: block;
 }
 
-input {
+input:not(.w50,.w100) {
 	max-width: 90%;
 	width: 300px;
 }


### PR DESCRIPTION
Before:
(all themes)
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/72964420-92cd-46a0-81fe-b0fa50c45e3c)

![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/ae2e42fd-9832-4891-879e-e8a53b840235)

After:
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/edc42c93-9a42-483a-92b2-9bbb60d5414a)

![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/98a42c90-1bea-42fa-a144-33f91505e2ea)


Changes proposed in this pull request:

- frss.css


How to test the feature manually:

1. edit a feed
2. see the inputs


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
