### PR TITLE
Fix: API mangement section in profile page

### DIFF
--- a/app/views/user/profile.phtml
+++ b/app/views/user/profile.phtml
@@ -75,8 +75,8 @@
 		</div>
 	</form>
 
-	<h2><?= _t('conf.profile.api') ?></h2>
 	<?php if (FreshRSS_Context::systemConf()->api_enabled) { ?>
+		<h2><?= _t('conf.profile.api') ?></h2>
 		<form method="post" action="<?= _url('api', 'updatePassword') ?>">
 			<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
 


### PR DESCRIPTION
Before:

if API access is disabled
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/cd9e3c96-e214-4ec6-9277-0f8f9e161cff)


The headline of the `API management` section is visible
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/11697147-462b-4633-bd30-c434f0a49b2b)


After:
Headline is not visible anymore
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/e26d8918-58c7-4370-a228-e966ec8ecc7d)

Checked: if API access is enabled headline is visible
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/1d87dd75-3403-489f-b670-3d1b8e6e8345)



Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
