### PR TITLE
Fix: (#6945) reading view: show subscr. mgm button

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2292,6 +2292,7 @@ html.slider-active {
 }
 
 .reader .aside .toggle_aside {
+	padding: 1rem 0px;
 	display: block;
 	width: 100%;
 }
@@ -2304,6 +2305,10 @@ html.slider-active {
 .reader .aside:target {
 	display: table-cell;
 	width: 300px;
+}
+
+.reader .aside_feed .configure-feeds {
+	margin-top: 10px;
 }
 
 .reader .flux {

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2306,10 +2306,6 @@ html.slider-active {
 	width: 300px;
 }
 
-.reader .aside .stick {
-	display: none;
-}
-
 .reader .flux {
 	padding: 1rem 0 2rem;
 }

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2292,6 +2292,7 @@ html.slider-active {
 }
 
 .reader .aside .toggle_aside {
+	padding: 1rem 0px;
 	display: block;
 	width: 100%;
 }
@@ -2304,6 +2305,10 @@ html.slider-active {
 .reader .aside:target {
 	display: table-cell;
 	width: 300px;
+}
+
+.reader .aside_feed .configure-feeds {
+	margin-top: 10px;
 }
 
 .reader .flux {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2306,10 +2306,6 @@ html.slider-active {
 	width: 300px;
 }
 
-.reader .aside .stick {
-	display: none;
-}
-
 .reader .flux {
 	padding: 1rem 0 2rem;
 }


### PR DESCRIPTION
Closes #6945


Changes proposed in this pull request:

- CSS: button was hidden by CSS. now it will not anymore
- CSS: took over some little CSS from the mobile view to have a bit more beauty there too ;)

How to test the feature manually:

1. go to reading view
2. open the side navigation
3. see the `subscription management` button

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
