### PR TITLE
API allow negative feed IDs

### DIFF
--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -419,7 +419,7 @@ final class GReaderAPI {
 			if (strpos($streamUrl, 'feed/') === 0) {
 				$streamUrl = '' . preg_replace('%^(feed/)+%', '', $streamUrl);
 				$feedId = 0;
-				if (ctype_digit($streamUrl)) {
+				if (is_numeric($streamUrl)) {
 					if ($action === 'subscribe') {
 						continue;
 					}
@@ -592,11 +592,11 @@ final class GReaderAPI {
 		string $filter_target, string $exclude_target, int $start_time, int $stop_time): array {
 		switch ($type) {
 			case 'f':	//feed
-				if ($streamId != '' && is_string($streamId) && !ctype_digit($streamId)) {
+				if ($streamId != '' && is_string($streamId) && !is_numeric($streamId)) {
 					$feedDAO = FreshRSS_Factory::createFeedDao();
 					$streamId = htmlspecialchars($streamId, ENT_COMPAT, 'UTF-8');
 					$feed = $feedDAO->searchByUrl($streamId);
-					$streamId = $feed == null ? -1 : $feed->id();
+					$streamId = $feed == null ? 0 : $feed->id();
 				}
 				break;
 			case 'c':	//category or label
@@ -946,7 +946,7 @@ final class GReaderAPI {
 		$entryDAO = FreshRSS_Factory::createEntryDao();
 		if (strpos($streamId, 'feed/') === 0) {
 			$f_id = basename($streamId);
-			if (!ctype_digit($f_id)) {
+			if (!is_numeric($f_id)) {
 				self::badRequest();
 			}
 			$f_id = (int)$f_id;
@@ -1068,7 +1068,7 @@ final class GReaderAPI {
 						if (isset($pathInfos[6]) && isset($pathInfos[7])) {
 							if ($pathInfos[6] === 'feed') {
 								$include_target = $pathInfos[7];
-								if ($include_target != '' && !ctype_digit($include_target)) {
+								if ($include_target != '' && !is_numeric($include_target)) {
 									$include_target = empty($_SERVER['REQUEST_URI']) ? '' : $_SERVER['REQUEST_URI'];
 									if (preg_match('#/reader/api/0/stream/contents/feed/([A-Za-z0-9\'!*()%$_.~+-]+)#', $include_target, $matches) === 1) {
 										$include_target = urldecode($matches[1]);


### PR DESCRIPTION
For future features (e.g. save articles by URL, save a manual note, ...), it would be good to allow special feeds, and to use negative integers for that. The rest of FreshRSS seems to be already ready, and there was only the Google Reader API, which required positive integers for feed IDs.
I quickly tested apps such as News+, EasyRSS, Rreadrops, which seem fine with that, but help welcome to test compatibility more thoroughly.
