### PR TITLE
Improve the padding of the notification banner

### DIFF
--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -888,7 +888,6 @@ li.item.active {
 
 /*=== Notification and actualize notification */
 .notification {
-	padding: 1rem 3rem 1rem 1rem;
 	background: var(--dropdown-bg);
 	color: var(--text-default);
 	font-size: 0.9rem;

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -888,7 +888,6 @@ li.item.active {
 
 /*=== Notification and actualize notification */
 .notification {
-	padding: 1rem 1rem 1rem 3rem;
 	background: var(--dropdown-bg);
 	color: var(--text-default);
 	font-size: 0.9rem;

--- a/p/themes/Origine-compact/origine-compact.css
+++ b/p/themes/Origine-compact/origine-compact.css
@@ -130,6 +130,9 @@
 
 /*=== Content of feed articles */
 /*=== Notification and actualize notification */
+.notification {
+	padding: 0.5rem 3rem 0.5rem 0.5rem;
+}
 /*=== "Load more" part */
 #bigMarkAsRead {
 	font-size: 1.2em;

--- a/p/themes/Origine-compact/origine-compact.rtl.css
+++ b/p/themes/Origine-compact/origine-compact.rtl.css
@@ -130,6 +130,9 @@
 
 /*=== Content of feed articles */
 /*=== Notification and actualize notification */
+.notification {
+	padding: 0.5rem 0.5rem 0.5rem 3rem;
+}
 /*=== "Load more" part */
 #bigMarkAsRead {
 	font-size: 1.2em;

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1495,7 +1495,7 @@ a.website:hover .favicon {
 
 /*=== Notification and actualize notification */
 .notification {
-	padding: 0.75rem 3.5rem 0.75rem 0.75rem;
+	padding: 1rem 3.5rem 1rem 1rem;
 	position: absolute;
 	top: 1rem;
 	left: 25%; right: 25%;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1495,7 +1495,7 @@ a.website:hover .favicon {
 
 /*=== Notification and actualize notification */
 .notification {
-	padding: 0.75rem 0.75rem 0.75rem 3.5rem;
+	padding: 1rem 1rem 1rem 3.5rem;
 	position: absolute;
 	top: 1rem;
 	right: 25%; left: 25%;


### PR DESCRIPTION
Changes proposed in this pull request:

- CSS


How to test the feature manually:

1. test it on a wide screen and on a mobile device screen
2. create a notification (f.e. press a save button or the mark read button)
3. see the notification banner

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
