### PR TITLE
fix: `base_url` becomes empty after saving configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 	* Fix crash regression when enabling extensions [#5979](https://github.com/FreshRSS/FreshRSS/pull/5979)
 	* Fix crash regression during export when using MySQL [#5988](https://github.com/FreshRSS/FreshRSS/pull/5988)
 	* More robust assignment of categories to feeds [#5986](https://github.com/FreshRSS/FreshRSS/pull/5986)
+	* Fix `base_url` being cleared when saving settings [#5992](https://github.com/FreshRSS/FreshRSS/pull/5992)
 * i18n
 	* Improve simplified Chinese [#5977](https://github.com/FreshRSS/FreshRSS/pull/5977)
 

--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -485,7 +485,6 @@ class FreshRSS_configure_Controller extends FreshRSS_ActionController {
 			FreshRSS_Context::systemConf()->title = Minz_Request::paramString('instance-name') ?: 'FreshRSS';
 			FreshRSS_Context::systemConf()->auto_update_url = Minz_Request::paramString('auto-update-url');
 			FreshRSS_Context::systemConf()->force_email_validation = Minz_Request::paramBoolean('force-email-validation');
-			FreshRSS_Context::systemConf()->base_url = Minz_Request::paramString('base-url') ?: FreshRSS_Context::$system_conf->base_url;
 			FreshRSS_Context::systemConf()->save();
 
 			invalidateHttpCache();

--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -485,7 +485,7 @@ class FreshRSS_configure_Controller extends FreshRSS_ActionController {
 			FreshRSS_Context::systemConf()->title = Minz_Request::paramString('instance-name') ?: 'FreshRSS';
 			FreshRSS_Context::systemConf()->auto_update_url = Minz_Request::paramString('auto-update-url');
 			FreshRSS_Context::systemConf()->force_email_validation = Minz_Request::paramBoolean('force-email-validation');
-			FreshRSS_Context::systemConf()->base_url = Minz_Request::paramString('base-url');
+			FreshRSS_Context::systemConf()->base_url = Minz_Request::paramString('base-url') ?: FreshRSS_Context::$system_conf->base_url;
 			FreshRSS_Context::systemConf()->save();
 
 			invalidateHttpCache();

--- a/app/views/configure/system.phtml
+++ b/app/views/configure/system.phtml
@@ -25,7 +25,7 @@
 			<label class="group-name" for="base-url"><?= _t('admin.system.base-url') ?></label>
 			<div class="group-controls">
 				<input type="text" id="base-url" name="base-url" value="<?= FreshRSS_Context::systemConf()->base_url ?>"
-					data-leave-validation="<?= FreshRSS_Context::systemConf()->base_url ?>" disabled="disabled" />
+					data-leave-validation="<?= FreshRSS_Context::systemConf()->base_url ?>" readonly="readonly" />
 					<p class="help"><?= _i('help') ?> <?= _t('admin.system.base-url.recommendation', dirname(Minz_Request::guessBaseUrl())) ?></p>
 					<p class="help"><?= _i('help') ?> <?= _t('admin.system.sensitive-parameter') ?></p>
 			</div>
@@ -34,7 +34,7 @@
 		<div class="form-group">
 			<label class="group-name" for="websub"><?= _t('sub.feed.websub') ?></label>
 			<div class="group-controls">
-				<input type="checkbox" id="websub" name="websub" disabled="disabled" <?=
+				<input type="checkbox" id="websub" name="websub" readonly="readonly" <?=
 					FreshRSS_Context::systemConf()->pubsubhubbub_enabled && Minz_Request::serverIsPublic(FreshRSS_Context::systemConf()->base_url) ? 'checked="checked"' : '' ?> />
 					<p class="help"><?= _i('help') ?> <?= _t('admin.system.websub.help') ?></p>
 					<p class="help"><?= _i('help') ?> <?= _t('admin.system.sensitive-parameter') ?></p>

--- a/app/views/configure/system.phtml
+++ b/app/views/configure/system.phtml
@@ -34,7 +34,7 @@
 		<div class="form-group">
 			<label class="group-name" for="websub"><?= _t('sub.feed.websub') ?></label>
 			<div class="group-controls">
-				<input type="checkbox" id="websub" name="websub" readonly="readonly" <?=
+				<input type="checkbox" id="websub" name="websub" disabled="disabled" <?=
 					FreshRSS_Context::systemConf()->pubsubhubbub_enabled && Minz_Request::serverIsPublic(FreshRSS_Context::systemConf()->base_url) ? 'checked="checked"' : '' ?> />
 					<p class="help"><?= _i('help') ?> <?= _t('admin.system.websub.help') ?></p>
 					<p class="help"><?= _i('help') ?> <?= _t('admin.system.sensitive-parameter') ?></p>


### PR DESCRIPTION
Changes proposed in this pull request:

Since #5657 sets the base URL input box to `disabled="disabled"`, the browser will not send the `base-url` parameter. As a result, when the submit button is clicked, the base URL will be cleared.

How to test the feature manually:

before:

https://github.com/FreshRSS/FreshRSS/assets/30341059/a9760aca-8742-4668-9f43-9ac0fc72dbe8

fixed:

https://github.com/FreshRSS/FreshRSS/assets/30341059/70e1f3f2-d1de-402f-b40f-f40634311f62


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated


