### PR TITLE
Fix: Favicon with protocol-relative URLs have duplicate slashes.

### DIFF
--- a/lib/favicons.php
+++ b/lib/favicons.php
@@ -92,7 +92,7 @@ function searchFavicon(string &$url): string {
 
 		// Handle protocol-relative URLs by adding the current URL's scheme
 		if (substr($href, 0, 2) === '//') {
-			$href = ($urlParts['scheme'] ?? 'https') . '://' . $href;
+			$href = ($urlParts['scheme'] ?? 'https') . ':' . $href;
 		}
 
 		$href = SimplePie_IRI::absolutize($baseUrl, $href);


### PR DESCRIPTION
The URL of favicons with protocol-relative URL's already start with "//" so by adding it again it will result in "http:////url" and the icon will never be retrieved.