### PR TITLE
Fix: Extension list: "installed" or "update available" message missed in some cases

### DIFF
--- a/app/views/extension/index.phtml
+++ b/app/views/extension/index.phtml
@@ -60,12 +60,12 @@
 						<td><?= $ext['author'] ?></td>
 						<td>
 							<?= $ext['description'] ?>
-							<?php if (isset($this->extensions_installed[$ext['name']])) { ?>
-								<?php if (version_compare(strval($this->extensions_installed[$ext['name']]), strval($ext['version'])) >= 0) { ?>
+							<?php if (isset($this->extensions_installed[$ext['entrypoint']])) { ?>
+								<?php if (version_compare(strval($this->extensions_installed[$ext['entrypoint']]), strval($ext['version'])) >= 0) { ?>
 									<span class="alert alert-success">
 										<?= _t('admin.extensions.latest') ?>
 									</span>
-								<?php } elseif (strval($this->extensions_installed[$ext['name']]) !== strval($ext['version'])) { ?>
+								<?php } elseif (strval($this->extensions_installed[$ext['entrypoint']]) !== strval($ext['version'])) { ?>
 									<span class="alert alert-warn">
 										<?= _t('admin.extensions.update') ?>
 									</span>


### PR DESCRIPTION
Bug description:

A bunch of extensions are installed
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/8effde23-9fc0-4620-b2fa-de2e82aa8fce)

But only a few extensions has the "installed" green box in the extensions list
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/b984f441-5c36-4ba1-aaca-92fa7658c780)
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/024654c9-65d0-4e39-b7dd-50da60caa63d)



After this fix:
"Installed" message box is available to each row of installed extension
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/4cf017b2-cdca-4de0-8373-cecbd42b5852)

What made the bug:
The bug appears only to extensions that have a space in the name (f.e. `ShowFeedID` does not have this issue, but `Custom CSS`).


How to test the feature manually:

1. go to the extension list
2. check the table below
3. installed/update available extensions have a message box

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
