### PR TITLE
Fix parentheses for complex `OR` boolean search expressions

### DIFF
--- a/app/Models/BooleanSearch.php
+++ b/app/Models/BooleanSearch.php
@@ -187,7 +187,6 @@ class FreshRSS_BooleanSearch {
 		for ($i = 0; $i < $length; $i++) {
 			$c = $input[$i];
 			$backslashed = $i >= 1 ? $input[$i - 1] === '\\' : false;
-
 			if (!$backslashed) {
 				if ($c === '(') {
 					if ($parenthesesCount === 0) {
@@ -212,7 +211,6 @@ class FreshRSS_BooleanSearch {
 					}
 				}
 			}
-
 			$segment .= $c;
 		}
 		if (trim($segment) !== '') {

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -577,12 +577,20 @@ HTML;
 		foreach ($booleanSearch->searches() as $filter) {
 			if ($filter instanceof FreshRSS_BooleanSearch) {
 				// BooleanSearches are combined by AND (default) or OR or AND NOT (special cases) operators and are recursive
-				if ($filter->operator() === 'OR') {
-					$ok |= $this->matches($filter);
-				} elseif ($filter->operator() === 'AND NOT') {
-					$ok &= !$this->matches($filter);
-				} else {	// AND
-					$ok &= $this->matches($filter);
+				switch ($filter->operator()) {
+					case 'OR':
+						$ok |= $this->matches($filter);
+						break;
+					case 'OR NOT':
+						$ok |= !$this->matches($filter);
+						break;
+					case 'AND NOT':
+						$ok &= !$this->matches($filter);
+						break;
+					case 'AND':
+					default:
+						$ok &= $this->matches($filter);
+						break;
 				}
 			} elseif ($filter instanceof FreshRSS_Search) {
 				// Searches are combined by OR and are not recursive

--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -762,7 +762,7 @@ SQL;
 				if ($filterSearch !== '') {
 					if ($search !== '') {
 						$search .= $filter->operator();
-					} elseif ($filter->operator() === 'AND NOT') {
+					} elseif (in_array($filter->operator(), ['AND NOT', 'OR NOT'], true)) {
 						// Special case if we start with a negation (there is already the default AND before)
 						$search .= ' NOT';
 					}

--- a/tests/app/Models/SearchTest.php
+++ b/tests/app/Models/SearchTest.php
@@ -296,8 +296,11 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 		return [
 			['ab', 'ab'],
 			['ab cd', 'ab cd'],
+			['!ab -cd', '!ab -cd'],
 			['ab OR cd', '(ab) OR (cd)'],
+			['!ab OR -cd', '(!ab) OR (-cd)'],
 			['ab cd OR ef OR "gh ij"', '(ab cd) OR (ef) OR ("gh ij")'],
+			['ab (!cd)', 'ab (!cd)'],
 		];
 	}
 
@@ -315,11 +318,16 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 			['(ab cd ef)', '(ab cd ef)'],
 			['("ab cd" ef)', '("ab cd" ef)'],
 			['"ab cd" (ef gh) "ij kl"', '"ab cd" (ef gh) "ij kl"'],
+			['ab (!cd)', 'ab (!cd)'],
+			['ab !(cd)', 'ab !(cd)'],
+			['(ab) -(cd)', '(ab) -(cd)'],
 			['ab cd OR ef OR "gh ij"', 'ab cd OR ef OR "gh ij"'],
 			['"plain or text" OR (cd)', '("plain or text") OR (cd)'],
 			['(ab) OR cd OR ef OR (gh)', '(ab) OR (cd) OR (ef) OR (gh)'],
 			['(ab (cd OR ef)) OR gh OR ij OR (kl)', '(ab (cd OR ef)) OR (gh) OR (ij) OR (kl)'],
 			['(ab (cd OR ef OR (gh))) OR ij', '(ab ((cd) OR (ef) OR (gh))) OR (ij)'],
+			['(ab (!cd OR ef OR (gh))) OR ij', '(ab ((!cd) OR (ef) OR (gh))) OR (ij)'],
+			['(ab !(cd OR ef OR !(gh))) OR ij', '(ab !((cd) OR (ef) OR !(gh))) OR (ij)'],
 		];
 	}
 

--- a/tests/app/Models/SearchTest.php
+++ b/tests/app/Models/SearchTest.php
@@ -294,32 +294,32 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 	/** @return array<array{string,string}> */
 	public function provideAddOrParentheses(): array {
 		return [
-			['ab', '(ab)'],
-			['ab cd', '(ab cd)'],
+			['ab', 'ab'],
+			['ab cd', 'ab cd'],
 			['ab OR cd', '(ab) OR (cd)'],
 			['ab cd OR ef OR "gh ij"', '(ab cd) OR (ef) OR ("gh ij")'],
 		];
 	}
 
 	/**
-	 * @dataProvider provideBooleanExpression
+	 * @dataProvider provideconsistentOrParentheses
 	 */
-	public function test__consistentParentheses(string $input, string $output): void {
-		self::assertEquals($output, FreshRSS_BooleanSearch::consistentParentheses($input));
+	public function test__consistentOrParentheses(string $input, string $output): void {
+		self::assertEquals($output, FreshRSS_BooleanSearch::consistentOrParentheses($input));
 	}
 
 	/** @return array<array{string,string}> */
-	public function provideBooleanExpression(): array {
+	public function provideconsistentOrParentheses(): array {
 		return [
-			// ['ab cd ef', 'ab cd ef'],
-			// ['(ab cd ef)', '(ab cd ef)'],
-			// ['("ab cd" ef)', '("ab cd" ef)'],
-			// ['ab (cd) ef', '(ab) (cd) (ef)'],
-			// ['"ab cd" (ef gh) "ij kl"', '("ab cd") (ef gh) ("ij kl")'],
-			// ['ab cd OR ef OR "gh ij"', 'ab cd OR ef OR "gh ij"'],
-			// ['"plain or text" OR (cd)', '("plain or text") OR (cd)'],
-			// ['(ab) OR cd OR ef OR (gh)', '(ab) OR (cd) OR (ef) OR (gh)'],
+			['ab cd ef', 'ab cd ef'],
+			['(ab cd ef)', '(ab cd ef)'],
+			['("ab cd" ef)', '("ab cd" ef)'],
+			['"ab cd" (ef gh) "ij kl"', '"ab cd" (ef gh) "ij kl"'],
+			['ab cd OR ef OR "gh ij"', 'ab cd OR ef OR "gh ij"'],
+			['"plain or text" OR (cd)', '("plain or text") OR (cd)'],
+			['(ab) OR cd OR ef OR (gh)', '(ab) OR (cd) OR (ef) OR (gh)'],
 			['(ab (cd OR ef)) OR gh OR ij OR (kl)', '(ab (cd OR ef)) OR (gh) OR (ij) OR (kl)'],
+			['(ab (cd OR ef OR (gh))) OR ij', '(ab ((cd) OR (ef) OR (gh))) OR (ij)'],
 		];
 	}
 
@@ -327,11 +327,11 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 	 * @dataProvider provideParentheses
 	 * @param array<string> $values
 	 */
-	/*public function test__parentheses(string $input, string $sql, array $values): void {
+	public function test__parentheses(string $input, string $sql, array $values): void {
 		[$filterValues, $filterSearch] = FreshRSS_EntryDAOPGSQL::sqlBooleanSearch('e.', new FreshRSS_BooleanSearch($input));
 		self::assertEquals(trim($sql), trim($filterSearch));
 		self::assertEquals($values, $filterValues);
-	}*/
+	}
 
 	/** @return array<array<mixed>> */
 	public function provideParentheses(): array {
@@ -378,42 +378,42 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 			],
 			[
 				'(ab) OR (cd) OR (ef)',
-				' (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) ',
+				'(((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) ))',
 				['%ab%', '%ab%', '%cd%', '%cd%', '%ef%', '%ef%'],
 			],
 			[
 				'("plain or text") OR (cd)',
-				' (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) ',
+				'(((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) ))',
 				['%plain or text%', '%plain or text%', '%cd%', '%cd%'],
 			],
 			[
 				'"plain or text" OR cd',
-				' ((e.title LIKE ? OR e.content LIKE ?) ) OR ((e.title LIKE ? OR e.content LIKE ?) ) ',
+				'((e.title LIKE ? OR e.content LIKE ?) ) OR ((e.title LIKE ? OR e.content LIKE ?) )',
 				['%plain or text%', '%plain or text%', '%cd%', '%cd%'],
 			],
 			[
 				'"plain OR text" OR cd',
-				' ((e.title LIKE ? OR e.content LIKE ?) ) OR ((e.title LIKE ? OR e.content LIKE ?) ) ',
+				'((e.title LIKE ? OR e.content LIKE ?) ) OR ((e.title LIKE ? OR e.content LIKE ?) ) ',
 				['%plain OR text%', '%plain OR text%', '%cd%', '%cd%'],
 			],
 			[
 				'ab OR cd OR (ef)',
-				' (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) ',
+				'(((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) ',
 				['%ab%', '%ab%', '%cd%', '%cd%', '%ef%', '%ef%'],
 			],
 			[
 				'ab OR cd OR ef',
-				' (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) ',
+				'((e.title LIKE ? OR e.content LIKE ?) ) OR ((e.title LIKE ? OR e.content LIKE ?) ) OR ((e.title LIKE ? OR e.content LIKE ?) )',
 				['%ab%', '%ab%', '%cd%', '%cd%', '%ef%', '%ef%'],
 			],
 			[
 				'(ab) cd OR ef OR (gh)',
-				' (((e.title LIKE ? OR e.content LIKE ?) )) AND (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) ',
+				'(((e.title LIKE ? OR e.content LIKE ?) )) AND (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) ))',
 				['%ab%', '%ab%', '%cd%', '%cd%', '%ef%', '%ef%', '%gh%', '%gh%'],
 			],
 			[
 				'(ab) OR cd OR ef OR (gh)',
-				' (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) ',
+				'(((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) ))',
 				['%ab%', '%ab%', '%cd%', '%cd%', '%ef%', '%ef%', '%gh%', '%gh%'],
 			],
 		];

--- a/tests/app/Models/SearchTest.php
+++ b/tests/app/Models/SearchTest.php
@@ -416,12 +416,14 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 			],
 			[
 				'(ab) cd OR ef OR (gh)',
-				'(((e.title LIKE ? OR e.content LIKE ?) )) AND (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) ))',
+				'(((e.title LIKE ? OR e.content LIKE ?) )) AND (((e.title LIKE ? OR e.content LIKE ?) )) ' .
+				'OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) ))',
 				['%ab%', '%ab%', '%cd%', '%cd%', '%ef%', '%ef%', '%gh%', '%gh%'],
 			],
 			[
 				'(ab) OR cd OR ef OR (gh)',
-				'(((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) ))',
+				'(((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) ' .
+				'OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) ))',
 				['%ab%', '%ab%', '%cd%', '%cd%', '%ef%', '%ef%', '%gh%', '%gh%'],
 			],
 		];

--- a/tests/app/Models/SearchTest.php
+++ b/tests/app/Models/SearchTest.php
@@ -426,6 +426,27 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 				'OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) ))',
 				['%ab%', '%ab%', '%cd%', '%cd%', '%ef%', '%ef%', '%gh%', '%gh%'],
 			],
+			[
+				'ab OR (!(cd OR ef))',
+				'(((e.title LIKE ? OR e.content LIKE ?) )) OR (NOT (((e.title LIKE ? OR e.content LIKE ?) ) OR ((e.title LIKE ? OR e.content LIKE ?) )))',
+				['%ab%', '%ab%', '%cd%', '%cd%', '%ef%', '%ef%'],
+			],
+			[
+				'ab !(cd OR ef)',
+				'(((e.title LIKE ? OR e.content LIKE ?) )) AND NOT (((e.title LIKE ? OR e.content LIKE ?) ) OR ((e.title LIKE ? OR e.content LIKE ?) ))',
+				['%ab%', '%ab%', '%cd%', '%cd%', '%ef%', '%ef%'],
+			],
+			[
+				'ab OR !(cd OR ef)',
+				'(((e.title LIKE ? OR e.content LIKE ?) )) OR NOT (((e.title LIKE ? OR e.content LIKE ?) ) OR ((e.title LIKE ? OR e.content LIKE ?) ))',
+				['%ab%', '%ab%', '%cd%', '%cd%', '%ef%', '%ef%'],
+			],
+			[
+				'(ab (!cd OR ef OR (gh))) OR !(ij OR kl)',
+				'((((e.title LIKE ? OR e.content LIKE ?) )) AND (((e.title NOT LIKE ? AND e.content NOT LIKE ? )) OR (((e.title LIKE ? OR e.content LIKE ?) )) ' .
+				'OR (((e.title LIKE ? OR e.content LIKE ?) )))) OR NOT (((e.title LIKE ? OR e.content LIKE ?) ) OR ((e.title LIKE ? OR e.content LIKE ?) ))',
+				['%ab%', '%ab%', '%cd%', '%cd%', '%ef%', '%ef%', '%gh%', '%gh%', '%ij%', '%ij%', '%kl%', '%kl%'],
+			],
 		];
 	}
 }

