### PR TITLE
Add a way to modify CSP rules within an extension

### DIFF
--- a/docs/en/developers/03_Backend/05_Extensions.md
+++ b/docs/en/developers/03_Backend/05_Extensions.md
@@ -164,6 +164,19 @@ The following events are available:
 * `post_update` (`function(none) -> none`): **TODO** add documentation.
 * `simplepie_before_init` (`function($simplePie, $feed) -> none`): **TODO** add documentation.
 
+### Injecting CDN content
+
+When using the `init` method, it is possible to inject scripts from CDN using the `Minz_View::appendScript` directive.
+FreshRSS will include the script in the page but will not load it since it will be blocked by the default content security policy (**CSP**).
+To amend the existing CSP, you need to define the extension CSP policies:
+```php
+// in the extension.php file
+protected array $csp_policies = [
+	'default-src' => 'example.org',
+];
+```
+This will only amend the extension CSP to FreshRSS CSP.
+
 ### Writing your own configure.phtml
 
 When you want to support user configurations for your extension or simply display some information, you have to create the `configure.phtml` file.

--- a/lib/Minz/ActionController.php
+++ b/lib/Minz/ActionController.php
@@ -99,6 +99,9 @@ abstract class Minz_ActionController {
 	 */
 	public function declareCspHeader(): void {
 		$policies = [];
+		foreach (Minz_ExtensionManager::listExtensions(true) as $extension) {
+			$extension->amendCsp($this->csp_policies);
+		}
 		foreach ($this->csp_policies as $directive => $sources) {
 			$policies[] = $directive . ' ' . $sources;
 		}

--- a/lib/Minz/Extension.php
+++ b/lib/Minz/Extension.php
@@ -26,6 +26,9 @@ abstract class Minz_Extension {
 
 	private bool $is_enabled;
 
+	/** @var string[] */
+	protected array $csp_policies = [];
+
 	/**
 	 * The constructor to assign specific information to the extension.
 	 *
@@ -388,6 +391,19 @@ abstract class Minz_Extension {
 
 		if (file_exists($path)) {
 			unlink($path);
+		}
+	}
+
+	/**
+	 * @param string[] $policies
+	 */
+	public function amendCsp(array &$policies): void {
+		foreach ($this->csp_policies as $policy => $source) {
+			if (array_key_exists($policy, $policies)) {
+				$policies[$policy] .= ' ' . $source;
+			} else {
+				$policies[$policy] = $source;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This will allow to change CSP rules to authorize the use of external scripts. We might need to add some safeguard since it will be virtually possible to load any script even malicious one.

Changes proposed in this pull request:

- Add support to extension CSP rules

How to test the feature manually:

1. Modify the CSP rules in an extension as described in the documentation
2. Validate that the new rule is appended to the existing rules

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
