### PR TITLE
fix hotkey trigger for clipboard sharing option

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -697,7 +697,7 @@ function auto_share(key) {
 	if (!share) {
 		return;
 	}
-	const shares = share.parentElement.querySelectorAll('.dropdown-menu .item a');
+	const shares = share.parentElement.querySelectorAll('.dropdown-menu .item [data-type]');
 	if (typeof key === 'undefined') {
 		// Display the share div
 		location.hash = share.id;


### PR DESCRIPTION
Clipboard sharing uses  `<button>` instead of `<a>`, so the hotkey does not work because the selector does not find it.

Closes #6276 

Changes proposed in this pull request:

- Fix the selector used to enumerate sharing option;

How to test the feature manually:

1. Enable clipboard sharing option;
2. Use the corresponding numeric key of the clipboard sharing;
3. Share dropdown should close and entry link copied to the clipboard;

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested

Additional info:
The selector `.dropdown-menu .item a, .dropdown-menu .item button` can be used too, but it's more verbose than the one proposed.