### PR TITLE
Improved: link back to rss feeds

### DIFF
--- a/app/i18n/cs/gen.php
+++ b/app/i18n/cs/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'Aktualizovat kanály',
 		'add' => 'Přidat',
-		'back' => '← Jít zpět',
 		'back_to_rss_feeds' => '← Jít zpět na vaše kanály RSS',
 		'cancel' => 'Zrušit',
 		'create' => 'Vytvořit',

--- a/app/i18n/de/gen.php
+++ b/app/i18n/de/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'Feeds aktualisieren',
 		'add' => 'Hinzufügen',
-		'back' => '← Zurück',
 		'back_to_rss_feeds' => '← Zurück zu Ihren RSS-Feeds gehen',
 		'cancel' => 'Abbrechen',
 		'create' => 'Erstellen',

--- a/app/i18n/el/gen.php
+++ b/app/i18n/el/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'Update feeds',	// TODO
 		'add' => 'Add',	// TODO
-		'back' => '← Go back',	// TODO
 		'back_to_rss_feeds' => '← Go back to your RSS feeds',	// TODO
 		'cancel' => 'Cancel',	// TODO
 		'create' => 'Create',	// TODO

--- a/app/i18n/en-us/gen.php
+++ b/app/i18n/en-us/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'Update feeds',	// IGNORE
 		'add' => 'Add',	// IGNORE
-		'back' => '← Go back',	// IGNORE
 		'back_to_rss_feeds' => '← Go back to your RSS feeds',	// IGNORE
 		'cancel' => 'Cancel',	// IGNORE
 		'create' => 'Create',	// IGNORE

--- a/app/i18n/en/gen.php
+++ b/app/i18n/en/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'Update feeds',
 		'add' => 'Add',
-		'back' => '← Go back',
 		'back_to_rss_feeds' => '← Go back to your RSS feeds',
 		'cancel' => 'Cancel',
 		'create' => 'Create',

--- a/app/i18n/es/gen.php
+++ b/app/i18n/es/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'Actualizar fuentes',
 		'add' => 'Añadir',
-		'back' => '← Volver',
 		'back_to_rss_feeds' => '← regresar a tus fuentes RSS',
 		'cancel' => 'Cancelar',
 		'create' => 'Crear',

--- a/app/i18n/fa/gen.php
+++ b/app/i18n/fa/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => ' فیدها را به روز کنید',
 		'add' => ' اضافه کنید',
-		'back' => '← به عقب برگرد',
 		'back_to_rss_feeds' => '← به فیدهای RSS خود برگردید',
 		'cancel' => ' لغو',
 		'create' => ' ایجاد کنید',

--- a/app/i18n/fi/gen.php
+++ b/app/i18n/fi/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'Päivitä syötteet',
 		'add' => 'Lisää',
-		'back' => '← Palaa',
 		'back_to_rss_feeds' => '← Palaa RSS-syötteisiin',
 		'cancel' => 'Peruuta',
 		'create' => 'Luo',

--- a/app/i18n/fr/gen.php
+++ b/app/i18n/fr/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'Actualiser flux',
 		'add' => 'Ajouter',
-		'back' => '← Retour',
 		'back_to_rss_feeds' => '← Retour à vos flux RSS',
 		'cancel' => 'Annuler',
 		'create' => 'Créer',

--- a/app/i18n/he/gen.php
+++ b/app/i18n/he/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'מימוש',
 		'add' => 'Add',	// TODO
-		'back' => '← Go back',	// TODO
 		'back_to_rss_feeds' => '← חזרה להזנות הRSS שלך',
 		'cancel' => 'ביטול',
 		'create' => 'יצירה',

--- a/app/i18n/hu/gen.php
+++ b/app/i18n/hu/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'Hírforrások frissítése',
 		'add' => 'Hozzáad',
-		'back' => '← Vissza',
 		'back_to_rss_feeds' => '← Vissza az RSS hírforrásokhoz',
 		'cancel' => 'Mégsem',
 		'create' => 'Létrehoz',

--- a/app/i18n/id/gen.php
+++ b/app/i18n/id/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'Update feeds',	// TODO
 		'add' => 'Add',	// TODO
-		'back' => '← Go back',	// TODO
 		'back_to_rss_feeds' => '← Go back to your RSS feeds',	// TODO
 		'cancel' => 'Cancel',	// TODO
 		'create' => 'Create',	// TODO

--- a/app/i18n/it/gen.php
+++ b/app/i18n/it/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'Aggiorna feeds',
 		'add' => 'Aggiungi',
