### PR TITLE
Fix: delete rss view shortcut

### DIFF
--- a/app/views/configure/shortcut.phtml
+++ b/app/views/configure/shortcut.phtml
@@ -55,14 +55,6 @@
 						data-leave-validation="<?= $s['reading_view'] ?>"/>
 				</div>
 			</div>
-
-			<div class="form-group">
-				<label class="group-name" for="rss_view_shortcut"><?= _t('conf.shortcut.rss_view') ?></label>
-				<div class="group-controls">
-					<input type="text" id="rss_view_shortcut" name="shortcuts[rss_view]" list="keys" value="<?= $s['rss_view'] ?>"
-						data-leave-validation="<?= $s['rss_view'] ?>"/>
-				</div>
-			</div>
 		</fieldset>
 
 		<fieldset>

--- a/config-user.default.php
+++ b/config-user.default.php
@@ -90,7 +90,6 @@ return array (
 		'normal_view' => '1',
 		'global_view' => '2',
 		'reading_view' => '3',
-		'rss_view' => '4',
 		'toggle_media' => 'v',
 	),
 

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1057,7 +1057,6 @@ function init_shortcuts() {
 		if (k === s.normal_view) { delayedClick(document.querySelector('#nav_menu_views .view-normal')); ev.preventDefault(); return; }
 		if (k === s.reading_view) { delayedClick(document.querySelector('#nav_menu_views .view-reader')); ev.preventDefault(); return; }
 		if (k === s.global_view) { delayedClick(document.querySelector('#nav_menu_views .view-global')); ev.preventDefault(); return; }
-		if (k === s.rss_view) { delayedClick(document.querySelector('#nav_menu_views .view-rss')); ev.preventDefault(); return; }
 		if (k === s.toggle_media) { toggle_media(); ev.preventDefault(); }
 	});
 }


### PR DESCRIPTION
Ref #6052

Changes proposed in this pull request:

- delete the shortcuts for rss view. The button was already removed with #6052


How to test the feature manually:

1. go to shortcuts config page
2. there is no entry for RSS view anymore


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
