### PR TITLE
Minor update whitespace PHPCS rules

### DIFF
--- a/app/Controllers/authController.php
+++ b/app/Controllers/authController.php
@@ -36,7 +36,6 @@ class FreshRSS_auth_Controller extends FreshRSS_ActionController {
 				$anon_refresh !== FreshRSS_Context::systemConf()->allow_anonymous_refresh ||
 				$unsafe_autologin !== FreshRSS_Context::systemConf()->unsafe_autologin_enabled ||
 				$api_enabled !== FreshRSS_Context::systemConf()->api_enabled) {
-
 				if (in_array($auth_type, ['form', 'http_auth', 'none'], true)) {
 					FreshRSS_Context::systemConf()->auth_type = $auth_type;
 				} else {
@@ -89,6 +88,7 @@ class FreshRSS_auth_Controller extends FreshRSS_ActionController {
 			case 'none':
 				// It should not happen!
 				Minz_Error::error(404);
+				break;
 			default:
 				// TODO load plugin instead
 				Minz_Error::error(404);

--- a/app/Controllers/categoryController.php
+++ b/app/Controllers/categoryController.php
@@ -28,7 +28,7 @@ class FreshRSS_category_Controller extends FreshRSS_ActionController {
 	 * Request parameter is:
 	 *   - new-category
 	 */
-	public function createAction() :void {
+	public function createAction(): void {
 		$catDAO = FreshRSS_Factory::createCategoryDao();
 		$tagDAO = FreshRSS_Factory::createTagDao();
 

--- a/app/Controllers/entryController.php
+++ b/app/Controllers/entryController.php
@@ -79,31 +79,31 @@ class FreshRSS_entry_Controller extends FreshRSS_ActionController {
 			} else {
 				$type_get = $get[0];
 				$get = (int)substr($get, 2);
-				switch($type_get) {
-				case 'c':
-					$entryDAO->markReadCat($get, $id_max, FreshRSS_Context::$search, FreshRSS_Context::$state, $is_read);
-					break;
-				case 'f':
-					$entryDAO->markReadFeed($get, $id_max, FreshRSS_Context::$search, FreshRSS_Context::$state, $is_read);
-					break;
-				case 's':
-					$entryDAO->markReadEntries($id_max, true, null, FreshRSS_Feed::PRIORITY_IMPORTANT,
-						FreshRSS_Context::$search, FreshRSS_Context::$state, $is_read);
-					break;
-				case 'a':
-					$entryDAO->markReadEntries($id_max, false, FreshRSS_Feed::PRIORITY_MAIN_STREAM, FreshRSS_Feed::PRIORITY_IMPORTANT,
-						FreshRSS_Context::$search, FreshRSS_Context::$state, $is_read);
-					break;
-				case 'i':
-					$entryDAO->markReadEntries($id_max, false, FreshRSS_Feed::PRIORITY_IMPORTANT, null,
-						FreshRSS_Context::$search, FreshRSS_Context::$state, $is_read);
-					break;
-				case 't':
-					$entryDAO->markReadTag($get, $id_max, FreshRSS_Context::$search, FreshRSS_Context::$state, $is_read);
-					break;
-				case 'T':
-					$entryDAO->markReadTag(0, $id_max, FreshRSS_Context::$search, FreshRSS_Context::$state, $is_read);
-					break;
+				switch ($type_get) {
+					case 'c':
+						$entryDAO->markReadCat($get, $id_max, FreshRSS_Context::$search, FreshRSS_Context::$state, $is_read);
+						break;
+					case 'f':
+						$entryDAO->markReadFeed($get, $id_max, FreshRSS_Context::$search, FreshRSS_Context::$state, $is_read);
+						break;
+					case 's':
+						$entryDAO->markReadEntries($id_max, true, null, FreshRSS_Feed::PRIORITY_IMPORTANT,
+							FreshRSS_Context::$search, FreshRSS_Context::$state, $is_read);
+						break;
+					case 'a':
+						$entryDAO->markReadEntries($id_max, false, FreshRSS_Feed::PRIORITY_MAIN_STREAM, FreshRSS_Feed::PRIORITY_IMPORTANT,
+							FreshRSS_Context::$search, FreshRSS_Context::$state, $is_read);
+						break;
+					case 'i':
+						$entryDAO->markReadEntries($id_max, false, FreshRSS_Feed::PRIORITY_IMPORTANT, null,
+							FreshRSS_Context::$search, FreshRSS_Context::$state, $is_read);
+						break;
+					case 't':
+						$entryDAO->markReadTag($get, $id_max, FreshRSS_Context::$search, FreshRSS_Context::$state, $is_read);
+						break;
+					case 'T':
+						$entryDAO->markReadTag(0, $id_max, FreshRSS_Context::$search, FreshRSS_Context::$state, $is_read);
+						break;
 				}
 
 				if ($next_get !== 'a') {

--- a/app/Controllers/errorController.php
+++ b/app/Controllers/errorController.php
@@ -24,40 +24,40 @@ class FreshRSS_error_Controller extends FreshRSS_ActionController {
 		]);
 
 		switch ($code_int) {
-		case 200 :
-			header('HTTP/1.1 200 OK');
-			break;
-		case 400:
-			header('HTTP/1.1 400 Bad Request');
-			$this->view->code = 'Error 400 - Bad Request';
-			$this->view->errorMessage = '';
-			break;
-		case 403:
-			header('HTTP/1.1 403 Forbidden');
-			$this->view->code = 'Error 403 - Forbidden';
-			$this->view->errorMessage = _t('feedback.access.denied');
-			break;
-		case 404:
-			header('HTTP/1.1 404 Not Found');
-			$this->view->code = 'Error 404 - Not found';
-			$this->view->errorMessage = _t('feedback.access.not_found');
-			break;
-		case 405:
-			header('HTTP/1.1 405 Method Not Allowed');
-			$this->view->code = 'Error 405 - Method Not Allowed';
-			$this->view->errorMessage = '';
-			break;
-		case 503:
-			header('HTTP/1.1 503 Service Unavailable');
-			$this->view->code = 'Error 503 - Service Unavailable';
-			$this->view->errorMessage = 'Error 503 - Service Unavailable';
-			break;
-		case 500:
-		default:
-			header('HTTP/1.1 500 Internal Server Error');
-			$this->view->code = 'Error 500 - Internal Server Error';
-			$this->view->errorMessage = 'Error 500 - Internal Server Error';
-			break;
+			case 200:
+				header('HTTP/1.1 200 OK');
+				break;
+			case 400:
+				header('HTTP/1.1 400 Bad Request');
+				$this->view->code = 'Error 400 - Bad Request';
+				$this->view->errorMessage = '';
+				break;
+			case 403:
+				header('HTTP/1.1 403 Forbidden');
+				$this->view->code = 'Error 403 - Forbidden';
+				$this->view->errorMessage = _t('feedback.access.denied');
+				break;
+			case 404:
+				header('HTTP/1.1 404 Not Found');
+				$this->view->code = 'Error 404 - Not found';
+				$this->view->errorMessage = _t('feedback.access.not_found');
+				break;
+			case 405:
+				header('HTTP/1.1 405 Method Not Allowed');
+				$this->view->code = 'Error 405 - Method Not Allowed';
+				$this->view->errorMessage = '';
+				break;
+			case 503:
+				header('HTTP/1.1 503 Service Unavailable');
+				$this->view->code = 'Error 503 - Service Unavailable';
+				$this->view->errorMessage = 'Error 503 - Service Unavailable';
+				break;
+			case 500:
+			default:
+				header('HTTP/1.1 500 Internal Server Error');
+				$this->view->code = 'Error 500 - Internal Server Error';
+				$this->view->errorMessage = 'Error 500 - Internal Server Error';
+				break;
 		}
 
 		$error_message = trim(implode($error_logs));

--- a/app/Controllers/extensionController.php
+++ b/app/Controllers/extensionController.php
@@ -158,7 +158,7 @@ class FreshRSS_extension_Controller extends FreshRSS_ActionController {
 
 			if ($conf !== null && $res === true) {
 				$ext_list = $conf->extensions_enabled;
-				$ext_list = array_filter($ext_list, static function(string $key) use($type) {
+				$ext_list = array_filter($ext_list, static function (string $key) use ($type) {
 					// Remove from list the extensions that have disappeared or changed type
 					$extension = Minz_ExtensionManager::findExtension($key);
 					return $extension !== null && $extension->getType() === $type;
@@ -220,7 +220,7 @@ class FreshRSS_extension_Controller extends FreshRSS_ActionController {
 
 			if ($conf !== null && $res === true) {
 				$ext_list = $conf->extensions_enabled;
-				$ext_list = array_filter($ext_list, static function(string $key) use($type) {
+				$ext_list = array_filter($ext_list, static function (string $key) use ($type) {
 					// Remove from list the extensions that have disappeared or changed type
 					$extension = Minz_ExtensionManager::findExtension($key);
 					return $extension !== null && $extension->getType() === $type;

--- a/app/Controllers/importExportController.php
+++ b/app/Controllers/importExportController.php
@@ -38,9 +38,15 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 	 */
 	private static function megabytes(string $size_str) {
 		switch (substr($size_str, -1)) {
-			case 'M': case 'm': return (int)$size_str;
-			case 'K': case 'k': return (int)$size_str / 1024;
-			case 'G': case 'g': return (int)$size_str * 1024;
+			case 'M':
+			case 'm':
+				return (int)$size_str;
+			case 'K':
+			case 'k':
+				return (int)$size_str / 1024;
+			case 'G':
+			case 'g':
+				return (int)$size_str * 1024;
 		}
 		return $size_str;
 	}
@@ -689,15 +695,15 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 	private static function filenameToContentType(string $filename): string {
 		$filetype = self::guessFileType($filename);
 		switch ($filetype) {
-		case 'zip':
-			return 'application/zip';
-		case 'opml':
-			return 'application/xml; charset=utf-8';
-		case 'json_starred':
-		case 'json_feed':
-			return 'application/json; charset=utf-8';
-		default:
-			return 'application/octet-stream';
+			case 'zip':
+				return 'application/zip';
+			case 'opml':
+				return 'application/xml; charset=utf-8';
+			case 'json_starred':
+			case 'json_feed':
+				return 'application/json; charset=utf-8';
+			default:
+				return 'application/octet-stream';
 		}
 	}
 }

--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -266,10 +266,9 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 		}
 
 		foreach ($entryDAO->listWhere(
-					$type, $id, FreshRSS_Context::$state, FreshRSS_Context::$order,
-					$postsPerPage ?? FreshRSS_Context::$number, FreshRSS_Context::$offset, FreshRSS_Context::$first_id,
-					FreshRSS_Context::$search, $date_min)
-				as $entry) {
+			$type, $id, FreshRSS_Context::$state, FreshRSS_Context::$order,
+			$postsPerPage ?? FreshRSS_Context::$number, FreshRSS_Context::$offset, FreshRSS_Context::$first_id,
+			FreshRSS_Context::$search, $date_min) as $entry) {
 			yield $entry;
 		}
 	}

--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -266,9 +266,10 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 		}
 
 		foreach ($entryDAO->listWhere(
-			$type, $id, FreshRSS_Context::$state, FreshRSS_Context::$order,
-			$postsPerPage ?? FreshRSS_Context::$number, FreshRSS_Context::$offset, FreshRSS_Context::$first_id,
-			FreshRSS_Context::$search, $date_min) as $entry) {
+					$type, $id, FreshRSS_Context::$state, FreshRSS_Context::$order,
+					$postsPerPage ?? FreshRSS_Context::$number, FreshRSS_Context::$offset, FreshRSS_Context::$first_id,
+					FreshRSS_Context::$search, $date_min
+				) as $entry) {
 			yield $entry;
 		}
 	}

--- a/app/Exceptions/BadUrlException.php
+++ b/app/Exceptions/BadUrlException.php
@@ -6,5 +6,4 @@ class FreshRSS_BadUrl_Exception extends FreshRSS_Feed_Exception {
 	public function __construct(string $url) {
 		parent::__construct('`' . $url . '` is not a valid URL');
 	}
-
 }

--- a/app/FreshRSS.php
+++ b/app/FreshRSS.php
@@ -74,10 +74,10 @@ class FreshRSS extends Minz_FrontController {
 			if (!FreshRSS_Context::hasSystemConf() || !(FreshRSS_Auth::isCsrfOk() ||
 				(Minz_Request::controllerName() === 'auth' && Minz_Request::actionName() === 'login') ||
 				(Minz_Request::controllerName() === 'user' && Minz_Request::actionName() === 'create' && !FreshRSS_Auth::hasAccess('admin')) ||
-				(Minz_Request::controllerName() === 'feed' && Minz_Request::actionName() === 'actualize'
-					&& FreshRSS_Context::systemConf()->allow_anonymous_refresh) ||
-				(Minz_Request::controllerName() === 'javascript' && Minz_Request::actionName() === 'actualize'
-					&& FreshRSS_Context::systemConf()->allow_anonymous)
+				(Minz_Request::controllerName() === 'feed' && Minz_Request::actionName() === 'actualize' &&
+					FreshRSS_Context::systemConf()->allow_anonymous_refresh) ||
+				(Minz_Request::controllerName() === 'javascript' && Minz_Request::actionName() === 'actualize' &&
+					FreshRSS_Context::systemConf()->allow_anonymous)
 				)) {
 				// Token-based protection against XSRF attacks, except for the login or self-create user forms
 				self::initI18n();
@@ -112,7 +112,7 @@ class FreshRSS extends Minz_FrontController {
 		}
 		$theme = FreshRSS_Themes::load(FreshRSS_Context::userConf()->theme);
 		if ($theme) {
-			foreach(array_reverse($theme['files']) as $file) {
+			foreach (array_reverse($theme['files']) as $file) {
 				switch (substr($file, -3)) {
 					case '.js':
 						$theme_id = $theme['id'];

--- a/app/Mailers/UserMailer.php
+++ b/app/Mailers/UserMailer.php
@@ -38,7 +38,7 @@ class FreshRSS_User_Mailer extends Minz_Mailer {
 		$subject_prefix = '[' . FreshRSS_Context::systemConf()->title . ']';
 		return $this->mail(
 			$user_config->mail_login,
-			$subject_prefix . ' ' ._t('user.mailer.email_need_validation.title')
+			$subject_prefix . ' ' . _t('user.mailer.email_need_validation.title')
 		);
 	}
 }

--- a/app/Models/Auth.php
+++ b/app/Models/Auth.php
@@ -54,48 +54,48 @@ class FreshRSS_Auth {
 	private static function accessControl(): bool {
 		$auth_type = FreshRSS_Context::systemConf()->auth_type;
 		switch ($auth_type) {
-		case 'form':
-			$credentials = FreshRSS_FormAuth::getCredentialsFromCookie();
-			$current_user = '';
-			if (isset($credentials[1])) {
-				$current_user = trim($credentials[0]);
-				Minz_Session::_params([
+			case 'form':
+				$credentials = FreshRSS_FormAuth::getCredentialsFromCookie();
+				$current_user = '';
+				if (isset($credentials[1])) {
+					$current_user = trim($credentials[0]);
+					Minz_Session::_params([
 					Minz_User::CURRENT_USER => $current_user,
 					'passwordHash' => trim($credentials[1]),
 					'csrf' => false,
-				]);
-			}
-			return $current_user != '';
-		case 'http_auth':
-			$current_user = httpAuthUser();
-			if ($current_user == '') {
-				return false;
-			}
-			$login_ok = FreshRSS_UserDAO::exists($current_user);
-			if (!$login_ok && FreshRSS_Context::systemConf()->http_auth_auto_register) {
-				$email = null;
-				if (FreshRSS_Context::systemConf()->http_auth_auto_register_email_field !== '' &&
-					isset($_SERVER[FreshRSS_Context::systemConf()->http_auth_auto_register_email_field])) {
-					$email = (string)$_SERVER[FreshRSS_Context::systemConf()->http_auth_auto_register_email_field];
+					]);
 				}
-				$language = Minz_Translate::getLanguage(null, Minz_Request::getPreferredLanguages(), FreshRSS_Context::systemConf()->language);
-				Minz_Translate::init($language);
-				$login_ok = FreshRSS_user_Controller::createUser($current_user, $email, '', [
+				return $current_user != '';
+			case 'http_auth':
+				$current_user = httpAuthUser();
+				if ($current_user == '') {
+					return false;
+				}
+				$login_ok = FreshRSS_UserDAO::exists($current_user);
+				if (!$login_ok && FreshRSS_Context::systemConf()->http_auth_auto_register) {
+					$email = null;
+					if (FreshRSS_Context::systemConf()->http_auth_auto_register_email_field !== '' &&
+						isset($_SERVER[FreshRSS_Context::systemConf()->http_auth_auto_register_email_field])) {
+						$email = (string)$_SERVER[FreshRSS_Context::systemConf()->http_auth_auto_register_email_field];
+					}
+					$language = Minz_Translate::getLanguage(null, Minz_Request::getPreferredLanguages(), FreshRSS_Context::systemConf()->language);
+					Minz_Translate::init($language);
+					$login_ok = FreshRSS_user_Controller::createUser($current_user, $email, '', [
 					'language' => $language,
-				]);
-			}
-			if ($login_ok) {
-				Minz_Session::_params([
+					]);
+				}
+				if ($login_ok) {
+					Minz_Session::_params([
 					Minz_User::CURRENT_USER => $current_user,
 					'csrf' => false,
-				]);
-			}
-			return $login_ok;
-		case 'none':
-			return true;
-		default:
-			// TODO load extension
-			return false;
+					]);
+				}
+				return $login_ok;
+			case 'none':
+				return true;
+			default:
+				// TODO load extension
+				return false;
 		}
 	}
 
@@ -110,19 +110,19 @@ class FreshRSS_Auth {
 		}
 
 		switch (FreshRSS_Context::systemConf()->auth_type) {
-		case 'form':
-			self::$login_ok = Minz_Session::paramString('passwordHash') === FreshRSS_Context::userConf()->passwordHash;
-			break;
-		case 'http_auth':
-			$current_user = Minz_User::name() ?? '';
-			self::$login_ok = strcasecmp($current_user, httpAuthUser()) === 0;
-			break;
-		case 'none':
-			self::$login_ok = true;
-			break;
-		default:
-			// TODO: extensions
-			self::$login_ok = false;
+			case 'form':
+				self::$login_ok = Minz_Session::paramString('passwordHash') === FreshRSS_Context::userConf()->passwordHash;
+				break;
+			case 'http_auth':
+				$current_user = Minz_User::name() ?? '';
+				self::$login_ok = strcasecmp($current_user, httpAuthUser()) === 0;
+				break;
+			case 'none':
+				self::$login_ok = true;
+				break;
+			default:
+				// TODO: extensions
+				self::$login_ok = false;
 		}
 
 		Minz_Session::_params([
@@ -147,13 +147,13 @@ class FreshRSS_Auth {
 		$default_user = FreshRSS_Context::systemConf()->default_user;
 		$ok = self::$login_ok;
 		switch ($scope) {
-		case 'general':
-			break;
-		case 'admin':
-			$ok &= $default_user === $currentUser || $isAdmin;
-			break;
-		default:
-			$ok = false;
+			case 'general':
+				break;
+			case 'admin':
+				$ok &= $default_user === $currentUser || $isAdmin;
+				break;
+			default:
+				$ok = false;
 		}
 		return (bool)$ok;
 	}
@@ -186,16 +186,16 @@ class FreshRSS_Auth {
 		Minz_User::change($username);
 
 		switch (FreshRSS_Context::systemConf()->auth_type) {
-		case 'form':
-			Minz_Session::_param('passwordHash');
-			FreshRSS_FormAuth::deleteCookie();
-			break;
-		case 'http_auth':
-		case 'none':
-			// Nothing to do…
-			break;
-		default:
-			// TODO: extensions
+			case 'form':
+				Minz_Session::_param('passwordHash');
+				FreshRSS_FormAuth::deleteCookie();
+				break;
+			case 'http_auth':
+			case 'none':
+				// Nothing to do…
+				break;
+			default:
+				// TODO: extensions
 		}
 	}
 

--- a/app/Models/CategoryDAOSQLite.php
+++ b/app/Models/CategoryDAOSQLite.php
@@ -16,5 +16,4 @@ class FreshRSS_CategoryDAOSQLite extends FreshRSS_CategoryDAO {
 		}
 		return false;
 	}
-
 }

--- a/app/Models/Context.php
+++ b/app/Models/Context.php
@@ -347,23 +347,23 @@ final class FreshRSS_Context {
 		$type = substr($get, 0, 1);
 		$id = substr($get, 2);
 
-		switch($type) {
-		case 'a':
-			return self::$current_get['all'];
-		case 'i':
-			return self::$current_get['important'];
-		case 's':
-			return self::$current_get['starred'];
-		case 'f':
-			return self::$current_get['feed'] == $id;
-		case 'c':
-			return self::$current_get['category'] == $id;
-		case 't':
-			return self::$current_get['tag'] == $id;
-		case 'T':
-			return self::$current_get['tags'] || self::$current_get['tag'];
-		default:
-			return false;
+		switch ($type) {
+			case 'a':
+				return self::$current_get['all'];
+			case 'i':
+				return self::$current_get['important'];
+			case 's':
+				return self::$current_get['starred'];
+			case 'f':
+				return self::$current_get['feed'] == $id;
+			case 'c':
+				return self::$current_get['category'] == $id;
+			case 't':
+				return self::$current_get['tag'] == $id;
+			case 'T':
+				return self::$current_get['tags'] || self::$current_get['tag'];
+			default:
+				return false;
 		}
 	}
 
@@ -393,84 +393,84 @@ final class FreshRSS_Context {
 			self::$categories = $catDAO->listCategories(true, $details);
 		}
 
-		switch($type) {
-		case 'a':
-			self::$current_get['all'] = true;
-			self::$name = _t('index.feed.title');
-			self::$description = FreshRSS_Context::systemConf()->meta_description;
-			self::$get_unread = self::$total_unread;
-			break;
-		case 'i':
-			self::$current_get['important'] = true;
-			self::$name = _t('index.menu.important');
-			self::$description = FreshRSS_Context::systemConf()->meta_description;
-			self::$get_unread = self::$total_unread;
-			break;
-		case 's':
-			self::$current_get['starred'] = true;
-			self::$name = _t('index.feed.title_fav');
-			self::$description = FreshRSS_Context::systemConf()->meta_description;
-			self::$get_unread = self::$total_starred['unread'];
+		switch ($type) {
+			case 'a':
+				self::$current_get['all'] = true;
+				self::$name = _t('index.feed.title');
+				self::$description = FreshRSS_Context::systemConf()->meta_description;
+				self::$get_unread = self::$total_unread;
+				break;
+			case 'i':
+				self::$current_get['important'] = true;
+				self::$name = _t('index.menu.important');
+				self::$description = FreshRSS_Context::systemConf()->meta_description;
+				self::$get_unread = self::$total_unread;
+				break;
+			case 's':
+				self::$current_get['starred'] = true;
+				self::$name = _t('index.feed.title_fav');
+				self::$description = FreshRSS_Context::systemConf()->meta_description;
+				self::$get_unread = self::$total_starred['unread'];
 
-			// Update state if favorite is not yet enabled.
-			self::$state = self::$state | FreshRSS_Entry::STATE_FAVORITE;
-			break;
-		case 'f':
-			// We try to find the corresponding feed. When allowing robots, always retrieve the full feed including description
-			$feed = FreshRSS_Context::systemConf()->allow_robots ? null : FreshRSS_Category::findFeed(self::$categories, $id);
-			if ($feed === null) {
-				$feedDAO = FreshRSS_Factory::createFeedDao();
-				$feed = $feedDAO->searchById($id);
+				// Update state if favorite is not yet enabled.
+				self::$state = self::$state | FreshRSS_Entry::STATE_FAVORITE;
+				break;
+			case 'f':
+				// We try to find the corresponding feed. When allowing robots, always retrieve the full feed including description
+				$feed = FreshRSS_Context::systemConf()->allow_robots ? null : FreshRSS_Category::findFeed(self::$categories, $id);
 				if ($feed === null) {
-					throw new FreshRSS_Context_Exception('Invalid feed: ' . $id);
+					$feedDAO = FreshRSS_Factory::createFeedDao();
+					$feed = $feedDAO->searchById($id);
+					if ($feed === null) {
+						throw new FreshRSS_Context_Exception('Invalid feed: ' . $id);
+					}
 				}
-			}
-			self::$current_get['feed'] = $id;
-			self::$current_get['category'] = $feed->categoryId();
-			self::$name = $feed->name();
-			self::$description = $feed->description();
-			self::$get_unread = $feed->nbNotRead();
-			break;
-		case 'c':
-			// We try to find the corresponding category.
-			self::$current_get['category'] = $id;
-			if (!isset(self::$categories[$id])) {
-				$catDAO = FreshRSS_Factory::createCategoryDao();
-				$cat = $catDAO->searchById($id);
-				if ($cat === null) {
-					throw new FreshRSS_Context_Exception('Invalid category: ' . $id);
+				self::$current_get['feed'] = $id;
+				self::$current_get['category'] = $feed->categoryId();
+				self::$name = $feed->name();
+				self::$description = $feed->description();
+				self::$get_unread = $feed->nbNotRead();
+				break;
+			case 'c':
+				// We try to find the corresponding category.
+				self::$current_get['category'] = $id;
+				if (!isset(self::$categories[$id])) {
+					$catDAO = FreshRSS_Factory::createCategoryDao();
+					$cat = $catDAO->searchById($id);
+					if ($cat === null) {
+						throw new FreshRSS_Context_Exception('Invalid category: ' . $id);
+					}
+					self::$categories[$id] = $cat;
+				} else {
+					$cat = self::$categories[$id];
 				}
-				self::$categories[$id] = $cat;
-			} else {
-				$cat = self::$categories[$id];
-			}
-			self::$name = $cat->name();
-			self::$get_unread = $cat->nbNotRead();
-			break;
-		case 't':
-			// We try to find the corresponding tag.
-			self::$current_get['tag'] = $id;
-			if (!isset(self::$tags[$id])) {
+				self::$name = $cat->name();
+				self::$get_unread = $cat->nbNotRead();
+				break;
+			case 't':
+				// We try to find the corresponding tag.
+				self::$current_get['tag'] = $id;
+				if (!isset(self::$tags[$id])) {
+					$tagDAO = FreshRSS_Factory::createTagDao();
+					$tag = $tagDAO->searchById($id);
+					if ($tag === null) {
+						throw new FreshRSS_Context_Exception('Invalid tag: ' . $id);
+					}
+					self::$tags[$id] = $tag;
+				} else {
+					$tag = self::$tags[$id];
+				}
+				self::$name = $tag->name();
+				self::$get_unread = $tag->nbUnread();
+				break;
+			case 'T':
 				$tagDAO = FreshRSS_Factory::createTagDao();
-				$tag = $tagDAO->searchById($id);
-				if ($tag === null) {
-					throw new FreshRSS_Context_Exception('Invalid tag: ' . $id);
-				}
-				self::$tags[$id] = $tag;
-			} else {
-				$tag = self::$tags[$id];
-			}
-			self::$name = $tag->name();
-			self::$get_unread = $tag->nbUnread();
-			break;
-		case 'T':
-			$tagDAO = FreshRSS_Factory::createTagDao();
-			self::$current_get['tags'] = true;
-			self::$name = _t('index.menu.tags');
-			self::$get_unread = $tagDAO->countNotRead();
-			break;
-		default:
-			throw new FreshRSS_Context_Exception('Invalid getter: ' . $get);
+				self::$current_get['tags'] = true;
+				self::$name = _t('index.menu.tags');
+				self::$get_unread = $tagDAO->countNotRead();
+				break;
+			default:
+				throw new FreshRSS_Context_Exception('Invalid getter: ' . $get);
 		}
 
 		self::_nextGet();
@@ -493,54 +493,54 @@ final class FreshRSS_Context {
 			$another_unread_id = '';
 			$found_current_get = false;
 			switch ($get[0]) {
-			case 'f':
-				// We search the next unread feed with the following priorities: next in same category, or previous in same category, or next, or previous.
-				foreach (self::$categories as $cat) {
-					$sameCat = false;
-					foreach ($cat->feeds() as $feed) {
-						if ($found_current_get) {
-							if ($feed->nbNotRead() > 0) {
+				case 'f':
+					// We search the next unread feed with the following priorities: next in same category, or previous in same category, or next, or previous.
+					foreach (self::$categories as $cat) {
+						$sameCat = false;
+						foreach ($cat->feeds() as $feed) {
+							if ($found_current_get) {
+								if ($feed->nbNotRead() > 0) {
+									$another_unread_id = $feed->id();
+									break 2;
+								}
+							} elseif ($feed->id() == self::$current_get['feed']) {
+								$found_current_get = true;
+							} elseif ($feed->nbNotRead() > 0) {
 								$another_unread_id = $feed->id();
-								break 2;
+								$sameCat = true;
 							}
-						} elseif ($feed->id() == self::$current_get['feed']) {
-							$found_current_get = true;
-						} elseif ($feed->nbNotRead() > 0) {
-							$another_unread_id = $feed->id();
-							$sameCat = true;
 						}
-					}
-					if ($found_current_get && $sameCat) {
-						break;
-					}
-				}
-
-				// If there is no more unread feed, show main stream
-				self::$next_get = $another_unread_id == '' ? 'a' : 'f_' . $another_unread_id;
-				break;
-			case 'c':
-				// We search the next category with at least one unread article.
-				foreach (self::$categories as $cat) {
-					if ($cat->id() == self::$current_get['category']) {
-						// Here is our current category! Next one could be our
-						// champion if it has unread articles.
-						$found_current_get = true;
-						continue;
-					}
-
-					if ($cat->nbNotRead() > 0) {
-						$another_unread_id = $cat->id();
-						if ($found_current_get) {
-							// Unread articles and the current category has
-							// already been found? Leave the loop!
+						if ($found_current_get && $sameCat) {
 							break;
 						}
 					}
-				}
 
-				// If there is no more unread category, show main stream
-				self::$next_get = $another_unread_id == '' ? 'a' : 'c_' . $another_unread_id;
-				break;
+					// If there is no more unread feed, show main stream
+					self::$next_get = $another_unread_id == '' ? 'a' : 'f_' . $another_unread_id;
+					break;
+				case 'c':
+					// We search the next category with at least one unread article.
+					foreach (self::$categories as $cat) {
+						if ($cat->id() == self::$current_get['category']) {
+							// Here is our current category! Next one could be our
+							// champion if it has unread articles.
+							$found_current_get = true;
+							continue;
+						}
+
+						if ($cat->nbNotRead() > 0) {
+							$another_unread_id = $cat->id();
+							if ($found_current_get) {
+								// Unread articles and the current category has
+								// already been found? Leave the loop!
+								break;
+							}
+						}
+					}
+
+					// If there is no more unread category, show main stream
+					self::$next_get = $another_unread_id == '' ? 'a' : 'c_' . $another_unread_id;
+					break;
 			}
 		}
 	}

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -393,7 +393,7 @@ HTML;
 		return timestamptodate($this->date);
 	}
 	public function machineReadableDate(): string {
-		return @date (DATE_ATOM, $this->date);
+		return @date(DATE_ATOM, $this->date);
 	}
 
 	public function lastSeen(): int {
@@ -720,17 +720,17 @@ HTML;
 	public function isDay(int $day, int $today): bool {
 		$date = $this->dateAdded(true);
 		switch ($day) {
-		case FreshRSS_Days::TODAY:
-			$tomorrow = $today + 86400;
-			return $date >= $today && $date < $tomorrow;
-		case FreshRSS_Days::YESTERDAY:
-			$yesterday = $today - 86400;
-			return $date >= $yesterday && $date < $today;
-		case FreshRSS_Days::BEFORE_YESTERDAY:
-			$yesterday = $today - 86400;
-			return $date < $yesterday;
-		default:
-			return false;
+			case FreshRSS_Days::TODAY:
+				$tomorrow = $today + 86400;
+				return $date >= $today && $date < $tomorrow;
+			case FreshRSS_Days::YESTERDAY:
+				$yesterday = $today - 86400;
+				return $date >= $yesterday && $date < $today;
+			case FreshRSS_Days::BEFORE_YESTERDAY:
+				$yesterday = $today - 86400;
+				return $date < $yesterday;
+			default:
+				return false;
 		}
 	}
 

--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -312,7 +312,7 @@ SQL;
 		}
 		$sql = 'UPDATE `_entry` '
 			. 'SET is_favorite=? '
-			. 'WHERE id IN (' . str_repeat('?,', count($ids) - 1). '?)';
+			. 'WHERE id IN (' . str_repeat('?,', count($ids) - 1) . '?)';
 		$values = [$is_favorite ? 1 : 0];
 		$values = array_merge($values, $ids);
 		$stm = $this->pdo->prepare($sql);
@@ -393,7 +393,7 @@ SQL;
 
 			$sql = 'UPDATE `_entry` '
 				 . 'SET is_read=? '
-				 . 'WHERE id IN (' . str_repeat('?,', count($ids) - 1). '?)';
+				 . 'WHERE id IN (' . str_repeat('?,', count($ids) - 1) . '?)';
 			$values = [$is_read ? 1 : 0];
 			$values = array_merge($values, $ids);
 			$stm = $this->pdo->prepare($sql);
@@ -1062,43 +1062,43 @@ SQL;
 		$where = '';
 		$values = [];
 		switch ($type) {
-		case 'a':	//All PRIORITY_MAIN_STREAM
-			$where .= 'f.priority >= ' . FreshRSS_Feed::PRIORITY_MAIN_STREAM . ' ';
-			break;
-		case 'A':	//All except PRIORITY_ARCHIVED
-			$where .= 'f.priority > ' . FreshRSS_Feed::PRIORITY_ARCHIVED . ' ';
-			break;
-		case 'i':	//Priority important feeds
-			$where .= 'f.priority >= ' . FreshRSS_Feed::PRIORITY_IMPORTANT . ' ';
-			break;
-		case 's':	//Starred. Deprecated: use $state instead
-			$where .= 'f.priority > ' . FreshRSS_Feed::PRIORITY_ARCHIVED . ' ';
-			$where .= 'AND e.is_favorite=1 ';
-			break;
-		case 'S':	//Starred
-			$where .= 'e.is_favorite=1 ';
-			break;
-		case 'c':	//Category
-			$where .= 'f.priority >= ' . FreshRSS_Feed::PRIORITY_CATEGORY . ' ';
-			$where .= 'AND f.category=? ';
-			$values[] = $id;
-			break;
-		case 'f':	//Feed
-			$where .= 'e.id_feed=? ';
-			$values[] = $id;
-			break;
-		case 't':	//Tag (label)
-			$where .= 'et.id_tag=? ';
-			$values[] = $id;
-			break;
-		case 'T':	//Any tag (label)
-			$where .= '1=1 ';
-			break;
-		case 'ST':	//Starred or tagged (label)
-			$where .= 'e.is_favorite=1 OR EXISTS (SELECT et2.id_tag FROM `_entrytag` et2 WHERE et2.id_entry = e.id) ';
-			break;
-		default:
-			throw new FreshRSS_EntriesGetter_Exception('Bad type in Entry->listByType: [' . $type . ']!');
+			case 'a':	//All PRIORITY_MAIN_STREAM
+				$where .= 'f.priority >= ' . FreshRSS_Feed::PRIORITY_MAIN_STREAM . ' ';
+				break;
+			case 'A':	//All except PRIORITY_ARCHIVED
+				$where .= 'f.priority > ' . FreshRSS_Feed::PRIORITY_ARCHIVED . ' ';
+				break;
+			case 'i':	//Priority important feeds
+				$where .= 'f.priority >= ' . FreshRSS_Feed::PRIORITY_IMPORTANT . ' ';
+				break;
+			case 's':	//Starred. Deprecated: use $state instead
+				$where .= 'f.priority > ' . FreshRSS_Feed::PRIORITY_ARCHIVED . ' ';
+				$where .= 'AND e.is_favorite=1 ';
+				break;
+			case 'S':	//Starred
+				$where .= 'e.is_favorite=1 ';
+				break;
+			case 'c':	//Category
+				$where .= 'f.priority >= ' . FreshRSS_Feed::PRIORITY_CATEGORY . ' ';
+				$where .= 'AND f.category=? ';
+				$values[] = $id;
+				break;
+			case 'f':	//Feed
+				$where .= 'e.id_feed=? ';
+				$values[] = $id;
+				break;
+			case 't':	//Tag (label)
+				$where .= 'et.id_tag=? ';
+				$values[] = $id;
+				break;
+			case 'T':	//Any tag (label)
+				$where .= '1=1 ';
+				break;
+			case 'ST':	//Starred or tagged (label)
+				$where .= 'e.is_favorite=1 OR EXISTS (SELECT et2.id_tag FROM `_entrytag` et2 WHERE et2.id_entry = e.id) ';
+				break;
+			default:
+				throw new FreshRSS_EntriesGetter_Exception('Bad type in Entry->listByType: [' . $type . ']!');
 		}
 
 		[$searchValues, $search] = $this->sqlListEntriesWhere('e.', $filters, $state, $order, $firstId, $date_min);
@@ -1257,7 +1257,7 @@ SQL;
 		}
 		$guids = array_unique($guids);
 		$sql = 'SELECT guid, ' . static::sqlHexEncode('hash') .
-			' AS hex_hash FROM `_entry` WHERE id_feed=? AND guid IN (' . str_repeat('?,', count($guids) - 1). '?)';
+			' AS hex_hash FROM `_entry` WHERE id_feed=? AND guid IN (' . str_repeat('?,', count($guids) - 1) . '?)';
 		$stm = $this->pdo->prepare($sql);
 		$values = [$id_feed];
 		$values = array_merge($values, $guids);
@@ -1294,7 +1294,7 @@ SQL;
 			}
 			return $affected;
 		}
-		$sql = 'UPDATE `_entry` SET `lastSeen`=? WHERE id_feed=? AND guid IN (' . str_repeat('?,', count($guids) - 1). '?)';
+		$sql = 'UPDATE `_entry` SET `lastSeen`=? WHERE id_feed=? AND guid IN (' . str_repeat('?,', count($guids) - 1) . '?)';
 		$stm = $this->pdo->prepare($sql);
 		if ($mtime <= 0) {
 			$mtime = time();

--- a/app/Models/EntryDAOSQLite.php
+++ b/app/Models/EntryDAOSQLite.php
@@ -86,11 +86,11 @@ SQL;
 		FreshRSS_UserDAO::touch();
 		if (is_array($ids)) {	//Many IDs at once (used by API)
 			//if (true) {	//Speed heuristics	//TODO: Not implemented yet for SQLite (so always call IDs one by one)
-				$affected = 0;
-				foreach ($ids as $id) {
-					$affected += ($this->markRead($id, $is_read) ?: 0);
-				}
-				return $affected;
+			$affected = 0;
+			foreach ($ids as $id) {
+				$affected += ($this->markRead($id, $is_read) ?: 0);
+			}
+			return $affected;
 			//}
 		} else {
 			$this->pdo->beginTransaction();

--- a/app/Models/Factory.php
+++ b/app/Models/Factory.php
@@ -89,5 +89,4 @@ class FreshRSS_Factory {
 				return new FreshRSS_DatabaseDAO($username);
 		}
 	}
-
 }

--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -464,7 +464,7 @@ SET `cache_nbEntries`=(SELECT COUNT(e1.id) FROM `_entry` e1 WHERE e1.id_feed=`_f
 	`cache_nbUnreads`=(SELECT COUNT(e2.id) FROM `_entry` e2 WHERE e2.id_feed=`_feed`.id AND e2.is_read=0)
 SQL;
 		if (count($feedIds) > 0) {
-			$sql .= ' WHERE id IN (' . str_repeat('?,', count($feedIds) - 1). '?)';
+			$sql .= ' WHERE id IN (' . str_repeat('?,', count($feedIds) - 1) . '?)';
 		}
 		$stm = $this->pdo->prepare($sql);
 		if ($stm !== false && $stm->execute($feedIds)) {

--- a/app/Models/FilterActionsTrait.php
+++ b/app/Models/FilterActionsTrait.php
@@ -84,7 +84,7 @@ trait FreshRSS_FilterActionsTrait {
 				}
 			}
 			//Update existing filter with new action
-			for ($k = count($filters) - 1; $k >= 0; $k --) {
+			for ($k = count($filters) - 1; $k >= 0; $k--) {
 				$filter = $filters[$k];
 				if ($filter === $filterAction->booleanSearch()->getRawInput()) {
 					$actions[] = $action;
@@ -100,7 +100,7 @@ trait FreshRSS_FilterActionsTrait {
 		}
 
 		//Add new filters
-		for ($k = count($filters) - 1; $k >= 0; $k --) {
+		for ($k = count($filters) - 1; $k >= 0; $k--) {
 			$filter = $filters[$k];
 			if ($filter != '') {
 				$filterAction = FreshRSS_FilterAction::fromJSON([

--- a/app/Models/Share.php
+++ b/app/Models/Share.php
@@ -157,7 +157,7 @@ class FreshRSS_Share {
 				case 'method':
 					$this->method = strcasecmp($value, 'POST') === 0 ? 'POST' : 'GET';
 					break;
-				case 'field';
+				case 'field':
 					$this->field = $value;
 					break;
 			}

--- a/app/Models/StatsDAO.php
+++ b/app/Models/StatsDAO.php
@@ -371,5 +371,4 @@ SQL;
 
 		return $translated;
 	}
-
 }

--- a/app/Models/StatsDAOPGSQL.php
+++ b/app/Models/StatsDAOPGSQL.php
@@ -68,7 +68,7 @@ SQL;
 				$periodMax = 12;
 				break;
 			default:
-			$periodMax = 30;
+				$periodMax = 30;
 		}
 
 		$repartition = array_fill(0, $periodMax, 0);
@@ -78,5 +78,4 @@ SQL;
 
 		return $repartition;
 	}
-
 }

--- a/app/Models/StatsDAOSQLite.php
+++ b/app/Models/StatsDAOSQLite.php
@@ -43,7 +43,7 @@ SQL;
 				$periodMax = 12;
 				break;
 			default:
-			$periodMax = 30;
+				$periodMax = 30;
 		}
 
 		$repartition = array_fill(0, $periodMax, 0);
@@ -53,5 +53,4 @@ SQL;
 
 		return $repartition;
 	}
-
 }

--- a/app/Models/TagDAO.php
+++ b/app/Models/TagDAO.php
@@ -381,7 +381,7 @@ SQL;
 				}
 				return $values;
 			}
-			$sql .= ' AND et.id_entry IN (' . str_repeat('?,', count($entries) - 1). '?)';
+			$sql .= ' AND et.id_entry IN (' . str_repeat('?,', count($entries) - 1) . '?)';
 			if (is_array($entries[0])) {
 				/** @var array<array<string,string>> $entries */
 				foreach ($entries as $entry) {

--- a/app/Models/TagDAOPGSQL.php
+++ b/app/Models/TagDAOPGSQL.php
@@ -7,5 +7,4 @@ class FreshRSS_TagDAOPGSQL extends FreshRSS_TagDAO {
 	public function sqlIgnore(): string {
 		return '';	//TODO
 	}
-
 }

--- a/app/Models/TagDAOSQLite.php
+++ b/app/Models/TagDAOSQLite.php
@@ -7,5 +7,4 @@ class FreshRSS_TagDAOSQLite extends FreshRSS_TagDAO {
 	public function sqlIgnore(): string {
 		return 'OR IGNORE';
 	}
-
 }

--- a/app/Models/Themes.php
+++ b/app/Models/Themes.php
@@ -158,7 +158,7 @@ class FreshRSS_Themes extends Minz_Model {
 		if ($type == self::ICON_DEFAULT) {
 			if ((FreshRSS_Context::hasUserConf() && FreshRSS_Context::userConf()->icons_as_emojis)
 				// default to emoji alternate for some icons
-				) {
+			) {
 				$type = self::ICON_EMOJI;
 			} else {
 				$type = self::ICON_IMG;

--- a/app/Models/View.php
+++ b/app/Models/View.php
@@ -129,5 +129,4 @@ class FreshRSS_View extends Minz_View {
 	public string $errorMessage;
 	/** @var array<string,string> */
 	public array $message;
-
 }

--- a/app/Models/ViewStats.php
+++ b/app/Models/ViewStats.php
@@ -44,5 +44,4 @@ final class FreshRSS_ViewStats extends FreshRSS_View {
 	public array $repartitionMonth;
 	/** @var array<array{'id':int,'name':string,'category':string,'count':int}> */
 	public array $topFeed;
-
 }

--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -692,7 +692,7 @@
 				<div class="group-controls">
 					<select name="proxy_type" id="proxy_type"><?php
 						$type = $curlParams[CURLOPT_PROXYTYPE] ?? '';
-						foreach(['' => '', 3 => 'NONE', 0 => 'HTTP', 2 => 'HTTPS', 4 => 'SOCKS4', 6 => 'SOCKS4A', 5 => 'SOCKS5', 7 => 'SOCKS5H'] as $k => $v) {
+						foreach (['' => '', 3 => 'NONE', 0 => 'HTTP', 2 => 'HTTPS', 4 => 'SOCKS4', 6 => 'SOCKS4A', 5 => 'SOCKS5', 7 => 'SOCKS5H'] as $k => $v) {
 							echo '<option value="' . $k . ($type === $k ? '" selected="selected' : '' ) . '">' . $v . '</option>';
 						}
 					?>

--- a/app/views/importExport/index.phtml
+++ b/app/views/importExport/index.phtml
@@ -62,7 +62,7 @@
 				<?php
 					$select_args = '';
 					if (extension_loaded('zip')) {
-						$select_args = ' size="' . min(10, count($this->feeds)) .'" multiple="multiple"';
+						$select_args = ' size="' . min(10, count($this->feeds)) . '" multiple="multiple"';
 					}
 				?>
 				<select name="export_feeds[]"<?= $select_args ?> size="10">

--- a/app/views/stats/index.phtml
+++ b/app/views/stats/index.phtml
@@ -83,16 +83,15 @@
 			<div>
 				<canvas id="statsEntriesPerDay"></canvas>
 				<script class="jsonData-stats" type="application/json">
-				<?php
-				echo json_encode(array(
+				<?= json_encode([
 					'canvasID' 		=> 'statsEntriesPerDay',
 					'charttype' 	=> 'barWithAverage',
 					'labelBarChart' => _t('admin.stats.entry_count'),
 					'dataBarChart' 	=> $this->entryCount,
-					'labelAverage' 	=> 'Average ('.$this->average.')',
+					'labelAverage' 	=> 'Average (' . $this->average . ')',
 					'dataAverage' 	=> $this->average,
 					'xAxisLabels' 	=> $this->last30DaysLabels,
-				), JSON_UNESCAPED_UNICODE);
+				], JSON_UNESCAPED_UNICODE)
 				?></script>
 			</div>
 		</div>

--- a/app/views/subscription/add.phtml
+++ b/app/views/subscription/add.phtml
@@ -310,7 +310,7 @@
 				<label class="group-name" for="proxy_type"><?= _t('sub.feed.proxy') ?></label>
 				<div class="group-controls">
 					<select class="number" name="proxy_type" id="proxy_type"><?php
-						foreach(['' => '', 3 => 'NONE', 0 => 'HTTP', 2 => 'HTTPS', 4 => 'SOCKS4', 6 => 'SOCKS4A', 5 => 'SOCKS5', 7 => 'SOCKS5H'] as $k => $v) {
+						foreach (['' => '', 3 => 'NONE', 0 => 'HTTP', 2 => 'HTTPS', 4 => 'SOCKS4', 6 => 'SOCKS4A', 5 => 'SOCKS5', 7 => 'SOCKS5H'] as $k => $v) {
 							echo '<option value="' . $k . '">' . $v . '</option>';
 						}
 					?>

--- a/app/views/subscription/index.phtml
+++ b/app/views/subscription/index.phtml
@@ -20,7 +20,7 @@
 
 	<?php endif; ?>
 
-	<?php if (!$this->onlyFeedsWithError && $this->signalError){ ?>
+	<?php if (!$this->onlyFeedsWithError && $this->signalError) { ?>
 		<div>
 			<a class="btn" href="<?= _url('subscription', 'index', 'error', '1') ?>"><?= _i('look') ?> <?= _t('sub.feed.show.error') ?></a>
 		</div>

--- a/app/views/update/index.phtml
+++ b/app/views/update/index.phtml
@@ -40,7 +40,7 @@
 	<div class="form-group">
 		<label class="group-name"><?= _t('admin.update.releaseChannel') ?></label>
 		<div class="group-controls">
-			<?php if($this->is_release_channel_stable) { ?>
+			<?php if ($this->is_release_channel_stable) { ?>
 				<a href="https://github.com/FreshRSS/FreshRSS/releases/latest" target="_blank">
 					<?= _t('admin.update.releaseChannel.latest') ?>
 				</a>

--- a/app/views/user/manage.phtml
+++ b/app/views/user/manage.phtml
@@ -108,7 +108,7 @@
 				</tr>
 			</thead>
 			<tbody>
-				<?php foreach ($this->users as $username => $values) : ?>
+				<?php foreach ($this->users as $username => $values): ?>
 					<tr <?= $values['is_default'] ? 'class="default-user"' : '' ?>>
 						<td><a href="<?= _url('user', 'details', 'username', $username) ?>" class="configure open-slider" ><?= _i('configure') ?></a></td>
 						<td><?= $username ?></td>

--- a/app/views/user_mailer/email_need_validation.txt.php
+++ b/app/views/user_mailer/email_need_validation.txt.php
@@ -7,3 +7,4 @@
 <?= _t('user.mailer.email_need_validation.body', $this->site_title) ?>
 
 <?= $this->validation_url ?>
+<?php

--- a/cli/CliOptionsParser.php
+++ b/cli/CliOptionsParser.php
@@ -136,10 +136,10 @@ abstract class CliOptionsParser {
 		foreach ($userInputs as $input) {
 			preg_match($regex, $input, $matches);
 
-			if(!empty($matches['short'])) {
+			if (!empty($matches['short'])) {
 				$foundAliases = array_merge($foundAliases, str_split($matches['short']));
 			}
-			if(!empty($matches['long'])) {
+			if (!empty($matches['long'])) {
 				$foundAliases[] = $matches['long'];
 			}
 		}
@@ -232,7 +232,7 @@ abstract class CliOptionsParser {
 		return implode(' ', $required) . ' ' . implode(' ', $optional);
 	}
 
-	private function makeInputRegex() : string {
+	private function makeInputRegex(): string {
 		$shortWithValues = '';
 		foreach ($this->options as $option) {
 			if (($option->getValueTaken() === 'required' || $option->getValueTaken() === 'optional') && $option->getShortAlias()) {

--- a/cli/i18n/I18nCompletionValidator.php
+++ b/cli/i18n/I18nCompletionValidator.php
@@ -63,5 +63,4 @@ class I18nCompletionValidator implements I18nValidatorInterface {
 
 		return $this->totalEntries === $this->passEntries;
 	}
-
 }

--- a/cli/i18n/I18nCompletionValidator.php
+++ b/cli/i18n/I18nCompletionValidator.php
@@ -63,4 +63,5 @@ class I18nCompletionValidator implements I18nValidatorInterface {
 
 		return $this->totalEntries === $this->passEntries;
 	}
+
 }

--- a/cli/i18n/I18nData.php
+++ b/cli/i18n/I18nData.php
@@ -329,5 +329,4 @@ class I18nData {
 	private function getFilenamePrefix(string $key): string {
 		return preg_replace('/\..*/', '.php', $key) ?? '';
 	}
-
 }

--- a/cli/i18n/I18nData.php
+++ b/cli/i18n/I18nData.php
@@ -329,4 +329,5 @@ class I18nData {
 	private function getFilenamePrefix(string $key): string {
 		return preg_replace('/\..*/', '.php', $key) ?? '';
 	}
+
 }

--- a/cli/i18n/I18nUsageValidator.php
+++ b/cli/i18n/I18nUsageValidator.php
@@ -56,4 +56,5 @@ class I18nUsageValidator implements I18nValidatorInterface {
 
 		return 0 === $this->failedEntries;
 	}
+
 }

--- a/cli/i18n/I18nUsageValidator.php
+++ b/cli/i18n/I18nUsageValidator.php
@@ -56,5 +56,4 @@ class I18nUsageValidator implements I18nValidatorInterface {
 
 		return 0 === $this->failedEntries;
 	}
-
 }

--- a/cli/i18n/I18nValidatorInterface.php
+++ b/cli/i18n/I18nValidatorInterface.php
@@ -15,4 +15,5 @@ interface I18nValidatorInterface {
 	 * Display the validation report.
 	 */
 	public function displayReport(): string;
+
 }

--- a/cli/i18n/I18nValidatorInterface.php
+++ b/cli/i18n/I18nValidatorInterface.php
@@ -15,5 +15,4 @@ interface I18nValidatorInterface {
 	 * Display the validation report.
 	 */
 	public function displayReport(): string;
-
 }

--- a/cli/manipulate.translation.php
+++ b/cli/manipulate.translation.php
@@ -38,7 +38,7 @@ $data = new I18nFile();
 $i18nData = new I18nData($data->load());
 
 switch ($cliOptions->action) {
-	case 'add' :
+	case 'add':
 		if (isset($cliOptions->key) && isset($cliOptions->value) && isset($cliOptions->language)) {
 			$i18nData->addValue($cliOptions->key, $cliOptions->value, $cliOptions->language);
 		} elseif (isset($cliOptions->key) && isset($cliOptions->value)) {
@@ -54,7 +54,7 @@ switch ($cliOptions->action) {
 			exit;
 		}
 		break;
-	case 'delete' :
+	case 'delete':
 		if (isset($cliOptions->key)) {
 			$i18nData->removeKey($cliOptions->key);
 		} else {
@@ -75,9 +75,9 @@ switch ($cliOptions->action) {
 			exit;
 		}
 		break;
-	case 'format' :
+	case 'format':
 		break;
-	case 'ignore' :
+	case 'ignore':
 		if (isset($cliOptions->language) && isset($cliOptions->key)) {
 			$i18nData->ignore($cliOptions->key, $cliOptions->language, isset($cliOptions->revert));
 		} else {
@@ -85,7 +85,7 @@ switch ($cliOptions->action) {
 			exit;
 		}
 		break;
-	case 'ignore_unmodified' :
+	case 'ignore_unmodified':
 		if (isset($cliOptions->language)) {
 			$i18nData->ignore_unmodified($cliOptions->language, isset($cliOptions->revert));
 		} else {
@@ -93,7 +93,7 @@ switch ($cliOptions->action) {
 			exit;
 		}
 		break;
-	default :
+	default:
 		manipulateHelp();
 		exit;
 }

--- a/cli/prepare.php
+++ b/cli/prepare.php
@@ -25,18 +25,19 @@ foreach ($dirs as $dir) {
 }
 
 file_put_contents(DATA_PATH . '/.htaccess', <<<'EOF'
-	# Apache 2.2
-	<IfModule !mod_authz_core.c>
-		Order	Allow,Deny
-		Deny	from all
-		Satisfy	all
-	</IfModule>
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+	Order	Allow,Deny
+	Deny	from all
+	Satisfy	all
+</IfModule>
 
-	# Apache 2.4
-	<IfModule mod_authz_core.c>
-		Require all denied
-	</IfModule>
-	EOF
+# Apache 2.4
+<IfModule mod_authz_core.c>
+	Require all denied
+</IfModule>
+
+EOF
 );
 
 accessRights();

--- a/composer.lock
+++ b/composer.lock
@@ -79,16 +79,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.1",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
                 "shasum": ""
             },
             "require": {
@@ -96,11 +96,12 @@
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
             },
             "require-dev": {
                 "doctrine/collections": "^1.6.8",
                 "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
                 "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
@@ -126,7 +127,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.0"
             },
             "funding": [
                 {
@@ -134,20 +135,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-08T13:26:56+00:00"
+            "time": "2024-06-12T14:39:25+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.0.2",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13"
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/139676794dc1e9231bf7bcd123cfc0c99182cb13",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/683130c2ff8c2739f4822ff7ac5c873ec529abd1",
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1",
                 "shasum": ""
             },
             "require": {
@@ -158,7 +159,7 @@
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -190,9 +191,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.1.0"
             },
-            "time": "2024-03-05T20:51:40+00:00"
+            "time": "2024-07-01T20:03:41+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -314,16 +315,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.11.6",
+            "version": "1.11.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "6ac78f1165346c83b4a753f7e4186d969c6ad0ee"
+                "reference": "6adbd118e6c0515dd2f36b06cde1d6da40f1b8ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/6ac78f1165346c83b4a753f7e4186d969c6ad0ee",
-                "reference": "6ac78f1165346c83b4a753f7e4186d969c6ad0ee",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/6adbd118e6c0515dd2f36b06cde1d6da40f1b8ec",
+                "reference": "6adbd118e6c0515dd2f36b06cde1d6da40f1b8ec",
                 "shasum": ""
             },
             "require": {
@@ -368,7 +369,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-01T15:33:06+00:00"
+            "time": "2024-07-24T07:01:22+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -792,45 +793,45 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.19",
+            "version": "9.6.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8"
+                "reference": "49d7820565836236411f5dc002d16dd689cde42f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a1a54a473501ef4cdeaae4e06891674114d79db8",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/49d7820565836236411f5dc002d16dd689cde42f",
+                "reference": "49d7820565836236411f5dc002d16dd689cde42f",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
+                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.12.0",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.28",
-                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-code-coverage": "^9.2.31",
+                "phpunit/php-file-iterator": "^3.0.6",
                 "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
                 "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.6",
+                "sebastian/global-state": "^5.0.7",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
@@ -875,7 +876,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.19"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.20"
             },
             "funding": [
                 {
@@ -891,7 +892,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-05T04:35:58+00:00"
+            "time": "2024-07-10T11:45:39+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1858,16 +1859,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.10.1",
+            "version": "3.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "8f90f7a53ce271935282967f53d0894f8f1ff877"
+                "reference": "86e5f5dd9a840c46810ebe5ff1885581c42a3017"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/8f90f7a53ce271935282967f53d0894f8f1ff877",
-                "reference": "8f90f7a53ce271935282967f53d0894f8f1ff877",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/86e5f5dd9a840c46810ebe5ff1885581c42a3017",
+                "reference": "86e5f5dd9a840c46810ebe5ff1885581c42a3017",
                 "shasum": ""
             },
             "require": {
@@ -1934,7 +1935,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-05-22T21:24:41+00:00"
+            "time": "2024-07-21T23:26:44+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/lib/Minz/ActionController.php
+++ b/lib/Minz/ActionController.php
@@ -51,7 +51,7 @@ abstract class Minz_ActionController {
 		$this->view = $view ?? new Minz_View();
 		$view_path = Minz_Request::controllerName() . '/' . Minz_Request::actionName() . '.phtml';
 		$this->view->_path($view_path);
-		$this->view->attributeParams ();
+		$this->view->attributeParams();
 	}
 
 	/**

--- a/lib/Minz/ActionException.php
+++ b/lib/Minz/ActionException.php
@@ -7,6 +7,6 @@ class Minz_ActionException extends Minz_Exception {
 		$action_name = rawurlencode($action_name);
 
 		$message = "Invalid action name “{$action_name}” for controller “{$controller_name}”.";
-		parent::__construct ($message, $code);
+		parent::__construct($message, $code);
 	}
 }

--- a/lib/Minz/Configuration.php
+++ b/lib/Minz/Configuration.php
@@ -106,7 +106,7 @@ class Minz_Configuration {
 	 * @param Minz_ConfigurationSetterInterface $configuration_setter an optional helper to set values in configuration
 	 * @throws Minz_FileNotExistException
 	 */
-	private final function __construct(string $namespace, string $config_filename, string $default_filename = null,
+	final private function __construct(string $namespace, string $config_filename, string $default_filename = null,
 		Minz_ConfigurationSetterInterface $configuration_setter = null) {
 		$this->namespace = $namespace;
 		$this->config_filename = $config_filename;

--- a/lib/Minz/ControllerNotActionControllerException.php
+++ b/lib/Minz/ControllerNotActionControllerException.php
@@ -5,6 +5,6 @@ class Minz_ControllerNotActionControllerException extends Minz_Exception {
 	public function __construct(string $controller_name, int $code = self::ERROR) {
 		$message = 'Controller `' . $controller_name . '` isn’t instance of ActionController';
 
-		parent::__construct ($message, $code);
+		parent::__construct($message, $code);
 	}
 }

--- a/lib/Minz/ControllerNotExistException.php
+++ b/lib/Minz/ControllerNotExistException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 class Minz_ControllerNotExistException extends Minz_Exception {
 	public function __construct(int $code = self::ERROR) {
 		$message = 'Controller not found!';
-		parent::__construct ($message, $code);
+		parent::__construct($message, $code);
 	}
 }

--- a/lib/Minz/CurrentPagePaginationException.php
+++ b/lib/Minz/CurrentPagePaginationException.php
@@ -5,6 +5,6 @@ class Minz_CurrentPagePaginationException extends Minz_Exception {
 	public function __construct(int $page) {
 		$message = 'Page number `' . $page . '` doesn’t exist';
 
-		parent::__construct ($message, self::ERROR);
+		parent::__construct($message, self::ERROR);
 	}
 }

--- a/lib/Minz/Dispatcher.php
+++ b/lib/Minz/Dispatcher.php
@@ -41,22 +41,22 @@ final class Minz_Dispatcher {
 			self::$needsReset = false;
 
 			try {
-				$this->createController (Minz_Request::controllerName ());
-				$this->controller->init ();
-				$this->controller->firstAction ();
+				$this->createController(Minz_Request::controllerName());
+				$this->controller->init();
+				$this->controller->firstAction();
 				// @phpstan-ignore booleanNot.alwaysTrue
 				if (!self::$needsReset) {
-					$this->launchAction (
-						Minz_Request::actionName ()
+					$this->launchAction(
+						Minz_Request::actionName()
 						. 'Action'
 					);
 				}
-				$this->controller->lastAction ();
+				$this->controller->lastAction();
 
 				// @phpstan-ignore booleanNot.alwaysTrue
 				if (!self::$needsReset) {
 					$this->controller->declareCspHeader();
-					$this->controller->view ()->build ();
+					$this->controller->view()->build();
 				}
 			} catch (Minz_Exception $e) {
 				throw $e;
@@ -87,14 +87,14 @@ final class Minz_Dispatcher {
 		}
 
 		if (!class_exists($controller_name)) {
-			throw new Minz_ControllerNotExistException (
+			throw new Minz_ControllerNotExistException(
 				Minz_Exception::ERROR
 			);
 		}
 		$controller = new $controller_name();
 
 		if (!($controller instanceof Minz_ActionController)) {
-			throw new Minz_ControllerNotActionControllerException (
+			throw new Minz_ControllerNotActionControllerException(
 				$controller_name,
 				Minz_Exception::ERROR
 			);
@@ -111,7 +111,7 @@ final class Minz_Dispatcher {
 	private function launchAction(string $action_name): void {
 		$call = [$this->controller, $action_name];
 		if (!is_callable($call)) {
-			throw new Minz_ActionException (
+			throw new Minz_ActionException(
 				get_class($this->controller),
 				$action_name,
 				Minz_Exception::ERROR

--- a/lib/Minz/Error.php
+++ b/lib/Minz/Error.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * The Minz_Error class logs and raises framework errors
  */
 class Minz_Error {
-	public function __construct() { }
+	public function __construct() {}
 
 	/**
 	* Permet de lancer une erreur
@@ -76,7 +76,7 @@ class Minz_Error {
 				return array_merge($error, $warning, $notice);
 			case 'production':
 			default:
-					return $error;
+				return $error;
 		}
 	}
 }

--- a/lib/Minz/Exception.php
+++ b/lib/Minz/Exception.php
@@ -2,9 +2,9 @@
 declare(strict_types=1);
 
 class Minz_Exception extends Exception {
-	const ERROR = 0;
-	const WARNING = 10;
-	const NOTICE = 20;
+	public const ERROR = 0;
+	public const WARNING = 10;
+	public const NOTICE = 20;
 
 	public function __construct(string $message = '', int $code = self::ERROR, ?Throwable $previous = null) {
 		if ($code !== Minz_Exception::ERROR

--- a/lib/Minz/Extension.php
+++ b/lib/Minz/Extension.php
@@ -87,7 +87,7 @@ abstract class Minz_Extension {
 	/**
 	 * Set the current extension to enable.
 	 */
-	public final function enable(): void {
+	final public function enable(): void {
 		$this->is_enabled = true;
 	}
 
@@ -96,7 +96,7 @@ abstract class Minz_Extension {
 	 *
 	 * @return bool true if extension is enabled, false otherwise.
 	 */
-	public final function isEnabled(): bool {
+	final public function isEnabled(): bool {
 		return $this->is_enabled;
 	}
 
@@ -105,7 +105,7 @@ abstract class Minz_Extension {
 	 *
 	 * @return string|false html content from ext_dir/configure.phtml, false if it does not exist.
 	 */
-	public final function getConfigureView() {
+	final public function getConfigureView() {
 		$filename = $this->path . '/configure.phtml';
 		if (!file_exists($filename)) {
 			return false;
@@ -127,26 +127,26 @@ abstract class Minz_Extension {
 	/**
 	 * Getters and setters.
 	 */
-	public final function getName(): string {
+	final public function getName(): string {
 		return $this->name;
 	}
-	public final function getEntrypoint(): string {
+	final public function getEntrypoint(): string {
 		return $this->entrypoint;
 	}
-	public final function getPath(): string {
+	final public function getPath(): string {
 		return $this->path;
 	}
-	public final function getAuthor(): string {
+	final public function getAuthor(): string {
 		return $this->author;
 	}
-	public final function getDescription(): string {
+	final public function getDescription(): string {
 		return $this->description;
 	}
-	public final function getVersion(): string {
+	final public function getVersion(): string {
 		return $this->version;
 	}
 	/** @return 'system'|'user' */
-	public final function getType() {
+	final public function getType() {
 		return $this->type;
 	}
 
@@ -159,7 +159,7 @@ abstract class Minz_Extension {
 	}
 
 	/** Return the user-specific, extension-specific, folder where this extension can save user-specific data */
-	protected final function getExtensionUserPath(): string {
+	final protected function getExtensionUserPath(): string {
 		$username = Minz_User::name() ?: '_';
 		return USERS_PATH . "/{$username}/extensions/{$this->getEntrypoint()}";
 	}
@@ -174,12 +174,12 @@ abstract class Minz_Extension {
 	}
 
 	/** Return whether a user-specific, extension-specific, file exists */
-	protected final function hasFile(string $filename): bool {
+	final protected function hasFile(string $filename): bool {
 		return file_exists($this->getExtensionUserPath() . '/' . $filename);
 	}
 
 	/** Return the user-specific, extension-specific, file content, or null if it does not exist */
-	protected final function getFile(string $filename): ?string {
+	final protected function getFile(string $filename): ?string {
 		$content = @file_get_contents($this->getExtensionUserPath() . '/' . $filename);
 		return is_string($content) ? $content : null;
 	}
@@ -192,7 +192,7 @@ abstract class Minz_Extension {
 	 * @param bool $isStatic indicates if the file is a static file or a user file. Default is static.
 	 * @return string url corresponding to the file.
 	 */
-	public final function getFileUrl(string $filename, string $type, bool $isStatic = true): string {
+	final public function getFileUrl(string $filename, string $type, bool $isStatic = true): string {
 		if ($isStatic) {
 			$dir = basename($this->path);
 			$file_name_url = urlencode("{$dir}/static/{$filename}");
@@ -215,21 +215,21 @@ abstract class Minz_Extension {
 	 *
 	 * @param string $base_name the base name of the controller. Final name will be FreshExtension_<base_name>_Controller.
 	 */
-	protected final function registerController(string $base_name): void {
+	final protected function registerController(string $base_name): void {
 		Minz_Dispatcher::registerController($base_name, $this->path);
 	}
 
 	/**
 	 * Register the views in order to be accessible by the application.
 	 */
-	protected final function registerViews(): void {
+	final protected function registerViews(): void {
 		Minz_View::addBasePathname($this->path);
 	}
 
 	/**
 	 * Register i18n files from ext_dir/i18n/
 	 */
-	protected final function registerTranslates(): void {
+	final protected function registerTranslates(): void {
 		$i18n_dir = $this->path . '/i18n';
 		Minz_Translate::registerPath($i18n_dir);
 	}
@@ -240,7 +240,7 @@ abstract class Minz_Extension {
 	 * @param string $hook_name the hook name (must exist).
 	 * @param callable $hook_function the function name to call (must be callable).
 	 */
-	protected final function registerHook(string $hook_name, $hook_function): void {
+	final protected function registerHook(string $hook_name, $hook_function): void {
 		Minz_ExtensionManager::addHook($hook_name, $hook_function);
 	}
 
@@ -279,7 +279,7 @@ abstract class Minz_Extension {
 	/**
 	 * @return array<string,mixed>
 	 */
-	protected final function getSystemConfiguration(): array {
+	final protected function getSystemConfiguration(): array {
 		if ($this->isConfigurationEnabled('system') && $this->isExtensionConfigured('system')) {
 			return FreshRSS_Context::systemConf()->extensions[$this->getName()];
 		}
@@ -289,7 +289,7 @@ abstract class Minz_Extension {
 	/**
 	 * @return array<string,mixed>
 	 */
-	protected final function getUserConfiguration(): array {
+	final protected function getUserConfiguration(): array {
 		if ($this->isConfigurationEnabled('user') && $this->isExtensionConfigured('user')) {
 			return FreshRSS_Context::userConf()->extensions[$this->getName()];
 		}
@@ -300,7 +300,7 @@ abstract class Minz_Extension {
 	 * @param mixed $default
 	 * @return mixed
 	 */
-	public final function getSystemConfigurationValue(string $key, $default = null) {
+	final public function getSystemConfigurationValue(string $key, $default = null) {
 		if (!is_array($this->system_configuration)) {
 			$this->system_configuration = $this->getSystemConfiguration();
 		}
@@ -315,7 +315,7 @@ abstract class Minz_Extension {
 	 * @param mixed $default
 	 * @return mixed
 	 */
-	public final function getUserConfigurationValue(string $key, $default = null) {
+	final public function getUserConfigurationValue(string $key, $default = null) {
 		if (!is_array($this->user_configuration)) {
 			$this->user_configuration = $this->getUserConfiguration();
 		}
@@ -354,13 +354,13 @@ abstract class Minz_Extension {
 	}
 
 	/** @param array<string,mixed> $configuration */
-	protected final function setSystemConfiguration(array $configuration): void {
+	final protected function setSystemConfiguration(array $configuration): void {
 		$this->setConfiguration('system', $configuration);
 		$this->system_configuration = $configuration;
 	}
 
 	/** @param array<string,mixed> $configuration */
-	protected final function setUserConfiguration(array $configuration): void {
+	final protected function setUserConfiguration(array $configuration): void {
 		$this->setConfiguration('user', $configuration);
 		$this->user_configuration = $configuration;
 	}
@@ -391,17 +391,17 @@ abstract class Minz_Extension {
 		$conf->save();
 	}
 
-	protected final function removeSystemConfiguration(): void {
+	final protected function removeSystemConfiguration(): void {
 		$this->removeConfiguration('system');
 		$this->system_configuration = null;
 	}
 
-	protected final function removeUserConfiguration(): void {
+	final protected function removeUserConfiguration(): void {
 		$this->removeConfiguration('user');
 		$this->user_configuration = null;
 	}
 
-	protected final function saveFile(string $filename, string $content): void {
+	final protected function saveFile(string $filename, string $content): void {
 		$path = $this->getExtensionUserPath();
 
 		if (!file_exists($path)) {
@@ -411,7 +411,7 @@ abstract class Minz_Extension {
 		file_put_contents("{$path}/{$filename}", $content);
 	}
 
-	protected final function removeFile(string $filename): void {
+	final protected function removeFile(string $filename): void {
 		$path = $path = $this->getExtensionUserPath() . '/' . $filename;
 		if (file_exists($path)) {
 			unlink($path);

--- a/lib/Minz/FileNotExistException.php
+++ b/lib/Minz/FileNotExistException.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 class Minz_FileNotExistException extends Minz_Exception {
 	public function __construct(string $file_name, int $code = self::ERROR) {
-		$message = 'File not found: `' . $file_name.'`';
+		$message = 'File not found: `' . $file_name . '`';
 
-		parent::__construct ($message, $code);
+		parent::__construct($message, $code);
 	}
 }

--- a/lib/Minz/FrontController.php
+++ b/lib/Minz/FrontController.php
@@ -33,7 +33,7 @@ class Minz_FrontController {
 	 * Constructeur
 	 * Initialise le dispatcher, met à jour la Request
 	 */
-	public function __construct () {
+	public function __construct() {
 		try {
 			$this->setReporting();
 

--- a/lib/Minz/Log.php
+++ b/lib/Minz/Log.php
@@ -39,21 +39,21 @@ class Minz_Log {
 			}
 
 			switch ($level) {
-			case LOG_ERR :
-				$level_label = 'error';
-				break;
-			case LOG_WARNING :
-				$level_label = 'warning';
-				break;
-			case LOG_NOTICE :
-				$level_label = 'notice';
-				break;
-			case LOG_DEBUG :
-				$level_label = 'debug';
-				break;
-			default :
-				$level = LOG_INFO;
-				$level_label = 'info';
+				case LOG_ERR:
+					$level_label = 'error';
+					break;
+				case LOG_WARNING:
+					$level_label = 'warning';
+					break;
+				case LOG_NOTICE:
+					$level_label = 'notice';
+					break;
+				case LOG_DEBUG:
+					$level_label = 'debug';
+					break;
+				default:
+					$level = LOG_INFO;
+					$level_label = 'info';
 			}
 
 			$log = '[' . date('r') . '] [' . $level_label . '] --- ' . $information . "\n";

--- a/lib/Minz/PDOConnectionException.php
+++ b/lib/Minz/PDOConnectionException.php
@@ -5,6 +5,6 @@ class Minz_PDOConnectionException extends Minz_Exception {
 	public function __construct(string $error, string $user, int $code = self::ERROR) {
 		$message = 'Access to database is denied for `' . $user . '`: ' . $error;
 
-		parent::__construct ($message, $code);
+		parent::__construct($message, $code);
 	}
 }

--- a/lib/Minz/Paginator.php
+++ b/lib/Minz/Paginator.php
@@ -90,7 +90,7 @@ class Minz_Paginator {
 				return $i;
 			}
 			$i++;
-		} while ($i < $this->nbItems ());
+		} while ($i < $this->nbItems());
 
 		return false;
 	}
@@ -102,7 +102,7 @@ class Minz_Paginator {
 	 */
 	public function itemByPosition(int $pos): Minz_Model {
 		if ($pos < 0) {
-			$pos = $this->nbItems () - 1;
+			$pos = $this->nbItems() - 1;
 		}
 		if ($pos >= count($this->items)) {
 			$pos = 0;
@@ -120,7 +120,7 @@ class Minz_Paginator {
 	 */
 	public function items(bool $all = false): array {
 		$array = array ();
-		$nbItems = $this->nbItems ();
+		$nbItems = $this->nbItems();
 
 		if ($nbItems <= $this->nbItemsPerPage || $all) {
 			$array = $this->items;
@@ -165,8 +165,8 @@ class Minz_Paginator {
 		$this->_nbPage();
 	}
 	public function _nbItemsPerPage(int $nbItemsPerPage): void {
-		if ($nbItemsPerPage > $this->nbItems ()) {
-			$nbItemsPerPage = $this->nbItems ();
+		if ($nbItemsPerPage > $this->nbItems()) {
+			$nbItemsPerPage = $this->nbItems();
 		}
 		if ($nbItemsPerPage < 0) {
 			$nbItemsPerPage = 0;

--- a/lib/Minz/PermissionDeniedException.php
+++ b/lib/Minz/PermissionDeniedException.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 class Minz_PermissionDeniedException extends Minz_Exception {
 	public function __construct(string $file_name, int $code = self::ERROR) {
-		$message = 'Permission is denied for `' . $file_name.'`';
+		$message = 'Permission is denied for `' . $file_name . '`';
 
-		parent::__construct ($message, $code);
+		parent::__construct($message, $code);
 	}
 }

--- a/lib/Minz/Session.php
+++ b/lib/Minz/Session.php
@@ -212,4 +212,5 @@ class Minz_Session {
 	public static function getLongTermCookie(string $name): string {
 		return $_COOKIE[$name] ?? '';
 	}
+
 }

--- a/lib/Minz/Session.php
+++ b/lib/Minz/Session.php
@@ -212,5 +212,4 @@ class Minz_Session {
 	public static function getLongTermCookie(string $name): string {
 		return $_COOKIE[$name] ?? '';
 	}
-
 }

--- a/lib/Minz/Url.php
+++ b/lib/Minz/Url.php
@@ -81,13 +81,13 @@ class Minz_Url {
 		}
 
 		if (isset($url['c']) && is_string($url['c'])
-		 && $url['c'] != Minz_Request::defaultControllerName()) {
+			&& $url['c'] != Minz_Request::defaultControllerName()) {
 			$uri .= $separator . 'c=' . $url['c'];
 			$separator = $and;
 		}
 
 		if (isset($url['a']) && is_string($url['a'])
-		 && $url['a'] != Minz_Request::defaultActionName()) {
+			&& $url['a'] != Minz_Request::defaultActionName()) {
 			$uri .= $separator . 'a=' . $url['a'];
 			$separator = $and;
 		}

--- a/lib/Minz/View.php
+++ b/lib/Minz/View.php
@@ -43,7 +43,7 @@ class Minz_View {
 	 */
 	public function change_view(string $controller_name, string $action_name): void {
 		Minz_Log::warning('Minz_View::change_view is deprecated, it will be removed in a future version. Please use Minz_View::_path instead.');
-		$this->_path($controller_name. '/' . $action_name . '.phtml');
+		$this->_path($controller_name . '/' . $action_name . '.phtml');
 	}
 
 	/**
@@ -71,9 +71,9 @@ class Minz_View {
 	 */
 	public function build(): void {
 		if ($this->layout_filename !== '') {
-			$this->buildLayout ();
+			$this->buildLayout();
 		} else {
-			$this->render ();
+			$this->render();
 		}
 	}
 

--- a/lib/lib_install.php
+++ b/lib/lib_install.php
@@ -73,7 +73,7 @@ function checkRequirements(string $dbType = ''): array {
 }
 
 function generateSalt(): string {
-	return sha1(uniqid('' . mt_rand(), true).implode('', stat(__FILE__) ?: []));
+	return sha1(uniqid('' . mt_rand(), true) . implode('', stat(__FILE__) ?: []));
 }
 
 /**

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -872,7 +872,7 @@ function check_install_database(): array {
 		$status['entrytmp'] = $dbDAO->entrytmpIsCorrect();
 		$status['tag'] = $dbDAO->tagIsCorrect();
 		$status['entrytag'] = $dbDAO->entrytagIsCorrect();
-	} catch(Minz_PDOConnectionException $e) {
+	} catch (Minz_PDOConnectionException $e) {
 		$status['connection'] = false;
 	}
 

--- a/p/api/fever.php
+++ b/p/api/fever.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * Fever API for FreshRSS
@@ -10,8 +11,6 @@
  * TinyTinyRSS Fever API plugin @dasmurphy
  * See https://github.com/dasmurphy/tinytinyrss-fever-plugin
  */
-
-declare(strict_types=1);
 
 // ================================================================================================
 // BOOTSTRAP FreshRSS

--- a/p/api/fever.php
+++ b/p/api/fever.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Fever API for FreshRSS
@@ -11,6 +10,8 @@ declare(strict_types=1);
  * TinyTinyRSS Fever API plugin @dasmurphy
  * See https://github.com/dasmurphy/tinytinyrss-fever-plugin
  */
+
+declare(strict_types=1);
 
 // ================================================================================================
 // BOOTSTRAP FreshRSS
@@ -270,7 +271,6 @@ final class FeverAPI
 					$response_arr['saved_item_ids'] = $this->getSavedItemIds();
 					break;
 			}
-
 		}
 
 		return $response_arr;
@@ -359,7 +359,6 @@ final class FeverAPI
 		$myFeeds = $this->feedDAO->listFeeds();
 
 		foreach ($myFeeds as $feed) {
-
 			$id = hash('crc32b', $salt . $feed->url());
 			$filename = DATA_PATH . '/favicons/' . $id . '.ico';
 			if (!file_exists($filename)) {

--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
 == Description ==
@@ -23,8 +24,6 @@ Server-side API compatible with Google Reader API layer 2
 * https://feedhq.readthedocs.io/en/latest/api/index.html
 * https://github.com/bazqux/bazqux-api
 */
-
-declare(strict_types=1);
 
 require(__DIR__ . '/../../constants.php');
 require(LIB_PATH . '/lib_rss.php');	//Includes class autoloader

--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 
 /**
 == Description ==
@@ -24,6 +23,8 @@ Server-side API compatible with Google Reader API layer 2
 * https://feedhq.readthedocs.io/en/latest/api/index.html
 * https://github.com/bazqux/bazqux-api
 */
+
+declare(strict_types=1);
 
 require(__DIR__ . '/../../constants.php');
 require(LIB_PATH . '/lib_rss.php');	//Includes class autoloader
@@ -394,7 +395,7 @@ final class GReaderAPI {
 			case 'edit':
 				break;
 			default:
-			self::badRequest();
+				self::badRequest();
 		}
 		$addCatId = 0;
 		$c_name = '';

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -33,8 +33,10 @@
 		<exclude name="PSR12.Classes.OpeningBraceSpace.Found"/><!-- Consider using PSR12 defaults instead -->
 		<exclude name="PSR12.ControlStructures.ControlStructureSpacing.CloseParenthesisLine"/>
 		<exclude name="PSR12.ControlStructures.ControlStructureSpacing.FirstExpressionLine"/><!-- Consider using PSR12 defaults instead -->
+		<exclude name="PSR12.Files.FileHeader.IncorrectOrder"/><!-- Consider using PSR12 defaults instead -->
 		<exclude name="PSR12.Files.FileHeader.SpacingAfterBlock"/><!-- Consider using PSR12 defaults instead -->
 		<exclude name="PSR12.Traits.UseDeclaration.MultipleImport"/>
+		<exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody"/><!-- Consider using PSR12 defaults instead -->
 		<exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine"/><!-- Consider using PSR12 defaults instead -->
 		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineCASE"/>
 		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakNotNewLine"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ruleset name="FreshRSS Ruleset">
-	<description>Created with the PHP Coding Standard Generator. https://edorian.github.com/php-coding-standard-generator/</description>
-	<arg name="extensions" value="php,phtml,css,js"/>
+<ruleset name="FreshRSS-Extensions">
+	<arg name="extensions" value="php"/>
 	<arg name="tab-width" value="4"/>
 	<exclude-pattern>./.git/</exclude-pattern>
+	<exclude-pattern>./node_modules/</exclude-pattern>
+	<exclude-pattern>./vendor/</exclude-pattern>
+	<exclude-pattern>./xExtension-TTRSS_API</exclude-pattern>
 	<exclude-pattern>./lib/SimplePie/</exclude-pattern>
 	<exclude-pattern>./lib/marienfressinaud/</exclude-pattern>
 	<exclude-pattern>./lib/phpgt/</exclude-pattern>
@@ -15,108 +17,75 @@
 	<exclude-pattern>./data/users/*/config.php</exclude-pattern>
 	<exclude-pattern>./extensions/</exclude-pattern>
 	<exclude-pattern>./p/scripts/vendor/</exclude-pattern>
-	<exclude-pattern>./vendor/</exclude-pattern>
 	<exclude-pattern>*.min.js$</exclude-pattern>
-	<!-- Duplicate class names are not allowed -->
+	<rule ref="PSR12">
+		<exclude name="Generic.ControlStructures.InlineControlStructure.NotAllowed"/>
+		<exclude name="Generic.Formatting.DisallowMultipleStatements.SameLine"/>
+		<exclude name="Generic.WhiteSpace.DisallowTabIndent.NonIndentTabsUsed"/>
+		<exclude name="Generic.WhiteSpace.DisallowTabIndent.TabsUsed"/>
+		<exclude name="Generic.WhiteSpace.DisallowTabIndent.TabsUsedHeredocCloser"/>
+		<exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace"/>
+		<exclude name="PSR1.Classes.ClassDeclaration.MultipleClasses"/>
+		<exclude name="PSR1.Files.SideEffects.FoundWithSymbols"/>
+		<exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps"/>
+		<exclude name="PSR12.Classes.OpeningBraceSpace.Found"/><!-- Consider using PSR12 defaults instead -->
+		<exclude name="PSR12.ControlStructures.ControlStructureSpacing.CloseParenthesisLine"/>
+		<exclude name="PSR12.ControlStructures.ControlStructureSpacing.FirstExpressionLine"/><!-- Consider using PSR12 defaults instead -->
+		<exclude name="PSR12.Files.FileHeader.SpacingAfterBlock"/><!-- Consider using PSR12 defaults instead -->
+		<exclude name="PSR12.Traits.UseDeclaration.MultipleImport"/>
+		<exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine"/><!-- Consider using PSR12 defaults instead -->
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineCASE"/>
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakNotNewLine"/>
+		<exclude name="PSR2.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>
+		<exclude name="PSR2.Methods.FunctionCallSignature.CloseBracketLine"/>
+		<exclude name="PSR2.Methods.FunctionCallSignature.ContentAfterOpenBracket"/>
+		<exclude name="PSR2.Methods.FunctionCallSignature.Indent"/>
+		<exclude name="PSR2.Methods.FunctionCallSignature.MultipleArguments"/>
+		<exclude name="PSR2.Methods.MethodDeclaration.Underscore"/>
+		<exclude name="Squiz.Classes.ValidClassName.NotCamelCaps"/>
+		<exclude name="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine"/>
+		<exclude name="Squiz.Functions.MultiLineFunctionDeclaration.CloseBracketLine"/>
+		<exclude name="Squiz.Functions.MultiLineFunctionDeclaration.ContentAfterBrace"/>
+		<exclude name="Squiz.Functions.MultiLineFunctionDeclaration.FirstParamSpacing"/>
+		<exclude name="Squiz.Functions.MultiLineFunctionDeclaration.Indent"/>
+		<exclude name="Squiz.Functions.MultiLineFunctionDeclaration.OneParamPerLine"/>
+		<exclude name="Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore"/>
+	</rule>
 	<rule ref="Generic.Classes.DuplicateClassName"/>
-	<!-- Statements must not be empty -->
 	<rule ref="Generic.CodeAnalysis.EmptyStatement"/>
-	<!-- Unconditional if-statements are not allowed -->
 	<rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
-	<!-- Do not use final statements inside final classes -->
 	<rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
-	<!-- Do not override methods to call their parent -->
 	<rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
-	<!-- Maximum line length -->
 	<rule ref="Generic.Files.LineLength">
-		<!-- For language strings maximum line lengths make little sense. -->
-		<exclude-pattern>./app/i18n/</exclude-pattern>
-		<!-- Don’t enforce line length on the HTML; the point is to improve legibility, not reduce it -->
-		<exclude-pattern>*.phtml$</exclude-pattern>
 		<properties>
 			<property name="lineLimit" value="165"/>
 			<property name="absoluteLineLimit" value="190"/>
 		</properties>
+		<exclude-pattern>/app/i18n/*.php$</exclude-pattern>
 	</rule>
-	<!-- When calling a function: -->
-	<!-- Do not add a space before the opening parenthesis -->
-	<!-- Do not add a space after the opening parenthesis -->
-	<!-- Do not add a space before the closing parenthesis -->
-	<!-- Do not add a space before a comma -->
-	<!-- Add a space after a comma -->
-	<rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
-	<rule ref="Generic.PHP.DisallowShortOpenTag">
-		<exclude name="Generic.PHP.DisallowShortOpenTag.EchoFound"/>
-	</rule>
-	<rule ref="Generic.PHP.DeprecatedFunctions" />
-	<!-- Use UPPERCARE for constants -->
-	<rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
-	<!-- Use lowercase for 'true', 'false' and 'null' -->
-	<rule ref="Generic.PHP.LowerCaseConstant"/>
-	<!-- Use a single string instead of concatenating -->
+	<rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/><!-- Consider using PSR12 defaults instead -->
+	<rule ref="Generic.PHP.DeprecatedFunctions"/>
 	<rule ref="Generic.Strings.UnnecessaryStringConcat">
 		<properties>
-			<!-- Allow string concatenating across multiple lines -->
 			<property name="allowMultiline" value="true"/>
 		</properties>
 	</rule>
-	<!-- Use tabs for indentation -->
 	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
-	<!-- Parameters with default values must appear last in functions -->
-	<rule ref="PEAR.Functions.ValidDefaultValue"/>
-	<!-- Use 'elseif' instead of 'else if' -->
-	<rule ref="PSR2.ControlStructures.ElseIfDeclaration"/>
-	<!-- Do not add spaces after opening or before closing bracket -->
-	<rule ref="PSR2.ControlStructures.ControlStructureSpacing"/>
-	<!-- Add a new line at the end of a file -->
-	<rule ref="PSR2.Files.EndFileNewline"/>
-	<!-- Use Unix newlines -->
-	<rule ref="Generic.Files.LineEndings">
-		<properties>
-			<property name="eolChar" value="\n" />
-		</properties>
+	<rule ref="Generic.WhiteSpace.ScopeIndent.Incorrect">
+		<exclude-pattern>/app/install.php</exclude-pattern>
 	</rule>
-	<!-- Add space after closing parenthesis -->
-	<!-- Add body into new line -->
-	<!-- Close body in new line -->
-	<rule ref="Squiz.ControlStructures.ControlSignature">
-		<!-- No space after keyword (before opening parenthesis) -->
-		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword"/>
+	<rule ref="Generic.WhiteSpace.ScopeIndent.IncorrectExact">
+		<exclude-pattern>/app/install.php</exclude-pattern>
 	</rule>
-	<!-- When declaring a function: -->
-	<!-- Do not add a space before a comma -->
-	<!-- Add a space after a comma -->
-	<!-- Add a space before and after an equal sign -->
-	<rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
-		<properties>
-			<property name="equalsSpacing" value="1"/>
-		</properties>
-	</rule>
-	<!-- Do not add spaces when casting -->
-	<rule ref="Squiz.WhiteSpace.CastSpacing"/>
-	<!-- Operators must have a space around them -->
-	<rule ref="Squiz.WhiteSpace.OperatorSpacing">
-		<properties>
-			<property name="ignoreNewlines" value="true" />
-		</properties>
-	</rule>
-	<!-- Do not add a whitespace before a semicolon -->
-	<rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
-	<!-- Do not add whitespace at start or end of a file or end of a line -->
-	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
-	<!-- Expected space after closing parenthesis -->
-	<rule ref="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseParenthesis">
-		<exclude-pattern>.phtml$</exclude-pattern>
-	</rule>
-	<!-- Opening brace on same line as function declaration -->
-	<rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie" />
-	<!-- Newline required after opening brace -->
+	<!-- <rule ref="Squiz.Commenting.ClassComment.Missing"/> --><!-- Consider adding -->
 	<rule ref="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace">
 		<exclude-pattern>.phtml$</exclude-pattern>
 		<exclude-pattern>.js$</exclude-pattern>
 	</rule>
-	<!-- No PHP code was found in this file -->
-	<rule ref="Internal.NoCodeFound">
-		<exclude-pattern>.phtml$</exclude-pattern>
+	<rule ref="Squiz.WhiteSpace.OperatorSpacing">
+		<properties>
+			<property name="ignoreNewlines" value="true"/>
+		</properties>
 	</rule>
+	<rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ruleset name="FreshRSS-Extensions">
-	<arg name="extensions" value="php"/>
+<ruleset name="FreshRSS">
+	<arg name="extensions" value="php,phtml"/>
 	<arg name="tab-width" value="4"/>
 	<exclude-pattern>./.git/</exclude-pattern>
 	<exclude-pattern>./node_modules/</exclude-pattern>
@@ -17,7 +17,6 @@
 	<exclude-pattern>./data/users/*/config.php</exclude-pattern>
 	<exclude-pattern>./extensions/</exclude-pattern>
 	<exclude-pattern>./p/scripts/vendor/</exclude-pattern>
-	<exclude-pattern>*.min.js$</exclude-pattern>
 	<rule ref="PSR12">
 		<exclude name="Generic.ControlStructures.InlineControlStructure.NotAllowed"/>
 		<exclude name="Generic.Formatting.DisallowMultipleStatements.SameLine"/>
@@ -61,7 +60,8 @@
 			<property name="lineLimit" value="165"/>
 			<property name="absoluteLineLimit" value="190"/>
 		</properties>
-		<exclude-pattern>/app/i18n/*.php$</exclude-pattern>
+		<exclude-pattern>/app/i18n/*\.php$</exclude-pattern>
+		<exclude-pattern>*\.phtml$</exclude-pattern>
 	</rule>
 	<rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/><!-- Consider using PSR12 defaults instead -->
 	<rule ref="Generic.PHP.DeprecatedFunctions"/>
@@ -72,20 +72,33 @@
 	</rule>
 	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
 	<rule ref="Generic.WhiteSpace.ScopeIndent.Incorrect">
+		<exclude-pattern>*\.phtml$</exclude-pattern>
 		<exclude-pattern>/app/install.php</exclude-pattern>
 	</rule>
 	<rule ref="Generic.WhiteSpace.ScopeIndent.IncorrectExact">
+		<exclude-pattern>*\.phtml$</exclude-pattern>
 		<exclude-pattern>/app/install.php</exclude-pattern>
 	</rule>
+	<rule ref="Internal.NoCodeFound">
+		<exclude-pattern>*\.phtml$</exclude-pattern>
+	</rule>
 	<!-- <rule ref="Squiz.Commenting.ClassComment.Missing"/> --><!-- Consider adding -->
+	<rule ref="Squiz.ControlStructures.ControlSignature">
+		<include-pattern>*\.phtml$</include-pattern>
+		<properties>
+			<property name="requiredSpacesBeforeColon" value="0" />
+		</properties>
+	</rule>
 	<rule ref="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace">
-		<exclude-pattern>.phtml$</exclude-pattern>
-		<exclude-pattern>.js$</exclude-pattern>
+		<exclude-pattern>*\.phtml$</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.WhiteSpace.OperatorSpacing">
 		<properties>
 			<property name="ignoreNewlines" value="true"/>
 		</properties>
+	</rule>
+	<rule ref="Squiz.WhiteSpace.ScopeClosingBrace.Indent">
+		<exclude-pattern>*\.phtml$</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,20 +3,23 @@
 	<arg name="extensions" value="php,phtml"/>
 	<arg name="tab-width" value="4"/>
 	<exclude-pattern>./.git/</exclude-pattern>
-	<exclude-pattern>./node_modules/</exclude-pattern>
-	<exclude-pattern>./vendor/</exclude-pattern>
-	<exclude-pattern>./xExtension-TTRSS_API</exclude-pattern>
-	<exclude-pattern>./lib/SimplePie/</exclude-pattern>
-	<exclude-pattern>./lib/marienfressinaud/</exclude-pattern>
-	<exclude-pattern>./lib/phpgt/</exclude-pattern>
-	<exclude-pattern>./lib/phpmailer/</exclude-pattern>
-	<exclude-pattern>./lib/http-conditional.php</exclude-pattern>
-	<exclude-pattern>./node_modules/</exclude-pattern>
 	<exclude-pattern>./data/config.php</exclude-pattern>
 	<exclude-pattern>./data/update.php</exclude-pattern>
 	<exclude-pattern>./data/users/*/config.php</exclude-pattern>
 	<exclude-pattern>./extensions/</exclude-pattern>
+	<exclude-pattern>./lib/http-conditional.php</exclude-pattern>
+	<exclude-pattern>./lib/marienfressinaud/</exclude-pattern>
+	<exclude-pattern>./lib/phpgt/</exclude-pattern>
+	<exclude-pattern>./lib/phpmailer/</exclude-pattern>
+	<exclude-pattern>./lib/SimplePie/</exclude-pattern>
+	<exclude-pattern>./node_modules/</exclude-pattern>
 	<exclude-pattern>./p/scripts/vendor/</exclude-pattern>
+	<exclude-pattern>./vendor/</exclude-pattern>
+	<!-- Additional exclusions for Extensions: -->
+	<exclude-pattern>./symbolic/</exclude-pattern>
+	<exclude-pattern>./third-party/</exclude-pattern>
+	<exclude-pattern>./tmp/</exclude-pattern>
+	<exclude-pattern>./xExtension-TTRSS_API</exclude-pattern>
 	<rule ref="PSR12">
 		<exclude name="Generic.ControlStructures.InlineControlStructure.NotAllowed"/>
 		<exclude name="Generic.Formatting.DisallowMultipleStatements.SameLine"/>

--- a/tests/app/Models/FeedDAOTest.php
+++ b/tests/app/Models/FeedDAOTest.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 class FeedDAOTest extends PHPUnit\Framework\TestCase {
-	function test_ttl_min(): void {
+	public function test_ttl_min(): void {
 		$feed = new FreshRSS_Feed('https://example.net/', false);
 		$feed->_ttl(-5);
 		self::assertEquals(-5, $feed->ttl(true));

--- a/tests/app/Models/UserQueryTest.php
+++ b/tests/app/Models/UserQueryTest.php
@@ -210,4 +210,5 @@ class UserQueryTest extends PHPUnit\Framework\TestCase {
 		$user_query = new FreshRSS_UserQuery($query, [], []);
 		self::assertFalse($user_query->isDeprecated());
 	}
+
 }

--- a/tests/app/Models/UserQueryTest.php
+++ b/tests/app/Models/UserQueryTest.php
@@ -210,5 +210,4 @@ class UserQueryTest extends PHPUnit\Framework\TestCase {
 		$user_query = new FreshRSS_UserQuery($query, [], []);
 		self::assertFalse($user_query->isDeprecated());
 	}
-
 }


### PR DESCRIPTION
To simplify our PHPCS configuration, apply more rules, and be clearer about what is added or removed compared with PSR12.
Does not change our current conventions, but just a bit more consistent.

Useful commands:

```sh
make test-all
make fix-all
# or individually:
composer run-script phpcs
composer run-script phpcbf
```
