### PR TITLE
docs: add link to freshrss_python_api

### DIFF
--- a/docs/en/developers/06_Fever_API.md
+++ b/docs/en/developers/06_Fever_API.md
@@ -29,6 +29,7 @@ Then point your mobile application to the `fever.php` address (e.g. `https://fre
 |[Unread](https://apps.apple.com/app/unread-rss-reader/id1252376153)                 |iOS                  |Closed Source                                             |
 |[Reeder Classic](https://www.reederapp.com/classic/)                                |iOS                  |Closed Source                                              |
 |[ReadKit](https://apps.apple.com/app/readkit/id588726889)                           |macOS                |Closed Source                                              |
+|[FreshRSS Python API Client](https://github.com/thiswillbeyourgithub/freshrss_python_api)                           |Python                |[GPLv3](https://github.com/thiswillbeyourgithub/freshrss_python_api)                                              |
 
 ## Features
 


### PR DESCRIPTION
as suggested here: https://github.com/FreshRSS/FreshRSS/discussions/7395

Signed-off-by: thiswillbeyourgithub <26625900+thiswillbeyourgithub@users.noreply.github.com>

Closes #7390

Changes proposed in this pull request:

- Add a link to a minimal Fever python api I made for freshrss.

How to test the feature manually:

1. `git clone https://github.com/thiswillbeyourgithub/freshrss_python_api`
2. `cd freshrss_python_api`
3. `python --m pytest`

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard)
- [x] documentation updated
