### PR TITLE
Fix: left side border of search bar input

### DIFF
--- a/app/layout/header.phtml
+++ b/app/layout/header.phtml
@@ -18,25 +18,25 @@
 	<div class="item search">
 		<?php if (FreshRSS_Auth::hasAccess() || FreshRSS_Context::systemConf()->allow_anonymous) { ?>
 		<form action="<?= $this->html_url ?>" method="get">
-			<div class="stick">
-				<?php if (Minz_Request::controllerName() === 'index'): ?>
-					<?php if (in_array(Minz_Request::actionName(), ['normal', 'global', 'reader'], true)) { ?>
-					<input type="hidden" name="a" value="<?= Minz_Request::actionName() ?>" />
-					<?php } if (Minz_Request::paramString('get') !== '') { ?>
-					<input type="hidden" name="get" value="<?= FreshRSS_Context::currentGet() ?>" />
-					<?php } if (Minz_Request::paramInt('state') !== 0) { ?>
-					<input type="hidden" name="state" value="<?= Minz_Request::paramInt('state') ?>" />
-					<?php } ?>
-				<?php endif; ?>
-				<?php if (Minz_Request::paramString('user') !== '') { ?>
-				<input type="hidden" name="user" value="<?= Minz_User::name() ?>" />
-				<?php } if (ctype_alnum(Minz_Request::paramString('t'))) { ?>
-				<input type="hidden" name="t" value="<?= Minz_Request::paramString('t') ?>" />
-				<?php } if (ctype_upper(Minz_Request::paramString('order'))) { ?>
-				<input type="hidden" name="order" value="<?= FreshRSS_Context::$order ?>" />
-				<?php } if (ctype_lower(Minz_Request::paramString('f'))) { ?>
-				<input type="hidden" name="f" value="<?= Minz_Request::paramString('f') ?>" />
+			<?php if (Minz_Request::controllerName() === 'index'): ?>
+				<?php if (in_array(Minz_Request::actionName(), ['normal', 'global', 'reader'], true)) { ?>
+				<input type="hidden" name="a" value="<?= Minz_Request::actionName() ?>" />
+				<?php } if (Minz_Request::paramString('get') !== '') { ?>
+				<input type="hidden" name="get" value="<?= FreshRSS_Context::currentGet() ?>" />
+				<?php } if (Minz_Request::paramInt('state') !== 0) { ?>
+				<input type="hidden" name="state" value="<?= Minz_Request::paramInt('state') ?>" />
 				<?php } ?>
+			<?php endif; ?>
+			<?php if (Minz_Request::paramString('user') !== '') { ?>
+			<input type="hidden" name="user" value="<?= Minz_User::name() ?>" />
+			<?php } if (ctype_alnum(Minz_Request::paramString('t'))) { ?>
+			<input type="hidden" name="t" value="<?= Minz_Request::paramString('t') ?>" />
+			<?php } if (ctype_upper(Minz_Request::paramString('order'))) { ?>
+			<input type="hidden" name="order" value="<?= FreshRSS_Context::$order ?>" />
+			<?php } if (ctype_lower(Minz_Request::paramString('f'))) { ?>
+			<input type="hidden" name="f" value="<?= Minz_Request::paramString('f') ?>" />
+			<?php } ?>
+			<div class="stick">
 				<input type="search" name="search" id="search"
 					value="<?= htmlspecialchars(htmlspecialchars_decode(Minz_Request::paramString('search'), ENT_QUOTES), ENT_COMPAT, 'UTF-8') ?>"
 					placeholder="<?= _t('gen.menu.search') ?>" />


### PR DESCRIPTION
Regression from #6052

Before:
left hand side border is missed in the search bar (f.e. normal view)
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/8728c27e-72cd-4a4f-b071-867b20027d2e)

After:
Voila. It is back.
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/fbd33d8c-c47d-4930-97aa-5d7121917b34)



Changes proposed in this pull request:

- moved the `<input type="hidden">` out of `<div class="stick">`


How to test the feature manually:

1. go to normal view
2. see the search bar


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
