### PR TITLE
Fix PHPUnit version for tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -2,7 +2,7 @@
 
 ```sh
 cd ./tests/
-wget https://phar.phpunit.de/phpunit.phar
+wget -O phpunit.phar https://phar.phpunit.de/phpunit-9.phar
 php phpunit.phar --bootstrap bootstrap.php
 ```
 


### PR DESCRIPTION
While working on https://github.com/Art4/FreshRSS/pull/1 I noticed that `wget https://phar.phpunit.de/phpunit.phar` will download the newest version 11 of PHPUnit. With this version one will get a lot of deprecation warnings and errors running the tests.

I get the download url [from the docs](https://phpunit.de/getting-started/phpunit-9.html) and have tested it successfully.

Changes proposed in this pull request:

- Downloading PHPUnit 9 explicitly for manual tests without deprecation warnings and errors

How to test the feature manually:

1. Follow the download instruction in `tests/README.md`
2. Run `php phpunit.phar --version` to see the PHPUnit version
3. Run the tests without warnings.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
