### PR TITLE
WIP Order Entries by date instead of insertion id

### DIFF
--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -1080,7 +1080,7 @@ SQL;
 			. ($type === 't' || $type === 'T' ? 'INNER JOIN `_entrytag` et ON et.id_entry = e.id ' : '')
 			. 'WHERE ' . $where
 			. $search
-			. 'ORDER BY e.id ' . $order
+			. 'ORDER BY e.date ' . $order
 			. ($limit > 0 ? ' LIMIT ' . intval($limit) : '')];	//TODO: See http://explainextended.com/2009/10/23/mysql-order-by-limit-performance-late-row-lookups/
 	}
 
@@ -1104,7 +1104,7 @@ SQL;
 SELECT e0.id, e0.guid, e0.title, e0.author, {$content}, e0.link, e0.date, {$hash} AS hash, e0.is_read, e0.is_favorite, e0.id_feed, e0.tags, e0.attributes
 FROM `_entry` e0
 INNER JOIN ({$sql}) e2 ON e2.id=e0.id
-ORDER BY e0.id {$order}
+ORDER BY e0.date {$order}
 SQL;
 		$stm = $this->pdo->prepare($sql);
 		if ($stm !== false && $stm->execute($values)) {


### PR DESCRIPTION
Closes #2596

Changes proposed in this pull request:

- Return entries ordered by date and not by id in the SQL getter functions. 

As it is with this fix, the items seem properly ordered but the new page loading (when scrolling down) is repeating the first page with a slight offset. I suspect this has to do with how the $next_id or $firstId variables are set and used but I haven't been able to figure it out.

Any input or help would be more than welcome as I have no experience with this codebase nor Php. 

How to test the feature manually:

1. Add a new feed if you haven't done recently so that the entries are out of order in main view
2. Rebuild
3. Reload the main feed

Pull request checklist:

- [x ] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
