### PR TITLE
Fix newlines not always displaying properly in description

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -71,6 +71,7 @@ People are sorted by name so please keep this order.
 * [fabianski7](https://github.com/fabianski7): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:fabianski7)
 * [Fake4d](https://github.com/Fake4d): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Fake4d)
 * [Felix2yu 石渠清心](https://github.com/Felix2yu): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Felix2yu), [Web](https://yufei.im/)
+* [FireFingers21](https://github.com/firefingers21): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:firefingers21)
 * [flo0627](https://github.com/flo0627): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:flo0627)
 * [Frans de Jonge](https://github.com/Frenzie): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Frenzie), [Web](http://fransdejonge.com/)
 * [FromTheMoon85](https://github.com/FromTheMoon85): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:FromTheMoon85)

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -185,7 +185,7 @@ HTML;
 				continue;
 			}
 			$credit = $enclosure['credit'] ?? '';
-			$description = nl2br($enclosure['description'] ?? '');
+			$description = nl2br($enclosure['description'] ?? '', true);
 			$length = $enclosure['length'] ?? 0;
 			$medium = $enclosure['medium'] ?? '';
 			$mime = $enclosure['type'] ?? '';

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -185,7 +185,7 @@ HTML;
 				continue;
 			}
 			$credit = $enclosure['credit'] ?? '';
-			$description = $enclosure['description'] ?? '';
+			$description = nl2br($enclosure['description'] ?? '');
 			$length = $enclosure['length'] ?? 0;
 			$medium = $enclosure['medium'] ?? '';
 			$mime = $enclosure['type'] ?? '';
@@ -222,7 +222,7 @@ HTML;
 				$content .= '<p class="enclosure-credits">© ' . $credit . '</p>';
 			}
 			if ($description != '') {
-				$content .= '<figcaption class="enclosure-description">' . $description . '</figcaption>';
+				$content .= '<figcaption>' . $description . '</figcaption>';
 			}
 			$content .= "</figure>\n";
 		}

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -222,7 +222,7 @@ HTML;
 				$content .= '<p class="enclosure-credits">© ' . $credit . '</p>';
 			}
 			if ($description != '') {
-				$content .= '<figcaption>' . $description . '</figcaption>';
+				$content .= '<figcaption class="enclosure-description">' . $description . '</figcaption>';
 			}
 			$content .= "</figure>\n";
 		}

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2096,10 +2096,6 @@ html.slider-active {
 	margin-left: .8em;
 }
 
-.enclosure-description {
-	white-space: pre-line;
-}
-
 .default-user {
 	font-style: italic;
 }

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2096,10 +2096,6 @@ html.slider-active {
 	margin-right: .8em;
 }
 
-.enclosure-description {
-	white-space: pre-line;
-}
-
 .default-user {
 	font-style: italic;
 }


### PR DESCRIPTION
Closes #5844 

Changes proposed in this pull request:

- Modify `$description` and `<figcaption>` so that newlines are properly rendered when using both web view and API

How to test the feature manually:

1. Subscribe to a [youtube.com](https://www.youtube.com) feed
2. Formatting should be unchanged in web view but newlines should now appear properly in RSS readers such as NetNewsWire
