### PR TITLE
Fix PHPCS ControlSignature

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -209,7 +209,7 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 					}
 				}
 			}
-			if(!empty($headers)) {
+			if (!empty($headers)) {
 				$headers = array_filter(array_map('trim', $headers));
 				$opts[CURLOPT_HTTPHEADER] = array_merge($headers, $opts[CURLOPT_HTTPHEADER] ?? []);
 			}

--- a/app/Controllers/subscriptionController.php
+++ b/app/Controllers/subscriptionController.php
@@ -190,7 +190,7 @@ class FreshRSS_subscription_Controller extends FreshRSS_ActionController {
 				}
 			}
 
-			if(!empty($headers)) {
+			if (!empty($headers)) {
 				$headers = array_filter(array_map('trim', $headers));
 				$opts[CURLOPT_HTTPHEADER] = array_merge($headers, $opts[CURLOPT_HTTPHEADER] ?? []);
 			}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -88,12 +88,17 @@
 		<exclude-pattern>*\.phtml$</exclude-pattern>
 	</rule>
 	<!-- <rule ref="Squiz.Commenting.ClassComment.Missing"/> --><!-- Consider adding -->
+
 	<rule ref="Squiz.ControlStructures.ControlSignature">
 		<include-pattern>*\.phtml$</include-pattern>
 		<properties>
 			<property name="requiredSpacesBeforeColon" value="0" />
 		</properties>
 	</rule>
+	<rule ref="Squiz.ControlStructures.ControlSignature">
+		<include-pattern>*\.php$</include-pattern>
+	</rule>
+
 	<rule ref="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace">
 		<exclude-pattern>*\.phtml$</exclude-pattern>
 	</rule>


### PR DESCRIPTION
Regression from https://github.com/FreshRSS/FreshRSS/pull/6666
We were not checking anymore for whitespace rules in e.g. `if (true) {`
