### PR TITLE
Fix: #6278 Clipboard sharing

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1114,7 +1114,7 @@ function init_stream(stream) {
 			if (navigator.clipboard) {
 				navigator.clipboard.writeText(el.dataset.url)
 					.then(() => {
-						toggleClass(el, 'error');
+						toggleClass(el, 'ok');
 					})
 					.catch(e => {
 						console.log(e);


### PR DESCRIPTION
Closes #6278

Fixed. Now the checkmark will be displayed:
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/7e9acc19-496e-44d4-8c95-036cf2c47c3c)

How to test the feature manually:

1. open sharing list
2. click on `clipboard`
3. a checkmark appears

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
