### PR TITLE
Initial support for PHP 8.4

### DIFF
--- a/Docker/Dockerfile-Newest
+++ b/Docker/Dockerfile-Newest
@@ -5,11 +5,11 @@ SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories && \
 	apk add --no-cache \
 	tzdata \
-	apache2 php83-apache2 \
+	apache2 php84-apache2 \
 	apache-mod-auth-openidc \
-	php83 php83-curl php83-gmp php83-intl php83-mbstring php83-xml php83-zip \
-	php83-ctype php83-dom php83-fileinfo php83-iconv php83-json php83-opcache php83-openssl php83-phar php83-session php83-simplexml php83-xmlreader php83-xmlwriter php83-xml php83-tokenizer php83-zlib \
-	php83-pdo_sqlite php83-pdo_mysql php83-pdo_pgsql
+	php84 php84-curl php84-gmp php84-intl php84-mbstring php84-xml php84-zip \
+	php84-ctype php84-dom php84-fileinfo php84-iconv php84-json php84-opcache php84-openssl php84-phar php84-session php84-simplexml php84-xmlreader php84-xmlwriter php84-xml php84-tokenizer php84-zlib \
+	php84-pdo_sqlite php84-pdo_mysql php84-pdo_pgsql
 
 RUN mkdir -p /var/www/FreshRSS /run/apache2/
 WORKDIR /var/www/FreshRSS
@@ -41,8 +41,8 @@ RUN rm -f /etc/apache2/conf.d/languages.conf /etc/apache2/conf.d/info.conf \
 	sed -r -i "/^\s*(CustomLog|ErrorLog|Listen) /s/^/#/" \
 		/etc/apache2/httpd.conf && \
 	mv /etc/apache2/conf.d/mod-auth-openidc.conf /etc/apache2/conf.d/mod-auth-openidc.conf.bak && \
-	if [ ! -f /usr/bin/php ]; then ln -s /usr/bin/php83 /usr/bin/php; else true; fi && \
-	echo 'memory_limit = 256M' > /etc/php83/conf.d/10_memory.ini && \
+	if [ ! -f /usr/bin/php ]; then ln -s /usr/bin/php84 /usr/bin/php; else true; fi && \
+	echo 'memory_limit = 256M' > /etc/php84/conf.d/10_memory.ini && \
 	# Disable built-in updates when using Docker, as the full image is supposed to be updated instead.
 	sed -r -i "\\#disable_update#s#^.*#\t'disable_update' => true,#" ./config.default.php && \
 	touch /var/www/FreshRSS/Docker/env.txt && \

--- a/Docker/Dockerfile-Newest
+++ b/Docker/Dockerfile-Newest
@@ -8,7 +8,8 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/reposit
 	apache2 php84-apache2 \
 	apache-mod-auth-openidc \
 	php84 php84-curl php84-gmp php84-intl php84-mbstring php84-xml php84-zip \
-	php84-ctype php84-dom php84-fileinfo php84-iconv php84-json php84-opcache php84-openssl php84-phar php84-session php84-simplexml php84-xmlreader php84-xmlwriter php84-xml php84-tokenizer php84-zlib \
+	php84-ctype php84-dom php84-fileinfo php84-iconv php84-json php84-openssl php84-phar php84-session php84-simplexml php84-xmlreader php84-xmlwriter php84-xml php84-tokenizer php84-zlib \
+	# TODO: Re-add php84-opcache with PHP > 8.4.0alpha1. See https://github.com/php/php-src/issues/14873
 	php84-pdo_sqlite php84-pdo_mysql php84-pdo_pgsql
 
 RUN mkdir -p /var/www/FreshRSS /run/apache2/

--- a/cli/CliOptionsParser.php
+++ b/cli/CliOptionsParser.php
@@ -43,7 +43,7 @@ abstract class CliOptionsParser {
 	 * @param string $defaultInput If not null this value is received as input in all cases where no
 	 *  user input is present. e.g. set this if you want an option to always return a value.
 	 */
-	protected function addOption(string $name, CliOption $option, string $defaultInput = null): void {
+	protected function addOption(string $name, CliOption $option, ?string $defaultInput = null): void {
 		$this->inputs[$name] = [
 			'defaultInput' => is_string($defaultInput) ? [$defaultInput] : $defaultInput,
 			'required' => null,

--- a/cli/i18n/I18nData.php
+++ b/cli/i18n/I18nData.php
@@ -101,7 +101,7 @@ class I18nData {
 	 * Add a new language. It’s a copy of the reference language.
 	 * @throws Exception
 	 */
-	public function addLanguage(string $language, string $reference = null): void {
+	public function addLanguage(string $language, ?string $reference = null): void {
 		if (array_key_exists($language, $this->data)) {
 			throw new Exception('The selected language already exist.');
 		}

--- a/tests/app/Models/FeedDAOTest.php
+++ b/tests/app/Models/FeedDAOTest.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+class FeedDAOTest extends PHPUnit\Framework\TestCase {
+	function test_ttl_min() {
+		$feed = new FreshRSS_Feed('https://example.net/', false);
+		$feed->_ttl(-5);
+		self::assertEquals(-5, $feed->ttl(true));
+		self::assertEquals(true, $feed->mute());
+	}
+}

--- a/tests/app/Models/FeedDAOTest.php
+++ b/tests/app/Models/FeedDAOTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 class FeedDAOTest extends PHPUnit\Framework\TestCase {
-	function test_ttl_min() {
+	function test_ttl_min(): void {
 		$feed = new FreshRSS_Feed('https://example.net/', false);
 		$feed->_ttl(-5);
 		self::assertEquals(-5, $feed->ttl(true));


### PR DESCRIPTION
Sole fix needed so far seems to be related to https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

See also upstream PR https://github.com/PhpGt/CssXPath/pull/227

We are also hitting a PHP bug with `min()` function, reported upstream https://github.com/php/php-src/issues/14873
