### PR TITLE
Fix regression on mark duplicate titles as read for modified articles

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -583,7 +583,8 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 								continue;
 							}
 
-							$entry->applyFilterActions($titlesAsRead);
+							// NB: Do not mark updated articles as read based on their title, as the duplicate title maybe be from the same article.
+							$entry->applyFilterActions([]);
 							if ($readWhenSameTitleInFeed > 0) {
 								$titlesAsRead[$entry->title()] = true;
 							}


### PR DESCRIPTION
When the option *mark as read if an identical title already exists in the top n newest articles*, that should not apply to updated articles, as they risk being marked as read due to themselves having the same title.
Identifying the different sub-cases would require a more complicated logic, so disable for now.
Regression due to https://github.com/FreshRSS/FreshRSS/pull/6334
