### PR TITLE
Add some error prevention to Debian/Ubuntu installation docs

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -126,7 +126,7 @@ sudo cli/access-permissions.sh
 sudo chown www-data:www-data -R .
 
 # Publier FreshRSS dans votre répertoire HTML public
-sudo ln -s /usr/share/FreshRSS/p /var/www/html/FreshRSS
+[ ! -e "/var/www/html/FreshRSS" ] && sudo ln -s /usr/share/FreshRSS/p /var/www/html/FreshRSS || echo "/var/www/html/FreshRSS existe déjà"
 # Naviguez vers http://example.net/FreshRSS pour terminer l’installation
 # (Si vous le faite depuis localhost, vous pourrez avoir à ajuster le réglage de votre adresse publique)
 # ou utilisez l’interface en ligne de commande

--- a/docs/en/admins/06_LinuxInstall.md
+++ b/docs/en/admins/06_LinuxInstall.md
@@ -1,4 +1,4 @@
-# Installation on Debian 9/Ubuntu 16.04
+# Installation on Debian/Ubuntu
 
 This tutorial will give you step-by-step commands to install the latest stable release of FreshRSS with Apache and MySQL using git. It’s always recommended that you [backup your installation](05_Backup.md) before updating
 
@@ -93,10 +93,10 @@ chown www-data:www-data -R .
 chown apache:www-data -R .
 ```
 
-Finally, symlink the public folder to the root of your web directory
+Finally, symlink the public folder to your FreshRSS directory
 
 ```sh
-ln -s /usr/share/FreshRSS/p /var/www/html/
+[ ! -e "/var/www/html/FreshRSS" ] && ln -s /usr/share/FreshRSS/p /var/www/html/FreshRSS || echo "/var/www/html/FreshRSS already exists"
 ```
 
 ## Part 3: Creating a Database for FreshRSS


### PR DESCRIPTION
Reverts a minor part of <https://github.com/FreshRSS/FreshRSS/pull/2164>. People who want to use the root can easily figure out how to do that themselves.

Fixes #4955.
