### PR TITLE
version_compare raise exception if param is not a string

### DIFF
--- a/app/views/extension/index.phtml
+++ b/app/views/extension/index.phtml
@@ -61,11 +61,11 @@
 						<td>
 							<?= $ext['description'] ?>
 							<?php if (isset($this->extensions_installed[$ext['name']])) { ?>
-								<?php if (version_compare($this->extensions_installed[$ext['name']], $ext['version']) >= 0) { ?>
+								<?php if (version_compare(strval($this->extensions_installed[$ext['name']]), strval($ext['version'])) >= 0) { ?>
 									<span class="alert alert-success">
 										<?= _t('admin.extensions.latest') ?>
 									</span>
-								<?php } elseif ($this->extensions_installed[$ext['name']] != $ext['version']) { ?>
+								<?php } elseif (strval($this->extensions_installed[$ext['name']]) != strval($ext['version'])) { ?>
 									<span class="alert alert-warn">
 										<?= _t('admin.extensions.update') ?>
 									</span>

--- a/app/views/extension/index.phtml
+++ b/app/views/extension/index.phtml
@@ -65,7 +65,7 @@
 									<span class="alert alert-success">
 										<?= _t('admin.extensions.latest') ?>
 									</span>
-								<?php } elseif (strval($this->extensions_installed[$ext['name']]) != strval($ext['version'])) { ?>
+								<?php } elseif (strval($this->extensions_installed[$ext['name']]) !== strval($ext['version'])) { ?>
 									<span class="alert alert-warn">
 										<?= _t('admin.extensions.update') ?>
 									</span>


### PR DESCRIPTION
In file "metadata.json" of extensions it's possible that the data of version is not a string. In this case the check of the version raises an exception. see [issue](https://github.com/cn-tools/cntools_FreshRssExtensions/issues/10)

Ex. [Auto-Refresh-Extension](https://github.com/Eisa01/FreshRSS---Auto-Refresh-Extension)

Maybe the file [generate.php](https://github.com/FreshRSS/Extensions/blob/master/generate.php) could fix this issue with additional line '$metadata['version'] = strval($metadata[' version']);' before line 58 instead of this PR.

Pull request checklist:

- [x] clear commit messages (i hope so)
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
