### PR TITLE
Make reader icon location configurable

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -121,6 +121,7 @@ class FreshRSS_configure_Controller extends FreshRSS_ActionController {
 			FreshRSS_Context::userConf()->show_tags = Minz_Request::paramString('show_tags') ?: '0';
 			FreshRSS_Context::userConf()->show_tags_max = Minz_Request::paramInt('show_tags_max');
 			FreshRSS_Context::userConf()->show_author_date = Minz_Request::paramString('show_author_date') ?: '0';
+			FreshRSS_Context::userConf()->show_icons = Minz_Request::paramString('show_icons') ?: 't';
 			FreshRSS_Context::userConf()->show_feed_name = Minz_Request::paramString('show_feed_name') ?: 't';
 			FreshRSS_Context::userConf()->hide_read_feeds = Minz_Request::paramBoolean('hide_read_feeds');
 			FreshRSS_Context::userConf()->onread_jump_next = Minz_Request::paramBoolean('onread_jump_next');

--- a/app/Models/UserConfiguration.php
+++ b/app/Models/UserConfiguration.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
  * @property string $show_tags
  * @property int $show_tags_max
  * @property string $show_author_date
+ * @property string $show_icons
  * @property string $show_feed_name
  * @property bool $display_posts
  * @property string $email_validation_token

--- a/app/i18n/cz/conf.php
+++ b/app/i18n/cz/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => 'V záhlaví',
 				'none' => 'Žádný',
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => 'Nad názvem/štítky',
+				'with_authors' => 'V řádku s autory a datem',
+				'header' => 'V záhlaví',
+			),
 			'feed_name' => array(
 				'above_title' => 'Nad názvem/štítky',
 				'none' => 'Žádný',

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => 'In Kopfzeile',
 				'none' => 'Nicht anzeigen',
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => 'Oberhalb der Überschrit und Hashtags',
+				'with_authors' => 'In der Zeile mit Autoren und Datum',
+				'header' => 'In Kopfzeile',
+			),
 			'feed_name' => array(
 				'above_title' => 'Oberhalb der Überschrit und Hashtags',
 				'none' => 'Nicht anzeigen',

--- a/app/i18n/el/conf.php
+++ b/app/i18n/el/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => 'In header',	// TODO
 				'none' => 'None',	// TODO
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => 'Above title/tags', // TODO
+				'with_authors' => 'In authors and date row', // TODO
+				'header' => 'In Header', // TODO
+			),
 			'feed_name' => array(
 				'above_title' => 'Above title/tags',	// TODO
 				'none' => 'None',	// TODO

--- a/app/i18n/en-us/conf.php
+++ b/app/i18n/en-us/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => 'In header',	// IGNORE
 				'none' => 'None',	// IGNORE
 			),
+			'icons' => array(
+				'_' => 'Icons',
+				'above_title' => 'Above title/tags',
+				'with_authors' => 'In authors and date row',
+				'header' => 'In header',
+			),
 			'feed_name' => array(
 				'above_title' => 'Above title/tags',	// IGNORE
 				'none' => 'None',	// IGNORE

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => 'In header',
 				'none' => 'None',
 			),
