### PR TITLE
SimplePie replace iframe allow attribute

### DIFF
--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -350,7 +350,7 @@ function customSimplePie(array $attributes = [], array $curl_options = []): Simp
 	$simplePie->add_attributes([
 		'audio' => ['controls' => 'controls', 'preload' => 'none'],
 		'iframe' => [
-			'allow' => 'fullscreen web-share',
+			'allow' => 'accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share',
 			'sandbox' => 'allow-scripts allow-same-origin',
 		],
 		'video' => ['controls' => 'controls', 'preload' => 'none'],

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -344,13 +344,15 @@ function customSimplePie(array $attributes = [], array $curl_options = []): Simp
 	]);
 	$simplePie->rename_attributes(['id', 'class']);
 	$simplePie->strip_attributes(array_merge($simplePie->strip_attributes, [
-		'allow', 'allowfullscreen',
 		'autoplay', 'class', 'onload', 'onunload', 'onclick', 'ondblclick', 'onmousedown', 'onmouseup',
 		'onmouseover', 'onmousemove', 'onmouseout', 'onfocus', 'onblur',
 		'onkeypress', 'onkeydown', 'onkeyup', 'onselect', 'onchange', 'seamless', 'sizes', 'srcset']));
 	$simplePie->add_attributes([
 		'audio' => ['controls' => 'controls', 'preload' => 'none'],
-		'iframe' => ['sandbox' => 'allow-scripts allow-same-origin'],
+		'iframe' => [
+			'allow' => 'fullscreen web-share',
+			'sandbox' => 'allow-scripts allow-same-origin',
+		],
 		'video' => ['controls' => 'controls', 'preload' => 'none'],
 	]);
 	$simplePie->set_url_replacements([

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -335,24 +335,25 @@ function customSimplePie(array $attributes = [], array $curl_options = []): Simp
 	$simplePie->set_curl_options($curl_options);
 
 	$simplePie->strip_comments(true);
-	$simplePie->strip_htmltags(array(
+	$simplePie->strip_htmltags([
 		'base', 'blink', 'body', 'doctype', 'embed',
 		'font', 'form', 'frame', 'frameset', 'html',
 		'link', 'input', 'marquee', 'meta', 'noscript',
 		'object', 'param', 'plaintext', 'script', 'style',
 		'svg',	//TODO: Support SVG after sanitizing and URL rewriting of xlink:href
-	));
-	$simplePie->rename_attributes(array('id', 'class'));
-	$simplePie->strip_attributes(array_merge($simplePie->strip_attributes, array(
+	]);
+	$simplePie->rename_attributes(['id', 'class']);
+	$simplePie->strip_attributes(array_merge($simplePie->strip_attributes, [
+		'allow', 'allowfullscreen',
 		'autoplay', 'class', 'onload', 'onunload', 'onclick', 'ondblclick', 'onmousedown', 'onmouseup',
 		'onmouseover', 'onmousemove', 'onmouseout', 'onfocus', 'onblur',
-		'onkeypress', 'onkeydown', 'onkeyup', 'onselect', 'onchange', 'seamless', 'sizes', 'srcset')));
-	$simplePie->add_attributes(array(
-		'audio' => array('controls' => 'controls', 'preload' => 'none'),
-		'iframe' => array('sandbox' => 'allow-scripts allow-same-origin'),
-		'video' => array('controls' => 'controls', 'preload' => 'none'),
-	));
-	$simplePie->set_url_replacements(array(
+		'onkeypress', 'onkeydown', 'onkeyup', 'onselect', 'onchange', 'seamless', 'sizes', 'srcset']));
+	$simplePie->add_attributes([
+		'audio' => ['controls' => 'controls', 'preload' => 'none'],
+		'iframe' => ['sandbox' => 'allow-scripts allow-same-origin'],
+		'video' => ['controls' => 'controls', 'preload' => 'none'],
+	]);
+	$simplePie->set_url_replacements([
 		'a' => 'href',
 		'area' => 'href',
 		'audio' => 'src',
@@ -360,21 +361,21 @@ function customSimplePie(array $attributes = [], array $curl_options = []): Simp
 		'del' => 'cite',
 		'form' => 'action',
 		'iframe' => 'src',
-		'img' => array(
+		'img' => [
 			'longdesc',
 			'src'
-		),
+		],
 		'input' => 'src',
 		'ins' => 'cite',
 		'q' => 'cite',
 		'source' => 'src',
 		'track' => 'src',
-		'video' => array(
+		'video' => [
 			'poster',
 			'src',
-		),
-	));
-	$https_domains = array();
+		],
+	]);
+	$https_domains = [];
 	$force = @file(FRESHRSS_PATH . '/force-https.default.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
 	if (is_array($force)) {
 		$https_domains = array_merge($https_domains, $force);


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#allow
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy#iframes

Besides security, the `allow autoplay` atttribute is especially problematic on mobile (Firefox on Android) as it asks to open the YouTube app as soon as the article is opened.
So we allow what is needed for a YouTube video to work fine, but not autoplay.

Example of code before:

```html
<iframe data-original="https://www.youtube.com/embed/??????feature=oembed"
allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
referrerpolicy="strict-origin-when-cross-origin"
allowfullscreen=""
sandbox="allow-scripts allow-same-origin"></iframe>
```

Example of feed https://www.lexpress.fr/arc/outboundfeeds/rss/alaune.xml