-		'back' => '← Torna indietro',
 		'back_to_rss_feeds' => '← Indietro',
 		'cancel' => 'Annulla',
 		'create' => 'Crea',

--- a/app/i18n/ja/gen.php
+++ b/app/i18n/ja/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'フィードを更新する',
 		'add' => '追加',
-		'back' => '← 戻る',
 		'back_to_rss_feeds' => '← RSSフィードに戻る',
 		'cancel' => 'キャンセル',
 		'create' => '作成',

--- a/app/i18n/ko/gen.php
+++ b/app/i18n/ko/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => '새 글 가져오기',
 		'add' => '추가',
-		'back' => '← 돌아가기',
 		'back_to_rss_feeds' => '← RSS 피드로 돌아가기',
 		'cancel' => '취소',
 		'create' => '생성',

--- a/app/i18n/lv/gen.php
+++ b/app/i18n/lv/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'Atjaunināt barotnes',
 		'add' => 'Pievienot',
-		'back' => '← Atgriezties',
 		'back_to_rss_feeds' => '← Atgriezieties pie RSS barotnēm',
 		'cancel' => 'Atcelt',
 		'create' => 'Uztaisīt',

--- a/app/i18n/nl/gen.php
+++ b/app/i18n/nl/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'Feeds actualiseren',
 		'add' => 'Toevoegen',
-		'back' => '← Terug',
 		'back_to_rss_feeds' => '← Ga terug naar je RSS feeds',
 		'cancel' => 'Annuleren',
 		'create' => 'Opslaan',

--- a/app/i18n/oc/gen.php
+++ b/app/i18n/oc/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'Actualizar flux',
 		'add' => 'Ajustar',
-		'back' => '← Tornar',
 		'back_to_rss_feeds' => '← Tornar a vòstres fluxes RSS',
 		'cancel' => 'Anullar',
 		'create' => 'Crear',

--- a/app/i18n/pl/gen.php
+++ b/app/i18n/pl/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'Aktualizuj kanały',
 		'add' => 'Dodaj',
-		'back' => '← Wróć',
 		'back_to_rss_feeds' => '← Wróć do subskrybowanych kanałów RSS',
 		'cancel' => 'Anuluj',
 		'create' => 'Stwórz',

--- a/app/i18n/pt-br/gen.php
+++ b/app/i18n/pt-br/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'Atualizar feeds',
 		'add' => 'Adicionar',
-		'back' => '← Voltar',
 		'back_to_rss_feeds' => '← Volte para o seu feeds RSS',
 		'cancel' => 'Cancelar',
 		'create' => 'Criar',

--- a/app/i18n/ru/gen.php
+++ b/app/i18n/ru/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'Обновить ленту',
 		'add' => 'Добавить',
-		'back' => '← Вернуться',
 		'back_to_rss_feeds' => '← Вернуться к вашим RSS-лентам',
 		'cancel' => 'Отменить',
 		'create' => 'Создать',

--- a/app/i18n/sk/gen.php
+++ b/app/i18n/sk/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'Aktualizovať kanály',
 		'add' => 'Pridať',
-		'back' => '← Späť',
 		'back_to_rss_feeds' => '← Späť na vaše RSS kanály',
 		'cancel' => 'Zrušiť',
 		'create' => 'Vytvoriť',

--- a/app/i18n/tr/gen.php
+++ b/app/i18n/tr/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => 'Yenile akışlarınız',
 		'add' => 'Ekle',
-		'back' => '← Geri dön',
 		'back_to_rss_feeds' => '← RSS akışlarınız için geri gidin',
 		'cancel' => 'İptal',
 		'create' => 'Oluştur',

--- a/app/i18n/zh-cn/gen.php
+++ b/app/i18n/zh-cn/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => '更新订阅源',
 		'add' => '添加',
-		'back' => '← 返回',
 		'back_to_rss_feeds' => '← 返回订阅源',
 		'cancel' => '取消',
 		'create' => '创建',

