### PR TITLE
Fixed: drag&drop Sharing/User Query

### DIFF
--- a/p/scripts/draggable.js
+++ b/p/scripts/draggable.js
@@ -13,9 +13,11 @@ const init_draggable_list = function () {
 	let source;
 	const draggableList = document.querySelector('.draggableList');
 	const addMarker = (position, element) => {
-		const hr = draggableList.querySelector('hr.drag-drop-marker');
-		if (null === hr) {
-			element.insertAdjacentHTML(position, '<hr class="drag-drop-marker" />');
+		if (source) {
+			const hr = draggableList.querySelector('hr.drag-drop-marker');
+			if (null === hr) {
+				element.insertAdjacentHTML(position, '<hr class="drag-drop-marker" />');
+			}
 		}
 	};
 	const removeMarker = () => {
@@ -27,12 +29,14 @@ const init_draggable_list = function () {
 
 	draggableList.addEventListener('dragstart', event => {
 		source = event.target.closest('[draggable="true"]');
-		const dragbox = source.closest('.dragbox');
-		if (dragbox) {
-			source = dragbox;
+		if (source) {
+			const dragbox = source.closest('.dragbox');
+			if (dragbox) {
+				source = dragbox;
+			}
+			event.dataTransfer.setData('text/html', source.outerHTML);
+			event.dataTransfer.effectAllowed = 'move';
 		}
-		event.dataTransfer.setData('text/html', source.outerHTML);
-		event.dataTransfer.effectAllowed = 'move';
 	});
 	draggableList.addEventListener('dragover', event => {
 		event.preventDefault();
@@ -72,7 +76,8 @@ const init_draggable_list = function () {
 		if (dragbox) {
 			draggableItem = dragbox;
 		}
-		if (null === draggableItem || source === draggableItem) {
+		if (!source || null === draggableItem || source === draggableItem) {
+			removeMarker();
 			return;
 		}
 


### PR DESCRIPTION
Fix #6455
Ref #6449

Changes proposed in this pull request:

- use only dragable items


How to test the feature manually:

1. go to sharing or to user query
2. drag an item from the navigation into the drop list
3. check the browser console

Do not forget to test the initial feature: drag&drop the list itself ;)

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
