### PR TITLE
Add quiet option to cli/db-backup.php

### DIFF
--- a/app/Models/DatabaseDAO.php
+++ b/app/Models/DatabaseDAO.php
@@ -269,7 +269,7 @@ SQL;
 	public const SQLITE_EXPORT = 1;
 	public const SQLITE_IMPORT = 2;
 
-	public function dbCopy(string $filename, int $mode, bool $clearFirst = false): bool {
+	public function dbCopy(string $filename, int $mode, bool $clearFirst = false, bool $verbose = true): bool {
 		if (!extension_loaded('pdo_sqlite')) {
 			return self::stdError('PHP extension pdo_sqlite is missing!');
 		}
@@ -354,7 +354,7 @@ SQL;
 
 		$idMaps = [];
 
-		if (defined('STDERR')) {
+		if (defined('STDERR') && $verbose) {
 			fwrite(STDERR, "Start SQL copy…\n");
 		}
 
@@ -397,11 +397,11 @@ SQL;
 					return self::stdError($error);
 				}
 			}
-			if ($n % 100 === 1 && defined('STDERR')) {	//Display progression
+			if ($n % 100 === 1 && defined('STDERR') && $verbose) {	//Display progression
 				fwrite(STDERR, "\033[0G" . $n . '/' . $nbEntries);
 			}
 		}
-		if (defined('STDERR')) {
+		if (defined('STDERR') && $verbose) {
 			fwrite(STDERR, "\033[0G" . $n . '/' . $nbEntries . "\n");
 		}
 		$entryTo->commit();

--- a/cli/README.md
+++ b/cli/README.md
@@ -123,7 +123,7 @@ cd /usr/share/FreshRSS
 
 ./cli/db-backup.php
 # Back-up all users respective database to `data/users/*/backup.sqlite`
-# -q, --quiet suppress all normal output
+# -q, --quiet suppress non-error messages
 
 ./cli/db-restore.php --delete-backup --force-overwrite
 # Restore all users respective database from `data/users/*/backup.sqlite`

--- a/cli/README.md
+++ b/cli/README.md
@@ -123,6 +123,7 @@ cd /usr/share/FreshRSS
 
 ./cli/db-backup.php
 # Back-up all users respective database to `data/users/*/backup.sqlite`
+# -q, --quiet suppress all normal output
 
 ./cli/db-restore.php --delete-backup --force-overwrite
 # Restore all users respective database from `data/users/*/backup.sqlite`

--- a/cli/db-backup.php
+++ b/cli/db-backup.php
@@ -9,8 +9,7 @@ $ok = true;
 $cliOptions = new class extends CliOptionsParser {
 	public string $quiet;
 
-	public function __construct()
-	{
+	public function __construct() {
 		$this->addOption('quiet', (new CliOption('quiet', 'q'))->withValueNone());
 		parent::__construct();
 	}

--- a/cli/db-backup.php
+++ b/cli/db-backup.php
@@ -6,15 +6,32 @@ require(__DIR__ . '/_cli.php');
 performRequirementCheck(FreshRSS_Context::systemConf()->db['type'] ?? '');
 $ok = true;
 
+$cliOptions = new class extends CliOptionsParser {
+	public string $quiet;
+
+	public function __construct()
+	{
+		$this->addOption('quiet', (new CliOption('quiet', 'q'))->withValueNone());
+		parent::__construct();
+	}
+};
+
+if (!empty($cliOptions->errors)) {
+	fail('FreshRSS error: ' . array_shift($cliOptions->errors) . "\n" . $cliOptions->usage);
+}
+
 foreach (listUsers() as $username) {
 	$username = cliInitUser($username);
 	$filename = DATA_PATH . '/users/' . $username . '/backup.sqlite';
 	@unlink($filename);
+	$verbose = !isset($cliOptions->quiet);
 
-	echo 'FreshRSS backup database to SQLite for user “', $username, "”…\n";
+	if ($verbose) {
+		echo 'FreshRSS backup database to SQLite for user “', $username, "”…\n";
+	}
 
 	$databaseDAO = FreshRSS_Factory::createDatabaseDAO($username);
-	$ok &= $databaseDAO->dbCopy($filename, FreshRSS_DatabaseDAO::SQLITE_EXPORT);
+	$ok &= $databaseDAO->dbCopy($filename, FreshRSS_DatabaseDAO::SQLITE_EXPORT, false, $verbose);
 }
 
 done((bool)$ok);


### PR DESCRIPTION
Closes #6582

Changes proposed in this pull request:

- Add `-q`, `--quiet` option to `cli/db-backup.php`

How to test the feature manually:

1. `cli/db-backup.php` with `-q`, `--quiet` does not output any normal output
2. `cli/db-backup.php` with `-q`, `--quiet` can create `data/users/*/backup.sqlite`
3. `cli/db-backup.php` without `-q`, `--quiet` can create `data/users/*/backup.sqlite`
4. `cli/db-backup.php` with undefined options displays usage

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
