### PR TITLE
Docker Compose Traefik 3

### DIFF
--- a/Docker/freshrss/docker-compose-proxy.yml
+++ b/Docker/freshrss/docker-compose-proxy.yml
@@ -7,7 +7,7 @@ volumes:
 services:
 
   traefik:
-    image: traefik:3.0
+    image: traefik:3
     container_name: traefik
     restart: unless-stopped
     logging:


### PR DESCRIPTION
Use `:3` instead of `3.0` to avoid having to update the documentation too often.
See https://hub.docker.com/_/traefik
Follow-up of https://github.com/FreshRSS/FreshRSS/pull/6401
