### PR TITLE
Add instructions for serving FreshRSS on a subdomain with Caddy

### DIFF
--- a/docs/en/admins/Caddy.md
+++ b/docs/en/admins/Caddy.md
@@ -1,4 +1,5 @@
 ## Using Caddy as a Reverse Proxy
+How to configure Caddy as a reverse proxy to serve FreshRSS through a subfolder or subdomain
 
 ## Using Caddy as a Reverse Proxy with a Subfolder
 
@@ -49,4 +50,51 @@ To set up FreshRSS behind a reverse proxy with Caddy and using a subfolder, foll
 
 4. **Access FreshRSS:**
 
-    FreshRSS should now be accessible at `https://example.com/freshrss`.
+    FreshRSS should now be accessible at `https://example.com/subfolder`.
+
+## Using Caddy as a Reverse Proxy with a Subdomain
+
+To set up FreshRSS behind a reverse proxy with Caddy and using a subdomain, follow these steps:
+
+1. **Configure Caddyfile:**
+
+    Update your Caddyfile with the following configuration:
+
+    ``` caddy
+	subdomain.example.com { # The url Caddy should serve the proxy on
+		reverse_proxy freshrss:80 # Enables the reverse proxy for the configured program:port
+	}
+    ```
+
+    Replace `example.com` with your actual domain and `subdomain` with the subfolder where you want FreshRSS to be hosted.
+
+    > **_NOTE:_** Ensure that the Docker container name for FreshRSS (freshrss in this example) matches the name used in the Caddyfile configuration.  
+    > **_NOTE:_** Make sure to set the DNS Records for your configured subdomain.
+
+2. **Update FreshRSS Configuration:**
+
+    Open the `config.php` file in your FreshRSS installation and update the `base_url` parameter to match the subdomain configuration:
+
+    ```php
+    'base_url' => 'https://subdomain.example.com/',
+    ```
+
+    Replace `example.com` with your actual domain and `subdomain` with the same subdomain specified in the Caddyfile.
+
+3. **Restart Caddy and FreshRSS:**
+
+    Restart Caddy to apply the configuration changes:
+
+    ```bash
+    docker compose restart caddy
+    ```
+
+    Restart FreshRSS to ensure that it recognizes the new base URL:
+
+    ```bash
+    docker compose restart freshrss
+    ```
+
+4. **Access FreshRSS:**
+
+    FreshRSS should now be accessible at `https://subdomain.example.com/`.

--- a/docs/en/admins/Caddy.md
+++ b/docs/en/admins/Caddy.md
@@ -1,4 +1,5 @@
 ## Using Caddy as a Reverse Proxy
+
 How to configure Caddy as a reverse proxy to serve FreshRSS through a subfolder or subdomain
 
 ## Using Caddy as a Reverse Proxy with a Subfolder


### PR DESCRIPTION
Follow up on: https://github.com/FreshRSS/FreshRSS/pull/7194

Gave serving on a subdomain a quick test, as expected this configuration works
This PR updates the documentation to reflect that

**Pull request checklist:**
- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated
