### PR TITLE
Fix Docker CRON_MIN for env with special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 	* Increase SQL (`VARCHAR`) text fields length to maximum possible [#5788](https://github.com/FreshRSS/FreshRSS/pull/5788)
 	* Increase SQL date fields to 64-bit to be ready for year 2038+ [#5570](https://github.com/FreshRSS/FreshRSS/pull/5570)
 * Bug fixing
+	* Fix regression in Docker `CRON_MIN` if any environment variable contains a single quote [#5795](https://github.com/FreshRSS/FreshRSS/pull/5795)
 	* Fix JavaScript regression in label dropdown [#5785](https://github.com/FreshRSS/FreshRSS/pull/5785)
 * Misc.
 	* Code improvements [#5511](https://github.com/FreshRSS/FreshRSS/pull/5511)

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -34,8 +34,7 @@ if [ -n "$OIDC_ENABLED" ] && [ "$OIDC_ENABLED" -ne 0 ]; then
 fi
 
 if [ -n "$CRON_MIN" ]; then
-	# shellcheck disable=SC2002
-	cat /proc/self/environ | tr '\0' '\n' | grep -vE '^(HOME|PATH|PWD|SHLVL|TERM|_)=' | sort -u | sed 's/^/export /' >/var/www/FreshRSS/Docker/env.txt
+	awk -v RS='\0' '!/^(HOME|PATH|PWD|SHLVL|TERM|_)/ {gsub("\047", "\047\\\047\047"); print "export \047" $0 "\047"}' /proc/self/environ >/var/www/FreshRSS/Docker/env.txt
 	sed </etc/crontab.freshrss.default \
 		-r "s#^[^ ]+ #$CRON_MIN #" | crontab -
 fi


### PR DESCRIPTION
fix https://github.com/FreshRSS/FreshRSS/issues/5792
regression from https://github.com/FreshRSS/FreshRSS/pull/5772

Inspired by https://unix.stackexchange.com/questions/125110/how-do-i-source-another-processs-environment-variables/125146#125146
