### PR TITLE
fixed: hover over title while having the navigation buttons in mobile view

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1667,6 +1667,7 @@ a.website:hover .favicon {
 	width: 300px;
 	table-layout: fixed;
 	padding-bottom: env(safe-area-inset-bottom);
+	z-index: 50;
 }
 
 #nav_entries .item {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1667,6 +1667,7 @@ a.website:hover .favicon {
 	width: 300px;
 	table-layout: fixed;
 	padding-bottom: env(safe-area-inset-bottom);
+	z-index: 50;
 }
 
 #nav_entries .item {


### PR DESCRIPTION
I guess it is a regression from #6444

before:
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/26997b85-1f01-4d82-8305-7e1ee28ea3ea)

After:
![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/8b7c290c-6cbf-4c9a-8186-98a24150b4da)



Changes proposed in this pull request:

- CSS: `z-index`

How to test the feature manually:

1. normal view in a small screen (mobile view)
2. hover over a article line that is partially hidden behind the navigation buttons


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
