### PR TITLE
Improve notifications: notificationID

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -75,7 +75,7 @@ class FreshRSS_configure_Controller extends FreshRSS_ActionController {
 			Minz_Translate::reset(FreshRSS_Context::userConf()->language);
 			invalidateHttpCache();
 
-			Minz_Request::good(_t('feedback.conf.updated'), [ 'c' => 'configure', 'a' => 'display' ]);
+			Minz_Request::good(_t('feedback.conf.updated'), [ 'c' => 'configure', 'a' => 'display' ], 'displayAction');
 		}
 
 		$this->view->themes = FreshRSS_Themes::get();

--- a/app/Controllers/entryController.php
+++ b/app/Controllers/entryController.php
@@ -189,7 +189,8 @@ class FreshRSS_entry_Controller extends FreshRSS_ActionController {
 					'c' => 'index',
 					'a' => 'index',
 					'params' => $params,
-				]
+				],
+				'readAction'
 			);
 		}
 	}

--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -918,7 +918,7 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 			// Redirect to the main page with correct notification.
 			Minz_Request::good(_t('feedback.sub.feed.actualized', $feed->name()), [
 				'params' => ['get' => 'f_' . $id]
-			]);
+			], 'actualizeAction');
 		} elseif ($nbUpdatedFeeds >= 1) {
 			Minz_Request::good(_t('feedback.sub.feed.n_actualized', $nbUpdatedFeeds), []);
 		} else {

--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -84,14 +84,16 @@
 <?php
 	$msg = '';
 	$status = 'closed';
+	$notificationID = '';
 	$notif = Minz_Request::getNotification();
 	if (!empty($notif)) {
 		$msg = $notif['content'];
 		$status = $notif['type'];
+		$notificationID = $notif['notificationID'];
 		invalidateHttpCache();
 	}
 ?>
-<div role="dialog" id="notification" class="notification <?= $status ?>" aria-describedby="dialogMsg">
+<div role="dialog" id="notification" class="notification <?= $status ?> <?= $notificationID ?>" aria-describedby="dialogMsg">
 	<span class="msg" id="dialogMsg"><?= $msg ?></span>
 	<button class="close" title="<?= _t('gen.action.close') ?>"><?= _i('close') ?></button>
 </div>

--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -84,16 +84,16 @@
 <?php
 	$msg = '';
 	$status = 'closed';
-	$notificationID = '';
+	$notificationName = '';
 	$notif = Minz_Request::getNotification();
 	if (!empty($notif)) {
 		$msg = $notif['content'];
 		$status = $notif['type'];
-		$notificationID = $notif['notificationID'];
+		$notificationName = $notif['notificationName'];
 		invalidateHttpCache();
 	}
 ?>
-<div role="dialog" id="notification" class="notification <?= $status ?> <?= $notificationID ?>" aria-describedby="dialogMsg">
+<div role="dialog" id="notification" class="notification <?= $status ?> <?= $notificationName ?>" aria-describedby="dialogMsg">
 	<span class="msg" id="dialogMsg"><?= $msg ?></span>
 	<button class="close" title="<?= _t('gen.action.close') ?>"><?= _i('close') ?></button>
 </div>

--- a/lib/Minz/Request.php
+++ b/lib/Minz/Request.php
@@ -385,33 +385,33 @@ class Minz_Request {
 		return $_GET['rid'];
 	}
 
-	private static function setNotification(string $type, string $content, string $notificationID = ''): void {
+	private static function setNotification(string $type, string $content, string $notificationName = ''): void {
 		Minz_Session::lock();
 		$requests = Minz_Session::paramArray('requests');
 		$requests[self::requestId()] = [
 				'time' => time(),
-				'notification' => [ 'type' => $type, 'content' => $content, 'notificationID' => $notificationID ],
+				'notification' => [ 'type' => $type, 'content' => $content, 'notificationName' => $notificationName ],
 			];
 		Minz_Session::_param('requests', $requests);
 		Minz_Session::unlock();
 	}
 
-	public static function setGoodNotification(string $content, string $notificationID = 'xx'): void {
-		self::setNotification('good', $content, $notificationID);
+	public static function setGoodNotification(string $content, string $notificationName = 'xx'): void {
+		self::setNotification('good', $content, $notificationName);
 	}
 
-	public static function setBadNotification(string $content, string $notificationID = ''): void {
-		self::setNotification('bad', $content, $notificationID);
+	public static function setBadNotification(string $content, string $notificationName = ''): void {
+		self::setNotification('bad', $content, $notificationName);
 	}
 
 	/**
 	 * @param $pop true (default) to remove the notification, false to keep it.
-	 * @return array{type:string,content:string,notificationID:string}|null
+	 * @return array{type:string,content:string,notificationName:string}|null
 	 */
 	public static function getNotification(bool $pop = true): ?array {
 		$notif = null;
 		Minz_Session::lock();
-		/** @var array<string,array{time:int,notification:array{type:string,content:string,notificationID:string}}> */
+		/** @var array<string,array{time:int,notification:array{type:string,content:string,notificationName:string}}> */
 		$requests = Minz_Session::paramArray('requests');
 		if (!empty($requests)) {
 			//Delete abandoned notifications
@@ -461,8 +461,8 @@ class Minz_Request {
 	 * @param string $msg notification content
 	 * @param array{c?:string,a?:string,params?:array<string,mixed>} $url url array to where we should be forwarded
 	 */
-	public static function good(string $msg, array $url = [], string $notificationID = ''): void {
-		Minz_Request::setGoodNotification($msg, $notificationID);
+	public static function good(string $msg, array $url = [], string $notificationName = ''): void {
+		Minz_Request::setGoodNotification($msg, $notificationName);
 		Minz_Request::forward($url, true);
 	}
 
@@ -471,8 +471,8 @@ class Minz_Request {
 	 * @param string $msg notification content
 	 * @param array{c?:string,a?:string,params?:array<string,mixed>} $url url array to where we should be forwarded
 	 */
-	public static function bad(string $msg, array $url = [], string $notificationID = ''): void {
-		Minz_Request::setBadNotification($msg, $notificationID);
+	public static function bad(string $msg, array $url = [], string $notificationName = ''): void {
+		Minz_Request::setBadNotification($msg, $notificationName);
 		Minz_Request::forward($url, true);
 	}
 

--- a/lib/Minz/Request.php
+++ b/lib/Minz/Request.php
@@ -385,23 +385,23 @@ class Minz_Request {
 		return $_GET['rid'];
 	}
 
-	private static function setNotification(string $type, string $content): void {
+	private static function setNotification(string $type, string $content, string $notificationID = ''): void {
 		Minz_Session::lock();
 		$requests = Minz_Session::paramArray('requests');
 		$requests[self::requestId()] = [
 				'time' => time(),
-				'notification' => [ 'type' => $type, 'content' => $content ],
+				'notification' => [ 'type' => $type, 'content' => $content, 'notificationID' => $notificationID ],
 			];
 		Minz_Session::_param('requests', $requests);
 		Minz_Session::unlock();
 	}
 
-	public static function setGoodNotification(string $content): void {
-		self::setNotification('good', $content);
+	public static function setGoodNotification(string $content, string $notificationID = 'xx'): void {
+		self::setNotification('good', $content, $notificationID);
 	}
 
-	public static function setBadNotification(string $content): void {
-		self::setNotification('bad', $content);
+	public static function setBadNotification(string $content, string $notificationID = ''): void {
+		self::setNotification('bad', $content, $notificationID);
 	}
 
 	/**
@@ -411,7 +411,7 @@ class Minz_Request {
 	public static function getNotification(bool $pop = true): ?array {
 		$notif = null;
 		Minz_Session::lock();
-		/** @var array<string,array{time:int,notification:array{type:string,content:string}}> */
+		/** @var array<string,array{time:int,notification:array{type:string,content:string,notificationID:string}}> */
 		$requests = Minz_Session::paramArray('requests');
 		if (!empty($requests)) {
 			//Delete abandoned notifications
@@ -461,8 +461,8 @@ class Minz_Request {
 	 * @param string $msg notification content
 	 * @param array{c?:string,a?:string,params?:array<string,mixed>} $url url array to where we should be forwarded
 	 */
-	public static function good(string $msg, array $url = []): void {
-		Minz_Request::setGoodNotification($msg);
+	public static function good(string $msg, array $url = [], string $notificationID = ''): void {
+		Minz_Request::setGoodNotification($msg, $notificationID);
 		Minz_Request::forward($url, true);
 	}
 
@@ -471,8 +471,8 @@ class Minz_Request {
 	 * @param string $msg notification content
 	 * @param array{c?:string,a?:string,params?:array<string,mixed>} $url url array to where we should be forwarded
 	 */
-	public static function bad(string $msg, array $url = []): void {
-		Minz_Request::setBadNotification($msg);
+	public static function bad(string $msg, array $url = [], string $notificationID = ''): void {
+		Minz_Request::setBadNotification($msg, $notificationID);
 		Minz_Request::forward($url, true);
 	}
 

--- a/lib/Minz/Request.php
+++ b/lib/Minz/Request.php
@@ -406,7 +406,7 @@ class Minz_Request {
 
 	/**
 	 * @param $pop true (default) to remove the notification, false to keep it.
-	 * @return array{type:string,content:string}|null
+	 * @return array{type:string,content:string,notificationID:string}|null
 	 */
 	public static function getNotification(bool $pop = true): ?array {
 		$notif = null;

--- a/lib/Minz/Request.php
+++ b/lib/Minz/Request.php
@@ -396,7 +396,7 @@ class Minz_Request {
 		Minz_Session::unlock();
 	}
 
-	public static function setGoodNotification(string $content, string $notificationName = 'xx'): void {
+	public static function setGoodNotification(string $content, string $notificationName = ''): void {
 		self::setNotification('good', $content, $notificationName);
 	}
 


### PR DESCRIPTION
Closes #6409

Notification banners could have a `notificationID` as additional CSS class.
So it will be possible to design the notification banners individually via the `User CSS` extension

Changes proposed in this pull request:

- add `notificationID` as optional parameter for the notification setters
- some first notification IDs given (especially `readAction` as demanded in #6409)
-

How to test the feature manually:

1. trigger a notification
2. see the additional CSS class in the notification banner


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
