### PR TITLE
refactor labels article menu

### DIFF
--- a/app/views/helpers/index/normal/entry_bottom.phtml
+++ b/app/views/helpers/index/normal/entry_bottom.phtml
@@ -41,16 +41,6 @@
 			<a class="dropdown-toggle" href="#dropdown-labels-<?= $this->entry->id() ?>">
 				<?= _i('label') ?><?= _t('index.menu.tags') ?>
 			</a>
-			<ul class="dropdown-menu dropdown-menu-scrollable scrollbar-thin">
-				<li class="dropdown-header">
-					<?= _t('index.menu.tags') ?>
-					<?php if (FreshRSS_Auth::hasAccess()) { ?>
-						<a href="<?= _url('tag', 'index') ?>"><?= _i('configure') ?></a>
-					<?php } ?>
-				</li>
-				<!-- Ajax -->
-			</ul>
-			<a class="dropdown-close" href="#close">❌</a>
 		</div>
 	</li><?php
 	}

--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -23,6 +23,19 @@ $today = @strtotime('today');
 	<a class="dropdown-close" href="#close">❌</a>
 </template>
 
+<template id="labels_article_template">
+	<ul class="dropdown-menu dropdown-menu-scrollable scrollbar-thin">
+		<li class="dropdown-header">
+			<?= _t('index.menu.tags') ?>
+			<?php if (FreshRSS_Auth::hasAccess()) { ?>
+				<a href="<?= _url('tag', 'index') ?>"><?= _i('configure') ?></a>
+			<?php } ?>
+		</li>
+		<!-- Ajax -->
+	</ul>
+	<a class="dropdown-close" href="#close">❌</a>
+</template>
+
 <main id="stream" class="normal<?= FreshRSS_Context::userConf()->display_posts ? '' : ' hide_posts' ?>">
 	<h1 class="title_hidden"><?= _t('conf.reading.view.normal') ?></h1>
 	<div id="new-article">

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -701,7 +701,12 @@ function show_labels_menu(el) {
 	const div = el.parentElement;
 	const dropdownMenu = div.querySelector('.dropdown-menu');
 
-	if (!dropdownMenu) {
+	if (!dropdownMenu || forceReloadLabelsList) {
+		if (dropdownMenu) {
+			dropdownMenu.nextElementSibling.remove();
+			dropdownMenu.remove();
+		}
+
 		const templateId = 'labels_article_template';
 		const template = document.getElementById(templateId).innerHTML;
 		div.insertAdjacentHTML('beforeend', template);
@@ -1319,6 +1324,7 @@ function init_stream(stream) {
 				req.onloadend = function (e) {
 					checkboxTag.disabled = false;
 					if (tagId == 0) {
+						forceReloadLabelsList = true;
 						loadDynamicTags(checkboxTag.closest('div.dropdown'));
 					}
 				};
@@ -1369,6 +1375,11 @@ function init_nav_entries() {
 		};
 	}
 }
+
+// forceReloadLabelsList default is false, so that the list does need a reload after opening it a second time.
+// will be set to true, if a new tag is added. Then the labels list will be reloaded each opening.
+// purpose of this flag: minimize the network traffic.
+let forceReloadLabelsList = false;
 
 function loadDynamicTags(div) {
 	div.querySelectorAll('li.item').forEach(function (li) { li.remove(); });

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -697,6 +697,20 @@ function user_filter(key) {
 	}
 }
 
+function show_labels_menu(el) {
+	const div = el.parentElement;
+	const dropdownMenu = div.querySelector('.dropdown-menu');
+
+	if (!dropdownMenu) {
+		const templateId = 'labels_article_template';
+		const template = document.getElementById(templateId).innerHTML;
+		div.insertAdjacentHTML('beforeend', template);
+
+		loadDynamicTags(div.closest('.dynamictags'));
+	}
+	return true;
+}
+
 function show_share_menu(el) {
 	const div = el.parentElement;
 	const dropdownMenu = div.querySelector('.dropdown-menu');
@@ -1116,12 +1130,6 @@ function init_stream(stream) {
 			return false;
 		}
 
-		el = ev.target.closest('.dynamictags');
-		if (el) {
-			loadDynamicTags(el);
-			return true;
-		}
-
 		el = ev.target.closest('.item a.title');
 		if (el) {	// Allow default control/command-click behaviour such as open in background-tab
 			return ev.ctrlKey || ev.metaKey;
@@ -1134,6 +1142,11 @@ function init_stream(stream) {
 				el.rel = 'noreferrer';
 			}
 			return true;
+		}
+
+		el = ev.target.closest('.item.labels a.dropdown-toggle');
+		if (el) {
+			return show_labels_menu(el);
 		}
 
 		el = ev.target.closest('.item.share a.dropdown-toggle');
@@ -1358,7 +1371,6 @@ function init_nav_entries() {
 }
 
 function loadDynamicTags(div) {
-	div.classList.remove('dynamictags');
 	div.querySelectorAll('li.item').forEach(function (li) { li.remove(); });
 	const entryId = div.closest('div.flux').id.replace(/^flux_/, '');
 
@@ -1367,7 +1379,6 @@ function loadDynamicTags(div) {
 	req.responseType = 'json';
 	req.onerror = function (e) {
 		div.querySelectorAll('li.item').forEach(function (li) { li.remove(); });
-		div.classList.add('dynamictags');
 	};
 	req.onload = function (e) {
 		if (this.status != 200) {


### PR DESCRIPTION
Prework for next step of https://github.com/FreshRSS/FreshRSS/pull/6395#issuecomment-2084595602
Prework for #5051

Changes proposed in this pull request:

- use `<template>` for the user article labels menu
- improved: labels list is always up to date (if this list will be opened it will not be reloaded as long as no new label was added)

How to test the feature manually:

1. open the article labels menu of an article
2. open the article labels menu of another article
3. add a new label
4. open the article labels menu of the article (of 1.)
5. the labels list has the new label included

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] no shortcut affected ;)
