### PR TITLE
fix: sharing menu entry id

### DIFF
--- a/app/views/helpers/index/normal/entry_share_menu.phtml
+++ b/app/views/helpers/index/normal/entry_share_menu.phtml
@@ -4,6 +4,7 @@
 ?>
 <ul class="dropdown-menu">
 	<li class="dropdown-header"><?= _t('index.share') ?> <a href="<?= _url('configure', 'integration') ?>"><?= _i('configure') ?></a></li><?php
+		$id = '--entryId--';
 		$link = '--link--';
 		$title = '--titleText----websiteName----articleAuthors--';
 		foreach (FreshRSS_Context::userConf()->sharing as $share_options) {
@@ -12,6 +13,7 @@
 				continue;
 			}
 			$cssClass = $share->isDeprecated() ? ' error' : '';
+			$share_options['id'] = $id;
 			$share_options['link'] = $link;
 			$share_options['title'] = $title;
 			$share->update($share_options);

--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -87,6 +87,7 @@ $today = @strtotime('today');
 		?><?= $this->entry->isFavorite() ? ' favorite' : ''
 		?><?= $useKeepUnreadImportant && ($this->feed->priority() >= FreshRSS_Feed::PRIORITY_IMPORTANT) ? ' keep_unread ' : ''
 		?>" id="flux_<?= $this->entry->id()
+		?>" data-entry="<?= $this->entry->id()
 		?>" data-feed="<?= $this->feed->id()
 		?>" data-priority="<?= $this->feed->priority()
 		?>"><?php

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -721,7 +721,7 @@ function show_share_menu(el) {
 	const dropdownMenu = div.querySelector('.dropdown-menu');
 
 	if (!dropdownMenu) {
-		const itemId = el.closest('.flux').id;
+		const itemId = el.closest('.flux').dataset.entry;
 		const templateId = 'share_article_template';
 		const id = itemId;
 		const flux_header_el = el.closest('.flux');


### PR DESCRIPTION
Closes https://github.com/FreshRSS/Extensions/issues/263
Regression #6825

How to test the feature manually:

1. install the sharebyemail extension
2. add `email´ sharing service
3. go to normal view. share an article via sharing menu with the email feature

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
