### PR TITLE
Improve filtering of Cron env variables

### DIFF
--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -34,7 +34,7 @@ if [ -n "$OIDC_ENABLED" ] && [ "$OIDC_ENABLED" -ne 0 ]; then
 fi
 
 if [ -n "$CRON_MIN" ]; then
-	awk -v RS='\0' '!/^(HOME|PATH|PWD|SHLVL|TERM|_)/ {gsub("\047", "\047\\\047\047"); print "export \047" $0 "\047"}' /proc/self/environ >/var/www/FreshRSS/Docker/env.txt
+	awk -v RS='\0' '!/^(FRESHRSS_INSTALL|FRESHRSS_USER|HOME|PATH|PWD|SHLVL|TERM|_)=/ {gsub("\047", "\047\\\047\047"); print "export \047" $0 "\047"}' /proc/self/environ >/var/www/FreshRSS/Docker/env.txt
 	sed </etc/crontab.freshrss.default \
 		-r "s#^[^ ]+ #$CRON_MIN #" | crontab -
 fi


### PR DESCRIPTION
Avoid keeping environment variables used for init.
Improvement of https://github.com/FreshRSS/FreshRSS/pull/5795
Spotted when checking https://github.com/FreshRSS/FreshRSS/issues/5894
