### PR TITLE
Fix: left hand side navigation of TOS item when selected

### DIFF
--- a/app/layout/aside_configure.phtml
+++ b/app/layout/aside_configure.phtml
@@ -88,7 +88,7 @@
 					<a href="<?= _url('index', 'about') ?>"><?= _t('gen.menu.about') ?></a>
 				</li>
 				<?php if (file_exists(TOS_FILENAME)) { ?>
-					<li class="item">
+					<li class="item<?= Minz_Request::actionName() === 'tos' ? ' active' : '' ?>">
 						<a href="<?= _url('index', 'tos') ?>"><?= _t('index.tos.title')?></a>
 					</li>
 				<?php } ?>


### PR DESCRIPTION
When TOS (Terms of Service) is set and opened in the admin configs:

Before:
(nav menu item is not highlighted)
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/ae5c6913-7bab-4262-a382-df8eae3b399d)

After:
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/11fdd597-5819-4f4c-8e84-6323ffc7e861)
