### PR TITLE
improved: article footer for small displays

### DIFF
--- a/app/views/helpers/index/normal/entry_bottom.phtml
+++ b/app/views/helpers/index/normal/entry_bottom.phtml
@@ -39,7 +39,7 @@
 		<div class="item-element dropdown dynamictags">
 			<div id="dropdown-labels-<?= $this->entry->id() ?>" class="dropdown-target"></div>
 			<a class="dropdown-toggle" href="#dropdown-labels-<?= $this->entry->id() ?>">
-				<?= _i('label') ?><?= _t('index.menu.tags') ?>
+				<?= _i('label') ?><span class="dropdown-label"><?= _t('index.menu.tags') ?></span>
 			</a>
 		</div>
 	</li><?php
@@ -50,7 +50,7 @@
 		<div class="item-element dropdown">
 			<div id="dropdown-tags-<?= $this->entry->id() ?>" class="dropdown-target"></div>
 			<a class="dropdown-toggle" href="#dropdown-tags-<?= $this->entry->id() ?>">
-				<?= _i('tag') ?><?= _t('index.tag.related') ?>
+				<?= _i('tag') ?><span class="dropdown-label"><?= _t('index.tag.related') ?></span>
 			</a>
 			<ul class="dropdown-menu">
 				<li class="dropdown-header"><?= _t('index.tag.related') ?></li>
@@ -68,7 +68,7 @@
 		?><div class="item-element dropdown">
 			<div id="dropdown-share-<?= $this->entry->id() ?>" class="dropdown-target"></div>
 			<a class="dropdown-toggle" href="#dropdown-share-<?= $this->entry->id() ?>">
-				<?= _i('share') ?><?= _t('index.share') ?>
+				<?= _i('share') ?><span class="dropdown-label"><?= _t('index.share') ?></span>
 			</a>
 			<?php /* entry_share_menu */ ?>
 		</div>

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -62,6 +62,17 @@ html, body {
 	font-size: 100%;
 }
 
+main#stream {
+	container-type: inline-size;
+	container-name: main;
+}
+
+@container main (max-width: 600px) {
+	.horizontal-list.bottom .dropdown-label {
+		display: none;
+	}
+}
+
 main.prompt {
 	margin: 3rem auto 0;
 	padding: 2rem;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -62,6 +62,17 @@ html, body {
 	font-size: 100%;
 }
 
+main#stream {
+	container-type: inline-size;
+	container-name: main;
+}
+
+@container main (max-width: 600px) {
+	.horizontal-list.bottom .dropdown-label {
+		display: none;
+	}
+}
+
 main.prompt {
 	margin: 3rem auto 0;
 	padding: 2rem;


### PR DESCRIPTION
Before:
on small screens the article footer links for `my labels`, `article tags`, `share` could have a line break

![grafik](https://github.com/user-attachments/assets/98a6fc47-ce95-4894-8acd-36b03f323acc)


After:
Do not show the text of the links, if the main stream is smaller than 600px.
![grafik](https://github.com/user-attachments/assets/dcabf089-8aba-47c1-990f-5249f1c08004)


Changes proposed in this pull request:

- CSS. Use of `@container` queries.


How to test the feature manually:

1. normal view
2. change the size of the window
3. see the article footer

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
