### PR TITLE
Allow regex parentheses

### DIFF
--- a/app/Models/BooleanSearch.php
+++ b/app/Models/BooleanSearch.php
@@ -37,6 +37,7 @@ class FreshRSS_BooleanSearch {
 		if ($level === 0) {
 			$input = $this->parseUserQueryNames($input, $allowUserQueries);
 			$input = $this->parseUserQueryIds($input, $allowUserQueries);
+			$input = self::escapeRegexParentheses($input);
 			$input = trim($input);
 		}
 
@@ -130,6 +131,20 @@ class FreshRSS_BooleanSearch {
 			$input = str_replace($fromS, $toS, $input);
 		}
 		return $input;
+	}
+
+	/**
+	 * Temporarily escape parentheses used in regex expressions.
+	 */
+	public static function escapeRegexParentheses(string $input): string {
+		return preg_replace_callback('#(?<=[\\s(:!-]|^)(?<![\\\\])/.*?(?<!\\\\)/[im]*#',
+			fn(array $matches): string => str_replace(['(', ')'], ['\\u0028', '\\u0029'], $matches[0]),
+			$input
+		) ?? '';
+	}
+
+	public static function unescapeRegexParentheses(string $input): string {
+		return str_replace(['\\u0028', '\\u0029'], ['(', ')'], $input);
 	}
 
 	/**
@@ -356,6 +371,7 @@ class FreshRSS_BooleanSearch {
 		if ($input === '') {
 			return;
 		}
+		$input = self::unescapeRegexParentheses($input);
 		$splits = preg_split('/\b(OR)\b/i', $input, -1, PREG_SPLIT_DELIM_CAPTURE) ?: [];
 		$segment = '';
 		$ns = count($splits);

--- a/app/Models/BooleanSearch.php
+++ b/app/Models/BooleanSearch.php
@@ -371,7 +371,6 @@ class FreshRSS_BooleanSearch {
 		if ($input === '') {
 			return;
 		}
-		$input = self::unescapeRegexParentheses($input);
 		$splits = preg_split('/\b(OR)\b/i', $input, -1, PREG_SPLIT_DELIM_CAPTURE) ?: [];
 		$segment = '';
 		$ns = count($splits);

--- a/app/Models/Search.php
+++ b/app/Models/Search.php
@@ -94,6 +94,7 @@ class FreshRSS_Search {
 	public function __construct(string $input) {
 		$input = self::cleanSearch($input);
 		$input = self::unescape($input);
+		$input = FreshRSS_BooleanSearch::unescapeRegexParentheses($input);
 		$this->raw_input = $input;
 
 		$input = $this->parseNotEntryIds($input);

--- a/tests/app/Models/SearchTest.php
+++ b/tests/app/Models/SearchTest.php
@@ -455,9 +455,9 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 				['%ab%', '%ab%', '%cd%', '%cd%', '%ef%', '%ef%', '%gh%', '%ij%', '%ij%', '%kl%', '%kl%']
 			],
 			[
-				'/^(ab|cd) [(] (ef|gh)/',
+				'/^(ab|cd) [(] \\) (ef|gh)/',
 				'((e.title ~ ? OR e.content ~ ?) )',
-				['^(ab|cd) [(] (ef|gh)', '^(ab|cd) [(] (ef|gh)']
+				['^(ab|cd) [(] \\) (ef|gh)', '^(ab|cd) [(] \\) (ef|gh)']
 			],
 		];
 	}

--- a/tests/app/Models/SearchTest.php
+++ b/tests/app/Models/SearchTest.php
@@ -454,6 +454,11 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 				'AND ((e.title LIKE ? AND e.title NOT LIKE ? AND e.content NOT LIKE ? AND e.title NOT LIKE ? AND e.content NOT LIKE ? ))',
 				['%ab%', '%ab%', '%cd%', '%cd%', '%ef%', '%ef%', '%gh%', '%ij%', '%ij%', '%kl%', '%kl%']
 			],
+			[
+				'/^(ab|cd) [(] (ef|gh)/',
+				'((e.title ~ ? OR e.content ~ ?) )',
+				['^(ab|cd) [(] (ef|gh)', '^(ab|cd) [(] (ef|gh)']
+			],
 		];
 	}
 

--- a/tests/app/Models/SearchTest.php
+++ b/tests/app/Models/SearchTest.php
@@ -459,6 +459,16 @@ class SearchTest extends PHPUnit\Framework\TestCase {
 				'((e.title ~ ? OR e.content ~ ?) )',
 				['^(ab|cd) [(] \\) (ef|gh)', '^(ab|cd) [(] \\) (ef|gh)']
 			],
+			[
+				'!/^(ab|cd)/',
+				'(NOT e.title ~ ? AND NOT e.content ~ ? )',
+				['^(ab|cd)', '^(ab|cd)']
+			],
+			[
+				'intitle:/^(ab|cd)/',
+				'(e.title ~ ? )',
+				['^(ab|cd)']
+			],
 		];
 	}
 


### PR DESCRIPTION
While waiting for a new better search parser, auto-escape parentheses in regex expressions to allow them like in `/^(ab|cd)/`, including escaped parentheses such as `/^(ab|cd) [(] \) (ef|gh)/`
