### PR TITLE
fix: Update the user's last activity on login action

### DIFF
--- a/app/Controllers/authController.php
+++ b/app/Controllers/authController.php
@@ -164,6 +164,8 @@ class FreshRSS_auth_Controller extends FreshRSS_ActionController {
 
 				Minz_Translate::init(FreshRSS_Context::userConf()->language);
 
+				FreshRSS_UserDAO::touch();
+
 				// All is good, go back to the original request or the index.
 				$url = Minz_Url::unserialize(Minz_Request::paramString('original_request'));
 				if (empty($url)) {


### PR DESCRIPTION
Changes proposed in this pull request:

- `touch` the user config file on successful form login

How to test the feature manually:

1. Login with a user
2. Verify in the admin that the user's last activity has been updated

Note that we already update the last activity in the `Auth` model, see https://github.com/FreshRSS/FreshRSS/blob/edge/app/Models/Auth.php#L38
Unfortunately, this only seems to work when the user is logged in with the "remember me" cookie.

Pull request checklist:

- [ ] clear commit messages
- [ ] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
