### PR TITLE
add image and description to user query share

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -397,6 +397,9 @@ class FreshRSS_configure_Controller extends FreshRSS_ActionController {
 			if (!empty($params['shareOpml']) && ctype_digit($params['shareOpml'])) {
 				$queryParams['shareOpml'] = (bool)$params['shareOpml'];
 			}
+			if (!empty($params['description']) && is_string($params['description'])) {
+				$queryParams['description'] = htmlspecialchars_decode($params['description'], ENT_QUOTES);
+			}
 			$queryParams['url'] = Minz_Url::display(['params' => $queryParams]);
 			$queryParams['name'] = $name;
 

--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -400,6 +400,9 @@ class FreshRSS_configure_Controller extends FreshRSS_ActionController {
 			if (!empty($params['description']) && is_string($params['description'])) {
 				$queryParams['description'] = htmlspecialchars_decode($params['description'], ENT_QUOTES);
 			}
+			if (!empty($params['imageUrl']) && is_string($params['imageUrl'])) {
+				$queryParams['imageUrl'] = $params['imageUrl'];
+			}
 			$queryParams['url'] = Minz_Url::display(['params' => $queryParams]);
 			$queryParams['name'] = $name;
 

--- a/app/Models/UserQuery.php
+++ b/app/Models/UserQuery.php
@@ -26,6 +26,7 @@ class FreshRSS_UserQuery {
 	/** @var array<int,FreshRSS_Tag> $labels */
 	private array $labels;
 	private string $description = '';
+	private string $imageUrl = '';
 
 	public static function generateToken(string $salt): string {
 		if (!FreshRSS_Context::hasSystemConf()) {
@@ -81,6 +82,9 @@ class FreshRSS_UserQuery {
 		if (isset($query['description'])) {
 			$this->description = $query['description'];
 		}
+		if (isset($query['imageUrl'])) {
+			$this->imageUrl = $query['imageUrl'];
+		}
 
 		// linked too deeply with the search object, need to use dependency injection
 		$this->search = new FreshRSS_BooleanSearch($query['search'], 0, 'AND', false);
@@ -106,6 +110,7 @@ class FreshRSS_UserQuery {
 			'shareRss' => $this->shareRss,
 			'shareOpml' => $this->shareOpml,
 			'description' => $this->description,
+			'imageUrl' => $this->imageUrl,
 		]);
 	}
 
@@ -294,5 +299,13 @@ class FreshRSS_UserQuery {
 
 	public function setDescription(string $description): void {
 		$this->description = $description;
+	}
+
+	public function getImageUrl(): string {
+		return $this->imageUrl;
+	}
+
+	public function setImageUrl(string $imageUrl): void {
+		$this->imageUrl = $imageUrl;
 	}
 }

--- a/app/Models/UserQuery.php
+++ b/app/Models/UserQuery.php
@@ -25,6 +25,7 @@ class FreshRSS_UserQuery {
 	private array $categories;
 	/** @var array<int,FreshRSS_Tag> $labels */
 	private array $labels;
+	private string $description = '';
 
 	public static function generateToken(string $salt): string {
 		if (!FreshRSS_Context::hasSystemConf()) {
@@ -77,6 +78,9 @@ class FreshRSS_UserQuery {
 		if (isset($query['shareOpml'])) {
 			$this->shareOpml = $query['shareOpml'];
 		}
+		if (isset($query['description'])) {
+			$this->description = $query['description'];
+		}
 
 		// linked too deeply with the search object, need to use dependency injection
 		$this->search = new FreshRSS_BooleanSearch($query['search'], 0, 'AND', false);
@@ -101,6 +105,7 @@ class FreshRSS_UserQuery {
 			'token' => $this->token,
 			'shareRss' => $this->shareRss,
 			'shareOpml' => $this->shareOpml,
+			'description' => $this->description,
 		]);
 	}
 
@@ -281,5 +286,13 @@ class FreshRSS_UserQuery {
 			return $this->sharedUrl($xmlEscaped) . ($xmlEscaped ? '&amp;' : '&') . 'f=opml';
 		}
 		return '';
+	}
+
+	public function getDescription(): string {
+		return $this->description;
+	}
+
+	public function setDescription(string $description): void {
+		$this->description = $description;
 	}
 }

--- a/app/Models/View.php
+++ b/app/Models/View.php
@@ -106,6 +106,7 @@ class FreshRSS_View extends Minz_View {
 	public string $rss_url = '';
 	public string $rss_base = '';
 	public bool $internal_rendering = false;
+	public string $description;
 
 	// Content preview
 	public string $fatalError;

--- a/app/Models/View.php
+++ b/app/Models/View.php
@@ -107,6 +107,7 @@ class FreshRSS_View extends Minz_View {
 	public string $rss_base = '';
 	public bool $internal_rendering = false;
 	public string $description;
+	public string $image_url;
 
 	// Content preview
 	public string $fatalError;

--- a/app/i18n/cz/conf.php
+++ b/app/i18n/cz/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => 'Uživatelské dotazy',
 		'deprecated' => 'Tento dotaz již není platný. Odkazovaná kategorie nebo kanál byly odstraněny.',
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => 'Použitý filtr:',
 			'categories' => 'Zobrazit podle kategorie',
@@ -134,6 +135,7 @@ return array(
 		'get_important' => 'Zobrazit články z důležitých kanálů',
 		'get_label' => 'Zobrazit články se štítkem “%s”',
 		'help' => 'Viz <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">dokumentace pro uživatelské dotazy a další sdílení pomocí HTML / RSS / OPML</a>.',
+		'image_url' => 'Image URL',	// TODO
 		'name' => 'Název',
 		'no_filter' => 'Žádný filtr',
 		'number' => 'Dotaz č. %d',

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => 'Benutzerabfragen',
 		'deprecated' => 'Diese Abfrage ist nicht länger gültig. Die referenzierte Kategorie oder der Feed ist gelöscht worden.',
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => 'Angewendeter Filter:',
 			'categories' => 'Nach Kategorie filtern',
@@ -134,6 +135,7 @@ return array(
 		'get_important' => 'Alle Artikel von den "Wichtige Feeds" anzeigen',
 		'get_label' => 'Artikel mit dem Label “%s” anzeigen',
 		'help' => 'Siehe die <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">Dokumentation für Benutzerabfragen und Teilen via HTML / RSS / OPML</a>.',
+		'image_url' => 'Image URL',	// TODO
 		'name' => 'Name',	// IGNORE
 		'no_filter' => 'Kein Filter',
 		'number' => 'Abfrage Nr. %d',

--- a/app/i18n/el/conf.php
+++ b/app/i18n/el/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => 'User queries',	// TODO
 		'deprecated' => 'This query is no longer valid. The referenced category or feed has been deleted.',	// TODO
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => 'Filter applied:',	// TODO
 			'categories' => 'Display by category',	// TODO
@@ -134,6 +135,7 @@ return array(
 		'get_important' => 'Display articles from important feeds',	// TODO
 		'get_label' => 'Display articles with “%s” label',	// TODO
 		'help' => 'See the <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">documentation for user queries and resharing by HTML / RSS / OPML</a>.',	// TODO
+		'image_url' => 'Image URL',	// TODO
 		'name' => 'Name',	// TODO
 		'no_filter' => 'No filter',	// TODO
 		'number' => 'Query n°%d',	// TODO

--- a/app/i18n/en-us/conf.php
+++ b/app/i18n/en-us/conf.php
@@ -136,6 +136,7 @@ return array(
 		'help' => 'See the <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">documentation for user queries and resharing by HTML / RSS / OPML</a>.',	// IGNORE
 		'name' => 'Name',	// IGNORE
 		'description' => 'Description',	// IGNORE
+		'image_url' => 'Image URL',	// IGNORE
 		'no_filter' => 'No filter',	// IGNORE
 		'number' => 'Query n°%d',	// IGNORE
 		'order_asc' => 'Display oldest articles first',	// IGNORE

--- a/app/i18n/en-us/conf.php
+++ b/app/i18n/en-us/conf.php
@@ -135,6 +135,7 @@ return array(
 		'get_label' => 'Display articles with “%s” label',	// IGNORE
 		'help' => 'See the <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">documentation for user queries and resharing by HTML / RSS / OPML</a>.',	// IGNORE
 		'name' => 'Name',	// IGNORE
+		'description' => 'Description',	// IGNORE
 		'no_filter' => 'No filter',	// IGNORE
 		'number' => 'Query n°%d',	// IGNORE
 		'order_asc' => 'Display oldest articles first',	// IGNORE

--- a/app/i18n/en-us/conf.php
+++ b/app/i18n/en-us/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => 'User queries',	// IGNORE
 		'deprecated' => 'This query is no longer valid. The referenced category or feed has been deleted.',	// IGNORE
+		'description' => 'Description',	// IGNORE
 		'filter' => array(
 			'_' => 'Filter applied:',	// IGNORE
 			'categories' => 'Display by category',	// IGNORE
@@ -134,9 +135,8 @@ return array(
 		'get_important' => 'Display articles from important feeds',	// IGNORE
 		'get_label' => 'Display articles with “%s” label',	// IGNORE
 		'help' => 'See the <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">documentation for user queries and resharing by HTML / RSS / OPML</a>.',	// IGNORE
-		'name' => 'Name',	// IGNORE
-		'description' => 'Description',	// IGNORE
 		'image_url' => 'Image URL',	// IGNORE
+		'name' => 'Name',	// IGNORE
 		'no_filter' => 'No filter',	// IGNORE
 		'number' => 'Query n°%d',	// IGNORE
 		'order_asc' => 'Display oldest articles first',	// IGNORE

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -136,6 +136,7 @@ return array(
 		'help' => 'See the <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">documentation for user queries and resharing by HTML / RSS / OPML</a>.',
 		'name' => 'Name',
 		'description' => 'Description',
+		'image_url' => 'Image URL',
 		'no_filter' => 'No filter',
 		'number' => 'Query n°%d',
 		'order_asc' => 'Display oldest articles first',

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => 'User queries',
 		'deprecated' => 'This query is no longer valid. The referenced category or feed has been deleted.',
+		'description' => 'Description',
 		'filter' => array(
 			'_' => 'Filter applied:',
 			'categories' => 'Display by category',
@@ -134,9 +135,8 @@ return array(
 		'get_important' => 'Display articles from important feeds',
 		'get_label' => 'Display articles with “%s” label',
 		'help' => 'See the <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">documentation for user queries and resharing by HTML / RSS / OPML</a>.',
-		'name' => 'Name',
-		'description' => 'Description',
 		'image_url' => 'Image URL',
+		'name' => 'Name',
 		'no_filter' => 'No filter',
 		'number' => 'Query n°%d',
 		'order_asc' => 'Display oldest articles first',

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -135,6 +135,7 @@ return array(
 		'get_label' => 'Display articles with “%s” label',
 		'help' => 'See the <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">documentation for user queries and resharing by HTML / RSS / OPML</a>.',
 		'name' => 'Name',
+		'description' => 'Description',
 		'no_filter' => 'No filter',
 		'number' => 'Query n°%d',
 		'order_asc' => 'Display oldest articles first',

--- a/app/i18n/es/conf.php
+++ b/app/i18n/es/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => 'Consultas de usuario',
 		'deprecated' => 'Esta consulta ya no es válida. La categoría referenciada o fuente ha sido eliminada.',
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => 'Filtro aplicado:',
 			'categories' => 'Mostrar por categoría',
@@ -134,6 +135,7 @@ return array(
 		'get_important' => 'Mostrar artículos de feeds importantes',
 		'get_label' => 'Mostrar artículos con la etiqueta “%s”',
 		'help' => 'Ver la <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">documentación para consultas de usuarios y compartir mediante HTML / RSS / OPML</a>.',
+		'image_url' => 'Image URL',	// TODO
 		'name' => 'Nombre',
 		'no_filter' => 'Sin filtro',
 		'number' => 'Consulta n° %d',

--- a/app/i18n/fa/conf.php
+++ b/app/i18n/fa/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => ' پرس و جوهای کاربر',
 		'deprecated' => ' این عبارت دیگر معتبر نیست. دسته یا فید ارجاع شده حذف شده است.',
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => ' فیلتر اعمال شده:',
 			'categories' => ' نمایش بر اساس دسته بندی',
@@ -134,6 +135,7 @@ return array(
 		'get_important' => 'Display articles from important feeds',	// TODO
 		'get_label' => 'Display articles with “%s” label',	// TODO
 		'help' => 'See the <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">documentation for user queries and resharing by HTML / RSS / OPML</a>.',	// TODO
+		'image_url' => 'Image URL',	// TODO
 		'name' => ' نام',
 		'no_filter' => ' بدون فیلتر',
 		'number' => ' پرس و جو n°%d',

--- a/app/i18n/fr/conf.php
+++ b/app/i18n/fr/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => 'Filtres utilisateurs',
 		'deprecated' => 'Ce filtre n’est plus valide. La catégorie ou le flux concerné a été supprimé.',
+		'description' => 'Description',	// IGNORE
 		'filter' => array(
 			'_' => 'Filtres appliqués :',
 			'categories' => 'Afficher par catégorie',
@@ -134,6 +135,7 @@ return array(
 		'get_important' => 'Afficher les articles des flux importants',
 		'get_label' => 'Afficher les articles avec l’étiquette “%s”',
 		'help' => 'Voir la <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">documentation pour les filtres utilisateurs et repartage par HTML / RSS / OPML</a>.',
+		'image_url' => 'URL de l’image',
 		'name' => 'Nom',
 		'no_filter' => 'Aucun filtre appliqué',
 		'number' => 'Filtre n°%d',

--- a/app/i18n/he/conf.php
+++ b/app/i18n/he/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => 'שאילתות',
 		'deprecated' => 'שאילתה זו אינה בתוקף יותר, הפיד או הקטגוריה לייחוס נמחקו.',
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => 'מסננים בשימוש:',
 			'categories' => 'Display by category',	// TODO
@@ -134,6 +135,7 @@ return array(
 		'get_important' => 'Display articles from important feeds',	// TODO
 		'get_label' => 'Display articles with “%s” label',	// TODO
 		'help' => 'See the <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">documentation for user queries and resharing by HTML / RSS / OPML</a>.',	// TODO
+		'image_url' => 'Image URL',	// TODO
 		'name' => 'Name',	// TODO
 		'no_filter' => 'ללא סינון',
 		'number' => 'שאילתה מספר °%d',

--- a/app/i18n/hu/conf.php
+++ b/app/i18n/hu/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => 'Felhasználói lekérdezések',
 		'deprecated' => 'Ez a lekérdezés már nem érvényes. A hivatkozott kategória vagy hírforrás törölve lett.',
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => 'Alkalmazott szűrő:',
 			'categories' => 'Rendezés kategória szerint',
@@ -134,6 +135,7 @@ return array(
 		'get_important' => 'Cikkek megjelenítése fontos hírforrásokból',
 		'get_label' => ' „%s” címkével rendelkező cikkek megjelenítése',
 		'help' => 'Lásd a <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank"> dokumentációt a felhasználói lekérdezések és HTML/RSS/OPML megosztás témákban</a>.',
+		'image_url' => 'Image URL',	// TODO
 		'name' => 'Név',
 		'no_filter' => 'Nincs szűrés',
 		'number' => '%d lekérdezés',

--- a/app/i18n/id/conf.php
+++ b/app/i18n/id/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => 'Permintaan Pengguna',
 		'deprecated' => 'Permintaan ini tidak valid lagi. Kategori atau feed yang dirujuk telah dihapus.',
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => 'Filter yang diterapkan:',
 			'categories' => 'Tampilkan berdasarkan kategori',
@@ -134,6 +135,7 @@ return array(
 		'get_important' => 'Tampilkan artikel dari feed penting',
 		'get_label' => 'Tampilkan artikel dengan label "%s"',
 		'help' => 'Lihat <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">dokumentasi untuk permintaan pengguna dan berbagi ulang melalui HTML / RSS / OPML</a>.',
+		'image_url' => 'Image URL',	// TODO
 		'name' => 'Nama',
 		'no_filter' => 'Tanpa filter',
 		'number' => 'Permintaan n°%d',

--- a/app/i18n/it/conf.php
+++ b/app/i18n/it/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => 'Ricerche personali',
 		'deprecated' => 'Questa query non è più valida. La categoria o il feed di riferimento non stati cancellati.',
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => 'Filtro applicato:',
 			'categories' => 'Mostra per categoria',
@@ -134,6 +135,7 @@ return array(
 		'get_important' => 'Mostra articoli dai feed importanti',
 		'get_label' => 'Mostra articoli con l’etichetta “%s”',
 		'help' => 'Vedi la <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">documentazione per le query utente e ricondivisioine tramite HTML / RSS / OPML</a>.',
+		'image_url' => 'Image URL',	// TODO
 		'name' => 'Nome',
 		'no_filter' => 'Nessun filtro',
 		'number' => 'Ricerca n°%d',

--- a/app/i18n/ja/conf.php
+++ b/app/i18n/ja/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => 'ユーザークエリ',
 		'deprecated' => 'このクエリは有効ではありません。参照されているカテゴリあるいはフィードはすでに消去されました。',
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => 'フィルターを適用:',
 			'categories' => 'カテゴリごとに表示する',
@@ -134,6 +135,7 @@ return array(
 		'get_important' => '重要なフィードからの記事を表示する',
 		'get_label' => '“%s”ラベルの記事を表示する',
 		'help' => 'HTML/RSS/OPMLによるユーザー照会と再共有については <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">こちら</a>をご覧ください',
+		'image_url' => 'Image URL',	// TODO
 		'name' => '名前',
 		'no_filter' => 'フィルターはありません',
 		'number' => 'クエリ n°%d',

--- a/app/i18n/ko/conf.php
+++ b/app/i18n/ko/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => '사용자 쿼리',
 		'deprecated' => '이 쿼리는 더 이상 유효하지 않습니다. 해당하는 카테고리나 피드가 삭제되었습니다.',
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => '필터 적용:',
 			'categories' => '카테고리별로 표시',
@@ -134,6 +135,7 @@ return array(
 		'get_important' => '중요 피드의 글 표시',
 		'get_label' => '“%s” 라벨을 가진 글 표시',
 		'help' => '<a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">유저 쿼리 및 HTML / RSS / OPML을 사용한 재공유 방법 문서</a> 살펴보기.',
+		'image_url' => 'Image URL',	// TODO
 		'name' => '이름',
 		'no_filter' => '필터가 없습니다',
 		'number' => '쿼리 #%d',

--- a/app/i18n/lv/conf.php
+++ b/app/i18n/lv/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => 'Lietotāja pieprasījumi',
 		'deprecated' => 'Šis pieprasījums vairs nav derīgs. Norādītā kategorija vai barotne ir dzēsta.',
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => 'Piemērotais filtrs:',
 			'categories' => 'Rādīt pēc kategorijas',
@@ -134,6 +135,7 @@ return array(
 		'get_important' => 'Display articles from important feeds',	// TODO
 		'get_label' => 'Display articles with “%s” label',	// TODO
 		'help' => 'See the <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">documentation for user queries and resharing by HTML / RSS / OPML</a>.',	// TODO
+		'image_url' => 'Image URL',	// TODO
 		'name' => 'Vārds',
 		'no_filter' => 'Bez filtra',
 		'number' => 'Pieprasījums nr. %d',

--- a/app/i18n/nl/conf.php
+++ b/app/i18n/nl/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => 'Gebruikersquery’s (informatie aanvragen)',
 		'deprecated' => 'Deze query (informatie aanvraag) is niet langer geldig. De bedoelde categorie of feed is al verwijderd.',
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => 'Filter toegepast:',
 			'categories' => 'Weergeven op categorie',
@@ -134,6 +135,7 @@ return array(
 		'get_important' => 'Artikelen van belangrijke feeds tonen',
 		'get_label' => 'Artikelen met het label „%s” tonen',
 		'help' => 'Zie de <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">documentatie voor gebruikersqueries en delen via HTML / RSS / OPML</a>.',
+		'image_url' => 'Image URL',	// TODO
 		'name' => 'Naam',
 		'no_filter' => 'Geen filter',
 		'number' => 'Query n°%d',	// IGNORE

--- a/app/i18n/oc/conf.php
+++ b/app/i18n/oc/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => 'Filtres utilizaires',
 		'deprecated' => 'Aqueste filtre es pas valid. La categoria o lo flux concernit es estat suprimit.',
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => 'Filtres aplicats :',
 			'categories' => 'Afichatge per categoria',
@@ -134,6 +135,7 @@ return array(
 		'get_important' => 'Display articles from important feeds',	// TODO
 		'get_label' => 'Display articles with “%s” label',	// TODO
 		'help' => 'See the <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">documentation for user queries and resharing by HTML / RSS / OPML</a>.',	// TODO
+		'image_url' => 'Image URL',	// TODO
 		'name' => 'Nom',
 		'no_filter' => 'Cap de filtre aplicat',
 		'number' => 'Filtre n°%d',

--- a/app/i18n/pl/conf.php
+++ b/app/i18n/pl/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => 'Zapisane zapytania',
 		'deprecated' => 'To zapytanie nie jest już poprawne. Kategoria lub kanał do którego się odnosi już nie istnieje.',
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => 'Zastosowane filtry:',
 			'categories' => 'Według kategorii',
@@ -134,6 +135,7 @@ return array(
 		'get_important' => 'Wyświetl wiadomości z ważnych kanałów',
 		'get_label' => 'Wyświetl wiadomości z etykietą “%s”',
 		'help' => 'Zapytania i dzielenie się nimi przez HTML / RSS / OPML opisane są w <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">dokumentacji</a>.',
+		'image_url' => 'Image URL',	// TODO
 		'name' => 'Nazwa',
 		'no_filter' => 'Brak filtrów',
 		'number' => 'Zapytanie nr %d',

--- a/app/i18n/pt-br/conf.php
+++ b/app/i18n/pt-br/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => 'Consultas do usuário',
 		'deprecated' => 'Esta não é mais válida. A categoria ou feed relacionado foi deletado.',
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => 'Filtro aplicado:',
 			'categories' => 'Exibir por categoria',
@@ -134,6 +135,7 @@ return array(
 		'get_important' => 'Exibir artigos de feeds importantes',
 		'get_label' => 'Exibir artigos com rótulo “%s”',
 		'help' => 'Veja a <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">documentação para consultas de usuários e recompartilhamentos por HTML / RSS / OPML</a>.',
+		'image_url' => 'Image URL',	// TODO
 		'name' => 'Nome',
 		'no_filter' => 'Sem filtro',
 		'number' => 'Consulta n°%d',

--- a/app/i18n/ru/conf.php
+++ b/app/i18n/ru/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => 'Пользовательские запросы',
 		'deprecated' => 'Этот запрос больше не действителен. Связанная категория или лента была удалена.',
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => 'Применённые фильтры:',
 			'categories' => 'Отображение по категории',
@@ -134,6 +135,7 @@ return array(
 		'get_important' => 'Отображать статьи из важных лент',
 		'get_label' => 'Показать статьи с “%s” меткой',
 		'help' => 'Смотрите <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">документацию по пользовательским запросам и повторному обмену данными с помощью HTML / RSS / OPML</a>.',
+		'image_url' => 'Image URL',	// TODO
 		'name' => 'Название',
 		'no_filter' => 'Нет фильтров',
 		'number' => 'Запрос №%d',

--- a/app/i18n/sk/conf.php
+++ b/app/i18n/sk/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => 'Dopyty používateľa',
 		'deprecated' => 'Tento dopyt už nie je platný. Kategória alebo kanál boli vymazané.',
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => 'Použitý filter:',
 			'categories' => 'Zobraziť podľa kategórie',
@@ -134,6 +135,7 @@ return array(
 		'get_important' => 'Zobraziť články z dôležitých kanálov',
 		'get_label' => 'Zobraziť články so štítkom “%s”',
 		'help' => 'Prečítajte si <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">documentáciu pre dopyt používateľov a zdieľanie prostredníctvom HTML / RSS / OPML</a>.',
+		'image_url' => 'Image URL',	// TODO
 		'name' => 'Meno',
 		'no_filter' => 'Žiadny filter',
 		'number' => 'Dopyt číslo %d',

--- a/app/i18n/tr/conf.php
+++ b/app/i18n/tr/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => 'Kullanıcı sorguları',
 		'deprecated' => 'Bu sorgu artık geçerli değil. İlgili akış veya kategori silinmiş.',
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => 'Filtre uygulandı:',
 			'categories' => 'Kategoriye göre göster',
@@ -134,6 +135,7 @@ return array(
 		'get_important' => 'Önemli akışındaki makaleleri göster',
 		'get_label' => '“%s” etiketine sahip makaleleri göster',
 		'help' => '<a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">Kullanıcı aramaları ve HTML / RSS / OPML ile paylaşım hakkında dökümantasyonu</a> görüntüleyin.',
+		'image_url' => 'Image URL',	// TODO
 		'name' => 'İsim',
 		'no_filter' => 'Filtre yok',
 		'number' => 'Sorgu n°%d',

--- a/app/i18n/zh-cn/conf.php
+++ b/app/i18n/zh-cn/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => '自定义查询',
 		'deprecated' => '此查询不再有效。相关的分类或订阅源已被删除。',
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => '生效的过滤器：',
 			'categories' => '按分类显示',
@@ -134,6 +135,7 @@ return array(
 		'get_important' => '显示来自“重要的订阅”的文章',
 		'get_label' => '显示打了“%s”标签的文章',
 		'help' => '参见文档： <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">queries and resharing by HTML / RSS / OPML</a>.',
+		'image_url' => 'Image URL',	// TODO
 		'name' => '名称',
 		'no_filter' => '无过滤器',
 		'number' => '查询 n°%d',

--- a/app/i18n/zh-tw/conf.php
+++ b/app/i18n/zh-tw/conf.php
@@ -114,6 +114,7 @@ return array(
 	'query' => array(
 		'_' => '自定義查詢',
 		'deprecated' => '此查詢不再有效。相關的分類或訂閱源已被刪除。',
+		'description' => 'Description',	// TODO
 		'filter' => array(
 			'_' => '生效的過濾器：',
 			'categories' => '按分類顯示',
@@ -134,6 +135,7 @@ return array(
 		'get_important' => '顯示來自重要源的文章',
 		'get_label' => '顯示帶有 “%s” 標籤的文章',
 		'help' => '請參閱 <a href="https://freshrss.github.io/FreshRSS/en/users/user_queries.html" target="_blank">有關使用者查詢和透過 HTML / RSS / OPML 重新共用的文件</a>.',
+		'image_url' => 'Image URL',	// TODO
 		'name' => '名稱',
 		'no_filter' => '無過濾器',
 		'number' => '查詢 n°%d',

--- a/app/views/helpers/configure/query.phtml
+++ b/app/views/helpers/configure/query.phtml
@@ -20,6 +20,10 @@
 				<input type="text" class="w100" name="name" id="name" value="<?= $this->query->getName() ?>" />
 				<input type="hidden" name="query[token]" id="query_token" value="<?= $this->query->getToken() ?>" />
 			</div>
+			<label class="group-name" for="description"><?= _t('conf.query.description') ?></label>
+			<div class="group-controls">
+				<input type="text" class="w100" name="query[description]" id="description" value="<?= $this->query->getDescription() ?>" />
+			</div>
 		</div>
 
 		<fieldset>

--- a/app/views/helpers/configure/query.phtml
+++ b/app/views/helpers/configure/query.phtml
@@ -24,6 +24,10 @@
 			<div class="group-controls">
 				<input type="text" class="w100" name="query[description]" id="description" value="<?= $this->query->getDescription() ?>" />
 			</div>
+			<label class="group-name" for="imageUrl"><?= _t('conf.query.image_url') ?></label>
+			<div class="group-controls">
+				<input type="text" class="w100" name="query[imageUrl]" id="imageUrl" value="<?= $this->query->getImageUrl() ?>" />
+			</div>
 		</div>
 
 		<fieldset>

--- a/app/views/index/rss.phtml
+++ b/app/views/index/rss.phtml
@@ -9,7 +9,7 @@
 	<channel>
 		<title><?= $this->rss_title ?></title>
 		<link><?= $this->html_url ?></link>
-		<description><?= _t('index.feed.rss_of', $this->rss_title) ?></description>
+		<description><?= $this->description ?></description>
 		<pubDate><?= date('D, d M Y H:i:s O') ?></pubDate>
 		<lastBuildDate><?= gmdate('D, d M Y H:i:s') ?> GMT</lastBuildDate>
 		<atom:link href="<?= $this->rss_url ?>" rel="self" type="application/rss+xml" />

--- a/app/views/index/rss.phtml
+++ b/app/views/index/rss.phtml
@@ -3,7 +3,7 @@
 	/** @var FreshRSS_View $this */
 ?>
 <?= '<?xml version="1.0" encoding="UTF-8" ?>'; ?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:media="http://search.yahoo.com/mrss/"
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:media="http://search.yahoo.com/mrss/" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
 	<?= $this->rss_base == '' ? '' : ' xml:base="' . $this->rss_base . '"' ?>
 >
 	<channel>
@@ -13,6 +13,12 @@
 		<pubDate><?= date('D, d M Y H:i:s O') ?></pubDate>
 		<lastBuildDate><?= gmdate('D, d M Y H:i:s') ?> GMT</lastBuildDate>
 		<atom:link href="<?= $this->rss_url ?>" rel="self" type="application/rss+xml" />
+		<itunes:image href="<?= $this->image_url ?>"></itunes:image>
+		<image>
+			<url><?= $this->image_url ?></url>
+			<title><?= $this->rss_title ?></title>
+			<link><?= $this->html_url ?></link>
+		</image>
 <?php
 foreach ($this->entries as $item) {
 	if (!$this->internal_rendering) {

--- a/app/views/index/rss.phtml
+++ b/app/views/index/rss.phtml
@@ -3,7 +3,7 @@
 	/** @var FreshRSS_View $this */
 ?>
 <?= '<?xml version="1.0" encoding="UTF-8" ?>'; ?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:media="http://search.yahoo.com/mrss/" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:media="http://search.yahoo.com/mrss/"
 	<?= $this->rss_base == '' ? '' : ' xml:base="' . $this->rss_base . '"' ?>
 >
 	<channel>
@@ -13,7 +13,6 @@
 		<pubDate><?= date('D, d M Y H:i:s O') ?></pubDate>
 		<lastBuildDate><?= gmdate('D, d M Y H:i:s') ?> GMT</lastBuildDate>
 		<atom:link href="<?= $this->rss_url ?>" rel="self" type="application/rss+xml" />
-		<itunes:image href="<?= $this->image_url ?>"></itunes:image>
 		<image>
 			<url><?= $this->image_url ?></url>
 			<title><?= $this->rss_title ?></title>

--- a/p/api/query.php
+++ b/p/api/query.php
@@ -151,11 +151,7 @@ $view->html_url = $query->sharedUrlHtml();
 $view->rss_url = $query->sharedUrlRss();
 $view->rss_title = $query->getName();
 $view->image_url = $query->getImageUrl();
-if ($query->getDescription() != '') {
-	$view->description = $query->getDescription();
-} else {
-	$view->description = _t('index.feed.rss_of', $view->rss_title);
-}
+$view->description = $query->getDescription() ?: _t('index.feed.rss_of', $view->rss_title);
 if ($query->getName() != '') {
 	FreshRSS_View::_title($query->getName());
 }

--- a/p/api/query.php
+++ b/p/api/query.php
@@ -150,6 +150,7 @@ $view->userQuery = $query;
 $view->html_url = $query->sharedUrlHtml();
 $view->rss_url = $query->sharedUrlRss();
 $view->rss_title = $query->getName();
+$view->image_url = $query->getImageUrl();
 if ($query->getDescription() != '') {
 	$view->description = $query->getDescription();
 } else {

--- a/p/api/query.php
+++ b/p/api/query.php
@@ -150,6 +150,11 @@ $view->userQuery = $query;
 $view->html_url = $query->sharedUrlHtml();
 $view->rss_url = $query->sharedUrlRss();
 $view->rss_title = $query->getName();
+if ($query->getDescription() != '') {
+	$view->description = $query->getDescription();
+} else {
+	$view->description = _t('index.feed.rss_of', $view->rss_title);
+}
 if ($query->getName() != '') {
 	FreshRSS_View::_title($query->getName());
 }


### PR DESCRIPTION
Closes #6538

Changes proposed in this pull request:

- add a field for feed description to user queries
- add a field for feed image url to user queries
- put these fields in the shared rss feed

How to test the feature manually:

1. add a user query
1. go to the user query config
1. add a description and image url
1. enable sharing by rss
1. save
1. load the rss from the link
1. the description and image in the rss should match the valuse entered in step 3

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
