### PR TITLE
Makefile: add `-it` to `make start` to allow for Ctrl+C SIGTERM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ start: ## Start the development environment (use Docker)
 	docker network create --driver bridge $(NETWORK) || true
 	$(foreach extension,$(extensions),$(eval volumes=$(volumes) --volume $(extension):/var/www/FreshRSS/extensions/$(notdir $(extension)):z))
 	docker run \
+		-it \
 		--rm \
 		--volume $(shell pwd):/var/www/FreshRSS:z \
 		$(volumes) \


### PR DESCRIPTION
How to test the feature manually:

1. `make start`
2. <kbd>Ctrl</kbd> + <kbd>C</kbd>
3. It stops, which is much easier than running `docker stop…` (`make stop`) from another terminal.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated