### PR TITLE
URL: queryID instead of ID

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -331,8 +331,8 @@ class FreshRSS_configure_Controller extends FreshRSS_ActionController {
 		$this->view->feeds = FreshRSS_Context::feeds();
 		$this->view->tags = FreshRSS_Context::labels();
 
-		if (Minz_Request::paramTernary('id') !== null) {
-			$id = Minz_Request::paramInt('id');
+		if (Minz_Request::paramTernary('queryId') !== null) {
+			$id = Minz_Request::paramInt('queryId');
 			$this->view->query = $this->view->queries[$id];
 			$this->view->queryId = $id;
 			$this->view->displaySlider = true;
@@ -353,8 +353,8 @@ class FreshRSS_configure_Controller extends FreshRSS_ActionController {
 			$this->view->_layout(null);
 		}
 
-		$id = Minz_Request::paramInt('id');
-		if (Minz_Request::paramTernary('id') === null || empty(FreshRSS_Context::userConf()->queries[$id])) {
+		$id = Minz_Request::paramInt('queryId');
+		if (Minz_Request::paramTernary('queryId') === null || empty(FreshRSS_Context::userConf()->queries[$id])) {
 			Minz_Error::error(404);
 			return;
 		}
@@ -404,7 +404,7 @@ class FreshRSS_configure_Controller extends FreshRSS_ActionController {
 			FreshRSS_Context::userConf()->queries = $queries;
 			FreshRSS_Context::userConf()->save();
 
-			Minz_Request::good(_t('feedback.conf.updated'), [ 'c' => 'configure', 'a' => 'queries', 'params' => ['id' => (string)$id] ]);
+			Minz_Request::good(_t('feedback.conf.updated'), [ 'c' => 'configure', 'a' => 'queries', 'params' => ['queryId' => (string)$id] ]);
 		}
 
 		FreshRSS_View::prependTitle($query->getName() . ' · ' . _t('conf.query.title') . ' · ');
@@ -414,8 +414,8 @@ class FreshRSS_configure_Controller extends FreshRSS_ActionController {
 	 * Handles query deletion
 	 */
 	public function deleteQueryAction(): void {
-		$id = Minz_Request::paramInt('id');
-		if (Minz_Request::paramTernary('id') === null || empty(FreshRSS_Context::userConf()->queries[$id])) {
+		$id = Minz_Request::paramInt('iqueryIdd');
+		if (Minz_Request::paramTernary('queryId') === null || empty(FreshRSS_Context::userConf()->queries[$id])) {
 			Minz_Error::error(404);
 			return;
 		}

--- a/app/views/configure/queries.phtml
+++ b/app/views/configure/queries.phtml
@@ -16,7 +16,7 @@
 		<div class="form-group" id="query-group-<?= $key ?>" draggable="true">
 			<div class="box">
 				<div class="box-title">
-					<a class="configure open-slider" href="<?= _url('configure', 'query', 'id', '' . $key) ?>"><?= _i('configure') ?></a><h2><?= $query->getName() ?></h2>
+					<a class="configure open-slider" href="<?= _url('configure', 'query', 'queryId', '' . $key) ?>"><?= _i('configure') ?></a><h2><?= $query->getName() ?></h2>
 					<input type="hidden" id="queries_<?= $key ?>_name" name="queries[<?= $key ?>][name]" value="<?= $query->getName() ?>"/>
 					<input type="hidden" id="queries_<?= $key ?>_token" name="queries[<?= $key ?>][token]" value="<?= $query->getToken() ?>"/>
 					<input type="hidden" id="queries_<?= $key ?>_shareRss" name="queries[<?= $key ?>][token]" value="<?= $query->shareRss() ?>"/>

--- a/app/views/helpers/configure/query.phtml
+++ b/app/views/helpers/configure/query.phtml
@@ -11,7 +11,7 @@
 		<a href="<?= $this->query->getUrl() ?>"><?= _i('link') ?> <?= _t('gen.action.filter') ?></a>
 	</div>
 
-	<form method="post" action="<?= _url('configure', 'query', 'id', $this->queryId, '#', 'slider') ?>" autocomplete="off">
+	<form method="post" action="<?= _url('configure', 'query', 'queryId', $this->queryId, '#', 'slider') ?>" autocomplete="off">
 		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
 
 		<div class="form-group">
@@ -133,7 +133,7 @@
 				<button type="submit" class="btn btn-important"><?= _t('gen.action.submit') ?></button>
 				<button type="submit" class="btn btn-attention confirm"
 					data-str-confirm="<?= _t('gen.js.confirm_action_feed_cat') ?>"
-					formaction="<?= _url('configure', 'deleteQuery', 'id', $this->queryId) ?>"
+					formaction="<?= _url('configure', 'deleteQuery', 'queryId', $this->queryId) ?>"
 					formmethod="post"><?= _t('gen.action.remove') ?></button>
 			</div>
 		</div>


### PR DESCRIPTION
I need some help.

While I worked on #6047 the view buttons (normal view, global view and reader view) will be displayed on every page, also on the configuration settings.

That situation creates a bug that is connected with the URL-parameters.

Step to follow the issue on the current `edge` branch:
- go to user query page
- open config of a user query
- click on save
- the URL will change: more parameters will be added, f.e. the `id` parameter

The view buttons (not in `edge` but in #6047, where them are global visible) will take all URL parameters. In this case: the `id` parameter is added to. When you click on the view button, the error will be shown: `Error 404 - Not found. You are looking for a page that doesn’t exist`

Screenshots made with #6047
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/07fd7bab-a0a4-4964-b1e5-503931ce81df)

![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/cc207c2a-2caf-46b5-9477-4d6ad2a548e3)

![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/1f6f9b36-0353-4459-8172-047798060004)

![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/42c0e798-bd32-40c4-aa59-22a7d4aeadab)

This PR here suggests a renaming of the `id` parameter of the user query configs. More renaming would be necessary.

Is there a better solution for `Minz_Url::display($mode->getUrlParams()` in:

```
foreach ($readingModes as $mode) {
				?>
				<a class="<?= $mode->getId() ?> btn <?php if ($mode->isActive()) { echo 'active'; } ?>" title="<?=
					$mode->getTitle() ?>" href="<?= Minz_Url::display($mode->getUrlParams()) ?>">
					<?= $mode->getName() ?>
				</a>
				<?php
			}
```


