### PR TITLE
Fix: click on feed title

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1081,7 +1081,7 @@ function init_stream(stream) {
 			return true;
 		}
 
-		el = ev.target.closest('.item .title > a');
+		el = ev.target.closest('.item a.title');
 		if (el) {	// Allow default control/command-click behaviour such as open in background-tab
 			return ev.ctrlKey || ev.metaKey;
 		}
@@ -1189,7 +1189,7 @@ function init_stream(stream) {
 			return;
 		}
 
-		let el = ev.target.closest('.item .title > a');
+		let el = ev.target.closest('.item a.title');
 		if (el) {
 			if (ev.which == 1) {
 				if (ev.ctrlKey) {	// Control+click


### PR DESCRIPTION
Regression [#6444 (comment)](https://github.com/FreshRSS/FreshRSS/pull/6444#issuecomment-2106218600)

Changes proposed in this pull request:

- javascript fixed

How to test the feature manually:

1. go to normal view
2. click on a title of a feed
3. the article expands (instead of opening it in a new tab)

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
