### PR TITLE
Fix manipulate.translation ignore behaviour

### DIFF
--- a/cli/i18n/I18nData.php
+++ b/cli/i18n/I18nData.php
@@ -288,27 +288,27 @@ class I18nData {
 	}
 
 	/**
-	 * Ignore a key from a language, or reverse it.
+	 * Ignore a key from a language, or revert an existing ignore on a key.
 	 */
-	public function ignore(string $key, string $language, bool $reverse = false): void {
+	public function ignore(string $key, string $language, bool $revert = false): void {
 		$value = $this->data[$language][$this->getFilenamePrefix($key)][$key];
-		if ($reverse) {
-			$value->markAsIgnore();
-		} else {
+		if ($revert) {
 			$value->unmarkAsIgnore();
+		} else {
+			$value->markAsIgnore();
 		}
 	}
 
 	/**
-	 * Ignore all unmodified keys from a language, or reverse it.
+	 * Ignore all unmodified keys from a language, or revert all existing ignores on unmodified keys.
 	 */
-	public function ignore_unmodified(string $language, bool $reverse = false): void {
+	public function ignore_unmodified(string $language, bool $revert = false): void {
 		$my_language = $this->getLanguage($language);
 		foreach ($this->getReferenceLanguage() as $file => $ref_language) {
 			foreach ($ref_language as $key => $ref_value) {
 				if (array_key_exists($key, $my_language[$file])) {
 					if ($ref_value->equal($my_language[$file][$key])) {
-						$this->ignore($key, $language, $reverse);
+						$this->ignore($key, $language, $revert);
 					}
 				}
 			}

--- a/tests/cli/i18n/I18nDataTest.php
+++ b/tests/cli/i18n/I18nDataTest.php
@@ -679,9 +679,9 @@ class I18nDataTest extends PHPUnit\Framework\TestCase {
 		$value = $this->getMockBuilder(I18nValue::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$value->expects(self::exactly(2))
-			->method('unmarkAsIgnore');
 		$value->expects(self::once())
+			->method('unmarkAsIgnore');
+		$value->expects(self::exactly(2))
 			->method('markAsIgnore');
 
 		$rawData = array_merge($this->referenceData, [
@@ -701,9 +701,9 @@ class I18nDataTest extends PHPUnit\Framework\TestCase {
 		$value = $this->getMockBuilder(I18nValue::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$value->expects(self::exactly(2))
+		$value->expects(self::once())
 			->method('unmarkAsIgnore');
-			$value->expects(self::once())
+			$value->expects(self::exactly(2))
 			->method('markAsIgnore');
 
 		$this->value->expects(self::atLeast(2))


### PR DESCRIPTION
# Changes proposed in this pull request:
When using `cli/manipulate.translation.php` we would expect that `cli/manipulate.translation.php -a ignore -l en -k install.auth.form` would add an ignore note to the key `install.auth.form` and that `cli/manipulate.translation.php -a ignore -l en -k install.auth.form -r` would remove the ignore note from `install.auth.form`. Instead, this behaviour is reversed. This same reversed behaviour is present when using `-a ignore_unmodified` with `cli/manipulate.translation` as well.

This fix gives us the behaviour from `cli/manipulate.translation.php` that we would expect e.g. the reverse of current behaviour.

I've also modified the tests for `ignore` and `ignore_unmodified` in I18nDataTest.php as they were checking for the incorrect output.

# How to test the feature manually:

1. Use `cli/manipulate.translation.php -a ignore -l en -k install.auth.form` to ignore a key.

2. Check the translation file (in this case `FreshRSS/app/i18n/en/install.php`) to confirm the key is ignored.
![image](https://github.com/FreshRSS/FreshRSS/assets/59581846/569b5a07-4d64-46af-b0c0-7450d2a018a3)

3. Use `cli/manipulate.translation.php -a ignore -l en -k install.auth.form -r` to remove the ignore note.

4. Confirm the key has been unignored.
![image](https://github.com/FreshRSS/FreshRSS/assets/59581846/12b84841-b879-4182-b038-de01557502b5)

# Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written