--- a/app/i18n/zh-tw/gen.php
+++ b/app/i18n/zh-tw/gen.php
@@ -14,7 +14,6 @@ return array(
 	'action' => array(
 		'actualize' => '更新提要',
 		'add' => '新增',
-		'back' => '← 返回',
 		'back_to_rss_feeds' => '← 返回訂閱源',
 		'cancel' => '取消',
 		'create' => '創建',

--- a/app/layout/aside_configure.phtml
+++ b/app/layout/aside_configure.phtml
@@ -6,6 +6,13 @@
 
 	<ul>
 		<li class="item nav-section">
+			<ul>
+				<li class="item">
+					<a href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
+				</li>
+			</ul>
+		</li>
+		<li class="item nav-section">
 			<div class="item nav-header"><?= _t('gen.menu.account') ?>: <?= htmlspecialchars(Minz_User::name() ?? '', ENT_NOQUOTES, 'UTF-8') ?></div>
 			<ul>
 				<li class="item<?= Minz_Request::controllerName() === 'user' && Minz_Request::actionName() === 'profile' ? ' active' : '' ?>">

--- a/app/layout/aside_subscription.phtml
+++ b/app/layout/aside_subscription.phtml
@@ -5,6 +5,13 @@
 	<a class="toggle_aside" href="#close"><?= _i('close') ?></a>
 	<ul>
 		<li class="item nav-section">
+			<ul>
+				<li class="item">
+					<a href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
+				</li>
+			</ul>
+		</li>
+		<li class="item nav-section">
 			<div class="nav-header"><?= _t('sub.menu.subscription_management') ?></div>
 			<ul>
 				<li class="item<?= Minz_Request::controllerName() === 'subscription' && Minz_Request::actionName() === 'add' ? ' active' : '' ?>">

--- a/app/views/auth/index.phtml
+++ b/app/views/auth/index.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_configure');
 ?>
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('gen.menu.authentication') ?></h1>
 	<form method="post" action="<?= _url('auth', 'index') ?>">
 		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />

--- a/app/views/configure/archiving.phtml
+++ b/app/views/configure/archiving.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_configure');
 ?>
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('conf.archiving') ?></h1>
 	<p class="help"><?= _i('help') ?> <?= _t('conf.archiving.help') ?></p>
 

--- a/app/views/configure/display.phtml
+++ b/app/views/configure/display.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_configure');
 ?>
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('conf.display') ?></h1>
 
 	<form method="post" action="<?= _url('configure', 'display') ?>">

--- a/app/views/configure/integration.phtml
+++ b/app/views/configure/integration.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_configure');
 ?>
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('conf.sharing') ?></h1>
 
 	<form method="post" action="<?= _url('configure', 'integration') ?>" class="draggableList">

--- a/app/views/configure/privacy.phtml
+++ b/app/views/configure/privacy.phtml
@@ -4,10 +4,6 @@
 ?>
 
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('conf.privacy') ?></h1>
 
 	<form method="post" action="<?= _url('configure', 'privacy') ?>">

--- a/app/views/configure/queries.phtml
+++ b/app/views/configure/queries.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_configure');
 ?>
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<form method="post" action="<?= _url('configure', 'queries') ?>" class="draggableList">
 		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
 		<h1><?= _t('conf.query') ?></h1>

--- a/app/views/configure/reading.phtml
+++ b/app/views/configure/reading.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_configure');
 ?>
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('conf.reading') ?></h1>
 
 	<form method="post" action="<?= _url('configure', 'reading') ?>">

--- a/app/views/configure/shortcut.phtml
+++ b/app/views/configure/shortcut.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_configure');
 ?>
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('conf.shortcut') ?></h1>
 
 	<datalist id="keys">

--- a/app/views/configure/system.phtml
+++ b/app/views/configure/system.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_configure');
 ?>
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('admin.system') ?></h1>
 
 	<form method="post" action="<?= _url('configure', 'system') ?>">

--- a/app/views/extension/index.phtml
+++ b/app/views/extension/index.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_configure');
 ?>
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('admin.extensions.title') ?></h1>
 	<form id="form-extension" method="post">
 	<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />

--- a/app/views/importExport/index.phtml
+++ b/app/views/importExport/index.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_subscription');
 ?>
 <main class="post ">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('sub.menu.import_export') ?></h1>
 
 	<h2><?= _t('sub.category.dynamic_opml') ?></h2>

--- a/app/views/index/about.phtml
+++ b/app/views/index/about.phtml
@@ -6,12 +6,6 @@
 	}
 ?>
 <main class="post content<?= !FreshRSS_Auth::hasAccess() ? ' centered' : ''?>">
-	<?php if (FreshRSS_Auth::hasAccess()) {?>
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-	<?php } ?>
-
 	<h1><?= _t('index.about') ?></h1>
 	<p><?= _t('index.about.freshrss_description') ?></p>
 

--- a/app/views/index/logs.phtml
+++ b/app/views/index/logs.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_configure');
 ?>
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('index.log') ?></h1>
 
 	<?php

--- a/app/views/index/tos.phtml
+++ b/app/views/index/tos.phtml
@@ -6,24 +6,6 @@
 	}
 ?>
 <main class="post content<?= !FreshRSS_Auth::hasAccess() ? ' centered' : ''?>">
