### PR TITLE
Improved: headlines font-sizes

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -122,6 +122,12 @@ h3 {
 	line-height: 1.5;
 }
 
+h4,
+h5,
+h6 {
+	font-size: 1em;
+}
+
 .title_hidden {
 	display: none;
 }

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -122,6 +122,12 @@ h3 {
 	line-height: 1.5;
 }
 
+h4,
+h5,
+h6 {
+	font-size: 1em;
+}
+
 .title_hidden {
 	display: none;
 }


### PR DESCRIPTION
Headlines should be never smaller than the text.

Before:
h1, h2, h3 have a font-size > 1rem
h4,h5,h6: depends on the theme (they to not care about it) and the browser defaults, that makes the font very small.

After:
h1, h2, h3 have a font-size > 1rem
h4, h5, h6: 1em (not rem!)

Changes proposed in this pull request:

- frss.css

How to test the feature manually:

have an article, that has h4, h5, h6 headlines

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).