### PR TITLE
Improved: Smoother scrolling while focussing articles

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -53,6 +53,10 @@
 		url('../fonts/OpenSans.woff') format('woff');
 }
 
+html {
+	scroll-behavior: smooth;
+}
+
 html, body {
 	margin: 0;
 	padding: 0;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -53,6 +53,10 @@
 		url('../fonts/OpenSans.woff') format('woff');
 }
 
+html {
+	scroll-behavior: smooth;
+}
+
 html, body {
 	margin: 0;
 	padding: 0;


### PR DESCRIPTION
Before:
Opening/Closing a article was very "harsh". It focused the article immediately (it "jumps" to it). Same with the navigation via the navigation buttons.

After:
It scrolls smoothly to the next article 


Changes proposed in this pull request:

- just a little CSS line


How to test the feature manually:

1. normal view: use the navigation buttons and navigate through the articles
2. activate in Reading config: ` Stick the article to the top when opened ` and open/close articles. It jumps smoothly


