### PR TITLE
Re-enable OPCache for PHP 8.4-alpha2

### DIFF
--- a/Docker/Dockerfile-Newest
+++ b/Docker/Dockerfile-Newest
@@ -8,8 +8,7 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/reposit
 	apache2 php84-apache2 \
 	apache-mod-auth-openidc \
 	php84 php84-curl php84-gmp php84-intl php84-mbstring php84-xml php84-zip \
-	php84-ctype php84-dom php84-fileinfo php84-iconv php84-json php84-openssl php84-phar php84-session php84-simplexml php84-xmlreader php84-xmlwriter php84-xml php84-tokenizer php84-zlib \
-	# TODO: Re-add php84-opcache with PHP > 8.4.0alpha1. See https://github.com/php/php-src/issues/14873
+	php84-ctype php84-dom php84-fileinfo php84-iconv php84-json php84-opcache php84-openssl php84-phar php84-session php84-simplexml php84-xmlreader php84-xmlwriter php84-xml php84-tokenizer php84-zlib \
 	php84-pdo_sqlite php84-pdo_mysql php84-pdo_pgsql
 
 RUN mkdir -p /var/www/FreshRSS /run/apache2/


### PR DESCRIPTION
Support https://www.php.net/index.php#2024-07-18-1
Follow-up of https://github.com/FreshRSS/FreshRSS/pull/6615
Bug https://github.com/php/php-src/issues/14873 was fixed https://github.com/nielsdos/php-src/commit/3d0885f9e54ba46bbb082df4c9c32f0be98ee423
