### PR TITLE
Fix issue #7383: Translation issue requiring character escape out.

### DIFF
--- a/app/i18n/fi/gen.php
+++ b/app/i18n/fi/gen.php
@@ -94,7 +94,7 @@ return array(
 		'feb' => 'helmi',
 		'february' => 'helmikuu',
 		'format_date' => 'j\\. %s\\t\\a Y',
-		'format_date_hour' => 'j\\. %s\\t\\a Y klo H\\:i',
+		'format_date_hour' => 'j\\. %s\\t\\a Y \\k\\l\\o H\\:i',
 		'fri' => 'pe',
 		'jan' => 'tammi',
 		'january' => 'tammikuu',


### PR DESCRIPTION
Escape out "klo" ("at") characters found in format_date_hour for Finnish/Suomi translation. Specifically to resolve issue #7383 
