### PR TITLE
Fix font priority for languages using Han characters

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -107,6 +107,7 @@ People are sorted by name so please keep this order.
 * [Julien-Pierre Avérous](https://github.com/javerous): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:javerous), [Web](https://www.sourcemac.com/)
 * [Justin Tracey](https://github.com/jtracey): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:jtracey), [Web](https://unsuspicious.click)
 * [Kaibin Yang](https://github.com/SkyYkb): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:SkyYkb), [Web](https://kaibinyang.com/)
+* [Kasimir Cash](https://github.com/KasimirCash): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:KasimirCash)
 * [Kevin Papst](https://github.com/kevinpapst): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:kevinpapst), [Web](http://www.kevinpapst.de/)
 * [Kiblyn11](https://github.com/Kiblyn11): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Kiblyn11)
 * [kinoushe](https://github.com/kinoushe): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:kinoushe)

--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -49,7 +49,7 @@
 html, body {
 	background-color: var(--background-color-dark);
 	color: var(--font-color-middle);
-	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
+	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif;
 }
 
 /*=== Links */

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -49,7 +49,7 @@
 html, body {
 	background-color: var(--background-color-dark);
 	color: var(--font-color-middle);
-	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
+	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif;
 }
 
 /*=== Links */

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -5,7 +5,7 @@
 html, body {
 	background: #fafafa;
 	color: black;
-	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
+	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif;
 }
 
 /*=== Links */

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -5,7 +5,7 @@
 html, body {
 	background: #fafafa;
 	color: black;
-	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
+	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif;
 }
 
 /*=== Links */

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -84,7 +84,7 @@
 html, body {
 	background-color: var(--background-color-light);
 	color: var(--font-color);
-	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
+	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif;
 }
 
 /*=== Links */

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -84,7 +84,7 @@
 html, body {
 	background-color: var(--background-color-light);
 	color: var(--font-color);
-	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
+	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif;
 }
 
 /*=== Links */

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -90,7 +90,7 @@
 html, body {
 	background-color: var(--background-color-grey-light);
 	color: var(--font-color-grey);
-	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
+	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif;
 }
 
 /*=== Links */

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -90,7 +90,7 @@
 html, body {
 	background-color: var(--background-color-grey-light);
 	color: var(--font-color-grey);
-	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
+	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif;
 }
 
 /*=== Links */

--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -7,7 +7,7 @@
 html, body {
 	height: 100%;
 	color: black;
-	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
+	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif;
 }
 
 /*=== Links */

--- a/p/themes/base-theme/base.rtl.css
+++ b/p/themes/base-theme/base.rtl.css
@@ -7,7 +7,7 @@
 html, body {
 	height: 100%;
 	color: black;
-	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", "PingFang SC", "Microsoft YaHei", sans-serif;
+	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif;
 }
 
 /*=== Links */


### PR DESCRIPTION
Closes #5670

# Changes proposed in this pull request:

The presence of the simplified Chinese fonts 'PingFang SC' and 'Microsoft YaHei' in several theme's font-family lists means that if they are installed on a users system they will be favoured over other fonts for displaying text in other languages that use 'Han characters' such as Japanese and traditional Chinese leading to broken text in those languages.

By removing 'PingFang SC' and 'Microsoft YaHei' from the font-family list of these themes we allow the browser to use the HTML lang attribute to display text in a font that is correct for the language if one is present on the users system.

We now simply leverage browser behaviour to provide a much fuller and more robust check for default language fonts.


# How to test the feature manually:

1. Enter Display page of Configuration.
![image](https://github.com/FreshRSS/FreshRSS/assets/59581846/5a8a0176-7a91-4700-a63b-9d9780a580cf)

2. From language menu select '日本語' then click submit button to display Japanese.
![image](https://github.com/FreshRSS/FreshRSS/assets/59581846/3b0238fe-accf-4008-94b0-5d6967a4e9fd)

3. From language menu select '简体中文' then click submit button to display simplified Chinese.
![image](https://github.com/FreshRSS/FreshRSS/assets/59581846/7db74b0f-4f88-4df7-956d-fac7a8f85123)

4. From language menu select '正體中文' then click submit button to display traditional Chinese.
![image](https://github.com/FreshRSS/FreshRSS/assets/59581846/0a070f57-0efa-435e-9bcb-97d76f74db59)


# Pull request checklist:

- [X] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [X] documentation updated
