### PR TITLE
Use case-insensitive sort for categories

### DIFF
--- a/app/Models/CategoryDAO.php
+++ b/app/Models/CategoryDAO.php
@@ -265,7 +265,7 @@ SQL;
 			$aPosition = $a->attributeInt('position');
 			$bPosition = $b->attributeInt('position');
 			if ($aPosition === $bPosition) {
-				return ($a->name() < $b->name()) ? -1 : 1;
+				return strnatcasecmp($a->name(), $b->name());
 			} elseif (null === $aPosition) {
 				return 1;
 			} elseif (null === $bPosition) {


### PR DESCRIPTION
Changes proposed in this pull request:

- Use `strnatcasecmp()` inside `listSortedCategories()`

How to test the feature manually:

1. Create categories `A`, `b`, and `C`
2. Observe that categories are sorted case-insensitively on the feed index and Subscription Management pages

Pull request checklist:

- [ ] clear commit messages
- [ ] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
