### PR TITLE
Improve: Article footer clickable area of dropdowns

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -643,6 +643,11 @@ input[type="checkbox"]:focus-visible {
 	padding: var(--frss-padding-top-bottom) 0;
 }
 
+.horizontal-list .item .item-element.dropdown .dropdown-toggle,
+.horizontal-list .item .item-element.dropdown .dropdown-toggle-close {
+	padding: var(--frss-padding-top-bottom) var(--frss-padding-flux-items);
+}
+
 /*=== manage-list */
 .manage-list {
 	list-style: none;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -643,6 +643,11 @@ input[type="checkbox"]:focus-visible {
 	padding: var(--frss-padding-top-bottom) 0;
 }
 
+.horizontal-list .item .item-element.dropdown .dropdown-toggle,
+.horizontal-list .item .item-element.dropdown .dropdown-toggle-close {
+	padding: var(--frss-padding-top-bottom) var(--frss-padding-flux-items);
+}
+
 /*=== manage-list */
 .manage-list {
 	list-style: none;


### PR DESCRIPTION
Clickable area

before:
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/42ea1f39-9ea9-4e84-87e3-7c4ee4e40948)

After:
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/b98ed11f-8347-427a-9d07-71d30db23ed4)

Changes proposed in this pull request:

- padding added


How to test the feature manually:

open the dropbox in the article footer (f.e. my label, tags, sharing)

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
