### PR TITLE
Fix: Clicking outside of article text area closes the article 

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1167,7 +1167,7 @@ function init_stream(stream) {
 			if (ev.target.closest('.reader, .content, .item.website, .item.link, .dropdown')) {
 				return true;
 			}
-			if (!context.sides_close_article && ev.target.matches('.flux_content')) {
+			if ((!context.sides_close_article && ev.target.matches('.flux_content')) || ev.target.closest('footer')) {
 				// setting for not-closing after clicking outside article area
 				return false;
 			}


### PR DESCRIPTION
Before:
If `Clicking outside of article text area closes the article` in `Reading` config is enabled, then.....

if the user clicks in the article footer on a white space, then the article will be closed
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/ef55baf7-4449-473c-9669-c68328a6ddef)

After:
A click on the footer does not close the article.

Changes proposed in this pull request:

- if click on the footer: do nothing


How to test the feature manually:
`Clicking outside of article text area closes the article` is `enabled`: 
1. click left or right hand side of the article: article will be closed
2. click on a white space in the footer: article will `NOT `be closed
3. click on `My labels` or `tags` or `Share`: dropdown will be opened and the article will `NOT `be closed


`Clicking outside of article text area closes the article` is disabled: 
1. click left or right hand side of the article: article will `NOT ` be closed
2. click on a white space in the footer: article will `NOT `be closed
3. click on `My labels` or `tags` or `Share`: dropdown will be opened and the article will `NOT `be closed

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
