### PR TITLE
Improve feed refresh

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -809,9 +809,11 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 			if (!$entryDAO->inTransaction()) {
 				$entryDAO->beginTransaction();
 			}
-			if ($entryDAO->commitNewEntries() && $nbNewUnreadEntries > 0) {
-				self::keepMaxUnreads();
+			if ($entryDAO->commitNewEntries()) {
 				self::applyLabelActions($nbNewEntries);
+				if ($nbNewUnreadEntries > 0) {
+					self::keepMaxUnreads();
+				}
 			}
 			if ($entryDAO->inTransaction()) {
 				$entryDAO->commit();

--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -844,6 +844,12 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 			self::commitNewEntries();
 		} else {
 			if ($id === 0 && $url === '') {
+				// Case of a batch refresh (e.g. cron)
+				$databaseDAO = FreshRSS_Factory::createDatabaseDAO();
+				$databaseDAO->minorDbMaintenance();
+				Minz_ExtensionManager::callHookVoid('freshrss_user_maintenance');
+
+				FreshRSS_feed_Controller::commitNewEntries();
 				FreshRSS_category_Controller::refreshDynamicOpmls();
 			}
 			[$updated_feeds, $feed, $nbNewArticles] = self::actualizeFeeds($id, $url, $maxFeeds);

--- a/app/Controllers/javascriptController.php
+++ b/app/Controllers/javascriptController.php
@@ -20,6 +20,10 @@ class FreshRSS_javascript_Controller extends FreshRSS_ActionController {
 		header('Content-Type: application/json; charset=UTF-8');
 		Minz_Session::_param('actualize_feeds', false);
 
+		$databaseDAO = FreshRSS_Factory::createDatabaseDAO();
+		$databaseDAO->minorDbMaintenance();
+		Minz_ExtensionManager::callHookVoid('freshrss_user_maintenance');
+
 		$catDAO = FreshRSS_Factory::createCategoryDao();
 		$this->view->categories = $catDAO->listCategoriesOrderUpdate(FreshRSS_Context::userConf()->dynamic_opml_ttl_default);
 

--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -274,7 +274,29 @@ SQL;
 	}
 
 	/**
-	 * Count the number of new entries in the temporary table (which have not yet been committed), grouped by feed ID.
+	 * Count the number of new entries in the temporary table (which have not yet been committed), grouped by read / unread.
+	 * @return array{'all':int,'unread':int,'read':int}
+	 */
+	public function countNewEntries(): array {
+		$sql = <<<'SQL'
+		SELECT is_read, COUNT(id) AS nb_entries FROM `_entrytmp`
+		GROUP BY is_read
+		SQL;
+		$lines = $this->fetchAssoc($sql) ?? [];
+		$nbRead = 0;
+		$nbUnread = 0;
+		foreach ($lines as $line) {
+			if (empty($line['is_read'])) {
+				$nbUnread = (int)($line['nb_entries'] ?? 0);
+			} else {
+				$nbRead = (int)($line['nb_entries'] ?? 0);
+			}
+		}
+		return ['all' => $nbRead + $nbUnread, 'unread' => $nbUnread, 'read' => $nbRead];
+	}
+
+	/**
+	 * Count the number of new unread entries in the temporary table (which have not yet been committed), grouped by feed ID.
 	 * @return array<int,int>
 	 */
 	public function newUnreadEntriesPerFeed(): array {

--- a/app/actualize_script.php
+++ b/app/actualize_script.php
@@ -103,6 +103,8 @@ foreach ($users as $user) {
 
 	notice('FreshRSS actualize ' . $user . '…');
 	echo $user, ' ';	//Buffered
+	$databaseDAO = FreshRSS_Factory::createDatabaseDAO();
+	$databaseDAO->minorDbMaintenance();
 	Minz_ExtensionManager::callHookVoid('freshrss_user_maintenance');
 	$app->run();
 

--- a/app/actualize_script.php
+++ b/app/actualize_script.php
@@ -103,9 +103,6 @@ foreach ($users as $user) {
 
 	notice('FreshRSS actualize ' . $user . '…');
 	echo $user, ' ';	//Buffered
-	$databaseDAO = FreshRSS_Factory::createDatabaseDAO();
-	$databaseDAO->minorDbMaintenance();
-	Minz_ExtensionManager::callHookVoid('freshrss_user_maintenance');
 	$app->run();
 
 	if (!invalidateHttpCache()) {

--- a/cli/actualize-user.php
+++ b/cli/actualize-user.php
@@ -20,11 +20,13 @@ if (!empty($options['invalid']) || empty($options['valid']['user']) || !is_strin
 }
 
 $username = cliInitUser($options['valid']['user']);
-
-Minz_ExtensionManager::callHookVoid('freshrss_user_maintenance');
-
 fwrite(STDERR, 'FreshRSS actualizing user “' . $username . "”…\n");
 
+$databaseDAO = FreshRSS_Factory::createDatabaseDAO();
+$databaseDAO->minorDbMaintenance();
+Minz_ExtensionManager::callHookVoid('freshrss_user_maintenance');
+
+FreshRSS_feed_Controller::commitNewEntries();
 $result = FreshRSS_category_Controller::refreshDynamicOpmls();
 if (!empty($result['errors'])) {
 	$errors = $result['errors'];


### PR DESCRIPTION
Better account for some edge cases for cron and automatic labels
fix https://github.com/FreshRSS/FreshRSS/issues/6089 (will start by committing entries from a previous aborted cron job, so that if the cron jobs are always aborted, new articles will still be coming, although with some delay)
fix https://github.com/FreshRSS/FreshRSS/issues/6109 (we might have had some counting issues when combined with automatically marking as read some articles)
