### PR TITLE
Fix the Makefile for test and fix targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,32 +59,29 @@ stop: ## Stop FreshRSS container if any
 ## Tests and linter ##
 ######################
 .PHONY: test
-test: vendor/bin/phpunit ## Run the test suite
-	$(PHP) vendor/bin/phpunit --bootstrap ./tests/bootstrap.php ./tests
+test: bin/phpunit ## Run the test suite
+	$(PHP) bin/phpunit --bootstrap ./tests/bootstrap.php ./tests
 
 .PHONY: lint
-lint: vendor/bin/phpcs ## Run the linter on the PHP files
-	$(PHP) vendor/bin/phpcs . -p -s
+lint: bin/phpcs ## Run the linter on the PHP files
+	$(PHP) bin/phpcs . -p -s
 
 .PHONY: lint-fix
-lint-fix: vendor/bin/phpcbf ## Fix the errors detected by the linter
-	$(PHP) vendor/bin/phpcbf . -p -s
+lint-fix: bin/phpcbf ## Fix the errors detected by the linter
+	$(PHP) bin/phpcbf . -p -s
 
 bin/composer:
 	mkdir -p bin/
 	wget 'https://raw.githubusercontent.com/composer/getcomposer.org/1a26c0dcb361332cb504e4861ed0f758281575aa/web/installer' -O - -q | php -- --quiet --install-dir='./bin/' --filename='composer'
 
-vendor/bin/phpunit: bin/composer
+# building any of these builds them all
+vendor/bin/phpunit vendor/bin/phpcs vendor/bin/phpcbf vendor/bin/phpstan &: bin/composer
 	bin/composer install --prefer-dist --no-progress
-	ln -s ../vendor/bin/phpunit bin/phpunit
 
-vendor/bin/phpcs: bin/composer
-	bin/composer install --prefer-dist --no-progress
-	ln -s ../vendor/bin/phpcs bin/phpcs
-
-vendor/bin/phpcbf: bin/composer
-	bin/composer install --prefer-dist --no-progress
-	ln -s ../vendor/bin/phpcbf bin/phpcbf
+# Any of these depend on the vendor/ target, and then symlink the vendor/bin/ to the bin/.
+# use -sf so if the symlink already exists it won't error out. Running this from a container often won't properly detect it already exists
+bin/phpunit bin/phpcs bin/phpcbf bin/phpstan : % : vendor/%
+	ln -sf $< $@
 
 bin/typos:
 	mkdir -p bin/
@@ -100,9 +97,6 @@ node_modules/.bin/eslint:
 
 node_modules/.bin/rtlcss:
 	npm install
-
-vendor/bin/phpstan: bin/composer
-	bin/composer install --prefer-dist --no-progress
 
 ##########
 ## I18N ##
@@ -198,11 +192,11 @@ refresh: ## Refresh feeds by fetching new messages
 
 # TODO: Add composer install
 .PHONY: composer-test
-composer-test: vendor/bin/phpstan
+composer-test: bin/phpstan bin/composer
 	bin/composer run-script test
 
 .PHONY: composer-fix
-composer-fix:
+composer-fix: bin/composer
 	bin/composer run-script fix
 
 .PHONY: npm-test


### PR DESCRIPTION
The bin/composer dependency was missing from half the targets that needed it.
The vendor/bin/* targets are all created by a single call to composer, but were all duplicating the composer call.
The php* tools defined a vendor/bin/php* target, but then proceeded to create the bin/php* target instead by symlinking from an incorrect path. php* tools were referenced as vendor/bin/php* even though they were symlinked to bin/php*.

Closes #6912 

Changes proposed in this pull request:

- Fixed the very broken Makefile fix* and test* targets
  - Dependencies were pretty messed up for the vendor/bin/php*. Commands and were symlinking a non-existent ../vendor/bin/php* to bin/php* as part of a vendor/bin/php* target (!?)
  - The "vendor/bin/php*" targets were all separately calling the bin/composer install ... even though a single call generated them all.
  - vendor/bin/php* commands were being used instead of the bin/php* that were symlinked.
  - The bin/composer dependency was missing from some targets

How to test the feature manually:

1. Open a vscode devcontainer
2. run the Makefile `test` and `fix` targets
3. Confirm they work

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] (N/A) unit tests written (optional if too hard)
- [x] (N/A) documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
