### PR TITLE
init_posts(): load more posts on window resize

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -740,8 +740,7 @@ function init_posts() {
 		box_to_follow = context.current_view === 'global' ? document.getElementById('panel') : document.scrollingElement;
 		let lastScroll = 0;	// Throttle
 		let timerId = 0;
-		window.addEventListener('resize', onScroll);
-		(box_to_follow === document.scrollingElement ? window : box_to_follow).onscroll = function () {
+		function debouncedOnScroll() {
 			clearTimeout(timerId);
 			if (lastScroll + 500 < Date.now()) {
 				lastScroll = Date.now();
@@ -749,7 +748,9 @@ function init_posts() {
 			} else {
 				timerId = setTimeout(onScroll, 500);
 			}
-		};
+		}
+		(box_to_follow === document.scrollingElement ? window : box_to_follow).onscroll = debouncedOnscroll;
+		window.addEventListener('resize', debouncedOnScroll);
 		onScroll();
 	}
 

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -750,7 +750,7 @@ function debouncedOnScroll() {
 function init_posts() {
 	if (context.auto_load_more || context.auto_mark_scroll || context.auto_remove_article) {
 		box_to_follow = context.current_view === 'global' ? document.getElementById('panel') : document.scrollingElement;
-		(box_to_follow === document.scrollingElement ? window : box_to_follow).onscroll = debouncedOnscroll;
+		(box_to_follow === document.scrollingElement ? window : box_to_follow).onscroll = debouncedOnScroll;
 		window.addEventListener('resize', debouncedOnScroll);
 		onScroll();
 	}

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -740,6 +740,7 @@ function init_posts() {
 		box_to_follow = context.current_view === 'global' ? document.getElementById('panel') : document.scrollingElement;
 		let lastScroll = 0;	// Throttle
 		let timerId = 0;
+		window.addEventListener('resize', onScroll);
 		(box_to_follow === document.scrollingElement ? window : box_to_follow).onscroll = function () {
 			clearTimeout(timerId);
 			if (lastScroll + 500 < Date.now()) {

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -735,20 +735,21 @@ function onScroll() {
 	}
 }
 
+let lastScroll = 0;	// Throttle
+let timerId = 0;
+function debouncedOnScroll() {
+	clearTimeout(timerId);
+	if (lastScroll + 500 < Date.now()) {
+		lastScroll = Date.now();
+		onScroll();
+	} else {
+		timerId = setTimeout(onScroll, 500);
+	}
+}
+
 function init_posts() {
 	if (context.auto_load_more || context.auto_mark_scroll || context.auto_remove_article) {
 		box_to_follow = context.current_view === 'global' ? document.getElementById('panel') : document.scrollingElement;
-		let lastScroll = 0;	// Throttle
-		let timerId = 0;
-		function debouncedOnScroll() {
-			clearTimeout(timerId);
-			if (lastScroll + 500 < Date.now()) {
-				lastScroll = Date.now();
-				onScroll();
-			} else {
-				timerId = setTimeout(onScroll, 500);
-			}
-		}
 		(box_to_follow === document.scrollingElement ? window : box_to_follow).onscroll = debouncedOnscroll;
 		window.addEventListener('resize', debouncedOnScroll);
 		onScroll();


### PR DESCRIPTION
Fixes:

1. Open FreshRSS in a shorter window
2. Resize to be much longer
3. Half the window remains empty

This is most obviously a problem on vertical monitors.

<img src=https://github.com/FreshRSS/FreshRSS/assets/202757/36857514-c05e-48b2-bda8-0b36e6185815 width=30%>

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
