### PR TITLE
improve origine theme

### DIFF
--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -1297,7 +1297,7 @@ a:hover .icon {
 	:root.darkMode_auto .nav_menu .btn.active,
 	:root.darkMode_auto .nav_menu .btn:active,
 	:root.darkMode_auto .nav_menu .dropdown-target:target ~ .btn.dropdown-toggle {
-		background: var(--border-color);
+		background: #292929;
 	}
 
 	:root.darkMode_auto .dropdown-menu {

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -1303,4 +1303,17 @@ a:hover .icon {
 	:root.darkMode_auto .dropdown-menu {
 		background-color: #0a0a0a;
 	}
+
+	:root.darkMode_auto .nav_menu {
+		background-color: #141414;
+	}
+
+	:root.darkMode_auto .header {
+		background-color: var(--background-color-light-shadowed);
+	}
+
+	:root.darkMode_auto .btn.active .icon,
+	:root.darkMode_auto .btn:active .icon {
+		filter: brightness(1.4);
+	}
 }

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -1297,7 +1297,7 @@ a:hover .icon {
 	:root.darkMode_auto .nav_menu .btn.active,
 	:root.darkMode_auto .nav_menu .btn:active,
 	:root.darkMode_auto .nav_menu .dropdown-target:target ~ .btn.dropdown-toggle {
-		background: var(--border-color);
+		background: #292929;
 	}
 
 	:root.darkMode_auto .dropdown-menu {

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -1303,4 +1303,17 @@ a:hover .icon {
 	:root.darkMode_auto .dropdown-menu {
 		background-color: #0a0a0a;
 	}
+
+	:root.darkMode_auto .nav_menu {
+		background-color: #141414;
+	}
+
+	:root.darkMode_auto .header {
+		background-color: var(--background-color-light-shadowed);
+	}
+
+	:root.darkMode_auto .btn.active .icon,
+	:root.darkMode_auto .btn:active .icon {
+		filter: brightness(1.4);
+	}
 }


### PR DESCRIPTION
Closes #7366

Before:
![grafik](https://github.com/user-attachments/assets/3f652fe3-c1a9-41f2-82bb-6aea9fade7c3)

After:
![grafik](https://github.com/user-attachments/assets/e4b7b21f-a719-41c2-b108-fb0c9d6fc5bf)


It is difficult to see the differences on the screen shots. That is a down side of dark themes. You need to check it directly on your screen

How to test the feature manually:

1. use Origine theme
2. set the dark mode to `auto`
3. use your browser in dark mode

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
