### PR TITLE
Sticky Footer Regression dark mode

### DIFF
--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -1200,6 +1200,7 @@ a:hover .icon {
 		--background-color-light-gradient2: #111;
 		--background-color-light: #111;
 		--background-color-light-shadowed: #191919;
+		--background-color-light-shadowed-transparent: #191919cf;
 		--background-color-grey: #1f1f1f;
 		--background-color-hover: #212227;
 

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -1200,6 +1200,7 @@ a:hover .icon {
 		--background-color-light-gradient2: #111;
 		--background-color-light: #111;
 		--background-color-light-shadowed: #191919;
+		--background-color-light-shadowed-transparent: #191919cf;
 		--background-color-grey: #1f1f1f;
 		--background-color-hover: #212227;
 


### PR DESCRIPTION
Regression #6304

Before:
Origine dark mode had a light background.

After:
Dark background
