### PR TITLE
Fix Japanese translation

### DIFF
--- a/app/i18n/ja/sub.php
+++ b/app/i18n/ja/sub.php
@@ -228,7 +228,7 @@ return array(
 		'title' => 'インポート / エクスポート',
 	),
 	'menu' => array(
-		'add' => 'フィード化カテゴリを追加します',
+		'add' => 'フィードあるいはカテゴリを追加します',
 		'import_export' => 'インポート / エクスポート',
 		'label_management' => 'ラベル管理',
 		'stats' => array(


### PR DESCRIPTION
Closes #6107

"Add feed or category" can mean the following in Japanese.

- フィードやカテゴリを追加する
- フィードまたはカテゴリを追加する
- フィードあるいはカテゴリを追加する

The expression `フィードあるいはカテゴリを追加する` is used in the immediate vicinity of the same file, so we have adapted it.

How to test the feature manually:

Sorry, not tested.

Pull request checklist:

- [x] clear commit messages
- [ ] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
