### PR TITLE
Implement JSON string concatenation with & operator

### DIFF
--- a/docs/en/users/11_website_scraping.md
+++ b/docs/en/users/11_website_scraping.md
@@ -50,6 +50,8 @@ and the link would be `links[1]`.
 
 It is a similar syntax to the JavaScript way to access JSON: `object.object.array[2].property`.
 
+Support string concatenation with a syntax like: `meta.title & " some text"` using single-quotes or double-quotes.
+
 ## Tips & tricks
 
 - [Timezone of date](https://github.com/FreshRSS/FreshRSS/discussions/5483)

--- a/tests/app/Utils/dotNotationUtilTest.php
+++ b/tests/app/Utils/dotNotationUtilTest.php
@@ -33,6 +33,9 @@ class dotNotationUtilTest extends PHPUnit\Framework\TestCase {
 		yield [$array, 'items[0].meta.title', 'first'];
 		yield [$array, 'items.1.meta.title', 'second'];
 		yield [$array, 'items[1].meta.title', 'second'];
+		yield [$array, '"Hello " & hello & \'!\'', 'Hello world!'];
+		yield [$array, '"Hello & goodbye " & hello & \'!\'', 'Hello & goodbye world!'];
+		yield [$array, '"Hello " & hello & deeper.hello & "!"', 'Hello worldagain!'];
 	}
 
 	/**


### PR DESCRIPTION
Inspired by [JSONata syntax](https://docs.jsonata.org/expressions).
Support string concatenation with a syntax like: `meta.title & " some text"` using single-quotes or double-quotes.
fix https://github.com/FreshRSS/FreshRSS/issues/6565
