### PR TITLE
Improved: side navigation headlines

### DIFF
--- a/p/themes/Ansum/_sidebar.scss
+++ b/p/themes/Ansum/_sidebar.scss
@@ -184,7 +184,6 @@
 		color: variables.$grey-dark;
 		text-transform: uppercase;
 		letter-spacing: 1px;
-		margin-top: 1rem;
 	}
 
 	.nav-form {

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -606,7 +606,6 @@ th {
 	color: #766556;
 	text-transform: uppercase;
 	letter-spacing: 1px;
-	margin-top: 1rem;
 }
 .nav-list .nav-form {
 	padding: 3px;

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -606,7 +606,6 @@ th {
 	color: #766556;
 	text-transform: uppercase;
 	letter-spacing: 1px;
-	margin-top: 1rem;
 }
 .nav-list .nav-form {
 	padding: 3px;

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -267,7 +267,6 @@ button.as-link[disabled] {
 
 .nav-list .nav-header {
 	background-color: var(--dark-background-color1);
-	border-bottom: 1px solid var(--dark-border-color3);
 }
 
 /*=== Dropdown */

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -267,7 +267,6 @@ button.as-link[disabled] {
 
 .nav-list .nav-header {
 	background-color: var(--dark-background-color1);
-	border-bottom: 1px solid var(--dark-border-color3);
 }
 
 /*=== Dropdown */

--- a/p/themes/Mapco/_sidebar.scss
+++ b/p/themes/Mapco/_sidebar.scss
@@ -183,7 +183,6 @@
 		color: variables.$grey-dark;
 		text-transform: uppercase;
 		letter-spacing: 1px;
-		margin-top: 1rem;
 	}
 
 	.nav-form {

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -620,7 +620,6 @@ th {
 	color: #5b6871;
 	text-transform: uppercase;
 	letter-spacing: 1px;
-	margin-top: 1rem;
 }
 .nav-list .nav-form {
 	padding: 3px;

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -620,7 +620,6 @@ th {
 	color: #5b6871;
 	text-transform: uppercase;
 	letter-spacing: 1px;
-	margin-top: 1rem;
 }
 .nav-list .nav-form {
 	padding: 3px;

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -661,7 +661,7 @@ img.favicon {
 }
 
 .aside_feed .tree-folder-items.active {
-	padding-bottom: 2rem;
+	padding-bottom: 1rem;
 	background-color: var(--main-background);
 }
 

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -1114,7 +1114,7 @@ optgroup::before {
 }
 
 .nav-list .nav-header {
-	padding: 1rem 1rem 0 1rem;
+	padding: 0 1rem;
 	font-weight: bold;
 }
 

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -661,7 +661,7 @@ img.favicon {
 }
 
 .aside_feed .tree-folder-items.active {
-	padding-bottom: 2rem;
+	padding-bottom: 1rem;
 	background-color: var(--main-background);
 }
 

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -1114,7 +1114,7 @@ optgroup::before {
 }
 
 .nav-list .nav-header {
-	padding: 1rem 1rem 0 1rem;
+	padding: 0 1rem;
 	font-weight: bold;
 }
 

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -404,7 +404,6 @@ a:hover .icon {
 .nav-list .nav-header {
 	background-color: var(--background-color-grey);
 	color: var(--font-color-grey);
-	border-bottom: 1px solid var(--border-color);
 	font-weight: bold;
 }
 

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -404,7 +404,6 @@ a:hover .icon {
 .nav-list .nav-header {
 	background-color: var(--background-color-grey);
 	color: var(--font-color-grey);
-	border-bottom: 1px solid var(--border-color);
 	font-weight: bold;
 }
 

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -328,7 +328,6 @@ th {
 	padding: 0 1rem;
 	background-color: var(--background-color-grey);
 	color: var(--font-color-grey);
-	border-bottom: 1px solid var(--border-color-grey-light);
 	font-weight: bold;
 }
 

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -328,7 +328,6 @@ th {
 	padding: 0 1rem;
 	background-color: var(--background-color-grey);
 	color: var(--font-color-grey);
-	border-bottom: 1px solid var(--border-color-grey-light);
 	font-weight: bold;
 }
 

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -641,6 +641,10 @@ input[type="checkbox"]:focus-visible {
 	text-overflow: ellipsis;
 }
 
+.nav-list .item.nav-section .item:last-child {
+	margin-bottom: 1rem;
+}
+
 /*=== Horizontal-list */
 .horizontal-list {
 	margin: 0;

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -641,7 +641,7 @@ input[type="checkbox"]:focus-visible {
 	text-overflow: ellipsis;
 }
 
-.nav-list .item.nav-section .item:last-child {
+.nav-list .item.nav-section > ul {
 	margin-bottom: 1rem;
 }
 

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -641,6 +641,10 @@ input[type="checkbox"]:focus-visible {
 	text-overflow: ellipsis;
 }
 
+.nav-list .item.nav-section .item:last-child {
+	margin-bottom: 1rem;
+}
+
 /*=== Horizontal-list */
 .horizontal-list {
 	margin: 0;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -641,7 +641,7 @@ input[type="checkbox"]:focus-visible {
 	text-overflow: ellipsis;
 }
 
-.nav-list .item.nav-section .item:last-child {
+.nav-list .item.nav-section > ul {
 	margin-bottom: 1rem;
 }
 


### PR DESCRIPTION
It made me odd to see this. Once seen it cannot be made unseen anymore.

Before:
Origine theme (and Dark and Pafat) has a border at the BOTTOM of the navigation section headlines. It looks like to separate the headline from the sub items below while it has no border at the TOP. But the semantic meaning is other way around: headline is semantically connected to the sub items below and separated to the navigation above.
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/ae46c032-eb46-4198-bfcf-7bbf5990d01a)

After:
no border at the bottom (and at the top) of headline.
Each section has a little margin to the next headline.

![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/90730e25-5ae1-4969-aa93-55ad96526503)


Changes proposed in this pull request:

- (S)CSS


How to test the feature manually:

chose a theme and see the navigation on the left hand side

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
