### PR TITLE
Rebuild Feed .ico and .txt on cache clear

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -1007,7 +1007,7 @@ class FreshRSS_Feed extends Minz_Model {
 	}
 
 	private function faviconRebuild(): void {
-		$this->faviconDelete($this->hash());
+		FreshRSS_Feed::faviconDelete($this->hash());
 		$this->faviconPrepare(true);
 	}
 

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -225,7 +225,7 @@ class FreshRSS_Feed extends Minz_Model {
 		return $this->nbNotRead;
 	}
 
-	public function faviconPrepare(): void {
+	public function faviconPrepare(bool $force = false): void {
 		require_once(LIB_PATH . '/favicons.php');
 		$url = $this->website;
 		if ($url == '') {
@@ -235,7 +235,7 @@ class FreshRSS_Feed extends Minz_Model {
 		if (@file_get_contents($txt) !== $url) {
 			file_put_contents($txt, $url);
 		}
-		if (FreshRSS_Context::$isCli) {
+		if (FreshRSS_Context::$isCli || $force) {
 			$ico = FAVICONS_DIR . $this->hash() . '.ico';
 			$ico_mtime = @filemtime($ico);
 			$txt_mtime = @filemtime($txt);
@@ -1006,7 +1006,13 @@ class FreshRSS_Feed extends Minz_Model {
 		}
 	}
 
+	private function faviconRebuild() : void {
+		$this->faviconDelete($this->hash());
+		$this->faviconPrepare(true);
+	}
+
 	public function clearCache(): bool {
+		$this->faviconRebuild();
 		return @unlink($this->cacheFilename());
 	}
 

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -1006,7 +1006,7 @@ class FreshRSS_Feed extends Minz_Model {
 		}
 	}
 
-	private function faviconRebuild() : void {
+	private function faviconRebuild(): void {
 		$this->faviconDelete($this->hash());
 		$this->faviconPrepare(true);
 	}


### PR DESCRIPTION
Closes #6927 

Changes proposed in this pull request:
 - Modify Feed.faviconPrepare signature to allow forced retrieval of the favicon   
 - Add faviconRebuild which clears file cache and re-retrieves icons   
 - Call faviconRebuild when clearCache is fired

How to test the feature manually:

1. Add feed
2. Manage feed -> Clear Cache
3. See original files being deleted, and new timestamps for files replaced

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [N/A] unit tests written (optional if too hard)
- [N/A] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
