### PR TITLE
Improve table scrolling

### DIFF
--- a/app/views/extension/index.phtml
+++ b/app/views/extension/index.phtml
@@ -45,7 +45,7 @@
 
 	<?php if (!empty($this->available_extensions)) { ?>
 		<h2><?= _t('admin.extensions.community') ?></h2>
-		<div class="table-wrapper">
+		<div class="table-wrapper scrollbar-thin">
 			<table>
 				<tr>
 					<th><?= _t('admin.extensions.name') ?></th>

--- a/app/views/index/logs.phtml
+++ b/app/views/index/logs.phtml
@@ -15,7 +15,7 @@
 
 	<?php if (!empty($items)) { ?>
 	<?php $this->logsPaginator->render('logs_pagination.phtml', 'page'); ?>
-	<div id="loglist-wrapper" class="table-wrapper">
+	<div id="loglist-wrapper" class="table-wrapper scrollbar-thin">
 		<table id="loglist">
 			<thead>
 				<th><?= _t('conf.logs.loglist.level') ?></th>

--- a/app/views/stats/index.phtml
+++ b/app/views/stats/index.phtml
@@ -13,65 +13,69 @@
 	<div class="stat-grid">
 		<div class="stat half">
 			<h2><?= _t('admin.stats.entry_repartition') ?></h2>
-			<table>
-				<thead>
-					<tr>
-						<th> </th>
-						<th><?= _t('admin.stats.main_stream') ?></th>
-						<th><?= _t('admin.stats.all_feeds') ?></th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<th><?= _t('admin.stats.status_total') ?></th>
-						<td class="numeric"><?= format_number($this->repartitions['main_stream']['total'] ?? -1) ?></td>
-						<td class="numeric"><?= format_number($this->repartitions['all_feeds']['total'] ?? -1) ?></td>
-					</tr>
-					<tr>
-						<th><?= _t('admin.stats.status_read') ?></th>
-						<td class="numeric"><?= format_number($this->repartitions['main_stream']['count_reads'] ?? -1) ?></td>
-						<td class="numeric"><?= format_number($this->repartitions['all_feeds']['count_reads'] ?? -1) ?></td>
-					</tr>
-					<tr>
-						<th><?= _t('admin.stats.status_unread') ?></th>
-						<td class="numeric"><?= format_number($this->repartitions['main_stream']['count_unreads'] ?? -1) ?></td>
-						<td class="numeric"><?= format_number($this->repartitions['all_feeds']['count_unreads'] ?? -1) ?></td>
-					</tr>
-					<tr>
-						<th><?= _t('admin.stats.status_favorites') ?></th>
-						<td class="numeric"><?= format_number($this->repartitions['main_stream']['count_favorites'] ?? -1) ?></td>
-						<td class="numeric"><?= format_number($this->repartitions['all_feeds']['count_favorites'] ?? -1) ?></td>
-					</tr>
-				</tbody>
-			</table>
+			<div class="table-wrapper scrollbar-thin">
+				<table>
+					<thead>
+						<tr>
+							<th> </th>
+							<th><?= _t('admin.stats.main_stream') ?></th>
+							<th><?= _t('admin.stats.all_feeds') ?></th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<th><?= _t('admin.stats.status_total') ?></th>
+							<td class="numeric"><?= format_number($this->repartitions['main_stream']['total'] ?? -1) ?></td>
+							<td class="numeric"><?= format_number($this->repartitions['all_feeds']['total'] ?? -1) ?></td>
+						</tr>
+						<tr>
+							<th><?= _t('admin.stats.status_read') ?></th>
+							<td class="numeric"><?= format_number($this->repartitions['main_stream']['count_reads'] ?? -1) ?></td>
+							<td class="numeric"><?= format_number($this->repartitions['all_feeds']['count_reads'] ?? -1) ?></td>
+						</tr>
+						<tr>
+							<th><?= _t('admin.stats.status_unread') ?></th>
+							<td class="numeric"><?= format_number($this->repartitions['main_stream']['count_unreads'] ?? -1) ?></td>
+							<td class="numeric"><?= format_number($this->repartitions['all_feeds']['count_unreads'] ?? -1) ?></td>
+						</tr>
+						<tr>
+							<th><?= _t('admin.stats.status_favorites') ?></th>
+							<td class="numeric"><?= format_number($this->repartitions['main_stream']['count_favorites'] ?? -1) ?></td>
+							<td class="numeric"><?= format_number($this->repartitions['all_feeds']['count_favorites'] ?? -1) ?></td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
 		</div>
 
 		<div class="stat half">
 			<h2><?= _t('admin.stats.top_feed') ?></h2>
-			<table>
-				<thead>
-					<tr>
-						<th><?= _t('admin.stats.feed') ?></th>
-						<th><?= _t('admin.stats.category') ?></th>
-						<th><?= _t('admin.stats.entry_count') ?></th>
-						<th><?= _t('admin.stats.percent_of_total') ?></th>
-					</tr>
-				</thead>
-				<tbody>
-					<?php foreach ($this->topFeed as $feed): ?>
+			<div class="table-wrapper scrollbar-thin">
+				<table>
+					<thead>
 						<tr>
-							<td><a href="<?= _url('stats', 'repartition', 'id', $feed['id']) ?>"><?= $feed['name'] ?></a></td>
-							<td><?= $feed['category'] ?></td>
-							<td class="numeric"><?= format_number($feed['count']) ?></td>
-							<td class="numeric"><?php
-								if (!empty($this->repartitions['all_feeds']['total'])) {
-									echo format_number($feed['count'] / $this->repartitions['all_feeds']['total'] * 100, 1);
-								}
-							?></td>
+							<th><?= _t('admin.stats.feed') ?></th>
+							<th><?= _t('admin.stats.category') ?></th>
+							<th><?= _t('admin.stats.entry_count') ?></th>
+							<th><?= _t('admin.stats.percent_of_total') ?></th>
 						</tr>
-					<?php endforeach; ?>
-				</tbody>
-			</table>
+					</thead>
+					<tbody>
+						<?php foreach ($this->topFeed as $feed): ?>
+							<tr>
+								<td><a href="<?= _url('stats', 'repartition', 'id', $feed['id']) ?>"><?= $feed['name'] ?></a></td>
+								<td><?= $feed['category'] ?></td>
+								<td class="numeric"><?= format_number($feed['count']) ?></td>
+								<td class="numeric"><?php
+									if (!empty($this->repartitions['all_feeds']['total'])) {
+										echo format_number($feed['count'] / $this->repartitions['all_feeds']['total'] * 100, 1);
+									}
+								?></td>
+							</tr>
+						<?php endforeach; ?>
+					</tbody>
+				</table>
+			</div>
 		</div>
 
 		<div class="stat">

--- a/app/views/stats/repartition.phtml
+++ b/app/views/stats/repartition.phtml
@@ -37,7 +37,7 @@
 	<?php }?>
 
 	<div class="stat-grid">
-		<div class="stat">
+		<div class="stat table-wrapper scrollbar-thin">
 			<table>
 			<tr>
 				<th><?= _t('admin.stats.status_total') ?></th>

--- a/app/views/user/manage.phtml
+++ b/app/views/user/manage.phtml
@@ -91,7 +91,7 @@
 	</form>
 
 	<h2><?= _t('admin.user.list'); ?></h2>
-	<div class="table-wrapper">
+	<div class="table-wrapper scrollbar-thin">
 		<table id="user-list">
 			<thead>
 				<tr>


### PR DESCRIPTION
When a table is to wide the table should be horizontal scroll-able and not the whole page.

If a table is scroll-able the thin scrollbars should be used (instead of the wider default scroll bars)

After:
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/009be441-ff31-45ed-b497-ffeef8f9f285)


![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/dd71c331-d92a-4a49-84b8-c52d1f184095)



Changes proposed in this pull request:

- phtml + CSS (frss.css)


How to test the feature manually:

1. go to statics pages with table or go to display config page
2. have a thin screen
3. scroll the table horizontal

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
