### PR TITLE
Fix:  (#6815) share menu shortcut

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -738,9 +738,13 @@ function auto_share(key) {
 		// Display the share div
 		location.hash = share.id;
 		// Force scrolling to the share div
-		const scrollTop = needsScroll(share.closest('.bottom'));
+		const scrollTop = needsScroll(share.closest('.horizontal-list'));
 		if (scrollTop !== 0) {
-			document.scrollingElement.scrollTop = scrollTop;
+			if (share.closest('.horizontal-list.flux_header')) {
+				share.nextElementSibling.nextElementSibling.scrollIntoView({ behavior: "smooth", block: "start" });
+			} else {
+				share.nextElementSibling.nextElementSibling.scrollIntoView({ behavior: "smooth", block: "end" });
+			}
 		}
 		// Force the key value if there is only one action, so we can trigger it automatically
 		if (shares.length === 1) {

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -698,29 +698,31 @@ function user_filter(key) {
 }
 
 function show_share_menu(el) {
-	const itemId = el.closest('.flux').id;
-	const templateId = 'share_article_template';
-	const id = itemId;
-	const flux_header_el = el.closest('.flux');
-	const title_el = flux_header_el.querySelector('.item.titleAuthorSummaryDate .item-element.title');
-	const websiteName = ' - ' + flux_header_el.querySelector('.flux_header').dataset.websiteName;
-	const articleAuthors = flux_header_el.querySelector('.flux_header').dataset.articleAuthors;
-	let articleAuthorsText = '';
-	if (articleAuthors.trim().length > 0) {
-		articleAuthorsText = ' (' + articleAuthors + ')';
-	}
-	const link = title_el.href;
-	const title = title_el.textContent;
-	const titleText = title;
 	const div = el.parentElement;
 	const dropdownMenu = div.querySelector('.dropdown-menu');
-	const template = document.getElementById(templateId).innerHTML
-		.replace(/--entryId--/g, id)
-		.replace(/--link--/g, link)
-		.replace(/--titleText--/g, titleText)
-		.replace(/--websiteName--/g, websiteName)
-		.replace(/--articleAuthors--/g, articleAuthorsText);
+
 	if (!dropdownMenu) {
+		const itemId = el.closest('.flux').id;
+		const templateId = 'share_article_template';
+		const id = itemId;
+		const flux_header_el = el.closest('.flux');
+		const title_el = flux_header_el.querySelector('.item.titleAuthorSummaryDate .item-element.title');
+		const websiteName = ' - ' + flux_header_el.querySelector('.flux_header').dataset.websiteName;
+		const articleAuthors = flux_header_el.querySelector('.flux_header').dataset.articleAuthors;
+		let articleAuthorsText = '';
+		if (articleAuthors.trim().length > 0) {
+			articleAuthorsText = ' (' + articleAuthors + ')';
+		}
+		const link = title_el.href;
+		const title = title_el.textContent;
+		const titleText = title;
+		const template = document.getElementById(templateId).innerHTML
+			.replace(/--entryId--/g, id)
+			.replace(/--link--/g, link)
+			.replace(/--titleText--/g, titleText)
+			.replace(/--websiteName--/g, websiteName)
+			.replace(/--articleAuthors--/g, articleAuthorsText);
+
 		div.insertAdjacentHTML('beforeend', template);
 	}
 	return true;

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -697,6 +697,35 @@ function user_filter(key) {
 	}
 }
 
+function show_share_menu(el) {
+	const itemId = el.closest('.flux').id;
+	const templateId = 'share_article_template';
+	const id = itemId;
+	const flux_header_el = el.closest('.flux');
+	const title_el = flux_header_el.querySelector('.item.titleAuthorSummaryDate .item-element.title');
+	const websiteName = ' - ' + flux_header_el.querySelector('.flux_header').dataset.websiteName;
+	const articleAuthors = flux_header_el.querySelector('.flux_header').dataset.articleAuthors;
+	let articleAuthorsText = '';
+	if (articleAuthors.trim().length > 0) {
+		articleAuthorsText = ' (' + articleAuthors + ')';
+	}
+	const link = title_el.href;
+	const title = title_el.textContent;
+	const titleText = title;
+	const div = el.parentElement;
+	const dropdownMenu = div.querySelector('.dropdown-menu');
+	const template = document.getElementById(templateId).innerHTML
+		.replace(/--entryId--/g, id)
+		.replace(/--link--/g, link)
+		.replace(/--titleText--/g, titleText)
+		.replace(/--websiteName--/g, websiteName)
+		.replace(/--articleAuthors--/g, articleAuthorsText);
+	if (!dropdownMenu) {
+		div.insertAdjacentHTML('beforeend', template);
+	}
+	return true;
+}
+
 function auto_share(key) {
 	const share = document.querySelector('.flux.current.active .dropdown-target[id^="dropdown-share"]');
 	if (!share) {
@@ -704,6 +733,8 @@ function auto_share(key) {
 	}
 	const shares = share.parentElement.querySelectorAll('.dropdown-menu .item [data-type]');
 	if (typeof key === 'undefined') {
+		show_share_menu(share);
+
 		// Display the share div
 		location.hash = share.id;
 		// Force scrolling to the share div
@@ -1100,32 +1131,7 @@ function init_stream(stream) {
 
 		el = ev.target.closest('.item.share a.dropdown-toggle');
 		if (el) {
-			const itemId = el.closest('.flux').id;
-			const templateId = 'share_article_template';
-			const id = itemId;
-			const flux_header_el = el.closest('.flux');
-			const title_el = flux_header_el.querySelector('.item.titleAuthorSummaryDate .item-element.title');
-			const websiteName = ' - ' + flux_header_el.querySelector('.flux_header').dataset.websiteName;
-			const articleAuthors = flux_header_el.querySelector('.flux_header').dataset.articleAuthors;
-			let articleAuthorsText = '';
-			if (articleAuthors.trim().length > 0) {
-				articleAuthorsText = ' (' + articleAuthors + ')';
-			}
-			const link = title_el.href;
-			const title = title_el.textContent;
-			const titleText = title;
-			const div = el.parentElement;
-			const dropdownMenu = div.querySelector('.dropdown-menu');
-			const template = document.getElementById(templateId).innerHTML
-				.replace(/--entryId--/g, id)
-				.replace(/--link--/g, link)
-				.replace(/--titleText--/g, titleText)
-				.replace(/--websiteName--/g, websiteName)
-				.replace(/--articleAuthors--/g, articleAuthorsText);
-			if (!dropdownMenu) {
-				div.insertAdjacentHTML('beforeend', template);
-			}
-			return true;
+			return show_share_menu(el);
 		}
 
 		el = ev.target.closest('.item.share > button[data-type="print"]');

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -708,6 +708,8 @@ input[type="checkbox"]:focus-visible {
 	min-width: 200px;
 	position: absolute;
 	right: 0;
+	scroll-margin-top: 2rem;
+	scroll-margin-bottom: 2rem;
 }
 
 .dropdown-menu::after {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -708,6 +708,8 @@ input[type="checkbox"]:focus-visible {
 	min-width: 200px;
 	position: absolute;
 	left: 0;
+	scroll-margin-top: 2rem;
+	scroll-margin-bottom: 2rem;
 }
 
 .dropdown-menu::after {


### PR DESCRIPTION
Closes #6815
Regression #6751

Changes proposed in this pull request:

- refactoring: add `function show_share_menu(el)` so that the new menu template is called with the shortcut too.
- improved: scroll the share button into the view if out of view
-

How to test the feature manually:

1. go to normal view and press the share shortcut (default: `s`)
2. it opens the `first`/`topmost` sharing menu of the article

check too:
- share menu icon is enabled/disabled in the top line (config page: display)
- share menu icon is enabled/disabled in the bottom line (config page: display)
- scroll the share button out of view (above, below): it scrolls the button into the view
- keep the share button in the view: no scrolling

Known edge case bug: If the top line sharing icon is disabled and the bottom line sharing icon is enabled and the share button is visible on the bottom view edge than the sharing menu opens but it does not scroll into the view (reason: the scrolling feature checks if the share button is in the view not the share menu.). 

In general we should discuss if it is better to open the menus in the bottom line to the top instead to the bottom.


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
