### PR TITLE
Changed deprecated default_user to default-user in README

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -61,7 +61,7 @@ docker exec --user www-data freshrss cli/list-users.php
 Example of installation via command line:
 
 ```sh
-docker exec --user www-data freshrss cli/do-install.php --default_user freshrss
+docker exec --user www-data freshrss cli/do-install.php --default-user freshrss
 
 docker exec --user www-data freshrss cli/create-user.php --user freshrss --password freshrss
 ```
@@ -366,7 +366,7 @@ services:
         --db-password ${DB_PASSWORD}
         --db-type pgsql
         --db-user ${DB_USER}
-        --default_user admin
+        --default-user admin
         --language en
       FRESHRSS_USER: |-
         --api-password ${ADMIN_API_PASSWORD}


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

"default_user" in the docker exec command throws a deprecation warning, and suggests to use "default-user" instead. I just adapted the README to use the newer "default-user" instead.  

How to test the feature manually:

1.  run docker exec --user www-data freshrss cli/do-install.php --default-user freshrss
2. Check if no errors during user creation get thrown
3.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
