### PR TITLE
Fix: Update page: Buttons

### DIFF
--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -291,24 +291,6 @@ form th {
 	text-decoration: none;
 }
 
-.btn-state1.hide {
-	display: none;
-}
-
-.btn-state2 {
-	display: none;
-}
-
-.btn-state2.show {
-	display: inline-block;
-}
-
-#button-update-loading {
-	background: var(--frss-loading-image) 0.5rem center no-repeat;
-	background-size: 1rem;
-	padding-left: 2rem;
-}
-
 a:hover .icon {
 	filter: brightness(1.5);
 	transition: 0.1s linear;

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -291,24 +291,6 @@ form th {
 	text-decoration: none;
 }
 
-.btn-state1.hide {
-	display: none;
-}
-
-.btn-state2 {
-	display: none;
-}
-
-.btn-state2.show {
-	display: inline-block;
-}
-
-#button-update-loading {
-	background: var(--frss-loading-image) 0.5rem center no-repeat;
-	background-size: 1rem;
-	padding-right: 2rem;
-}
-
 a:hover .icon {
 	filter: brightness(1.5);
 	transition: 0.1s linear;

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -477,6 +477,24 @@ td.numeric {
 	font-weight: bold;
 }
 
+.btn-state1.hide {
+	display: none;
+}
+
+.btn-state2 {
+	display: none;
+}
+
+.btn-state2.show {
+	display: inline-block;
+}
+
+#button-update-loading {
+	background: var(--frss-loading-image) 0.5rem center no-repeat;
+	background-size: 1rem;
+	padding-left: 2rem;
+}
+
 /*=== switch */
 .switch {
 	margin: 0 0.5em;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -477,6 +477,24 @@ td.numeric {
 	font-weight: bold;
 }
 
+.btn-state1.hide {
+	display: none;
+}
+
+.btn-state2 {
+	display: none;
+}
+
+.btn-state2.show {
+	display: inline-block;
+}
+
+#button-update-loading {
+	background: var(--frss-loading-image) 0.5rem center no-repeat;
+	background-size: 1rem;
+	padding-right: 2rem;
+}
+
 /*=== switch */
 .switch {
 	margin: 0 0.5em;


### PR DESCRIPTION
Regression from #5647

The needed CSS code were delivered just in Origine theme, but it is needed in all themes.

Before:
The "Updating..." button is shown, when an update is available but not yet started
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/0bb27bcc-0f83-4017-9648-c3aa443a0cf6)

After:
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/a87f36b9-dc9d-48d7-be3d-3ebc7ab130a1)


How to test the feature manually:

1. go to update page
2. search for an update
3. if there is an update available: no "updating..." button is shown before you started the update process

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested