### PR TITLE
improved: Gap between header and first image

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1424,6 +1424,7 @@ a.website:hover .favicon {
 
 .content header {
 	padding-top: calc(2 * var(--frss-padding-top-bottom));
+	padding-bottom: calc(var(--frss-padding-top-bottom));
 }
 
 .content footer {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1424,6 +1424,7 @@ a.website:hover .favicon {
 
 .content header {
 	padding-top: calc(2 * var(--frss-padding-top-bottom));
+	padding-bottom: calc(var(--frss-padding-top-bottom));
 }
 
 .content footer {


### PR DESCRIPTION
In some rare cases the first image is not wrapped into a `<p>` so that there is no gap between the header and the image (the `<p>` has some margin).

Before:
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/ad092227-28b7-44c9-8b51-5722d286ae87)

After:
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/a56d50c7-486f-42fe-8c31-e263fbe6a0ee)


Changes proposed in this pull request:

- `padding-bottom` added


How to test the feature manually:

1.  a useful feed could be: https://gizmodo.com/rss
2. normal view/reading view
3. see the gap over the image

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
