### PR TITLE
Skip toggle password button on keyboard navigation

### DIFF
--- a/app/views/auth/formLogin.phtml
+++ b/app/views/auth/formLogin.phtml
@@ -25,7 +25,7 @@
 			<label for="passwordPlain"><?= _t('gen.auth.password') ?></label>
 			<div class="stick">
 				<input type="password" id="passwordPlain" required="required" />
-				<button type="button" class="btn toggle-password" data-toggle="passwordPlain"><?= _i('key') ?></button>
+				<button type="button" class="btn toggle-password" data-toggle="passwordPlain" tabindex="-1"><?= _i('key') ?></button>
 			</div>
 			<input type="hidden" id="challenge" name="challenge" />
 			<noscript><strong><?= _t('gen.js.should_be_activated') ?></strong></noscript>


### PR DESCRIPTION
Set `tabindex` of the  toggle password button in the login form to "-1", so that when the user do keyboard navigation (i.e. use tab to move between fields) skip the toggle button.

In the end, the user will be presented:

- username
- password
- keep me logged
- login button (but can login any time with enter)

[Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) suggest to use any value different than 0 or -1.

Changes proposed in this pull request:

- A small change in the usability of the login form


How to test the feature manually:

1. Go to the login form
2. Use tab to move between form element

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