--- a/tests/app/Models/SearchTest.php
+++ b/tests/app/Models/SearchTest.php
@@ -285,14 +285,53 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 	}
 
 	/**
+	 * @dataProvider provideAddOrParentheses
+	 */
+	public function test__addOrParentheses(string $input, string $output): void {
+		self::assertEquals($output, FreshRSS_BooleanSearch::addOrParentheses($input));
+	}
+
+	/** @return array<array{string,string}> */
+	public function provideAddOrParentheses(): array {
+		return [
+			['ab', '(ab)'],
+			['ab cd', '(ab cd)'],
+			['ab OR cd', '(ab) OR (cd)'],
+			['ab cd OR ef OR "gh ij"', '(ab cd) OR (ef) OR ("gh ij")'],
+		];
+	}
+
+	/**
+	 * @dataProvider provideBooleanExpression
+	 */
+	public function test__consistentParentheses(string $input, string $output): void {
+		self::assertEquals($output, FreshRSS_BooleanSearch::consistentParentheses($input));
+	}
+
+	/** @return array<array{string,string}> */
+	public function provideBooleanExpression(): array {
+		return [
+			// ['ab cd ef', 'ab cd ef'],
+			// ['(ab cd ef)', '(ab cd ef)'],
+			// ['("ab cd" ef)', '("ab cd" ef)'],
+			// ['ab (cd) ef', '(ab) (cd) (ef)'],
+			// ['"ab cd" (ef gh) "ij kl"', '("ab cd") (ef gh) ("ij kl")'],
+			// ['ab cd OR ef OR "gh ij"', 'ab cd OR ef OR "gh ij"'],
+			// ['"plain or text" OR (cd)', '("plain or text") OR (cd)'],
+			// ['(ab) OR cd OR ef OR (gh)', '(ab) OR (cd) OR (ef) OR (gh)'],
+			['(ab (cd OR ef)) OR gh OR ij OR (kl)', '(ab (cd OR ef)) OR (gh) OR (ij) OR (kl)'],
+		];
+	}
+
+	/**
 	 * @dataProvider provideParentheses
 	 * @param array<string> $values
 	 */
