### PR TITLE
Allow dynamic search operator in user queries

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -413,7 +413,6 @@ class FreshRSS_configure_Controller extends FreshRSS_ActionController {
 
 			$queries = FreshRSS_Context::userConf()->queries;
 			$queries[$id] = (new FreshRSS_UserQuery($queryParams, FreshRSS_Context::categories(), FreshRSS_Context::labels()))->toArray();
-			$queries[$id]['search'] == $queryParams['search'] ?? '';	// Keep original search string, e.g. for allowing a dynamic `search:` operator
 			FreshRSS_Context::userConf()->queries = $queries;
 			FreshRSS_Context::userConf()->save();
 

--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -413,6 +413,7 @@ class FreshRSS_configure_Controller extends FreshRSS_ActionController {
 
 			$queries = FreshRSS_Context::userConf()->queries;
 			$queries[$id] = (new FreshRSS_UserQuery($queryParams, FreshRSS_Context::categories(), FreshRSS_Context::labels()))->toArray();
+			$queries[$id]['search'] == $queryParams['search'] ?? '';	// Keep original search string, e.g. for allowing a dynamic `search:` operator
 			FreshRSS_Context::userConf()->queries = $queries;
 			FreshRSS_Context::userConf()->save();
 

--- a/app/Models/BooleanSearch.php
+++ b/app/Models/BooleanSearch.php
@@ -31,12 +31,14 @@ class FreshRSS_BooleanSearch {
 			if (!is_string($input)) {
 				return;
 			}
+		}
+		$this->raw_input = $input;
 
+		if ($level === 0) {
 			$input = $this->parseUserQueryNames($input, $allowUserQueries);
 			$input = $this->parseUserQueryIds($input, $allowUserQueries);
 			$input = trim($input);
 		}
-		$this->raw_input = $input;
 
 		$input = self::consistentOrParentheses($input);
 
@@ -58,11 +60,11 @@ class FreshRSS_BooleanSearch {
 		}
 
 		if (!empty($all_matches)) {
-			/** @var array<string,FreshRSS_UserQuery> */
 			$queries = [];
 			foreach (FreshRSS_Context::userConf()->queries as $raw_query) {
-				$query = new FreshRSS_UserQuery($raw_query, FreshRSS_Context::categories(), FreshRSS_Context::labels());
-				$queries[$query->getName()] = $query;
+				if (($raw_query['name'] ?? '') !== '' && ($raw_query['search'] ?? '') !== '') {
+					$queries[$raw_query['name']] = trim($raw_query['search']);
+				}
 			}
 
 			$fromS = [];
@@ -76,7 +78,7 @@ class FreshRSS_BooleanSearch {
 					if (!empty($queries[$name])) {
 						$fromS[] = $matches[0][$i];
 						if ($allowUserQueries) {
-							$toS[] = '(' . trim($queries[$name]->getSearch()->getRawInput()) . ')';
+							$toS[] = '(' . $queries[$name] . ')';
 						} else {
 							$toS[] = '';
 						}
@@ -100,11 +102,9 @@ class FreshRSS_BooleanSearch {
 		}
 
 		if (!empty($all_matches)) {
-			/** @var array<string,FreshRSS_UserQuery> */
 			$queries = [];
 			foreach (FreshRSS_Context::userConf()->queries as $raw_query) {
-				$query = new FreshRSS_UserQuery($raw_query, FreshRSS_Context::categories(), FreshRSS_Context::labels());
-				$queries[] = $query;
+				$queries[] = trim($raw_query['search'] ?? '');
 			}
 
 			$fromS = [];
@@ -119,7 +119,7 @@ class FreshRSS_BooleanSearch {
 					if (!empty($queries[$id])) {
 						$fromS[] = $matches[0][$i];
 						if ($allowUserQueries) {
-							$toS[] = '(' . trim($queries[$id]->getSearch()->getRawInput()) . ')';
+							$toS[] = '(' . $queries[$id] . ')';
 						} else {
 							$toS[] = '';
 						}

--- a/app/Models/UserQuery.php
+++ b/app/Models/UserQuery.php
@@ -95,7 +95,7 @@ class FreshRSS_UserQuery {
 		}
 
 		// linked too deeply with the search object, need to use dependency injection
-		$this->search = new FreshRSS_BooleanSearch($query['search'], 0, 'AND', false);
+		$this->search = new FreshRSS_BooleanSearch($query['search'], 0, 'AND', allowUserQueries: true);
 		if (!empty($query['state'])) {
 			$this->state = intval($query['state']);
 		}

--- a/p/api/query.php
+++ b/p/api/query.php
@@ -93,7 +93,7 @@ foreach (FreshRSS_Context::userConf()->queries as $raw_query) {
 
 		$search = $query->getSearch()->getRawInput();
 		// Note: we disallow references to user queries in public user search to avoid sniffing internal user queries
-		$userSearch = new FreshRSS_BooleanSearch(Minz_Request::paramString('search'), 0, 'AND', false);
+		$userSearch = new FreshRSS_BooleanSearch(Minz_Request::paramString('search'), 0, 'AND', allowUserQueries: false);
 		if ($userSearch->getRawInput() !== '') {
 			if ($search === '') {
 				$search = $userSearch->getRawInput();


### PR DESCRIPTION
Allow saving a user query with a search referring to another user query like `search:A date:P1d`
fix https://github.com/FreshRSS/FreshRSS/issues/6849
