### PR TITLE
Improve manage feeds: purge section

### DIFF
--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -302,7 +302,7 @@
 		</p>
 
 		<div class="form-group">
-			<label class="group-name" for="use_default_purge_options"><?= _t('conf.archiving.policy') ?></label>
+			<div class="group-name"><?= _t('conf.archiving.policy') ?></div>
 			<div class="group-controls">
 				<label class="checkbox">
 					<input type="checkbox" name="use_default_purge_options" id="use_default_purge_options" value="1"<?= $archiving['default'] ? ' checked="checked"' : '' ?>


### PR DESCRIPTION

![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/20498eca-2d7d-48e2-a2b9-91ef7d39d67d)

Before:
The left hand side title `purge policy` was a `<label>` of the checkbox `By default`.
The problem: if the user clicks on the `purge policy` the checkbox will be toggled.

After:
 `purge policy` is not a `<label>` anymore so the the checkbox will be untouched.
`by default` is still a `<label>` so that there is enough space to click on it to change the checkbox state.

Changes proposed in this pull request:
- phtml

How to test the feature manually:
1. go to manage feeds
2. edit a feed
3. scroll down to the purge policy


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