-	<?php if (FreshRSS_Auth::hasAccess()) {?>
-		<div class="link-back-wrapper">
-			<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-		</div>
-	<?php } elseif ($this->can_register) { ?>
-		<div class="link-back-wrapper">
-			<a href="<?= _url('auth', 'register') ?>">
-				<?= _t('gen.action.back') ?>
-			</a>
-		</div>
-	<?php } else { ?>
-		<div class="link-back-wrapper">
-			<a href="<?= _url('index', 'index') ?>">
-				<?= _t('gen.action.back') ?>
-			</a>
-		</div>
-	<?php } ?>
-
 	<h1><?= _t('index.tos.title')?></h1>
 	<?= $this->terms_of_service ?>
 </main>

--- a/app/views/stats/idle.phtml
+++ b/app/views/stats/idle.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_subscription');
 ?>
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('admin.stats.idle') ?></h1>
 
 	<?php

--- a/app/views/stats/index.phtml
+++ b/app/views/stats/index.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_subscription');
 ?>
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('admin.stats.main') ?></h1>
 
 	<div class="stat-grid">

--- a/app/views/stats/repartition.phtml
+++ b/app/views/stats/repartition.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_subscription');
 ?>
 <main class="post ">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('admin.stats.repartition') ?></h1>
 
 	<select id="feed_select" class="select-change">

--- a/app/views/subscription/add.phtml
+++ b/app/views/subscription/add.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_subscription');
 ?>
 <main class="post drop-section">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('sub.menu.add') ?></h1>
 	<h2><?= _t('sub.title.add_category') ?></h2>
 	<form action="<?= _url('category', 'create') ?>" method="post">

--- a/app/views/subscription/bookmarklet.phtml
+++ b/app/views/subscription/bookmarklet.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_subscription');
 ?>
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('sub.menu.subscription_tools') ?></h1>
 	<h2><?= _t('sub.bookmarklet.title') ?></h2>
 	<p><a class="btn btn-important"

--- a/app/views/subscription/index.phtml
+++ b/app/views/subscription/index.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_subscription');
 ?>
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('sub.title') ?></h1>
 
 	<?php if ($this->onlyFeedsWithError): ?>

--- a/app/views/tag/index.phtml
+++ b/app/views/tag/index.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_subscription');
 ?>
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('sub.menu.label_management') ?></h1>
 
 	<h2><?= _t('sub.title.add_label') ?></h2>

--- a/app/views/update/apply.phtml
+++ b/app/views/update/apply.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_configure');
 ?>
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('admin.update') ?></h1>
 
 	<?php

--- a/app/views/update/checkInstall.phtml
+++ b/app/views/update/checkInstall.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_configure');
 ?>
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('gen.menu.check_install') ?></h1>
 	<h2><?= _t('admin.check_install.php') ?></h2>
 

--- a/app/views/update/index.phtml
+++ b/app/views/update/index.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_configure');
 ?>
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('admin.update') ?></h1>
 
 	<?php if (!empty($this->message)) { ?>

--- a/app/views/user/manage.phtml
+++ b/app/views/user/manage.phtml
@@ -4,10 +4,6 @@
 	$this->partial('aside_configure');
 ?>
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<h1><?= _t('gen.menu.user_management') ?></h1>
 	<h2><?= _t('admin.user.create') ?></h2>
 	<form method="post" action="<?= _url('user', 'create') ?>" autocomplete="off">

--- a/app/views/user/profile.phtml
+++ b/app/views/user/profile.phtml
@@ -7,10 +7,6 @@
 ?>
 
 <main class="post">
-	<div class="link-back-wrapper">
-		<a class="link-back" href="<?= _url('index', 'index') ?>"><?= _t('gen.action.back_to_rss_feeds') ?></a>
-	</div>
-
 	<form method="post" action="<?= _url('user', 'profile') ?>">
 		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
 		<h1><?= _t('conf.profile') ?></h1>


### PR DESCRIPTION
It moves the "Go back to your RSS feeds" link from the main box into the navigation sidebar
![grafik](https://github.com/user-attachments/assets/1a9887aa-db78-49b5-9c46-a97fb8f2690c)

I can remember the times where FreshRSS UI was not really mobile ready so the "back" link was useful. Now it appears first over the `<h1>` headline. Semantically it is a piece of navigation. So it is time to shift the link into the sidebar IMHO.



Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
