### PR TITLE
Fix bigint timestamps on 32-bit

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -58,9 +58,16 @@ class FreshRSS_Category extends Minz_Model {
 	public function lastUpdate(): int {
 		return $this->lastUpdate;
 	}
-	public function _lastUpdate(int $value): void {
+
+	/**
+	 * @param int|numeric-string $value
+	 * 32-bit systems provide a string and will fail in year 2038
+	 */
+	public function _lastUpdate(int|string $value): void {
+		$value = (int)$value;
 		$this->lastUpdate = $value;
 	}
+
 	public function inError(): bool {
 		return $this->error;
 	}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -64,8 +64,7 @@ class FreshRSS_Category extends Minz_Model {
 	 * 32-bit systems provide a string and will fail in year 2038
 	 */
 	public function _lastUpdate(int|string $value): void {
-		$value = (int)$value;
-		$this->lastUpdate = $value;
+		$this->lastUpdate = (int)$value;
 	}
 
 	public function inError(): bool {

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -546,7 +546,12 @@ HTML;
 		$this->date = $value > 1 ? $value : time();
 	}
 
-	public function _lastSeen(int $value): void {
+	/**
+	 * @param int|numeric-string $value
+	 * 32-bit systems provide a string and will fail in year 2038
+	 */
+	public function _lastSeen(int|string $value): void {
+		$value = (int)$value;
 		$this->lastSeen = $value > 0 ? $value : 0;
 	}
 

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -314,8 +314,7 @@ class FreshRSS_Feed extends Minz_Model {
 	 * 32-bit systems provide a string and will fail in year 2038
 	 */
 	public function _lastUpdate(int|string $value): void {
-		$value = (int)$value;
-		$this->lastUpdate = $value;
+		$this->lastUpdate = (int)$value;
 	}
 
 	public function _priority(int $value): void {

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -308,9 +308,16 @@ class FreshRSS_Feed extends Minz_Model {
 	public function _description(string $value): void {
 		$this->description = $value == '' ? '' : $value;
 	}
-	public function _lastUpdate(int $value): void {
+
+	/**
+	 * @param int|numeric-string $value
+	 * 32-bit systems provide a string and will fail in year 2038
+	 */
+	public function _lastUpdate(int|string $value): void {
+		$value = (int)$value;
 		$this->lastUpdate = $value;
 	}
+
 	public function _priority(int $value): void {
 		$this->priority = $value;
 	}

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -49,7 +49,8 @@ class FreshRSS_Tag extends Minz_Model {
 		return $this->nbUnread;
 	}
 
-	public function _nbUnread(int $value): void {
-		$this->nbUnread = $value;
+	/** @param int|numeric-string $value */
+	public function _nbUnread(int|string $value): void {
+		$this->nbUnread = (int)$value;
 	}
 }


### PR DESCRIPTION
fix https://github.com/FreshRSS/FreshRSS/issues/7374
SQL requests for BIGINT fields may return a string on 32-bit systems instead of an integer
