### PR TITLE
Fix Docker documents for port mapping and caddy use.

### DIFF
--- a/Docker/freshrss/docker-compose-local.yml
+++ b/Docker/freshrss/docker-compose-local.yml
@@ -4,4 +4,4 @@ services:
 
   freshrss:
     ports:
-      - "${PUBLISHED_PORT:-8080}:${LISTEN:-80}"
+      - "${PUBLISHED_PORT:-8080}:${LISTEN:-8080}"

--- a/Docker/freshrss/example.env
+++ b/Docker/freshrss/example.env
@@ -8,6 +8,7 @@
 ADMIN_EMAIL=admin@example.net
 
 # Published port for development or local use (optional)
+# WARNING: this must match the LISTEN port as well
 PUBLISHED_PORT=8080
 
 # =========================================


### PR DESCRIPTION
Closes #6727 

Changes proposed in this pull request:

- Document that `LISTEN` and `PUBLISHED_PORT` must match
- Add copied and fixed Caddy reverse proxy setup from Admin documentation

How to test the feature manually:

1. Try using any of the existing docker compose example files/code
2. Verify the FreshRSS page loads as a blank screen
3. Try it with the changes proposed here
4. Verify the FreshRSS page loads with content

And for the Caddy docs:  
1. Try the Caddy configs 

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).