### PR TITLE
Remove Referer header from SimplePie feed request

### DIFF
--- a/lib/SimplePie/SimplePie/File.php
+++ b/lib/SimplePie/SimplePie/File.php
@@ -106,7 +106,6 @@ class SimplePie_File
 				curl_setopt($fp, CURLOPT_FAILONERROR, 1);
 				curl_setopt($fp, CURLOPT_TIMEOUT, $timeout);
 				curl_setopt($fp, CURLOPT_CONNECTTIMEOUT, $timeout);
-				curl_setopt($fp, CURLOPT_REFERER, SimplePie_Misc::url_remove_credentials($url));
 				curl_setopt($fp, CURLOPT_USERAGENT, $useragent);
 				curl_setopt($fp, CURLOPT_HTTPHEADER, $headers2);
 				foreach ($curl_options as $curl_param => $curl_value) {


### PR DESCRIPTION
This seems unnecessary, and the equivalent behaviour was removed for other downloads in [this PR](https://github.com/FreshRSS/FreshRSS/pull/4372).