### PR TITLE
Improve feed sidebar: main stream, favorites, important

### DIFF
--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -42,11 +42,9 @@
 		</li>
 
 		<li class="tree-folder category favorites<?= FreshRSS_Context::isCurrentGet('s') ? ' active' : '' ?>">
-			<div class="tree-folder-title">
-				<?= _i('starred') ?><a class="title" data-unread="<?= format_number(FreshRSS_Context::$total_starred['unread']) ?>" href="<?= _url('index', $actual_view, 'get', 's') . $state_filter_manual ?>">
-					<?= _t('index.menu.favorites', format_number(FreshRSS_Context::$total_starred['all'])) ?>
-				</a>
-			</div>
+			<a class="tree-folder-title" data-unread="<?= format_number(FreshRSS_Context::$total_starred['unread']) ?>" href="<?= _url('index', $actual_view, 'get', 's') . $state_filter_manual ?>">
+				<?= _i('starred') ?><span class="title" data-unread="<?= format_number(FreshRSS_Context::$total_starred['unread']) ?>"><?= _t('index.menu.favorites', format_number(FreshRSS_Context::$total_starred['all'])) ?></span>
+			</a>
 		</li>
 
 		<?php

--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -36,11 +36,9 @@
 		</li>
 
 		<li class="tree-folder category important<?= FreshRSS_Context::isCurrentGet('i') ? ' active' : '' ?>">
-			<div class="tree-folder-title">
-				<?= _i('important') ?><a class="title" data-unread="<?= format_number(FreshRSS_Context::$total_important_unread) ?>" href="<?= _url('index', $actual_view, 'get', 'i') . $state_filter_manual ?>">
-					<?= _t('index.menu.important') ?>
-				</a>
-			</div>
+			<a class="tree-folder-title" data-unread="<?= format_number(FreshRSS_Context::$total_important_unread) ?>" href="<?= _url('index', $actual_view, 'get', 'i') . $state_filter_manual ?>">
+				<?= _i('important') ?><span class="title" data-unread="<?= format_number(FreshRSS_Context::$total_important_unread) ?>"><?= _t('index.menu.important') ?></span>
+			</a>
 		</li>
 
 		<li class="tree-folder category favorites<?= FreshRSS_Context::isCurrentGet('s') ? ' active' : '' ?>">

--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -30,10 +30,9 @@
 	<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
 	<ul id="sidebar" class="tree scrollbar-thin">
 		<li class="tree-folder category all<?= FreshRSS_Context::isCurrentGet('a') ? ' active' : '' ?>">
-			<div class="tree-folder-title">
-				<?= _i('all') ?><a class="title" data-unread="<?= format_number(FreshRSS_Context::$total_unread) ?>" href="<?=
-					_url('index', $actual_view) . $state_filter_manual ?>"><?= _t('index.menu.main_stream') ?></a>
-			</div>
+			<a class="tree-folder-title" data-unread="<?= format_number(FreshRSS_Context::$total_unread) ?>" href="<?= _url('index', $actual_view) . $state_filter_manual ?>">
+				<?= _i('all') ?><span class="title" data-unread="<?= format_number(FreshRSS_Context::$total_unread) ?>"><?= _t('index.menu.main_stream') ?></span>
+			</a>
 		</li>
 
 		<li class="tree-folder category important<?= FreshRSS_Context::isCurrentGet('i') ? ' active' : '' ?>">

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -603,6 +603,12 @@ a:hover .icon {
 	font-size: 1rem;
 }
 
+.aside_feed .tree-folder.all .tree-folder-title .title,
+.aside_feed .tree-folder.important .tree-folder-title .title,
+.aside_feed .tree-folder.favorites .tree-folder-title .title {
+	margin-left: 0.25rem;
+}
+
 .aside_feed .tree-folder-title button.dropdown-toggle {
 	margin: -0.75rem 0.25rem -0.75rem -0.75rem;
 	padding: 0.75rem 0 0.75rem 0.75rem;

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -603,6 +603,12 @@ a:hover .icon {
 	font-size: 1rem;
 }
 
+.aside_feed .tree-folder.all .tree-folder-title .title,
+.aside_feed .tree-folder.important .tree-folder-title .title,
+.aside_feed .tree-folder.favorites .tree-folder-title .title {
+	margin-right: 0.25rem;
+}
+
 .aside_feed .tree-folder-title button.dropdown-toggle {
 	margin: -0.75rem -0.75rem -0.75rem 0.25rem;
 	padding: 0.75rem 0.75rem 0.75rem 0;


### PR DESCRIPTION
Follow up of #6446

Changes proposed in this pull request:

- the streams "main stream", "important", "favorites" are touched
- the whole menu item is now a link, incl. the icon
- the icon changes the color while hovering over the menu item

How to test the feature manually:

1. go to normal view
2. hover over the menu item
3. see the changes as described above

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
