### PR TITLE
Fix notifications

### DIFF
--- a/app/Controllers/authController.php
+++ b/app/Controllers/authController.php
@@ -182,7 +182,6 @@ class FreshRSS_auth_Controller extends FreshRSS_ActionController {
 				Minz_Request::good(_t('feedback.auth.login.success'), $url);
 			} else {
 				Minz_Log::warning("Password mismatch for user={$username}, nonce={$nonce}, c={$challenge}");
-
 				header('HTTP/1.1 403 Forbidden');
 				Minz_Session::_param('POST_to_GET', true);	//Prevent infinite internal redirect
 				Minz_Request::setBadNotification(_t('feedback.auth.login.invalid'));

--- a/app/FreshRSS.php
+++ b/app/FreshRSS.php
@@ -16,7 +16,6 @@ class FreshRSS extends Minz_FrontController {
 	 * - Init i18n (need context)
 	 * - Init sharing system (need user conf and i18n)
 	 * - Init generic styles and scripts (need user conf)
-	 * - Init notifications
 	 * - Enable user extensions (need all the other initializations)
 	 */
 	public function init(): void {
@@ -58,7 +57,6 @@ class FreshRSS extends Minz_FrontController {
 
 		// Complete initialization of the other FreshRSS / Minz components.
 		self::initI18n();
-		self::loadNotifications();
 		// Enable extensions for the current (logged) user.
 		if (FreshRSS_Auth::hasAccess() || FreshRSS_Context::systemConf()->allow_anonymous) {
 			$ext_list = FreshRSS_Context::userConf()->extensions_enabled;
@@ -149,13 +147,6 @@ class FreshRSS extends Minz_FrontController {
 			FreshRSS_View::prependScript(Minz_Url::display('/scripts/extra.js?' . @filemtime(PUBLIC_PATH . '/scripts/extra.js')));
 		}
 		FreshRSS_View::prependScript(Minz_Url::display('/scripts/main.js?' . @filemtime(PUBLIC_PATH . '/scripts/main.js')));
-	}
-
-	private static function loadNotifications(): void {
-		$notif = Minz_Request::getNotification();
-		if (!empty($notif)) {
-			FreshRSS_View::_param('notification', $notif);
-		}
 	}
 
 	public static function preLayout(): void {

--- a/app/Models/View.php
+++ b/app/Models/View.php
@@ -27,8 +27,6 @@ class FreshRSS_View extends Minz_View {
 	public array $tagsForEntry;
 	/** @var array<string,array<string>> */
 	public array $tagsForEntries;
-	/** @var array<string,string> */
-	public array $notification;
 	public bool $excludeMutedFeeds;
 
 	// Substriptions

--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -77,10 +77,10 @@ if (_t('gen.dir') === 'rtl') {
 <?php
 	$msg = '';
 	$status = 'closed';
-	if (!empty($this->notification)) {
-		$msg = $this->notification['content'];
-		$status = $this->notification['type'];
-
+	$notif = Minz_Request::getNotification();
+	if (!empty($notif)) {
+		$msg = $notif['content'];
+		$status = $notif['type'];
 		invalidateHttpCache();
 	}
 ?>

--- a/app/layout/simple.phtml
+++ b/app/layout/simple.phtml
@@ -59,9 +59,10 @@
 <?php
 	$msg = '';
 	$status = 'closed';
-	if (!empty($this->notification)) {
-		$msg = $this->notification['content'];
-		$status = $this->notification['type'];
+	$notif = Minz_Request::getNotification();
+	if (!empty($notif)) {
+		$msg = $notif['content'];
+		$status = $notif['type'];
 		invalidateHttpCache();
 	}
 ?>

--- a/lib/Minz/Request.php
+++ b/lib/Minz/Request.php
@@ -352,8 +352,11 @@ class Minz_Request {
 		self::setNotification('bad', $content);
 	}
 
-	/** @return array{type:string,content:string}|null */
-	public static function getNotification(): ?array {
+	/**
+	 * @param $pop true (default) to remove the notification, false to keep it.
+	 * @return array{type:string,content:string}|null
+	 */
+	public static function getNotification(bool $pop = true): ?array {
 		$notif = null;
 		Minz_Session::lock();
 		/** @var array<string,array{time:int,notification:array{type:string,content:string}}> */
@@ -365,7 +368,9 @@ class Minz_Request {
 			$requestId = self::requestId();
 			if (!empty($requests[$requestId]['notification'])) {
 				$notif = $requests[$requestId]['notification'];
-				unset($requests[$requestId]);
+				if ($pop) {
+					unset($requests[$requestId]);
+				}
 			}
 			Minz_Session::_param('requests', $requests);
 		}


### PR DESCRIPTION
The notification about wrong login was not working. Noticed while working on https://github.com/FreshRSS/FreshRSS/pull/5955
This was due to timing of when the notification is retrieved.
Simplified code to make the logic easier and more robust.
