### PR TITLE
Simplify the Caddy configuraton

### DIFF
--- a/docs/en/admins/Caddy.md
+++ b/docs/en/admins/Caddy.md
@@ -21,7 +21,7 @@ To set up FreshRSS behind a reverse proxy with Caddy and using a subfolder, foll
 
     Replace `example.com` with your actual domain and the four instances of `subfolder` with the subfolder where you want FreshRSS to be hosted.
 
-> **_NOTE:_** Ensure that the Docker container name for FreshRSS (freshrss in this example) matches the name used in the Caddyfile configuration.
+    > **_NOTE:_** Ensure that the Docker container name for FreshRSS (freshrss in this example) matches the name used in the Caddyfile configuration.
 
 2. **Update FreshRSS Configuration:**
 

--- a/docs/en/admins/Caddy.md
+++ b/docs/en/admins/Caddy.md
@@ -8,42 +8,36 @@ To set up FreshRSS behind a reverse proxy with Caddy and using a subfolder, foll
 
     Update your Caddyfile with the following configuration:
 
-    ```plaintext
-    example.com {
-        redir /freshrss /freshrss/i/
-        route /freshrss* {
-            uri strip_prefix /freshrss
-            reverse_proxy freshrss:80 {
-                header_up Host {host}
-                header_up X-Real-IP {remote}
-                header_up X-Forwarded-Proto {scheme}
-                header_up X-Forwarded-Host {host}
-                header_up X-Forwarded-For {remote}
-                header_up X-Forwarded-Ssl {on}
-                header_up X-Forwarded-Prefix "/freshrss/"
-            }
-        }
-    }
+    ``` caddy
+	example.com {
+		redir /subfolder /subfolder/ # Just to redirect users that are missing the closing slash to the correct page
+		handle_path /subfolder/* { # Actually configures the used subfolder (also internally strips the path prefix)
+			reverse_proxy freshrss:80 { # Enables the reverse proxy for the configured program:port
+				header_up X-Forwarded-Prefix "/subfolder" # Sets the correct header for the login cookies
+			}
+		}
     ```
 
-    Replace `example.com` with your actual domain and `freshrss` with the subfolder where FreshRSS is hosted.
+    Replace `example.com` with your actual domain and the four instances of `subfolder` with the subfolder where you want FreshRSS to be hosted.
+
+> **_NOTE:_** Ensure that the Docker container name for FreshRSS (freshrss in this example) matches the name used in the Caddyfile configuration.
 
 2. **Update FreshRSS Configuration:**
 
     Open the `config.php` file in your FreshRSS installation and update the `base_url` parameter to match the subfolder configuration:
 
     ```php
-    'base_url' => 'https://example.com/freshrss',
+    'base_url' => 'https://example.com/subfolder',
     ```
 
-    Replace `example.com` with your actual domain and `freshrss` with the subfolder name specified in the Caddyfile.
+    Replace `example.com` with your actual domain and `subfolder` with the same subfolder name specified in the Caddyfile.
 
 3. **Restart Caddy and FreshRSS:**
 
     Restart Caddy to apply the configuration changes:
 
     ```bash
-    systemctl restart caddy
+    docker compose restart caddy
     ```
 
     Restart FreshRSS to ensure that it recognizes the new base URL:
@@ -55,30 +49,3 @@ To set up FreshRSS behind a reverse proxy with Caddy and using a subfolder, foll
 4. **Access FreshRSS:**
 
     FreshRSS should now be accessible at `https://example.com/freshrss`.
-
-### Example Caddyfile Entry
-
-```plaintext
-example.com {
-    redir /freshrss /freshrss/i/
-    route /freshrss* {
-        uri strip_prefix /freshrss
-        reverse_proxy freshrss:80 {
-            header_up Host {host}
-            header_up X-Real-IP {remote}
-            header_up X-Forwarded-Proto {scheme}
-            header_up X-Forwarded-Host {host}
-            header_up X-Forwarded-For {remote}
-            header_up X-Forwarded-Ssl {on}
-            header_up X-Forwarded-Prefix "/freshrss/"
-        }
-    }
-}
-```
-
-Replace `example.com` with your actual domain and `freshrss` with the subfolder name where FreshRSS is hosted.
-
-### Note
-
-
-Ensure that the Docker container name for FreshRSS (freshrss in this example) matches the name used in the Caddyfile configuration. By following these steps, you should be able to successfully configure Caddy as a reverse proxy with a subfolder for FreshRSS. Remember to update the base_url parameter in the FreshRSS configuration to match the subfolder configuration set in Caddy.

--- a/docs/en/admins/Caddy.md
+++ b/docs/en/admins/Caddy.md
@@ -16,6 +16,7 @@ To set up FreshRSS behind a reverse proxy with Caddy and using a subfolder, foll
 				header_up X-Forwarded-Prefix "/subfolder" # Sets the correct header for the login cookies
 			}
 		}
+	}
     ```
 
     Replace `example.com` with your actual domain and the four instances of `subfolder` with the subfolder where you want FreshRSS to be hosted.


### PR DESCRIPTION
Most of the Caddy config was overly complicated, this greatly simplifies the setup!

I am currently running this for personal use, so can confirm it still works

I am unable to get this same config working without https though, so I am pretty confused on that, if somebody else would be willing to confirm that'd be great
I very much doubt that these changes would be the issue for that, but trying to get freshrss working behind a proxy was enough of an headache already (I am more than glad that I got it working at all), and this unnecessarily complicated config didn't help 😅

As a bonus, I am pretty sure this is all that should be needed for running on a subdomain instead of in a subfolder
Not adding to the PR, because I haven't tested it
``` caddy
subdomain.example.com {
	reverse_proxy freshrss:80  # Enables the reverse proxy for the configured program:port
}
```


**How to test the feature manually:**
1. Replace existing Caddy config with this updated version
2. See that it ~hopefully~ still works just fine

**Pull request checklist:**
- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated