### PR TITLE
Fix: Properly set the priority field when saving a new feed

### DIFF
--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -93,6 +93,7 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo {
 				'name' => $feed->name(true),
 				'website' => $feed->website(),
 				'description' => $feed->description(),
+				'priority' => $feed->priority(),
 				'lastUpdate' => 0,
 				'error' => false,
 				'pathEntries' => $feed->pathEntries(),


### PR DESCRIPTION
Background:

I am writing a extension solely for my personal need: not putting entries feeds in a category in my main stream.

For that, I am hooking into the `feed_before_insert` hook and set the `priority` field to `0` (so that it only appear in its category).

But I find the priority does not change after doing so (but I tested all other fields including `website` etc is working). After dig into the source code of `FeedDAO.php`, I find that the `priority` field (unlike others) is missing from the values passed to `addFeed` so comes the proposed patch to solve this issue.

Changes proposed in this pull request:

- Pass the `priority` field of `FreshRSS_Feed` object into the `addFeed` method of `FreshRSS_FeedDAO` properly so that the priority of a feed is properly set when a feed is added.

How to test the feature manually:

1. Hook into the `feed_before_insert` hook in an extension and change the `priority` to value other than the default (`10`);
2. Add a feed with the extension enabled.
3. Observe the difference before and after the patch applied:
    - Before, the patch the `priority` field will be `10`, the default value;
    - After, the field is correctly set;

A minimal extension that tests the feature is

```php
<?php

final class MuteExtension extends Minz_Extension
{
    #[\Override]
    public function init(): void
    {
        $this->registerHook('feed_before_insert', [$this, 'hook_feed_before_insert']);
    }

    public function hook_feed_before_insert(FreshRSS_Feed $feed): FreshRSS_Feed
    {
        $feed->_priority(0);
        $feed->_attribute('priority', 0); // Should be either or?

        return $feed;
    }
}
```

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
<del>- [ ] unit tests written (optional if too hard)</del>
<del>- [ ] documentation updated</del>

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