+			'icons' => array(
+				'_' => 'Icons',
+				'above_title' => 'Above title/tags',
+				'with_authors' => 'In authors and date row',
+				'header' => 'In header',
+			),
 			'feed_name' => array(
 				'above_title' => 'Above title/tags',
 				'none' => 'None',

--- a/app/i18n/es/conf.php
+++ b/app/i18n/es/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => 'En el encabezado',
 				'none' => 'Ninguno',
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => 'Encima de título/etiquetas',
+				'with_authors' => 'En la fila de autores y fecha',
+				'header' => 'En el encabezado',
+			),
 			'feed_name' => array(
 				'above_title' => 'Encima de título/etiquetas',
 				'none' => 'Ninguno',

--- a/app/i18n/fa/conf.php
+++ b/app/i18n/fa/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => ' در سربرگ',
 				'none' => ' هیچکدام',
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => ' بالای عنوان/برچسب ها',
+				'with_authors' => ' در نویسندگان و ردیف تاریخ',
+				'header' => ' در سربرگ',
+			),
 			'feed_name' => array(
 				'above_title' => ' بالای عنوان/برچسب ها',
 				'none' => ' هیچ',

--- a/app/i18n/fr/conf.php
+++ b/app/i18n/fr/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => 'En en-tête',
 				'none' => 'Caché',
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => 'Au-dessus du titre',
+				'with_authors' => 'Sur la ligne « Auteurs et date »',
+				'header' => 'En en-tête',
+			),
 			'feed_name' => array(
 				'above_title' => 'Au-dessus du titre',
 				'none' => 'Caché',

--- a/app/i18n/he/conf.php
+++ b/app/i18n/he/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => 'In header',	// TODO
 				'none' => 'None',	// TODO
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => 'Above title/tags', // TODO
+				'with_authors' => 'In authors and date row', // TODO
+				'header' => 'In Header', // TODO
+			),
 			'feed_name' => array(
 				'above_title' => 'Above title/tags',	// TODO
 				'none' => 'None',	// TODO

--- a/app/i18n/hu/conf.php
+++ b/app/i18n/hu/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => 'Fejlécben',
 				'none' => 'Sehol',
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => 'Cím/Tag felett',
+				'with_authors' => 'A szerzők és dátum sorban',
+				'header' => 'Fejlécben',
+			),
 			'feed_name' => array(
 				'above_title' => 'Cím/Tag felett',
 				'none' => 'Sehol',

--- a/app/i18n/id/conf.php
+++ b/app/i18n/id/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => 'In header',	// TODO
 				'none' => 'None',	// TODO
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => 'Above title/tags', // TODO
+				'with_authors' => 'In authors and date row', // TODO
+				'header' => 'In Header', // TODO
+			),
 			'feed_name' => array(
 				'above_title' => 'Above title/tags',	// TODO
 				'none' => 'None',	// TODO

--- a/app/i18n/it/conf.php
+++ b/app/i18n/it/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => 'Nell’intestazione',
 				'none' => 'Nessuno',
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => 'Sopra il titolo/tag',
+				'with_authors' => 'Nella riga degli autori e data',
+				'header' => 'Nell’intestazione',
+			),
 			'feed_name' => array(
 				'above_title' => 'Sopra il titolo/tag',
 				'none' => 'Nessuno',

--- a/app/i18n/ja/conf.php
+++ b/app/i18n/ja/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => 'ヘッダー',
 				'none' => 'なし',
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => '上のタイトル/タグ',
+				'with_authors' => '著者と日付の行',
+				'header' => 'ヘッダー',
+			),
 			'feed_name' => array(
 				'above_title' => '上のタイトル/タグ',
 				'none' => 'なし',

--- a/app/i18n/ko/conf.php
+++ b/app/i18n/ko/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => '머리말에',
 				'none' => '숨김',
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => '제목/태그 위에',
+				'with_authors' => '작성자, 작성일과 같은 줄에',
+				'header' => '머리말에',
+			),
 			'feed_name' => array(
 				'above_title' => '제목/태그 위에',
 				'none' => '숨김',

--- a/app/i18n/lv/conf.php
+++ b/app/i18n/lv/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => 'Virsrakstā',
 				'none' => 'Nekāds',
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => 'Virs titula/birkām',
+				'with_authors' => 'Autoru un datuma rindā',
+				'header' => 'Virsrakstā',
+			),
 			'feed_name' => array(
 				'above_title' => 'Virs titula/birkām',
 				'none' => 'Nekāds',

--- a/app/i18n/nl/conf.php
+++ b/app/i18n/nl/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => 'In kop',
 				'none' => 'Geen',
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => 'Boven titel/tags',
+				'with_authors' => 'In lijn met auteurs en datum',
+				'header' => 'In kop',
+			),
 			'feed_name' => array(
 				'above_title' => 'Boven titel/tags',
 				'none' => 'Geen',

--- a/app/i18n/oc/conf.php
+++ b/app/i18n/oc/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => 'Dins l’entèsta',
 				'none' => 'Cap',
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => 'Al dessús títol/etiquetas',
+				'with_authors' => 'Dins la linha autors e data',
+				'header' => 'Dins l’entèsta',
+			),
 			'feed_name' => array(
 				'above_title' => 'Al dessús títol/etiquetas',
 				'none' => 'Cap',

--- a/app/i18n/pl/conf.php
+++ b/app/i18n/pl/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => 'W nagłówku',
 				'none' => 'Brak',
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => 'Ponad tytułem/tagami',
+				'with_authors' => 'W tej samej linii co autor i data',
+				'header' => 'W nagłówku',
+			),
 			'feed_name' => array(
 				'above_title' => 'Ponad tytułem/tagami',
 				'none' => 'Brak',

--- a/app/i18n/pt-br/conf.php
+++ b/app/i18n/pt-br/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => 'No cabeçalho',
 				'none' => 'Nenhum',
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => 'Acima do titulo/etiqueta',
+				'with_authors' => 'Com autores e data',
+				'header' => 'No cabeçalho',
+			),
 			'feed_name' => array(
 				'above_title' => 'Acima do titulo/etiqueta',
 				'none' => 'Nenhum',

--- a/app/i18n/ru/conf.php
+++ b/app/i18n/ru/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => 'В верхнем колонтитуле',
 				'none' => 'Нигде',
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => 'Над титулом и метками',
+				'with_authors' => 'В строке с автором и датой',
+				'header' => 'В верхнем колонтитуле',
+			),
 			'feed_name' => array(
 				'above_title' => 'Над титулом и метками',
 				'none' => 'Нигде',

--- a/app/i18n/sk/conf.php
+++ b/app/i18n/sk/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => 'V záhlaví',
 				'none' => 'Žiadne',
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => 'O zápise/značky',
+				'with_authors' => 'V riadku autori a dátum',
+				'header' => 'V záhlaví',
+			),
 			'feed_name' => array(
 				'above_title' => 'O zápise/značky',
 				'none' => 'Žiadne',

--- a/app/i18n/tr/conf.php
+++ b/app/i18n/tr/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => 'Üst Bilgi',
 				'none' => 'Hiçbiri',
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => 'Başlıklar/Etiklerin Üstünde',
+				'with_authors' => 'Yazarlar ve tarihler satırında',
+				'header' => 'Üst Bilgide',
+			),
 			'feed_name' => array(
 				'above_title' => 'Başlıklar/Etiklerin Üstünde',
 				'none' => 'Hiçbiri',

--- a/app/i18n/zh-cn/conf.php
+++ b/app/i18n/zh-cn/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => '页眉',
 				'none' => '不显示',
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => '在标题/标签上方',
+				'with_authors' => '与作者和日期一行',
+				'header' => '页眉',
+			),
 			'feed_name' => array(
 				'above_title' => '在标题/标签上方',
 				'none' => '不显示',

--- a/app/i18n/zh-tw/conf.php
+++ b/app/i18n/zh-tw/conf.php
@@ -177,6 +177,12 @@ return array(
 				'header' => '僅頁眉顯示',
 				'none' => '不顯示',
 			),
+			'icons' => array(
+				'_' => 'Icons', // TODO
+				'above_title' => '在文章標題和標簽上方',
+				'with_authors' => '與作者和日期一行',
+				'header' => '僅頁眉顯示',
+			),
 			'feed_name' => array(
 				'above_title' => '在文章標題和標簽上方',
 				'none' => '不顯示',

--- a/app/views/configure/reading.phtml
+++ b/app/views/configure/reading.phtml
@@ -136,6 +136,16 @@
 				</div>
 			</div>
 			<div class="form-group">
+				<label class="group-name" for="show_icons"><?= _t('conf.reading.article.icons') ?></label>
+				<div class="group-controls">
+					<select name="show_icons" id="show_icons" data-leave-validation="<?= FreshRSS_Context::userConf()->show_icons ?>">
+						<option value="a" <?= FreshRSS_Context::userConf()->show_icons === 'a' ? ' selected="selected"' : '' ?> data-input-visible="true"><?= _t('conf.reading.article.icons.with_authors') ?></option>
+						<option value="h" <?= FreshRSS_Context::userConf()->show_icons === 'h' ? ' selected="selected"' : '' ?> data-input-visible="true"><?= _t('conf.reading.article.icons.header') ?></option>
+						<option value="t" <?= FreshRSS_Context::userConf()->show_icons === 't' ? ' selected="selected"' : '' ?> data-input-visible="true"><?= _t('conf.reading.article.icons.above_title') ?></option>
+					</select>
+				</div>
+			</div>
+			<div class="form-group">
 				<label class="group-name" for="show_tags"><?= _t('conf.reading.article.tags') ?></label>
 				<div class="group-controls">
 					<select class="select-input-changer" name="show_tags" id="show_tags" data-name="show_tags_max" data-leave-validation="<?= FreshRSS_Context::userConf()->show_tags ?>">

--- a/app/views/helpers/index/article.phtml
+++ b/app/views/helpers/index/article.phtml
@@ -18,7 +18,7 @@
 			}
 		?>
 		<div class="article-header-topline">
-			<?php if (FreshRSS_Auth::hasAccess()) { ?>
+			<?php if (FreshRSS_Auth::hasAccess() && FreshRSS_Context::userConf()->show_icons === 't') { ?>
 				<a class="read" href="<?= Minz_Url::display($readUrl) ?>" title="<?= _t('conf.shortcut.mark_read') ?>"><?= _i($entry->isRead() ? 'read' : 'unread') ?></a>
 				<a class="bookmark" href="<?= Minz_Url::display($favoriteUrl) ?>" title="<?= _t('conf.shortcut.mark_favorite') ?>"><?= _i($entry->isFavorite() ? 'starred' : 'non-starred') ?></a>
 			<?php } ?>
@@ -36,7 +36,13 @@
 			}
 		?>
 
-		<h1 class="title"><a target="_blank" rel="noreferrer" class="go_website" href="<?= $entry->link() ?>"><?= $entry->title() ?></a></h1>
+		<h1 class="title">
+			<a target="_blank" rel="noreferrer" class="go_website" href="<?= $entry->link() ?>"><?= $entry->title() ?></a>
+			<?php if (FreshRSS_Auth::hasAccess() && FreshRSS_Context::userConf()->show_icons === 'h') { ?>
+				<a class="read" href="<?= Minz_Url::display($readUrl) ?>" title="<?= _t('conf.shortcut.mark_read') ?>"><?= _i($entry->isRead() ? 'read' : 'unread') ?></a>
+				<a class="bookmark" href="<?= Minz_Url::display($favoriteUrl) ?>" title="<?= _t('conf.shortcut.mark_favorite') ?>"><?= _i($entry->isFavorite() ? 'starred' : 'non-starred') ?></a>
+			<?php } ?>
+		</h1>
 		<?php if (FreshRSS_Context::userConf()->show_author_date === 'h' || FreshRSS_Context::userConf()->show_author_date === 'b') { ?>
 			<div class="subtitle">
 				<?php if (FreshRSS_Context::userConf()->show_feed_name === 'a') { ?>
@@ -64,6 +70,10 @@
 				<div class="date">
 					<time datetime="<?= $entry->machineReadableDate() ?>"><?= $entry->date() ?></time>
 				</div>
+				<?php if (FreshRSS_Auth::hasAccess() && FreshRSS_Context::userConf()->show_icons === 'a') { ?>
+					<a class="read" href="<?= Minz_Url::display($readUrl) ?>" title="<?= _t('conf.shortcut.mark_read') ?>"><?= _i($entry->isRead() ? 'read' : 'unread') ?></a>
+					<a class="bookmark" href="<?= Minz_Url::display($favoriteUrl) ?>" title="<?= _t('conf.shortcut.mark_favorite') ?>"><?= _i($entry->isFavorite() ? 'starred' : 'non-starred') ?></a>
+				<?php } ?>
 			</div>
 		<?php } ?>
 	</header>

--- a/app/views/index/html.phtml
+++ b/app/views/index/html.phtml
@@ -4,6 +4,7 @@
 	// Override some layout preferences for the public API output
 	FreshRSS_Context::userConf()->content_width = 'large';
 	FreshRSS_Context::userConf()->show_author_date = FreshRSS_UserConfiguration::default()->show_author_date;
+	FreshRSS_Context::userConf()->show_icons = FreshRSS_UserConfiguration::default()->show_icons;
 	FreshRSS_Context::userConf()->show_favicons = FreshRSS_UserConfiguration::default()->show_favicons;
 	FreshRSS_Context::userConf()->show_feed_name = FreshRSS_UserConfiguration::default()->show_feed_name;
 	FreshRSS_Context::userConf()->show_tags = FreshRSS_UserConfiguration::default()->show_tags;

--- a/config-user.default.php
+++ b/config-user.default.php
@@ -39,6 +39,7 @@ return array (
 	'show_tags' => 'f',	// {0 => none, b => both, f => footer, h => header}
 	'show_tags_max' => 7,
 	'show_author_date' => 'h',	// {0 => none, b => both, f => footer, h => header}
+	'show_icons' => 't', // {a => with_authors, h => header, t => above title}
 	'show_feed_name' => 'a',	// {0 => none, a => with authors, t => above title}
 	'hide_read_feeds' => true,
 	'onread_jump_next' => true,


### PR DESCRIPTION
Putting the Icons for read/unread and bookmark above the header can break a user's reading flow.

This makes the location of these icons configurable to be placed in one of the following locations:
- above the title
- in the same line as the header
- in the same line as the authors and date

Closes #

Changes proposed in this pull request:

- Configuration for icons
- Change icon location in reader view

How to test the feature manually:

1. Open settings | config | reading
2. Change option for Icons to each
3. Open reader view and notice the location of the icons changing

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

there didn't seem to be an obvious place for tests / docs for this.

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
