### PR TITLE
Adds BASE_URL to example .env file

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -274,7 +274,7 @@ sudo nano /var/lib/docker/volumes/freshrss_data/_data/config.php
 First, put variables such as passwords in your `.env` file, which can live where your `docker-compose.yml` should be. See [`example.env`](./freshrss/example.env).
 
 ```ini
-BASE_URL=http://localhost
+BASE_URL=https://freshrss.example.net
 ADMIN_EMAIL=admin@example.net
 ADMIN_PASSWORD=freshrss
 ADMIN_API_PASSWORD=freshrss

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -274,6 +274,7 @@ sudo nano /var/lib/docker/volumes/freshrss_data/_data/config.php
 First, put variables such as passwords in your `.env` file, which can live where your `docker-compose.yml` should be. See [`example.env`](./freshrss/example.env).
 
 ```ini
+BASE_URL=http://localhost
 ADMIN_EMAIL=admin@example.net
 ADMIN_PASSWORD=freshrss
 ADMIN_API_PASSWORD=freshrss


### PR DESCRIPTION
I found without specifying a BASE_URL then the installation command gets confused

❌ FreshRSS error during installation!
FreshRSS error: invalid input: default-user cannot be empty

The provided example base url may not be desired, but the readme should be updated with 'something' to make first use more user friendly.

Closes #

Changes proposed in this pull request:

- add an example `BASE_URL` to the readme for people to copy / paste into their `.env` file

How to test the feature manually:

1. Copy the given docker-compose.yml, .env, and start the environment without the `BASE_URL`. Then check the docker logs - error shown above. 
2. Stop, remove container. 
3. Add BASE_URL to `.env` file, and restart. Now it installs as expected.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard) - n/a
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
