### PR TITLE
New: sharing service archive.is added

### DIFF
--- a/app/i18n/cs/gen.php
+++ b/app/i18n/cs/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Známé základní stránky',
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/cs/gen.php
+++ b/app/i18n/cs/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Známé základní stránky',
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/de/gen.php
+++ b/app/i18n/de/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known-Seite (https://withknown.com)',
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/de/gen.php
+++ b/app/i18n/de/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known-Seite (https://withknown.com)',
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/el/gen.php
+++ b/app/i18n/el/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known based sites',	// TODO
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// TODO
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/el/gen.php
+++ b/app/i18n/el/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known based sites',	// TODO
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// TODO
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/en-us/gen.php
+++ b/app/i18n/en-us/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known based sites',	// IGNORE
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/en/gen.php
+++ b/app/i18n/en/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known based sites',
+		'archiveIS' => 'archive.is',
 		'archiveORG' => 'archive.org',
 		'archivePH' => 'archive.ph',
 		'buffer' => 'Buffer',

--- a/app/i18n/es/gen.php
+++ b/app/i18n/es/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Sitios basados en conocidos',
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/es/gen.php
+++ b/app/i18n/es/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Sitios basados en conocidos',
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/fa/gen.php
+++ b/app/i18n/fa/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => ' سایت های مبتنی بر شناخته شده',
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => ' archive.org',
 		'archivePH' => ' archive.ph',
 		'buffer' => ' بافر',

--- a/app/i18n/fa/gen.php
+++ b/app/i18n/fa/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => ' سایت های مبتنی بر شناخته شده',
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => ' archive.org',
 		'archivePH' => ' archive.ph',
 		'buffer' => ' بافر',

--- a/app/i18n/fr/gen.php
+++ b/app/i18n/fr/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Sites basés sur Known',
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/fr/gen.php
+++ b/app/i18n/fr/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Sites basés sur Known',
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/he/gen.php
+++ b/app/i18n/he/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known based sites',	// TODO
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/he/gen.php
+++ b/app/i18n/he/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known based sites',	// TODO
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/hu/gen.php
+++ b/app/i18n/hu/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Ismert weboldalak',
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/hu/gen.php
+++ b/app/i18n/hu/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Ismert weboldalak',
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/id/gen.php
+++ b/app/i18n/id/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known based sites',	// TODO
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// TODO
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/id/gen.php
+++ b/app/i18n/id/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known based sites',	// TODO
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// TODO
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/it/gen.php
+++ b/app/i18n/it/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Siti basati su Known',
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/it/gen.php
+++ b/app/i18n/it/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Siti basati su Known',
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/ja/gen.php
+++ b/app/i18n/ja/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'よく使われるサイト',
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/ja/gen.php
+++ b/app/i18n/ja/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'よく使われるサイト',
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/ko/gen.php
+++ b/app/i18n/ko/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known based sites',	// IGNORE
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/ko/gen.php
+++ b/app/i18n/ko/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known based sites',	// IGNORE
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/lv/gen.php
+++ b/app/i18n/lv/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Zināmas vietnes',
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/lv/gen.php
+++ b/app/i18n/lv/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Zināmas vietnes',
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/nl/gen.php
+++ b/app/i18n/nl/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known-gebaseerde sites',
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/nl/gen.php
+++ b/app/i18n/nl/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Known-gebaseerde sites',
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/oc/gen.php
+++ b/app/i18n/oc/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Sites basats sus Known',
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/oc/gen.php
+++ b/app/i18n/oc/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Sites basats sus Known',
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/pl/gen.php
+++ b/app/i18n/pl/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Strony bazujące na usłudze Known',
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/pl/gen.php
+++ b/app/i18n/pl/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Strony bazujące na usłudze Known',
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/pt-br/gen.php
+++ b/app/i18n/pt-br/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Sites no Known',
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/pt-br/gen.php
+++ b/app/i18n/pt-br/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Sites no Known',
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/ru/gen.php
+++ b/app/i18n/ru/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Сайты на Known',
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/ru/gen.php
+++ b/app/i18n/ru/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Сайты на Known',
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/sk/gen.php
+++ b/app/i18n/sk/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Stránky založené na Known',
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/sk/gen.php
+++ b/app/i18n/sk/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Stránky založené na Known',
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/tr/gen.php
+++ b/app/i18n/tr/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Bilinen siteler',
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/tr/gen.php
+++ b/app/i18n/tr/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => 'Bilinen siteler',
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/zh-cn/gen.php
+++ b/app/i18n/zh-cn/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => '基于 Known 的站点',
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/zh-cn/gen.php
+++ b/app/i18n/zh-cn/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => '基于 Known 的站点',
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/zh-tw/gen.php
+++ b/app/i18n/zh-tw/gen.php
@@ -204,7 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => '基於 Known 的站點',
-		'archiveIS' => 'archive.is',	// TODO
+		'archiveIS' => 'archive.is',	// IGNORE
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/i18n/zh-tw/gen.php
+++ b/app/i18n/zh-tw/gen.php
@@ -204,6 +204,7 @@ return array(
 	),
 	'share' => array(
 		'Known' => '基於 Known 的站點',
+		'archiveIS' => 'archive.is',	// TODO
 		'archiveORG' => 'archive.org',	// IGNORE
 		'archivePH' => 'archive.ph',	// IGNORE
 		'buffer' => 'Buffer',	// IGNORE

--- a/app/shares.php
+++ b/app/shares.php
@@ -36,6 +36,13 @@ return [
 		'form' => 'simple',
 		'method' => 'GET',
 	],
+	'archiveIS' => [
+		'url' => 'https://archive.is/submit/?url=~LINK~',
+		'transform' => [],
+		'help' => 'https://archive.is/',
+		'form' => 'simple',
+		'method' => 'GET',
+	],
 	'archivePH' => [
 		'url' => 'https://archive.ph/submit/?url=~LINK~',
 		'transform' => [],


### PR DESCRIPTION
Closes #6635

Changes proposed in this pull request:

- `archive.is` added (it is the same as `archive.ph` just another domain)

How to test the feature manually:

1. add `archive.is` to the sharing services
2. share a link via `archive.is`

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
