### PR TITLE
perf(image): replace js images lazy loading by html `loading` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 	* Code improvements [#5511](https://github.com/FreshRSS/FreshRSS/pull/5511)
 	* Update dev dependencies [#5787](https://github.com/FreshRSS/FreshRSS/pull/5787),
 		[stylelint-config-recommended-scss/#252](https://github.com/stylelint-scss/stylelint-config-recommended-scss/pull/252)
+	* Replace js images lazy loading by html `loading` attribute [#5816](https://github.com/FreshRSS/FreshRSS/pull/5816)
 
 
 ## 2023-10-30 FreshRSS 1.22.1

--- a/app/views/helpers/javascript_vars.phtml
+++ b/app/views/helpers/javascript_vars.phtml
@@ -15,7 +15,6 @@ echo htmlspecialchars(json_encode(array(
 		'auto_mark_scroll' => !!$mark['scroll'],
 		'auto_load_more' => !!FreshRSS_Context::$user_conf->auto_load_more,
 		'auto_actualize_feeds' => !!Minz_Session::param('actualize_feeds', false),
-		'does_lazyload' => !!FreshRSS_Context::$user_conf->lazyload ,
 		'sides_close_article' => !!FreshRSS_Context::$user_conf->sides_close_article,
 		'sticky_post' => !!FreshRSS_Context::isStickyPostEnabled(),
 		'html5_notif_timeout' => FreshRSS_Context::$user_conf->html5_notif_timeout,

--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -162,7 +162,7 @@ $today = @strtotime('today');
 					<?php } ?>
 				</header>
 				<div class="text"><?php
-					echo $lazyload && $hidePosts ? lazyimg($this->entry->content(true)) : $this->entry->content(true);
+					echo $lazyload ? lazyimg($this->entry->content(true)) : $this->entry->content(true);
 				?></div>
 				<?php
 				$display_authors_date = FreshRSS_Context::$user_conf->show_author_date === 'f' || FreshRSS_Context::$user_conf->show_author_date === 'b';

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -515,13 +515,9 @@ function validateEmailAddress(string $email): bool {
  * @param string $content is the text we want to parse
  */
 function lazyimg(string $content): string {
-	return preg_replace([
-			'/<((?:img|iframe)[^>]+?)src="([^"]+)"([^>]*)>/i',
-			"/<((?:img|iframe)[^>]+?)src='([^']+)'([^>]*)>/i",
-		], [
-			'<$1src="' . Minz_Url::display('/themes/icons/grey.gif') . '" data-original="$2"$3>',
-			"<$1src='" . Minz_Url::display('/themes/icons/grey.gif') . "' data-original='$2'$3>",
-		],
+	return preg_replace(
+		'/<((?:img|iframe)[^>]+?)([^>]*)>/i',
+		'<$1 loading="lazy"$2>',
 		$content
 	) ?? '';
 }

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -399,13 +399,6 @@ function toggleContent(new_active, old_active, skipping) {
 		return;
 	}
 
-	if (context.does_lazyload && !skipping) {
-		new_active.querySelectorAll('img[data-original], iframe[data-original]').forEach(function (el) {
-			el.src = el.getAttribute('data-original');
-			el.removeAttribute('data-original');
-		});
-	}
-
 	if (old_active !== new_active) {
 		if (!skipping) {
 			new_active.classList.add('active');


### PR DESCRIPTION
Closes #2371

Changes proposed in this pull request:

- Replace js image lazy loading by `loading="lazy"` html attribute
- Add `loading="lazy"` on all rss content image if lazy-loading configuration is true (even if the "display_post is enabled)

How to test the feature manually:

1. Enable Lazy loading from setting
2. Open a feed with images
3. Check if `loading="lazy"` attribute is set
4. You can also open "Network" tab of your browser developer options and check if the feed images is only load when the feed is open, and on scroll.

Pull request checklist:

- [X] clear commit messages
- [X] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
