### PR TITLE
Fix issue where $keepMax is defaulted to const when non-zero value is…

### DIFF
--- a/app/Controllers/categoryController.php
+++ b/app/Controllers/categoryController.php
@@ -113,7 +113,7 @@ class FreshRSS_category_Controller extends FreshRSS_ActionController {
 			} else {
 				if (!Minz_Request::paramBoolean('enable_keep_max')) {
 					$keepMax = false;
-				} elseif (($keepMax = Minz_Request::paramInt('keep_max')) !== 0) {
+				} elseif (($keepMax = Minz_Request::paramInt('keep_max')) === 0) {
 					$keepMax = FreshRSS_Feed::ARCHIVING_RETENTION_COUNT_LIMIT;
 				}
 				if (Minz_Request::paramBoolean('enable_keep_period')) {


### PR DESCRIPTION
… compared.

Fix issue where $keepMax is defaulted to const when non-zero value is compared.

Fix an issue where $keepMax var is set to ARCHIVING_RETENTION_COUNT_LIMIT when a user sets "Archiving" -> "Maximum number of articles to keep per feed" to a non-zero value for a given category.

[EXAMPLE]:
User sets value to 50 (int), This matches the !== comparison and thus is overridden by ARCHIVING_RETENTION_COUNT_LIMIT.
