### PR TITLE
Remove variable default_category

### DIFF
--- a/app/Controllers/statsController.php
+++ b/app/Controllers/statsController.php
@@ -34,7 +34,6 @@ class FreshRSS_stats_Controller extends FreshRSS_ActionController {
 		$catDAO = FreshRSS_Factory::createCategoryDao();
 		$catDAO->checkDefault();
 		$this->view->categories = $catDAO->listSortedCategories(false) ?: [];
-		$this->view->default_category = $catDAO->getDefault();
 
 		FreshRSS_View::prependTitle(_t('admin.stats.title') . ' · ');
 	}

--- a/app/Controllers/subscriptionController.php
+++ b/app/Controllers/subscriptionController.php
@@ -18,7 +18,6 @@ class FreshRSS_subscription_Controller extends FreshRSS_ActionController {
 		$catDAO = FreshRSS_Factory::createCategoryDao();
 		$catDAO->checkDefault();
 		$this->view->categories = $catDAO->listSortedCategories(false, true) ?: [];
-		$this->view->default_category = $catDAO->getDefault();
 
 		$signalError = false;
 		foreach ($this->view->categories as $cat) {

--- a/app/Models/View.php
+++ b/app/Models/View.php
@@ -32,7 +32,6 @@ class FreshRSS_View extends Minz_View {
 	public bool $excludeMutedFeeds;
 
 	// Substriptions
-	public ?FreshRSS_Category $default_category;
 	public bool $displaySlider = false;
 	public bool $load_ok;
 	public bool $onlyFeedsWithError;

--- a/app/Models/ViewStats.php
+++ b/app/Models/ViewStats.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 final class FreshRSS_ViewStats extends FreshRSS_View {
 
-	public ?FreshRSS_Category $default_category;
 	/** @var array<FreshRSS_Category> */
 	public array $categories;
 	public ?FreshRSS_Feed $feed;

--- a/app/Services/ImportService.php
+++ b/app/Services/ImportService.php
@@ -50,7 +50,7 @@ class FreshRSS_Import_Service {
 
 		$this->catDAO->checkDefault();
 		$default_category = $this->catDAO->getDefault();
-		if (!$default_category) {
+		if ($default_category === null) {
 			self::log('Cannot get the default category');
 			$this->lastStatus = false;
 			return;

--- a/app/views/helpers/category/update.phtml
+++ b/app/views/helpers/category/update.phtml
@@ -195,7 +195,7 @@
 
 		<?php if (!$this->category->isDefault()): ?>
 		<p class="alert alert-warn">
-			<?= _t('sub.feed.moved_category_deleted', $this->default_category->name()) ?>
+			<?= _t('sub.feed.moved_category_deleted', _t('gen.short.default_category')) ?>
 		</p>
 		<?php endif;?>
 		<div class="form-group form-actions">


### PR DESCRIPTION
Not really used, and causing bug in https://github.com/FreshRSS/FreshRSS/pull/5942

```
Fatal error: Uncaught Error: Typed property FreshRSS_View::$default_category must not be accessed before initialization in /var/www/FreshRSS/app/views/helpers/category/update.phtml:218
Stack trace:
#0 /var/www/FreshRSS/lib/Minz/View.php(93): include()
#1 /var/www/FreshRSS/lib/Minz/View.php(143): Minz_View->includeFile()
#2 /var/www/FreshRSS/app/views/category/update.phtml(9): Minz_View->renderHelper()
#3 /var/www/FreshRSS/lib/Minz/View.php(93): include('...')
#4 /var/www/FreshRSS/lib/Minz/View.php(115): Minz_View->includeFile()
#5 /var/www/FreshRSS/lib/Minz/View.php(75): Minz_View->render()
#6 /var/www/FreshRSS/lib/Minz/Dispatcher.php(59): Minz_View->build()
#7 /var/www/FreshRSS/lib/Minz/FrontController.php(61): Minz_Dispatcher->run()
#8 /var/www/FreshRSS/p/i/index.php(59): Minz_FrontController->run()
#9 {main} thrown in /var/www/FreshRSS/app/views/helpers/category/update.phtml on line 218
```
