### PR TITLE
improved: Default styles for pre and code 

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -838,19 +838,14 @@ kbd {
 }
 
 .content pre {
-	margin: 10px auto;
-	padding: 10px 20px;
-	overflow: auto;
 	background: var(--background-color-dark);
 	color: var(--font-color-light);
-	font-size: 0.9rem;
 	border-radius: 3px;
 }
 
 .content code {
-	padding: 2px 5px;
 	background: var(--background-color-light);
-	border: 1px solid var(--background-color-light);
+	border-color: var(--background-color-light);
 	border-radius: 3px;
 }
 

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -838,19 +838,14 @@ kbd {
 }
 
 .content pre {
-	margin: 10px auto;
-	padding: 10px 20px;
-	overflow: auto;
 	background: var(--background-color-dark);
 	color: var(--font-color-light);
-	font-size: 0.9rem;
 	border-radius: 3px;
 }
 
 .content code {
-	padding: 2px 5px;
 	background: var(--background-color-light);
-	border: 1px solid var(--background-color-light);
+	border-color: var(--background-color-light);
 	border-radius: 3px;
 }
 

--- a/p/themes/Ansum/_layout.scss
+++ b/p/themes/Ansum/_layout.scss
@@ -273,12 +273,8 @@ main.prompt {
 	}
 
 	pre {
-		margin: 10px auto;
-		padding: 10px 20px;
-		overflow: auto;
 		background: variables.$main-first-darker;
 		color: variables.$white;
-		font-size: 0.9rem;
 		border-radius: 3px;
 
 		code {
@@ -289,9 +285,8 @@ main.prompt {
 	}
 
 	code {
-		padding: 2px 5px;
 		background: variables.$grey-lighter;
-		border: 1px solid variables.$grey-light;
+		border-color: variables.$grey-light;
 		border-radius: 3px;
 	}
 

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -482,7 +482,7 @@ button.as-link[disabled] {
 
 .content code {
 	background-color: var(--dark-background-color1);
-	border: 1px solid var(--dark-border-color3);
+	border-color: var(--dark-border-color3);
 }
 
 .content pre code {

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -482,7 +482,7 @@ button.as-link[disabled] {
 
 .content code {
 	background-color: var(--dark-background-color1);
-	border: 1px solid var(--dark-border-color3);
+	border-color: var(--dark-border-color3);
 }
 
 .content pre code {

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -757,20 +757,15 @@ th {
 }
 
 .content pre {
-	margin: 10px auto;
-	padding: 10px 20px;
-	overflow: auto;
 	background: #222;
 	color: #fff;
-	font-size: 0.9rem;
 	border-radius: 3px;
 }
 
 .content code {
-	padding: 2px 5px;
 	background: #fafafa;
 	color: #d14;
-	border: 1px solid #eee;
+	border-color: #eee;
 	border-radius: 3px;
 }
 

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -757,20 +757,15 @@ th {
 }
 
 .content pre {
-	margin: 10px auto;
-	padding: 10px 20px;
-	overflow: auto;
 	background: #222;
 	color: #fff;
-	font-size: 0.9rem;
 	border-radius: 3px;
 }
 
 .content code {
-	padding: 2px 5px;
 	background: #fafafa;
 	color: #d14;
-	border: 1px solid #eee;
+	border-color: #eee;
 	border-radius: 3px;
 }
 

--- a/p/themes/Mapco/_layout.scss
+++ b/p/themes/Mapco/_layout.scss
@@ -285,12 +285,8 @@ main.prompt {
 	}
 
 	pre {
-		margin: 10px auto;
-		padding: 10px 20px;
-		overflow: auto;
 		background: variables.$main-first-darker;
 		color: variables.$white;
-		font-size: 0.9rem;
 		border-radius: 3px;
 
 		code {
@@ -301,11 +297,9 @@ main.prompt {
 	}
 
 	code {
-		padding: 2px 5px;
 		background: variables.$code-bg;
 		color: variables.$code-text;
 		font-size: 1rem;
-		// border: 1px solid variables.$alert-light;
 		border-radius: 3px;
 	}
 

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -866,17 +866,9 @@ li.item.active {
 }
 
 .content pre {
-	margin: 10px auto;
-	padding: 10px 20px;
-	overflow: auto;
-	font-size: 0.9rem;
 	border: 1px solid var(--accent);
 	border-radius: 6px;
 
-}
-
-.content code {
-	padding: 2px 5px;
 }
 
 .content blockquote {

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -866,17 +866,9 @@ li.item.active {
 }
 
 .content pre {
-	margin: 10px auto;
-	padding: 10px 20px;
-	overflow: auto;
-	font-size: 0.9rem;
 	border: 1px solid var(--accent);
 	border-radius: 6px;
 
-}
-
-.content code {
-	padding: 2px 5px;
 }
 
 .content blockquote {

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -919,19 +919,14 @@ a:hover .icon {
 }
 
 .content pre {
-	margin: 10px auto;
-	padding: 10px 20px;
-	overflow: auto;
-	font-size: 0.9rem;
 	border: 1px solid var(--border-color);
 	border-radius: 3px;
 }
 
 .content code {
-	padding: 2px 5px;
 	background-color: var(--background-color-light-shadowed);
 	color: var(--error-feed-color);
-	border: 1px solid var(--border-color);
+	border-color: var(--border-color);
 	border-radius: 3px;
 }
 

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -919,19 +919,14 @@ a:hover .icon {
 }
 
 .content pre {
-	margin: 10px auto;
-	padding: 10px 20px;
-	overflow: auto;
-	font-size: 0.9rem;
 	border: 1px solid var(--border-color);
 	border-radius: 3px;
 }
 
 .content code {
-	padding: 2px 5px;
 	background-color: var(--background-color-light-shadowed);
 	color: var(--error-feed-color);
-	border: 1px solid var(--border-color);
+	border-color: var(--border-color);
 	border-radius: 3px;
 }
 

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -876,20 +876,15 @@ a.signin {
 }
 
 .content pre {
-	margin: 10px auto;
-	padding: 10px 20px;
-	overflow: auto;
 	background-color: var(--background-color-dark);
 	color: var(--font-color-white);
-	font-size: 0.9rem;
 	border-radius: 3px;
 }
 
 .content code {
-	padding: 2px 5px;
 	background-color: var(--background-color-grey-light);
 	color: var(--font-color-code);
-	border: 1px solid var(--border-color-grey-light);
+	border-color: var(--border-color-grey-light);
 	border-radius: 3px;
 }
 

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -876,20 +876,15 @@ a.signin {
 }
 
 .content pre {
-	margin: 10px auto;
-	padding: 10px 20px;
-	overflow: auto;
 	background-color: var(--background-color-dark);
 	color: var(--font-color-white);
-	font-size: 0.9rem;
 	border-radius: 3px;
 }
 
 .content code {
-	padding: 2px 5px;
 	background-color: var(--background-color-grey-light);
 	color: var(--font-color-code);
-	border: 1px solid var(--border-color-grey-light);
+	border-color: var(--border-color-grey-light);
 	border-radius: 3px;
 }
 

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -434,12 +434,8 @@ form th {
 	box-shadow: 0 2px 5px var(--color-box-shadow-light);
 }
 .content pre {
-	margin: 10px auto;
-	padding: 10px 20px;
-	overflow: auto;
 	background-color: var(--color-background-dark);
 	color: var(--color-text-light);
-	font-size: 0.9rem;
 }
 .content pre code {
 	background: transparent;
@@ -447,10 +443,9 @@ form th {
 	border: none;
 }
 .content code {
-	padding: 2px 5px;
 	background-color: var(--color-background-light);
 	color: var(--color-text-bad);
-	border: 1px solid var(--color-border-light);
+	border-color: var(--color-border-light);
 }
 .content blockquote {
 	margin: 0;

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -434,12 +434,8 @@ form th {
 	box-shadow: 0 2px 5px var(--color-box-shadow-light);
 }
 .content pre {
-	margin: 10px auto;
-	padding: 10px 20px;
-	overflow: auto;
 	background-color: var(--color-background-dark);
 	color: var(--color-text-light);
-	font-size: 0.9rem;
 }
 .content pre code {
 	background: transparent;
@@ -447,10 +443,9 @@ form th {
 	border: none;
 }
 .content code {
-	padding: 2px 5px;
 	background-color: var(--color-background-light);
 	color: var(--color-text-bad);
-	border: 1px solid var(--color-border-light);
+	border-color: var(--color-border-light);
 }
 .content blockquote {
 	margin: 0;

--- a/p/themes/Swage/swage.scss
+++ b/p/themes/Swage/swage.scss
@@ -559,12 +559,8 @@ form {
 	}
 
 	pre {
-		margin: 10px auto;
-		padding: 10px 20px;
-		overflow: auto;
 		background-color: var(--color-background-dark);
 		color: var(--color-text-light);
-		font-size: 0.9rem;
 
 		code {
 			background: transparent;
@@ -574,10 +570,9 @@ form {
 	}
 
 	code {
-		padding: 2px 5px;
 		background-color: var(--color-background-light);
 		color: var(--color-text-bad);
-		border: 1px solid var(--color-border-light);
+		border-color: var(--color-border-light);
 	}
 
 	blockquote {

--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -577,14 +577,9 @@ th {
 }
 
 .content pre {
-	margin: 10px auto;
-	padding: 10px 20px;
-	overflow: auto;
-	font-size: 0.9rem;
 }
 
 .content code {
-	padding: 2px 5px;
 }
 
 .content pre code {

--- a/p/themes/base-theme/base.rtl.css
+++ b/p/themes/base-theme/base.rtl.css
@@ -577,14 +577,9 @@ th {
 }
 
 .content pre {
-	margin: 10px auto;
-	padding: 10px 20px;
-	overflow: auto;
-	font-size: 0.9rem;
 }
 
 .content code {
-	padding: 2px 5px;
 }
 
 .content pre code {

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1604,7 +1604,15 @@ a.website:hover .favicon {
 }
 
 .content pre {
+	margin: 10px auto;
+	padding: 10px 20px;
 	overflow: auto;
+	font-size: 0.9rem;
+}
+
+.content code {
+	padding: 2px 5px;
+	border: 1px solid var(--frss-border-color);
 }
 
 .subtitle > div {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1604,7 +1604,15 @@ a.website:hover .favicon {
 }
 
 .content pre {
+	margin: 10px auto;
+	padding: 10px 20px;
 	overflow: auto;
+	font-size: 0.9rem;
+}
+
+.content code {
+	padding: 2px 5px;
+	border: 1px solid var(--frss-border-color);
 }
 
 .subtitle > div {


### PR DESCRIPTION
Closes #4689

nothing spectacular. Just a bit housekeeping. 

Changes proposed in this pull request:

- move some essential CSS lines for `<pre>` and `<code>` into `frss.css`


