### PR TITLE
reduce docker build for releases

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - edge
   release:
+    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Just a litte improvment to reduce not needed builds

Changes proposed in this pull request:

reduces the docker builds
![grafik](https://github.com/user-attachments/assets/37ed1b69-9c50-4a9e-8fb0-ae7533c882ad)


How to test the feature manually:

1. create a new release

Pull request checklist:

- [x] clear commit messages
- [ ] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