-	public function test__construct_parentheses(string $input, string $sql, array $values): void {
+	/*public function test__parentheses(string $input, string $sql, array $values): void {
 		[$filterValues, $filterSearch] = FreshRSS_EntryDAOPGSQL::sqlBooleanSearch('e.', new FreshRSS_BooleanSearch($input));
-		self::assertEquals($sql, $filterSearch);
+		self::assertEquals(trim($sql), trim($filterSearch));
 		self::assertEquals($values, $filterValues);
-	}
+	}*/
 
 	/** @return array<array<mixed>> */
 	public function provideParentheses(): array {
@@ -336,6 +375,46 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 				'intitle:\'"hello world"\'',
 				'(e.title LIKE ? )',
 				['%"hello world"%'],
+			],
+			[
+				'(ab) OR (cd) OR (ef)',
+				' (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) ',
+				['%ab%', '%ab%', '%cd%', '%cd%', '%ef%', '%ef%'],
+			],
+			[
+				'("plain or text") OR (cd)',
+				' (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) ',
+				['%plain or text%', '%plain or text%', '%cd%', '%cd%'],
+			],
+			[
+				'"plain or text" OR cd',
+				' ((e.title LIKE ? OR e.content LIKE ?) ) OR ((e.title LIKE ? OR e.content LIKE ?) ) ',
+				['%plain or text%', '%plain or text%', '%cd%', '%cd%'],
+			],
+			[
+				'"plain OR text" OR cd',
+				' ((e.title LIKE ? OR e.content LIKE ?) ) OR ((e.title LIKE ? OR e.content LIKE ?) ) ',
+				['%plain OR text%', '%plain OR text%', '%cd%', '%cd%'],
+			],
+			[
+				'ab OR cd OR (ef)',
+				' (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) ',
+				['%ab%', '%ab%', '%cd%', '%cd%', '%ef%', '%ef%'],
+			],
+			[
+				'ab OR cd OR ef',
+				' (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) ',
+				['%ab%', '%ab%', '%cd%', '%cd%', '%ef%', '%ef%'],
+			],
+			[
+				'(ab) cd OR ef OR (gh)',
+				' (((e.title LIKE ? OR e.content LIKE ?) )) AND (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) ',
+				['%ab%', '%ab%', '%cd%', '%cd%', '%ef%', '%ef%', '%gh%', '%gh%'],
+			],
+			[
+				'(ab) OR cd OR ef OR (gh)',
+				' (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) OR (((e.title LIKE ? OR e.content LIKE ?) )) ',
+				['%ab%', '%ab%', '%cd%', '%cd%', '%ef%', '%ef%', '%gh%', '%gh%'],
 			],
 		];
 	}

