### PR TITLE
Fix HTML pattern in install

### DIFF
--- a/app/install.php
+++ b/app/install.php
@@ -551,7 +551,7 @@ function printStep2(): void {
 		<div class="form-group">
 			<label class="group-name" for="host"><?= _t('install.bdd.host') ?></label>
 			<div class="group-controls">
-				<input type="text" id="host" name="host" pattern="[0-9A-Z/a-z_.\-]{1,64}(:[0-9]{2,5})?" value="<?=
+				<input type="text" id="host" name="host" pattern="[0-9A-Z\/a-z_.\-]{1,64}(:[0-9]{2,5})?" value="<?=
 					$_SESSION['bd_host'] ?? $system_default_config->db['host'] ?? '' ?>" tabindex="2" />
 			</div>
 		</div>


### PR DESCRIPTION
Slashes now need to be escaped because of `v` mode:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class#v-mode_character_class

> Because the character class syntax is now more sophisticated, more characters are reserved and forbidden from appearing literally.
> In addition to `]` and `\`, the following characters must be escaped in character classes if they represent literal characters: `(, ), [, {, }, /, -, |`. This list is somewhat similar to the list of [syntax characters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Literal_character), except that `^, $, *, +`, and `?` are not reserved inside character classes, while `/` and `-` are not reserved outside character classes (although `/` may delimit a regex literal and therefore still needs to be escaped). All these characters may also be optionally escaped in u-mode character classes.

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/pattern#overview

> The pattern's regular expression is compiled with the ['v' flag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class#v-mode_character_class). This makes the regular expression [unicode-aware](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode-aware_mode), and also changes how character classes are interpreted. This allows character class set intersection and subtraction operations, and in addition to `] `and `\`, the following characters must be escaped using a `\` backslash if they represent literal characters: `(, ), [, {, }, /, -, |`. Before mid-2023, the 'u' flag was specified instead; If you're updating older code, [this document outlines the differences](https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag).

Edge:
> Pattern attribute value `[0-9A-Z/a-z_.\-]{1,64}(:[0-9]{2,5})?` is not a valid regular expression: Uncaught SyntaxError: Invalid regular expression: `/[0-9A-Z/a-z_.\-]{1,64}(:[0-9]{2,5})?/v`: Invalid character in character class

Firefox:
> Impossible de vérifier `<input pattern='[0-9A-Z/a-z_.\-]{1,64}(:[0-9]{2,5})?'>` car « `/[0-9A-Z/a-z_.\-]{1,64}(:[0-9]{2,5})?/v` » n’est pas une expression régulière valide : invalid character in class in regular expression
