### PR TITLE
Fix XPath for HTML documents with broken root

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -785,7 +785,7 @@ HTML;
 			$content = '';
 			$cssSelector = htmlspecialchars_decode($feed->pathEntries(), ENT_QUOTES);
 			$cssSelector = trim($cssSelector, ', ');
-			$nodes = $xpath->query((new Gt\CssXPath\Translator($cssSelector))->asXPath());
+			$nodes = $xpath->query((new Gt\CssXPath\Translator($cssSelector, '//'))->asXPath());
 			if ($nodes != false) {
 				$path_entries_filter = $feed->attributeString('path_entries_filter') ?? '';
 				$path_entries_filter = trim($path_entries_filter, ', ');


### PR DESCRIPTION
fix https://github.com/FreshRSS/FreshRSS/issues/6773

The default `.//` prefix for the XPath does not work for HTML documents, which have content after the end of their main node.
But `//` works in both cases.