--- a/tests/app/Models/UserQueryTest.php
+++ b/tests/app/Models/UserQueryTest.php
@@ -96,27 +96,27 @@ class UserQueryTest extends PHPUnit\Framework\TestCase {
 		self::assertCount(0, $user_query->toArray());
 	}
 
-	// public function testToArray_whenData_returnsArray(): void {
-	// 	$query = array(
-	// 		'get' => 's',
-	// 		'name' => 'some name',
-	// 		'order' => 'some order',
-	// 		'search' => 'some search',
-	// 		'state' => FreshRSS_Entry::STATE_ALL,
-	// 		'url' => 'some url',
-	// 	);
-	// 	$user_query = new FreshRSS_UserQuery($query, [], []);
-	// 	self::assertCount(6, $user_query->toArray());
-	// 	self::assertEquals($query, $user_query->toArray());
-	// }
+	public function testToArray_whenData_returnsArray(): void {
+		$query = array(
+			'get' => 's',
+			'name' => 'some name',
+			'order' => 'some order',
+			'search' => 'some search',
+			'state' => FreshRSS_Entry::STATE_ALL,
+			'url' => 'some url',
+		);
+		$user_query = new FreshRSS_UserQuery($query, [], []);
+		self::assertCount(6, $user_query->toArray());
+		self::assertEquals($query, $user_query->toArray());
+	}
 
