### PR TITLE
Docker entrypoint optimize find sed

### DIFF
--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -3,9 +3,10 @@
 ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime
 echo "$TZ" >/etc/timezone
 
-find /etc/php*/ -type f -name php.ini -exec sed -r -i "\\#^;?date.timezone#s#^.*#date.timezone = $TZ#" {} \;
-find /etc/php*/ -type f -name php.ini -exec sed -r -i "\\#^;?post_max_size#s#^.*#post_max_size = 32M#" {} \;
-find /etc/php*/ -type f -name php.ini -exec sed -r -i "\\#^;?upload_max_filesize#s#^.*#upload_max_filesize = 32M#" {} \;
+find /etc/php*/ -type f -name php.ini -exec sed -i -E \
+	-e "\\#^;?date.timezone#s#^.*#date.timezone = $TZ#" \
+	-e "\\#^;?post_max_size#s#^.*#post_max_size = 32M#" \
+	-e "\\#^;?upload_max_filesize#s#^.*#upload_max_filesize = 32M#" {} \;
 
 if [ -n "$LISTEN" ]; then
 	find /etc/apache2/ -type f -name FreshRSS.Apache.conf -exec sed -r -i "\\#^Listen#s#^.*#Listen $LISTEN#" {} \;


### PR DESCRIPTION
Single `find` and single `sed` command instead of 3
