### PR TITLE
Docker Debian disable unused PHP modules

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -36,6 +36,7 @@ LABEL \
 
 RUN a2dismod -q -f alias autoindex negotiation status && \
 	a2dismod -q auth_openidc && \
+	phpdismod calendar exif ffi ftp gettext mysqli posix readline shmop sockets sysvmsg sysvsem sysvshm xsl && \
 	a2enmod -q deflate expires headers mime remoteip setenvif && \
 	a2disconf -q '*' && \
 	a2dissite -q '*' && \


### PR DESCRIPTION
Debian has several PHP modules enabled by default, which we do not use.
Aligns Debian image with the PHP modules of the Alpine image

fix https://github.com/FreshRSS/FreshRSS/issues/5993
