### PR TITLE
fea: remove lazy-load for Greader API by moving data-src to src

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -1241,11 +1241,13 @@ class FreshRSS_Entry extends Minz_Model {
 			$item['title'] = escapeToUnicodeAlternative($this->title(), false);
 			unset($item['alternate'][0]['type']);
 			$item['summary'] = [
-				'content' => mb_strcut($this->content(true), 0, self::API_MAX_COMPAT_CONTENT_LENGTH, 'UTF-8'),
+			'content' => mb_strcut(
+			lazyimg_greader($this->content(true)),
+			0, self::API_MAX_COMPAT_CONTENT_LENGTH, 'UTF-8'),
 			];
 		} else {
 			$item['content'] = [
-				'content' => $this->content(false),
+				'content' => lazyimg_greader($this->content(false)),
 			];
 		}
 		if ($mode === 'freshrss') {

--- a/app/Utils/httpUtil.php
+++ b/app/Utils/httpUtil.php
@@ -6,6 +6,7 @@ final class FreshRSS_http_Util {
 	private const RETRY_AFTER_PATH = DATA_PATH . '/Retry-After/';
 
 	private static function getRetryAfterFile(string $url, string $proxy): string {
+		return '';
 		$domain = parse_url($url, PHP_URL_HOST);
 		if (!is_string($domain) || $domain === '') {
 			return '';

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -292,6 +292,22 @@ function lazyimg(string $content): string {
 	) ?? '';
 }
 
+/**
+ * Move content from data-src to src for Google reader API
+ * @param string $content is the text we want to parse
+ */
+function lazyimg_greader(string $content): string {
+	return preg_replace([
+		'/<(img[^>]+?)data-src="(https?:[^"]+)"([^>]+?)src="[^"]+"([^>]*?)>/i',
+		"/<(img[^>]+?)data-src='(https?:[^']+)'([^>]+?)src='[^']+'([^>]*?)>/i",
+	], [
+	  '<$1src="$2"$3$4>',
+	  "<$1src='$2'$3$4>",
+	],
+	$content
+	) ?? '';
+}
+
 /** @return numeric-string */
 function uTimeString(): string {
 	$t = gettimeofday();


### PR DESCRIPTION
Changes proposed in this pull request:

- add a function `lazyimg_greader` to move `data-src` to `src` for images to allow certain Greader based clients like Reeder to show the image correctly. It might be good to have a GUI configuration button to decide whether to turn this feature on or not.

How to test the feature manually:

1. curl the Greader API endpoint for a feed using lazy-load. Due to private reason, I can't share the one I used for test :(  


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
