### PR TITLE
Improved: Button to export OMPL of a category

### DIFF
--- a/app/views/helpers/category/update.phtml
+++ b/app/views/helpers/category/update.phtml
@@ -251,7 +251,7 @@
 			<div class="form-group">
 				<label class="group-name"><?= _t('sub.feed.export-as-opml.label') ?></label>
 				<div class="group-controls">
-					<a class="btn btn-important" href="<?= _url('index', 'opml', 'get', 'c_'.$this->category->id()) ?>" download="<?= 'f_'.$this->category->id()?> <?= $this->category->name() ?>.opml.xml">
+					<a class="btn btn-important" href="<?= _url('index', 'opml', 'get', 'c_'.$this->category->id()) ?>" download="f_<?= $this->category->id() ?> <?= $this->category->name() ?>.opml.xml">
 						<?= _t('sub.feed.export-as-opml.download') ?>
 					</a>
 					<p class="help"><?= _i('help') ?> <?= _t('sub.feed.export-as-opml.help') ?></p>

--- a/app/views/helpers/category/update.phtml
+++ b/app/views/helpers/category/update.phtml
@@ -251,7 +251,7 @@
 			<div class="form-group">
 				<label class="group-name"><?= _t('sub.feed.export-as-opml.label') ?></label>
 				<div class="group-controls">
-					<a class="btn btn-important" href="<?= _url('index', 'opml', 'get', 'c_'.$this->category->id()) ?>" download="<?= 'f_'.$this->category->id()?> <?= $this->category->name(true) ?>.opml.xml">
+					<a class="btn btn-important" href="<?= _url('index', 'opml', 'get', 'c_'.$this->category->id()) ?>" download="<?= 'f_'.$this->category->id()?> <?= $this->category->name() ?>.opml.xml">
 						<?= _t('sub.feed.export-as-opml.download') ?>
 					</a>
 					<p class="help"><?= _i('help') ?> <?= _t('sub.feed.export-as-opml.help') ?></p>

--- a/app/views/helpers/category/update.phtml
+++ b/app/views/helpers/category/update.phtml
@@ -251,7 +251,7 @@
 			<div class="form-group">
 				<label class="group-name"><?= _t('sub.feed.export-as-opml.label') ?></label>
 				<div class="group-controls">
-					<a class="btn btn-important" href="<?= _url('index', 'opml', 'get', 'c_'.$this->category->id()) ?>" download="c_<?= $this->category->id() ?> <?= $this->category->name() ?>.opml.xml">
+					<a class="btn btn-important" href="<?= _url('index', 'opml', 'get', 'c_' . $this->category->id()) ?>" download="c_<?= $this->category->id() ?> <?= $this->category->name() ?>.opml.xml">
 						<?= _t('sub.feed.export-as-opml.download') ?>
 					</a>
 					<p class="help"><?= _i('help') ?> <?= _t('sub.feed.export-as-opml.help') ?></p>

--- a/app/views/helpers/category/update.phtml
+++ b/app/views/helpers/category/update.phtml
@@ -222,7 +222,9 @@
 					<button type="reset" class="btn"><?= _t('gen.action.cancel') ?></button>
 				</div>
 			</div>
+		</fieldset>
 
+		<fieldset>
 			<?php if (!$this->category->isDefault()): ?>
 			<p class="alert alert-warn">
 				<?= _t('sub.feed.moved_category_deleted', _t('gen.short.default_category')) ?>
@@ -240,6 +242,19 @@
 						formaction="<?= _url('category', 'delete', 'id', $this->category->id()) ?>"
 						formmethod="post"><?= _t('gen.action.remove') ?></button>
 					<?php endif;?>
+				</div>
+			</div>
+		</fieldset>
+
+		<fieldset>
+			<legend><?= _t('sub.import_export.export') ?></legend>
+			<div class="form-group">
+				<label class="group-name"><?= _t('sub.feed.export-as-opml.label') ?></label>
+				<div class="group-controls">
+					<a class="btn btn-important" href="<?= _url('index', 'opml', 'get', 'c_'.$this->category->id()) ?>" download="<?= 'f_'.$this->category->id()?> <?= $this->category->name(true) ?>.opml.xml">
+						<?= _t('sub.feed.export-as-opml.download') ?>
+					</a>
+					<p class="help"><?= _i('help') ?> <?= _t('sub.feed.export-as-opml.help') ?></p>
 				</div>
 			</div>
 		</fieldset>

--- a/app/views/helpers/category/update.phtml
+++ b/app/views/helpers/category/update.phtml
@@ -251,7 +251,7 @@
 			<div class="form-group">
 				<label class="group-name"><?= _t('sub.feed.export-as-opml.label') ?></label>
 				<div class="group-controls">
-					<a class="btn btn-important" href="<?= _url('index', 'opml', 'get', 'c_'.$this->category->id()) ?>" download="f_<?= $this->category->id() ?> <?= $this->category->name() ?>.opml.xml">
+					<a class="btn btn-important" href="<?= _url('index', 'opml', 'get', 'c_'.$this->category->id()) ?>" download="c_<?= $this->category->id() ?> <?= $this->category->name() ?>.opml.xml">
 						<?= _t('sub.feed.export-as-opml.download') ?>
 					</a>
 					<p class="help"><?= _i('help') ?> <?= _t('sub.feed.export-as-opml.help') ?></p>

--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -791,7 +791,7 @@
 	<div class="form-group">
 		<label class="group-name"><?= _t('sub.feed.export-as-opml.label') ?></label>
 		<div class="group-controls">
-			<a class="btn btn-important" href="<?= _url('index', 'opml', 'get', 'f_'.$this->feed->id()) ?>" download="<?= 'f_'.$this->feed->id()?> <?= $this->feed->name(true) ?>.opml.xml">
+			<a class="btn btn-important" href="<?= _url('index', 'opml', 'get', 'f_'.$this->feed->id()) ?>" download="'f_<?= $this->feed->id() ?> <?= $this->feed->name(true) ?>.opml.xml">
 				<?= _t('sub.feed.export-as-opml.download') ?>
 			</a>
 			<p class="help"><?= _i('help') ?> <?= _t('sub.feed.export-as-opml.help') ?></p>

--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -765,7 +765,7 @@
 		</fieldset>
 	</form>
 
-	
+
 	<h2><?= _t('sub.feed.maintenance.title') ?></h2>
 	<div class="form-group">
 		<div class="group-controls">
@@ -791,7 +791,7 @@
 	<div class="form-group">
 		<label class="group-name"><?= _t('sub.feed.export-as-opml.label') ?></label>
 		<div class="group-controls">
-			<a class="btn btn-important" href="<?= _url('index', 'opml', 'get', 'f_'.$this->feed->id()) ?>" download="f_<?= $this->feed->id() ?> <?= $this->feed->name(true) ?>.opml.xml">
+			<a class="btn btn-important" href="<?= _url('index', 'opml', 'get', 'f_' . $this->feed->id()) ?>" download="f_<?= $this->feed->id() ?> <?= $this->feed->name(true) ?>.opml.xml">
 				<?= _t('sub.feed.export-as-opml.download') ?>
 			</a>
 			<p class="help"><?= _i('help') ?> <?= _t('sub.feed.export-as-opml.help') ?></p>

--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -791,7 +791,7 @@
 	<div class="form-group">
 		<label class="group-name"><?= _t('sub.feed.export-as-opml.label') ?></label>
 		<div class="group-controls">
-			<a class="btn btn-important" href="<?= _url('index', 'opml', 'get', 'f_'.$this->feed->id()) ?>" download="'f_<?= $this->feed->id() ?> <?= $this->feed->name(true) ?>.opml.xml">
+			<a class="btn btn-important" href="<?= _url('index', 'opml', 'get', 'f_'.$this->feed->id()) ?>" download="f_<?= $this->feed->id() ?> <?= $this->feed->name(true) ?>.opml.xml">
 				<?= _t('sub.feed.export-as-opml.download') ?>
 			</a>
 			<p class="help"><?= _i('help') ?> <?= _t('sub.feed.export-as-opml.help') ?></p>


### PR DESCRIPTION
Ref #6517
Ref #6312

![grafik](https://github.com/FreshRSS/FreshRSS/assets/1645099/ac8979f1-74b0-4a2f-bd85-2d5d8beb7f89)


How to test the feature manually:

1. go to category
2. export OPML file


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
