### PR TITLE
Replace opml generateing nline tool with working link

### DIFF
--- a/docs/en/users/04_Subscriptions.md
+++ b/docs/en/users/04_Subscriptions.md
@@ -117,8 +117,7 @@ See [SQLite export/import]( https://github.com/FreshRSS/FreshRSS/tree/edge/cli) 
 > Here is some tools you could use :
 >
 > * [Pandoc](https://pandoc.org/) available for most systems,
-> * [OPML generator](https://opml-gen.ovh/) available online,
-> * [txt2opml](https://alterfiles.com/convert/txt/opml) available online.
+> * [opmlmaker](https://rssgizmos.com/opmlmaker.html) available online.
 
 ## Use bookmarklet
 

--- a/docs/fr/users/04_Subscriptions.md
+++ b/docs/fr/users/04_Subscriptions.md
@@ -31,8 +31,7 @@ Voir [export/import SQLite]( https://github.com/FreshRSS/FreshRSS/tree/edge/cli)
 > Voici une liste d’outils que vous pouvez utiliser :
 >
 > - [Pandoc](https://pandoc.org/) disponible sur la plus part des systèmes,
-> - [OPML generator](https://opml-gen.ovh/) disponible en ligne,
-> - [txt2opml](https://alterfiles.com/convert/txt/opml) disponible en ligne.
+> - [opmlmaker](https://rssgizmos.com/opmlmaker.html) disponible en ligne.
 
 ## Utiliser le « bookmarklet »
 


### PR DESCRIPTION

Changes proposed in this pull request:
Fixed some broken links in Documentation.

How to test the feature manually:

1. Test links

Pull request checklist:

- [ x] documentation updated