-	// public function testHasSearch_whenSearch_returnsTrue(): void {
-	// 	$query = array(
-	// 		'search' => 'some search',
-	// 	);
-	// 	$user_query = new FreshRSS_UserQuery($query, [], []);
-	// 	self::assertTrue($user_query->hasSearch());
-	// }
+	public function testHasSearch_whenSearch_returnsTrue(): void {
+		$query = array(
+			'search' => 'some search',
+		);
+		$user_query = new FreshRSS_UserQuery($query, [], []);
+		self::assertTrue($user_query->hasSearch());
+	}
 
 	public function testHasSearch_whenNoSearch_returnsFalse(): void {
 		$user_query = new FreshRSS_UserQuery([], [], []);

--- a/tests/app/Models/UserQueryTest.php
+++ b/tests/app/Models/UserQueryTest.php
@@ -96,27 +96,27 @@ class UserQueryTest extends PHPUnit\Framework\TestCase {
 		self::assertCount(0, $user_query->toArray());
 	}
 
-	public function testToArray_whenData_returnsArray(): void {
-		$query = array(
-			'get' => 's',
-			'name' => 'some name',
-			'order' => 'some order',
-			'search' => 'some search',
-			'state' => FreshRSS_Entry::STATE_ALL,
-			'url' => 'some url',
-		);
-		$user_query = new FreshRSS_UserQuery($query, [], []);
-		self::assertCount(6, $user_query->toArray());
-		self::assertEquals($query, $user_query->toArray());
-	}
+	// public function testToArray_whenData_returnsArray(): void {
+	// 	$query = array(
+	// 		'get' => 's',
+	// 		'name' => 'some name',
+	// 		'order' => 'some order',
+	// 		'search' => 'some search',
+	// 		'state' => FreshRSS_Entry::STATE_ALL,
+	// 		'url' => 'some url',
+	// 	);
+	// 	$user_query = new FreshRSS_UserQuery($query, [], []);
+	// 	self::assertCount(6, $user_query->toArray());
+	// 	self::assertEquals($query, $user_query->toArray());
+	// }
 
-	public function testHasSearch_whenSearch_returnsTrue(): void {
-		$query = array(
-			'search' => 'some search',
-		);
-		$user_query = new FreshRSS_UserQuery($query, [], []);
-		self::assertTrue($user_query->hasSearch());
-	}
+	// public function testHasSearch_whenSearch_returnsTrue(): void {
+	// 	$query = array(
+	// 		'search' => 'some search',
+	// 	);
+	// 	$user_query = new FreshRSS_UserQuery($query, [], []);
+	// 	self::assertTrue($user_query->hasSearch());
+	// }
 
 	public function testHasSearch_whenNoSearch_returnsFalse(): void {
 		$user_query = new FreshRSS_UserQuery([], [], []);


### PR DESCRIPTION
Search expressions combining some non-uniform parentheses and `OR` expressions where failing.
For instance:
* `(ab) OR cd OR ef OR (gh)` was wrongly parsed as `(ab) (cd OR ef) OR (gh)`

Improved the parser, also for expressions involving negations, and add several unit tests.