### PR TITLE
Reduce API memory consumption

### DIFF
--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -715,8 +715,9 @@ final class GReaderAPI {
 				$response['continuation'] = '' . $entry->id();
 			}
 		}
-
-		echo json_encode($response, JSON_OPTIONS), "\n";
+		unset($entries, $entryDAO, $items);
+		gc_collect_cycles();
+		echoJson($response, 2);	// $optimisationDepth=2 as we are interested in being memory efficient for {"items":[...]}
 		exit();
 	}
 
@@ -805,8 +806,9 @@ final class GReaderAPI {
 			'updated' => time(),
 			'items' => $items,
 		);
-
-		echo json_encode($response, JSON_OPTIONS), "\n";
+		unset($entries, $entryDAO, $items);
+		gc_collect_cycles();
+		echoJson($response, 2);	// $optimisationDepth=2 as we are interested in being memory efficient for {"items":[...]}
 		exit();
 	}
 


### PR DESCRIPTION
`echo json_encode(...)` is very memory demanding for large responses, so optimised.
Contributes to https://github.com/FreshRSS/FreshRSS/issues/6136
https://github.com/FreshRSS/FreshRSS/pull/6013#discussion_r1506779881
