### PR TITLE
Extend regex for enclosure images

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -172,7 +172,7 @@ class FreshRSS_Entry extends Minz_Model {
 		$mime = $enclosure['type'] ?? '';
 
 		return ($elink != '' && $medium === 'image') || strpos($mime, 'image') === 0 ||
-			($mime == '' && $length == 0 && preg_match('/[.](avif|gif|jpe?g|png|svg|webp)$/i', $elink));
+			($mime == '' && $length == 0 && preg_match('/[.](avif|gif|jpe?g|png|svg|webp)([?#]|$)/i', $elink));
 	}
 
 	/**


### PR DESCRIPTION
fix https://github.com/FreshRSS/FreshRSS/discussions/6652
Case of enclosures without any hint about the type besides the file extension, and file extension followed by fragments such as `test.jpg?123` or `test.jpg#123`
