### PR TITLE
greader.php: only return 'OK' on greader.php without query parameters

### DIFF
--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -992,7 +992,7 @@ final class GReaderAPI {
 		}
 		$pathInfo = urldecode($pathInfo);
 		$pathInfo = '' . preg_replace('%^(/api)?(/greader\.php)?%', '', $pathInfo);	//Discard common errors
-		if ($pathInfo == '') {
+		if ($pathInfo == '' && empty($_SERVER['QUERY_STRING'])) {
 			exit('OK');
 		}
 		$pathInfos = explode('/', $pathInfo);


### PR DESCRIPTION
It'd be clearer if the API endpoint didn't return `OK` when adding the `Email` and `Passwd` parameters. Whether it should instead return `OK` if they're correct is debatable.

In reply to <https://github.com/FreshRSS/FreshRSS/issues/5856#issuecomment-2019814077>.

How to test the feature manually:

Before:
```
$ http 'http://localhost:8080/api/greader.php?Email=<user>&Passwd=<pass>'
HTTP/1.1 200 OK
Connection: Keep-Alive
Content-Length: 2
Content-Type: text/html; charset=UTF-8
Date: Tue, 26 Mar 2024 20:24:45 GMT
Keep-Alive: timeout=5, max=100
Server: Apache/2.4.54 (Unix)
X-Powered-By: PHP/8.0.26

OK
```

After:
```
$ http 'http://localhost:8080/api/greader.php?Email=<user>&Passwd=<pass>'
HTTP/1.1 400 Bad Request
Connection: close
Content-Length: 12
Content-Type: text/plain; charset=UTF-8
Date: Tue, 26 Mar 2024 20:25:14 GMT
Server: Apache/2.4.54 (Unix)
X-Powered-By: PHP/8.0.26

Bad Request!
```

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
