### PR TITLE
Avoid duplicates in Dynamic OPML

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -214,6 +214,7 @@ class FreshRSS_Category extends Minz_Model {
 						// The feed does not exist in the current category, so add that feed
 						$dryRunFeed->_category($this);
 						$ok &= ($feedDAO->addFeedObject($dryRunFeed) !== false);
+						$existingFeeds[$dryRunFeed->url()] = $dryRunFeed;
 					} else {
 						$existingFeed = $existingFeeds[$dryRunFeed->url()];
 						if ($existingFeed->mute()) {


### PR DESCRIPTION
Avoid duplicate feeds if the dynamic OPML contains the same feed multiple times
