### PR TITLE
Fix trusted cidrs check

### DIFF
--- a/docs/en/admins/09_AccessControl.md
+++ b/docs/en/admins/09_AccessControl.md
@@ -34,6 +34,23 @@ You may alternatively pass a `TRUSTED_PROXY` environment variable in a format co
 
 > ☠️ WARNING: FreshRSS will trust any IP configured in the `trusted_sources` option, if your proxy isn’t properly secured, an attacker could simply attach this header and get admin access.
 
+### Authentik Proxy Provider
+
+If you wish to use external authentication with Authentik, you will need to configure a [Proxy Provider](https://version-2023-10.goauthentik.io/docs/providers/proxy/) with a Property Mapping that tells Authentik to inject the `X-Remote-User` and/or `X-WebAuth-User`. You can do so with the following expression:
+
+```python
+return {
+    "ak_proxy": {
+        "user_attributes": {
+            "additionalHeaders": {
+                "X-Remote-User": request.user.username,
+                "X-WebAuth-User": request.user.username,
+            }
+        }
+    }
+}
+```
+
 ## No Authentication
 
 Not using authentication on your server is dangerous, as anyone with access to your server would be able to make changes as an admin.

--- a/docs/en/admins/09_AccessControl.md
+++ b/docs/en/admins/09_AccessControl.md
@@ -36,20 +36,23 @@ You may alternatively pass a `TRUSTED_PROXY` environment variable in a format co
 
 ### Authentik Proxy Provider
 
-If you wish to use external authentication with Authentik, you will need to configure a [Proxy Provider](https://version-2023-10.goauthentik.io/docs/providers/proxy/) with a Property Mapping that tells Authentik to inject the `X-Remote-User` and/or `X-WebAuth-User` headers. You can do so with the following expression:
+If you wish to use external authentication with [Authentik](https://goauthentik.io/),
+you will need to configure a [Proxy Provider](https://goauthentik.io/docs/providers/proxy/) with a *Property Mapping* that tells Authentik to inject the `X-WebAuth-User` HTTP header.
+You can do so with the following expression:
 
 ```python
 return {
     "ak_proxy": {
         "user_attributes": {
             "additionalHeaders": {
-                "X-Remote-User": request.user.username,
                 "X-WebAuth-User": request.user.username,
             }
         }
     }
 }
 ```
+
+See also another option for Authentik, [using the OAuth2 Provider with OpenID](16_OpenID-Connect-Authentik.md).
 
 ## No Authentication
 

--- a/docs/en/admins/09_AccessControl.md
+++ b/docs/en/admins/09_AccessControl.md
@@ -36,7 +36,7 @@ You may alternatively pass a `TRUSTED_PROXY` environment variable in a format co
 
 ### Authentik Proxy Provider
 
-If you wish to use external authentication with Authentik, you will need to configure a [Proxy Provider](https://version-2023-10.goauthentik.io/docs/providers/proxy/) with a Property Mapping that tells Authentik to inject the `X-Remote-User` and/or `X-WebAuth-User`. You can do so with the following expression:
+If you wish to use external authentication with Authentik, you will need to configure a [Proxy Provider](https://version-2023-10.goauthentik.io/docs/providers/proxy/) with a Property Mapping that tells Authentik to inject the `X-Remote-User` and/or `X-WebAuth-User` headers. You can do so with the following expression:
 
 ```python
 return {

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -683,7 +683,7 @@ function checkTrustedIP(): bool {
 	if ($trusted != 0 && is_string($trusted)) {
 		$trusted = preg_split('/\s+/', $trusted, -1, PREG_SPLIT_NO_EMPTY);
 	}
-	if (empty($trusted)) {
+	if (!is_array($trusted) || empty($trusted)) {
 		$trusted = FreshRSS_Context::$system_conf->trusted_sources;
 	}
 	foreach ($trusted as $cidr) {

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -686,7 +686,7 @@ function checkTrustedIP(): bool {
 	if (empty($trusted)) {
 		$trusted = FreshRSS_Context::$system_conf->trusted_sources;
 	}
-	foreach (FreshRSS_Context::$system_conf->trusted_sources as $cidr) {
+	foreach ($trusted as $cidr) {
 		if (checkCIDR($remoteIp, $cidr)) {
 			return true;
 		}


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

- Address an issue discussed in this thread: https://github.com/FreshRSS/FreshRSS/pull/5549/files#r1388845647
- Added a sub-section to the "External Authentication" docs on how to set `X-Remote-User` in Authentik.

How to test the feature manually:

1. Set `TRUSTED_PROXY` to your proxy
2. Make sure your proxy is setting correctly.
3. `REMOTE_USER` should be set in the Authentication section.

I tested this manually using version 1.22.2-dev. Exec'd into the container, made a quick edit, and voila it worked. 

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
