### PR TITLE
Fix HTTP cache of main page

### DIFF
--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -373,7 +373,6 @@ SQL;
 	 * @return int|false affected rows
 	 */
 	public function markRead($ids, bool $is_read = true) {
-		FreshRSS_UserDAO::touch();
 		if (is_array($ids)) {	//Many IDs at once
 			if (count($ids) < 6) {	//Speed heuristics
 				$affected = 0;
@@ -391,6 +390,7 @@ SQL;
 				return $affected;
 			}
 
+			FreshRSS_UserDAO::touch();
 			$sql = 'UPDATE `_entry` '
 				 . 'SET is_read=? '
 				 . 'WHERE id IN (' . str_repeat('?,', count($ids) - 1) . '?)';
@@ -408,6 +408,7 @@ SQL;
 			}
 			return $affected;
 		} else {
+			FreshRSS_UserDAO::touch();
 			$sql = 'UPDATE `_entry` e INNER JOIN `_feed` f ON e.id_feed=f.id '
 				 . 'SET e.is_read=?,'
 				 . 'f.`cache_nbUnreads`=f.`cache_nbUnreads`' . ($is_read ? '-' : '+') . '1 '

--- a/app/Models/EntryDAOSQLite.php
+++ b/app/Models/EntryDAOSQLite.php
@@ -83,7 +83,6 @@ SQL;
 	 */
 	#[\Override]
 	public function markRead($ids, bool $is_read = true) {
-		FreshRSS_UserDAO::touch();
 		if (is_array($ids)) {	//Many IDs at once (used by API)
 			//if (true) {	//Speed heuristics	//TODO: Not implemented yet for SQLite (so always call IDs one by one)
 			$affected = 0;
@@ -93,6 +92,7 @@ SQL;
 			return $affected;
 			//}
 		} else {
+			FreshRSS_UserDAO::touch();
 			$this->pdo->beginTransaction();
 			$sql = 'UPDATE `_entry` SET is_read=? WHERE id=? AND is_read=?';
 			$values = [$is_read ? 1 : 0, $ids, $is_read ? 0 : 1];

--- a/p/i/index.php
+++ b/p/i/index.php
@@ -32,6 +32,8 @@ if (!file_exists($applied_migrations_path)) {
 	require(APP_PATH . '/install.php');
 } else {
 	session_cache_limiter('');
+	Minz_Session::init('FreshRSS');
+	Minz_Session::_param('keepAlive', 1);	//To prevent the PHP session from expiring
 
 	if (!file_exists(DATA_PATH . '/no-cache.txt')) {
 		require(LIB_PATH . '/http-conditional.php');
@@ -42,8 +44,6 @@ if (!file_exists($applied_migrations_path)) {
 			@filemtime(DATA_PATH . '/config.php') ?: 0
 		);
 		if (httpConditional($dateLastModification ?: time(), 0, 0, false, PHP_COMPRESSION, true)) {
-			Minz_Session::init('FreshRSS');
-			Minz_Session::_param('keepAlive', 1);	//To prevent the PHP session from expiring
 			exit();	//No need to send anything
 		}
 	}
@@ -56,7 +56,6 @@ if (!file_exists($applied_migrations_path)) {
 			FreshRSS_Context::initSystem();
 			$front_controller = new FreshRSS();
 			$front_controller->init();
-			Minz_Session::_param('keepAlive', 1);	//To prevent the PHP session from expiring
 			$front_controller->run();
 		} else {
 			$error = $result;


### PR DESCRIPTION
Revert bug introduced by https://github.com/FreshRSS/FreshRSS/pull/3096 in which username was always null, preventing HTTP cache from working and always returning 200 instead of 304.
Discovered when checking https://github.com/FreshRSS/FreshRSS/pull/6718
