### PR TITLE
Add check for Apache mod_filter to ensure "AddOutputFilterByType" works.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,7 +15,7 @@ RUN rm -f /etc/apache2/conf.d/languages.conf /etc/apache2/conf.d/info.conf \
 		/etc/apache2/conf.d/status.conf /etc/apache2/conf.d/userdir.conf && \
 	sed -r -i "/^\s*LoadModule .*mod_(alias|autoindex|negotiation|status).so$/s/^/#/" \
 		/etc/apache2/httpd.conf && \
-	sed -r -i "/^\s*#\s*LoadModule .*mod_(deflate|expires|headers|mime|remoteip|setenvif).so$/s/^\s*#//" \
+	sed -r -i "/^\s*#\s*LoadModule .*mod_(deflate|expires|filter|headers|mime|remoteip|setenvif).so$/s/^\s*#//" \
 		/etc/apache2/httpd.conf && \
 	sed -r -i "/^\s*(CustomLog|ErrorLog|Listen) /s/^/#/" \
 		/etc/apache2/httpd.conf

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -37,7 +37,7 @@ LABEL \
 RUN a2dismod -q -f alias autoindex negotiation status && \
 	a2dismod -q auth_openidc && \
 	phpdismod calendar exif ffi ftp gettext mysqli posix readline shmop sockets sysvmsg sysvsem sysvshm xsl && \
-	a2enmod -q deflate expires headers mime remoteip setenvif && \
+	a2enmod -q deflate expires filter headers mime remoteip setenvif && \
 	a2disconf -q '*' && \
 	a2dissite -q '*' && \
 	a2ensite -q 'FreshRSS*'

--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -35,7 +35,7 @@ RUN rm -f /etc/apache2/conf.d/languages.conf /etc/apache2/conf.d/info.conf \
 		/etc/apache2/conf.d/status.conf /etc/apache2/conf.d/userdir.conf && \
 	sed -r -i "/^\s*LoadModule .*mod_(alias|autoindex|negotiation|status).so$/s/^/#/" \
 		/etc/apache2/httpd.conf && \
-	sed -r -i "/^\s*#\s*LoadModule .*mod_(deflate|expires|headers|mime|remoteip|setenvif).so$/s/^\s*#//" \
+	sed -r -i "/^\s*#\s*LoadModule .*mod_(deflate|expires|filter|headers|mime|remoteip|setenvif).so$/s/^\s*#//" \
 		/etc/apache2/httpd.conf && \
 	sed -r -i "/^\s*(CustomLog|ErrorLog|Listen) /s/^/#/" \
 		/etc/apache2/httpd.conf && \

--- a/Docker/Dockerfile-Newest
+++ b/Docker/Dockerfile-Newest
@@ -36,7 +36,7 @@ RUN rm -f /etc/apache2/conf.d/languages.conf /etc/apache2/conf.d/info.conf \
 		/etc/apache2/conf.d/status.conf /etc/apache2/conf.d/userdir.conf && \
 	sed -r -i "/^\s*LoadModule .*mod_(alias|autoindex|negotiation|status).so$/s/^/#/" \
 		/etc/apache2/httpd.conf && \
-	sed -r -i "/^\s*#\s*LoadModule .*mod_(deflate|expires|headers|mime|remoteip|setenvif).so$/s/^\s*#//" \
+	sed -r -i "/^\s*#\s*LoadModule .*mod_(deflate|expires|filter|headers|mime|remoteip|setenvif).so$/s/^\s*#//" \
 		/etc/apache2/httpd.conf && \
 	sed -r -i "/^\s*(CustomLog|ErrorLog|Listen) /s/^/#/" \
 		/etc/apache2/httpd.conf && \

--- a/Docker/Dockerfile-Oldest
+++ b/Docker/Dockerfile-Oldest
@@ -35,7 +35,7 @@ RUN rm -f /etc/apache2/conf.d/languages.conf /etc/apache2/conf.d/info.conf \
 		/etc/apache2/conf.d/status.conf /etc/apache2/conf.d/userdir.conf && \
 	sed -r -i "/^\s*LoadModule .*mod_(alias|autoindex|negotiation|status).so$/s/^/#/" \
 		/etc/apache2/httpd.conf && \
-	sed -r -i "/^\s*#\s*LoadModule .*mod_(deflate|expires|headers|mime|remoteip|setenvif).so$/s/^\s*#//" \
+	sed -r -i "/^\s*#\s*LoadModule .*mod_(deflate|expires|filter|headers|mime|remoteip|setenvif).so$/s/^\s*#//" \
 		/etc/apache2/httpd.conf && \
 	sed -r -i "/^\s*(CustomLog|ErrorLog|Listen) /s/^/#/" \
 		/etc/apache2/httpd.conf && \

--- a/p/.htaccess
+++ b/p/.htaccess
@@ -18,8 +18,10 @@ AddDefaultCharset	UTF-8
 	AddCharset	UTF-8	.js
 </IfModule>
 
-<IfModule mod_deflate.c>
-	AddOutputFilterByType DEFLATE application/javascript application/json application/xhtml+xml image/svg+xml text/css text/html
+<IfModule mod_filter.c>
+	<IfModule mod_deflate.c>
+		AddOutputFilterByType DEFLATE application/javascript application/json application/xhtml+xml image/svg+xml text/css text/html
+	</IfModule>
 </IfModule>
 
 <IfModule mod_expires.c>


### PR DESCRIPTION
`AddOutputFilterByType` has been moved from `mod_deflate` to `mod_filter` in Apache 2.3.7. Without the `mod_filter` module loaded Apache will error out reading the `p/.htaccess` file.

Apache documentation about the `AddOutputFilterByType` directive for reference:
https://httpd.apache.org/docs/2.4/mod/mod_filter.html#addoutputfilterbytype

This issue was encountered when installing FreshRSS 1.26.0 in a shared hosting environment where compression is applied at the reverse proxy, not the Apache web server.

**Changes proposed in this pull request:**

Add check in .htaccess for Apache `mod_filter` to ensure `AddOutputFilterByType` works.

It may also be necessary to update the Apache `LoadModule` configuration to include `mod_filter` for the Docker container files. I haven't tested running this with Docker.

**How to test the feature manually:**

1. Setup Apache 2.4 with `mod_deflate`, but without `mod_filter` loaded.
2. Install FreshRSS 1.26.0 and try to run it.
3. Notice it doesn't work and the Apache error logs complains about missing the module for `AddOutputFilterByType`
4. Apply this patched .htaccess and try again, notice that it now works as Apache knows to ignore the `AddOutputFilterByType` directive due to missing `mod_filter`. If both `mod_filter` and `mod_deflate` are loaded it will also work.

**Pull request checklist:**

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
