### PR TITLE
Always prevent default regardless of window.open() return status

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1099,7 +1099,7 @@ function init_shortcuts() {
 
 			const link_go_website = document.querySelector('.flux.current a.go_website');
 			if (link_go_website) {
-				const newWindow = window.open(link_go_website.href, '_blank', 'noopener');
+				window.open(link_go_website.href, '_blank', 'noopener');
 				ev.preventDefault();
 			}
 			return;

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1100,9 +1100,7 @@ function init_shortcuts() {
 			const link_go_website = document.querySelector('.flux.current a.go_website');
 			if (link_go_website) {
 				const newWindow = window.open(link_go_website.href, '_blank', 'noopener');
-				if (newWindow) {
-					ev.preventDefault();
-				}
+				ev.preventDefault();
 			}
 			return;
 		}


### PR DESCRIPTION
Fixes regression noted in https://github.com/FreshRSS/FreshRSS/pull/7077#discussion_r1879016226

How to test the feature manually:

1. Use a key like space to open new windows
2. Press space
3. Only a window should open without any scrolling

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
