### PR TITLE
Sanitize parsing list of extensions

### DIFF
--- a/app/Controllers/extensionController.php
+++ b/app/Controllers/extensionController.php
@@ -39,7 +39,7 @@ class FreshRSS_extension_Controller extends FreshRSS_ActionController {
 
 	/**
 	 * fetch extension list from GitHub
-	 * @return array<string,array{'name':string,'author':string,'description':string,'version':string,'entrypoint':string,'type':'system'|'user','url':string,'method':string,'directory':string}>
+	 * @return array<array{'name':string,'author':string,'description':string,'version':string,'entrypoint':string,'type':'system'|'user','url':string,'method':string,'directory':string}>
 	 */
 	protected function getAvailableExtensionList(): array {
 		$extensionListUrl = 'https://raw.githubusercontent.com/FreshRSS/Extensions/master/extensions.json';
@@ -54,7 +54,7 @@ class FreshRSS_extension_Controller extends FreshRSS_ActionController {
 		// fetch the list as an array
 		/** @var array<string,mixed> $list*/
 		$list = json_decode($json, true);
-		if (empty($list) || !is_array($list)) {
+		if (!is_array($list) || empty($list['extensions']) || !is_array($list['extensions'])) {
 			Minz_Log::warning('Failed to convert extension file list');
 			return [];
 		}
@@ -62,9 +62,21 @@ class FreshRSS_extension_Controller extends FreshRSS_ActionController {
 		// By now, all the needed data is kept in the main extension file.
 		// In the future we could fetch detail information from the extensions metadata.json, but I tend to stick with
 		// the current implementation for now, unless it becomes too much effort maintain the extension list manually
-		/** @var array<string,array{'name':string,'author':string,'description':string,'version':string,'entrypoint':string,'type':'system'|'user','url':string,'method':string,'directory':string}> $extensions*/
-		$extensions = $list['extensions'];
-
+		$extensions = [];
+		foreach ($list['extensions'] as $extension) {
+			if (isset($extension['version']) && is_numeric($extension['version'])) {
+				$extension['version'] = (string)$extension['version'];
+			}
+			foreach (['author', 'description', 'directory', 'entrypoint', 'method', 'name', 'type', 'url', 'version'] as $key) {
+				if (empty($extension[$key]) || !is_string($extension[$key])) {
+					continue 2;
+				}
+			}
+			if (!in_array($extension['type'], ['system', 'user'], true)) {
+				continue;
+			}
+			$extensions[] = $extension;
+		}
 		return $extensions;
 	}
 

--- a/app/Models/View.php
+++ b/app/Models/View.php
@@ -110,7 +110,7 @@ class FreshRSS_View extends Minz_View {
 	public bool $selectorSuccess;
 
 	// Extensions
-	/** @var array<string,array{'name':string,'author':string,'description':string,'version':string,'entrypoint':string,'type':'system'|'user','url':string,'method':string,'directory':string}> */
+	/** @var array<array{'name':string,'author':string,'description':string,'version':string,'entrypoint':string,'type':'system'|'user','url':string,'method':string,'directory':string}> */
 	public array $available_extensions;
 	public ?Minz_Extension $ext_details;
 	/** @var array{'system':array<Minz_Extension>,'user':array<Minz_Extension>} */


### PR DESCRIPTION
Extensions declaring their version as float (which cannot be compared in a semver manner) instead of the expected string would cause a crash (regression from https://github.com/FreshRSS/FreshRSS/pull/5830)
fix https://github.com/FreshRSS/FreshRSS/issues/6015
