### PR TITLE
Fixing dropdown menu for labels

### DIFF
--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -66,8 +66,8 @@
 				?>
 				<li id="t_<?= $tag->id() ?>" class="item feed<?= FreshRSS_Context::isCurrentGet('t_' . $tag->id()) ? ' active' : '' ?>" data-unread="<?= $tag->nbUnread() ?>">
 					<div class="dropdown no-mobile">
-						<div class="dropdown-target"></div>
-						<a class="dropdown-toggle"><?= _i('configure') ?></a>
+						<div id="dropdown-t-<?= $tag->id() ?>" class="dropdown-target"></div>
+						<a class="dropdown-toggle" href="#dropdown-t-<?= $tag->id() ?>"><?= _i('configure') ?></a>
 						<?php /* tag_config_template */ ?>
 					</div>
 					<a class="item-title" data-unread="<?= format_number($tag->nbUnread()) ?>" href="<?=


### PR DESCRIPTION
Regression #6446
But it fixes more than this bug.

It fixes too:
Label-ID and feed-ID could be the same. And it will open the dropdown of the feed instead of label.

Before:
In this case: the label "first label" has the label ID `1`, the feed Framablog has the feed ID `1` too. If user clicks on the dropdown of the feed it opens the dropdown of the label
![same-feed-label-id](https://github.com/FreshRSS/FreshRSS/assets/1645099/33eaaf9f-5b29-4fd2-a95f-bdd0ea8a9a40)

Changes proposed in this pull request:

- give label dropdown another id name


How to test the feature manually:

1. click on the cog icon to open the dropdown of a label
2. see the dropdown menu


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
