### PR TITLE
Clarify MINZ usage

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -255,17 +255,18 @@ et [l’API Fever](https://freshrss.github.io/FreshRSS/fr/users/06_Fever_API.htm
 # Bibliothèques incluses
 
 * [SimplePie](https://simplepie.org/)
-* [MINZ](https://framagit.org/marienfressinaud/MINZ)
 * [php-http-304](https://alexandre.alapetite.fr/doc-alex/php-http-304/)
 * [lib_opml](https://framagit.org/marienfressinaud/lib_opml)
+* [bcrypt.js](https://github.com/dcodeIO/bcrypt.js)
 * [PhpGt/CssXPath](https://github.com/PhpGt/CssXPath)
 * [PHPMailer](https://github.com/PHPMailer/PHPMailer)
 * [Chart.js](https://www.chartjs.org)
 
-## Uniquement pour certaines options ou configurations
+# Crédits additionels
 
-* [bcrypt.js](https://github.com/dcodeIO/bcrypt.js)
-* [phpQuery](https://github.com/phpquery/phpquery)
+* Basé sur une version modifiée du [framework MINZ](https://framagit.org/marienfressinaud/MINZ)
+* Certaines [icônes](https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic) sont issues du [projet GNOME](https://www.gnome.org/)
+* Polices : [*Open Sans*](https://fonts.google.com/specimen/Open+Sans), [*Lato*](https://www.latofonts.com/lato-free-fonts/), [*Spectral*](https://github.com/productiontype/spectral)
 
 # Alternatives
 

--- a/README.md
+++ b/README.md
@@ -152,25 +152,18 @@ and [Fever API](https://freshrss.github.io/FreshRSS/en/developers/06_Fever_API.h
 # Included libraries
 
 * [SimplePie](https://simplepie.org/)
-* [MINZ](https://framagit.org/marienfressinaud/MINZ)
 * [php-http-304](https://alexandre.alapetite.fr/doc-alex/php-http-304/)
 * [lib_opml](https://framagit.org/marienfressinaud/lib_opml)
+* [bcrypt.js](https://github.com/dcodeIO/bcrypt.js)
 * [PhpGt/CssXPath](https://github.com/PhpGt/CssXPath)
 * [PHPMailer](https://github.com/PHPMailer/PHPMailer)
 * [Chart.js](https://www.chartjs.org)
 
-## Only for some options or configurations
+# Additional credits
 
-* [bcrypt.js](https://github.com/dcodeIO/bcrypt.js)
-* [phpQuery](https://github.com/phpquery/phpquery)
-
-# Credits
-
-* Some design elements come from [Bootstrap](http://twitter.github.io/bootstrap/)
-although FreshRSS doesn’t use this framework.
-* [Icons](https://gitlab.gnome.or0g/Archive/gnome-icon-theme-symbolic) come from the [GNOME project](https://www.gnome.org/).
-* *Open Sans* font police has been created by [Steve Matteson](https://fonts.google.com/specimen/Open+Sans).
-* FreshRSS is based on [Minz](https://framagit.org/marienfressinaud/MINZ), a PHP framework.
+* Based on a modified version of the [MINZ framework](https://framagit.org/marienfressinaud/MINZ).
+* Some [icons](https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic) come from the [GNOME project](https://www.gnome.org/)
+* Fonts: [*Open Sans*](https://fonts.google.com/specimen/Open+Sans), [*Lato*](https://www.latofonts.com/lato-free-fonts/), [*Spectral*](https://github.com/productiontype/spectral)
 
 # Alternatives
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,14 @@ and [Fever API](https://freshrss.github.io/FreshRSS/en/developers/06_Fever_API.h
 * [bcrypt.js](https://github.com/dcodeIO/bcrypt.js)
 * [phpQuery](https://github.com/phpquery/phpquery)
 
+# Credits
+
+* Some design elements come from [Bootstrap](http://twitter.github.io/bootstrap/)
+although FreshRSS doesn’t use this framework.
+* [Icons](https://gitlab.gnome.or0g/Archive/gnome-icon-theme-symbolic) come from the [GNOME project](https://www.gnome.org/).
+* *Open Sans* font police has been created by [Steve Matteson](https://fonts.google.com/specimen/Open+Sans).
+* FreshRSS is based on [Minz](https://framagit.org/marienfressinaud/MINZ), a PHP framework.
+
 # Alternatives
 
 If FreshRSS does not suit you for one reason or another, here are alternative solutions to consider:

--- a/app/i18n/cs/index.php
+++ b/app/i18n/cs/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'Hlášení chyb',
-		'credits' => 'Poděkování',
-		'credits_content' => 'Některé designové prvky pocházejí z <a href="http://twitter.github.io/bootstrap/">Bootstrap</a>, FreshRSS ale tuto platformu nevyužívá. <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">Ikony</a> pocházejí z <a href="https://www.gnome.org/">projektu GNOME</a>. Písmo <em>Open Sans</em> vytvořil <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a>. FreshRSS je založeno na PHP framework <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>.',
 		'documentation' => 'Dokumentace',
 		'freshrss_description' => 'FreshRSS je čtečka kanálů RSS určená k provozu na vlastním serveru. Je to nenáročný a jednoduchý, zároveň ale mocný a konfigurovatelný nástroj.',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">na GitHub</a>',

--- a/app/i18n/de/index.php
+++ b/app/i18n/de/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'Fehlerberichte',
-		'credits' => 'Mitwirkende',
-		'credits_content' => 'Einige Designelemente stammen von <a href="http://twitter.github.io/bootstrap/">Bootstrap</a>, obwohl FreshRSS dieses Framework nicht nutzt. <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">Icons</a> stammen vom <a href="https://www.gnome.org/">GNOME project</a>. <em>Open Sans</em> Font wurde von <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a> erstellt. FreshRSS basiert auf <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>, einem PHP-Framework.',
 		'documentation' => 'Handbuch',
 		'freshrss_description' => 'FreshRSS ist ein RSS-Feedsaggregator zum selbst hosten. Er ist leicht und einfach zu handhaben und gleichzeitig ein leistungsstarkes und konfigurierbares Werkzeug.',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">auf GitHub</a>',

--- a/app/i18n/el/index.php
+++ b/app/i18n/el/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'Bug reports',	// TODO
-		'credits' => 'Credits',	// TODO
-		'credits_content' => 'Some design elements come from <a href="http://twitter.github.io/bootstrap/">Bootstrap</a> although FreshRSS doesn’t use this framework. <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">Icons</a> come from the <a href="https://www.gnome.org/">GNOME project</a>. <em>Open Sans</em> font police has been created by <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a>. FreshRSS is based on <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>, a PHP framework.',	// TODO
 		'documentation' => 'Documentation',	// TODO
 		'freshrss_description' => 'FreshRSS is a self-hostable RSS aggregator and reader. It allows you to read and follow several news websites at a glance without the need to browse from one website to another. FreshRSS is lightweight, configurable, and easy to use.',	// TODO
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">on GitHub</a>',	// TODO

--- a/app/i18n/en-us/index.php
+++ b/app/i18n/en-us/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'Bug reports',	// IGNORE
-		'credits' => 'Credits',	// IGNORE
-		'credits_content' => 'Some design elements come from <a href="http://twitter.github.io/bootstrap/">Bootstrap</a> although FreshRSS doesn’t use this framework. <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">Icons</a> come from the <a href="https://www.gnome.org/">GNOME project</a>. <em>Open Sans</em> font police has been created by <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a>. FreshRSS is based on <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>, a PHP framework.',	// IGNORE
 		'documentation' => 'Documentation',	// IGNORE
 		'freshrss_description' => 'FreshRSS is a self-hostable RSS aggregator and reader. It allows you to read and follow several news websites at a glance without the need to browse from one website to another. FreshRSS is lightweight, configurable, and easy to use.',	// IGNORE
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">on GitHub</a>',	// IGNORE

--- a/app/i18n/en/index.php
+++ b/app/i18n/en/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'Bug reports',
-		'credits' => 'Credits',
-		'credits_content' => 'Some design elements come from <a href="http://twitter.github.io/bootstrap/">Bootstrap</a> although FreshRSS doesn’t use this framework. <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">Icons</a> come from the <a href="https://www.gnome.org/">GNOME project</a>. <em>Open Sans</em> font police has been created by <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a>.',
 		'documentation' => 'Documentation',
 		'freshrss_description' => 'FreshRSS is a self-hostable RSS aggregator and reader. It allows you to read and follow several news websites at a glance without the need to browse from one website to another. FreshRSS is lightweight, configurable, and easy to use.',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">on GitHub</a>',

--- a/app/i18n/en/index.php
+++ b/app/i18n/en/index.php
@@ -27,7 +27,7 @@ return array(
 		),
 		'bugs_reports' => 'Bug reports',
 		'credits' => 'Credits',
-		'credits_content' => 'Some design elements come from <a href="http://twitter.github.io/bootstrap/">Bootstrap</a> although FreshRSS doesn’t use this framework. <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">Icons</a> come from the <a href="https://www.gnome.org/">GNOME project</a>. <em>Open Sans</em> font police has been created by <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a>. FreshRSS is based on <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>, a PHP framework.',
+		'credits_content' => 'Some design elements come from <a href="http://twitter.github.io/bootstrap/">Bootstrap</a> although FreshRSS doesn’t use this framework. <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">Icons</a> come from the <a href="https://www.gnome.org/">GNOME project</a>. <em>Open Sans</em> font police has been created by <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a>.',
 		'documentation' => 'Documentation',
 		'freshrss_description' => 'FreshRSS is a self-hostable RSS aggregator and reader. It allows you to read and follow several news websites at a glance without the need to browse from one website to another. FreshRSS is lightweight, configurable, and easy to use.',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">on GitHub</a>',

--- a/app/i18n/es/index.php
+++ b/app/i18n/es/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'Informe de fallos',
-		'credits' => 'Créditos',
-		'credits_content' => 'Aunque FreshRSS no usa ese entorno, algunos elementos del diseño están obtenidos de <a href="http://twitter.github.io/bootstrap/">Bootstrap</a>. Los <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">Iconos</a> han sido obtenidos del <a href="https://www.gnome.org/">proyecto GNOME</a>. La fuente <em>Open Sans</em> es una creación de <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a>. FreshRSS usa el entorno PHP <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>.',
 		'documentation' => 'Documentación',
 		'freshrss_description' => 'FreshRSS es un agregador de fuentes RSS de alojamiento privado. Es una herramienta potente, pero ligera y fácil de usar y configurar.',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">en GitHub</a>',

--- a/app/i18n/fa/index.php
+++ b/app/i18n/fa/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => ' گزارش اشکال',
-		'credits' => ' اعتبار',
-		'credits_content' => ' برخی از عناصر طراحی از <a href="http://twitter.github.io/bootstrap/">Bootstrap</a> می آیند',
 		'documentation' => ' اسناد و مدارک',
 		'freshrss_description' => ' FreshRSS یک جمع کننده و خواننده RSS خود میزبان است. این به شما امکان می دهد بدون نیاز به مرور از یک وب سایت به وب سایت دیگر',
 		'github' => ' <a href="https://github.com/FreshRSS/FreshRSS/issues">در GitHub</a>',

--- a/app/i18n/fi/index.php
+++ b/app/i18n/fi/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'Virheraportit',
-		'credits' => 'Tekijät',
-		'credits_content' => 'Jotkin suunnitteluelementit perustuvat <a href="http://twitter.github.io/bootstrap/">Bootstrapiin</a>, mutta FreshRSS ei käytä tätä kehystä. <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">Kuvakkeet</a> tulevat <a href="https://www.gnome.org/">GNOME-projektista</a>. <em>Open Sans</em> -fontin on luonut <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a>. FreshRSS perustuu PHP-kehykseen <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>.',
 		'documentation' => 'Ohjeet',
 		'freshrss_description' => 'FreshRSS on itse asennettava RSS-syötteiden luku- ja hallintaohjelma. Sen avulla voit helposti lukea ja seurata useita uutissivustoja yhdessä näkymässä, eikä sinun tarvitse siirtyä sivustolta toiselle. FreshRSS on kevyt, muokattavissa ja helppokäyttöinen.',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">GitHubissa</a>',

--- a/app/i18n/fr/index.php
+++ b/app/i18n/fr/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'Rapports de bugs',
-		'credits' => 'Crédits',
-		'credits_content' => 'Des éléments de design sont issus du <a href="http://twitter.github.io/bootstrap/">projet Bootstrap</a> bien que FreshRSS n’utilise pas ce framework. Les <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">icônes</a> sont issues du <a href="https://www.gnome.org/">projet GNOME</a>. La police <em>Open Sans</em> utilisée a été créée par <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a>. FreshRSS repose sur <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>, un framework PHP.',
 		'documentation' => 'Documentation',	// IGNORE
 		'freshrss_description' => 'FreshRSS est un agrégateur de flux RSS à auto-héberger. Il se veut léger et facile à prendre en main tout en étant un outil puissant et paramétrable.',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">sur GitHub</a>',

--- a/app/i18n/he/index.php
+++ b/app/i18n/he/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'דיווח באגים',
-		'credits' => 'קרדיטים',
-		'credits_content' => 'מאפייני עיצוב מסויימים הגיעו מ <a href="http://twitter.github.io/bootstrap/">Bootstrap</a> אף על פי ש FreshRSS אינו משתמש בתשתית הזו. <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">סמלילים</a> הגיעו מ <a href="https://www.gnome.org/"> פרוייקט GNOME </a>. <em>Open Sans</em> הגופן police נוצר על ידי <a href="https://www.google.com/webfonts/specimen/Open+Sans">Steve Matteson</a>. Favicons נאספים בעזרת <a href="https://getfavicon.appspot.com/">getFavicon API</a>. FreshRSS מבוסס על <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>, תשתית PHP.',
 		'documentation' => 'Documentation',	// TODO
 		'freshrss_description' => 'FreshRSS הוא קורא RSS לאחסון עצמי .אינו צורך משאבים רבים, וקל לתפעול אך בו בזמן חזק וניתן להתאמה.',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">בגיטהאב</a>',

--- a/app/i18n/hu/index.php
+++ b/app/i18n/hu/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'Hiba jelentések',
-		'credits' => 'Credits',	// IGNORE
-		'credits_content' => 'Néhány dizájn elem a <a href="http://twitter.github.io/bootstrap/">Bootstrap</a> segítségével működik, habár a FreshRSS nem használja ezt a framework-öt. Az <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">Ikonok</a> a <a href="https://www.gnome.org/">GNOME projekt-ből származnak</a>. <em>Open Sans</em> betűtípust készítette <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a>. A FreshRSS a <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a> PHP keretrendszeren alapul.',
 		'documentation' => 'Dokumentáció',
 		'freshrss_description' => 'A FreshRSS egy saját magunk által host-olható RSS hírgyűjtő és olvasó. Lehetővé teszi hogy kövess és olvass sok híroldalt egy pillantás alatt anélkül hogy mindegyiket meglátogatnád egyesével. A FreshRSS könnyű, gyors, jól konfigurálható, és könnyen használható.',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">GitHub-on</a>',

--- a/app/i18n/id/index.php
+++ b/app/i18n/id/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'Bug reports',	// TODO
-		'credits' => 'Credits',	// TODO
-		'credits_content' => 'Some design elements come from <a href="http://twitter.github.io/bootstrap/">Bootstrap</a> although FreshRSS doesn’t use this framework. <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">Icons</a> come from the <a href="https://www.gnome.org/">GNOME project</a>. <em>Open Sans</em> font police has been created by <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a>. FreshRSS is based on <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>, a PHP framework.',	// TODO
 		'documentation' => 'Documentation',	// TODO
 		'freshrss_description' => 'FreshRSS is a self-hostable RSS aggregator and reader. It allows you to read and follow several news websites at a glance without the need to browse from one website to another. FreshRSS is lightweight, configurable, and easy to use.',	// TODO
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">on GitHub</a>',	// TODO

--- a/app/i18n/it/index.php
+++ b/app/i18n/it/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'Bugs',
-		'credits' => 'Crediti',
-		'credits_content' => 'Alcuni elementi di design provengono da <a href="http://twitter.github.io/bootstrap/">Bootstrap</a> sebbene FreshRSS non usi questo framework. Le <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">icone</a> provengono dal progetto <a href="https://www.gnome.org/">GNOME</a>. Il carattere <em>Open Sans</em> è stato creato da <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a>. FreshRSS è basato su <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>, un framework PHP.',
 		'documentation' => 'Documentazione',
 		'freshrss_description' => 'FreshRSS è un aggregatore di feeds RSS da installare sul proprio host. Leggero e facile da mantenere pur essendo molto configurabile e potente.',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">su GitHub</a>',

--- a/app/i18n/ja/index.php
+++ b/app/i18n/ja/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'バグレポート',
-		'credits' => 'クレジット',
-		'credits_content' => 'いくつかのデザイン要素は<a href="http://twitter.github.io/bootstrap/">Bootstrap</a>に由来しますが、FreshRSSはこのフレームワークを使用していません。<a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">アイコン</a>は<a href="https://www.gnome.org/">GNOMEプロジェクト</a>に由来します。<em>Open Sans</em>フォントは<a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a>によって作成されました。FreshRSSはPHPフレームワークの<a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>を採用しています。',
 		'documentation' => 'ドキュメント',
 		'freshrss_description' => 'FreshRSSはセルフホストできるRSSフィード収集ツールです。強力なツールで、軽量で簡単に使え、豊富な設定が特徴です。',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">Githubへお願いします</a>',

--- a/app/i18n/ko/index.php
+++ b/app/i18n/ko/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => '버그 제보하기',
-		'credits' => '크레딧',
-		'credits_content' => 'FreshRSS는 <a href="http://twitter.github.io/bootstrap/">Bootstrap</a> 프레임워크를 사용하진 않지만, 일부 디자인 요소를 가져왔습니다. <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">아이콘들</a>은 <a href="https://www.gnome.org/">GNOME 프로젝트</a>에서 가져왔습니다. <em>Open Sans</em> 글꼴은 <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a>가 제작하였습니다. FreshRSS는 PHP 프레임워크인 <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>에 기반하고 있습니다.',
 		'documentation' => '문서',
 		'freshrss_description' => 'FreshRSS는 같은 셀프 호스팅 기반의 RSS 피드 수집기입니다. FreshRSS는 강력하고 다양한 설정을 할 수 있으면서도 가볍고 사용하기 쉽습니다.',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">GitHub 저장소에 제보</a>',

--- a/app/i18n/lv/index.php
+++ b/app/i18n/lv/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'Ziņojumi par kļūdām',
-		'credits' => 'Kredīti',
-		'credits_content' => 'Daži dizaina elementi nāk no <a href="http://twitter.github.io/bootstrap/">Bootstrap</a>, lai gan FreshRSS neizmanto šo ietvaru. <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">Ikonas</a> ir no <a href="https://www.gnome.org/">GNOME projekta</a>. <em>Open Sans</em> fontu policiju ir izveidojis <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a>. FreshRSS pamatā ir PHP ietvarstruktūra <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>.',
 		'documentation' => 'Dokumentācija',
 		'freshrss_description' => 'FreshRSS ir paš-hostējams RSS agregators un lasītājs. Tas ļauj jums lasīt un sekot līdzi vairākām ziņu vietnēm vienā mirklī, bez nepieciešamības pārvietoties no vienas vietnes uz citu. FreshRSS ir viegls, konfigurējams un viegli lietojams.',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">GitHubā</a>',

--- a/app/i18n/nl/index.php
+++ b/app/i18n/nl/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'Rapporteer fouten',
-		'credits' => 'Waarderingen',
-		'credits_content' => 'Sommige ontwerp elementen komen van <a href="http://twitter.github.io/bootstrap/">Bootstrap</a> alhoewel FreshRSS dit raamwerk niet gebruikt. <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">Pictogrammen</a> komen van het <a href="https://www.gnome.org/">GNOME project</a>. <em>De Open Sans</em> font police is gemaakt door <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a>. FreshRSS is gebaseerd op <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>, een PHP raamwerk. Nederlandse vertaling door Wanabo, <a href="http://www.nieuwskop.be" title="NieuwsKop">NieuwsKop.be</a>. Link naar de Nederlandse vertaling, <a href="https://github.com/Wanabo/FreshRSS-Dutch-translation/tree/master">FreshRSS-Dutch-translation</a>.',
 		'documentation' => 'Documentatie',
 		'freshrss_description' => 'FreshRSS is een RSS-feed aggregator om zelf te hosten. Het gebruikt weinig systeembronnen en is makkelijk te beheren terwijl het een krachtig en makkelijk te configureren programma is.',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">op GitHub</a>',

--- a/app/i18n/oc/index.php
+++ b/app/i18n/oc/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'Senhalament de problèmas',
-		'credits' => 'Crèdits',
-		'credits_content' => 'Unes elements de l’estil venon del <a href="http://twitter.github.io/bootstrap/">projècte Bootstrap</a> encara que FreshRSS utilize pas aqueste framework. Las <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">icònas</a> venon del <a href="https://www.gnome.org/">projècte GNOME</a>. La polissa <em>Open Sans</em> utilizada foguèt creada per en <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a>. FreshRSS es basat sus <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>, un framework PHP.',
 		'documentation' => 'Documentation',	// TODO
 		'freshrss_description' => 'FreshRSS es un agregador de fluxes RSS per l’auto-albergar tal. Sa tòca es d’èsser leugièr e de bon utilizar de prima abòrd mas tanben d’èsser potent e parametrable.',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">sus GitHub</a>',

--- a/app/i18n/pl/index.php
+++ b/app/i18n/pl/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'Zgłaszanie problemów',
-		'credits' => 'Uznanie autorstwa',
-		'credits_content' => 'Niektóre elementy designu pochodzą z <a href="http://twitter.github.io/bootstrap/">Bootstrapa</a>, przy czym FreshRSS nie używa tego frameworku. <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">Ikony</a> zostały pierwotnie stworzone dla <a href="https://www.gnome.org/">projektu GNOME</a>. Font <em>Open Sans</em> jest autorstwa <a href="https://fonts.google.com/specimen/Open+Sans">Steve’a Mattesona</a>. FreshRSS opiera się na <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>, frameworku PHP.',
 		'documentation' => 'Dokumentacja',
 		'freshrss_description' => 'FreshRSS jest agregatorem kanałów RSS przeznaczonym do zainstalowania na własnym serwerze. Jest lekki i łatwy do schowania w kieszeni, pozostając przy tym potężnym i konfigurowalnym narzędziem.',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">na GitHubie</a>',

--- a/app/i18n/pt-br/index.php
+++ b/app/i18n/pt-br/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'Reportar Bugs',
-		'credits' => 'Créditos',
-		'credits_content' => 'Alguns elementos de design vieram do <a href="http://twitter.github.io/bootstrap/">Bootstrap</a> Embora FreshRRS não utiliza este framework. <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">Ícones</a> vieram do <a href="https://www.gnome.org/">GNOME project</a>. <em>Open Sans</em> font police foi criada por <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a>. FreshRSS é baseado no <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>, um framework PHP.',
 		'documentation' => 'Documentação',
 		'freshrss_description' => 'FreshRSS é um RSS feeds aggregator para um host próprio. É leve e fácil de utilizar enquanto é uma ferramenta poderosa e configurável. ',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">no GitHub</a>',

--- a/app/i18n/pt-pt/index.php
+++ b/app/i18n/pt-pt/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'Reportar Erros',
-		'credits' => 'Créditos',
-		'credits_content' => 'Alguns elementos de design vieram do <a href="http://twitter.github.io/bootstrap/">Bootstrap</a> Embora FreshRRS não utiliza este framework. <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">Ícones</a> vieram do <a href="https://www.gnome.org/">GNOME project</a>. <em>Open Sans</em> font police foi criada por <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a>. FreshRSS é baseado no <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>, um framework PHP.',
 		'documentation' => 'Documentação',
 		'freshrss_description' => 'FreshRSS é um RSS feeds aggregator para um host próprio. É leve e fácil de utilizar enquanto é uma ferramenta poderosa e configurável. ',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">no GitHub</a>',

--- a/app/i18n/ru/index.php
+++ b/app/i18n/ru/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'Баг репорты',
-		'credits' => 'Авторство',
-		'credits_content' => 'Некоторые элементы дизайна взяты из <a href="http://twitter.github.io/bootstrap/">Bootstrap</a>, хотя FreshRSS не использует этот фреймворк. <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">Иконки</a> взяты из <a href="https://www.gnome.org/">проекта GNOME</a>. Шрифт <em>Open Sans</em> создан <a href="https://fonts.google.com/specimen/Open+Sans">Стивом Мэттесоном</a>. FreshRSS основан на <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>, PHP-фреймворке.',
 		'documentation' => 'Документация',
 		'freshrss_description' => 'FreshRSS — агрегатор RSS-лент для размещения на своём сервере. Лёгкий и простой в использовании, будучи при этом мощным и настраиваемым инструментом.',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">в GitHub</a>',

--- a/app/i18n/sk/index.php
+++ b/app/i18n/sk/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'Nahlásiť chybu',
-		'credits' => 'Poďakovanie',
-		'credits_content' => 'Niektoré časti vzhľadu pochádzajú z <a href="http://twitter.github.io/bootstrap/">Bootstrap</a>u, aj keď FreshRSS tento framework nepoužíva. <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">Ikony</a> sú z <a href="https://www.gnome.org/">GNOME project</a>. Font <em>Open Sans</em> zabezpečil <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a>. FreshRSS je založený na PHP frameworku <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>.',
 		'documentation' => 'Dokumentácia',
 		'freshrss_description' => 'FreshRSS je čítačka RSS kanálov, ktorú môžete nasadiť na vlastný server. Ide o jednoduchý a zároveň dobre nastaviteľný nástroj.',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">na GitHub</a>e',

--- a/app/i18n/tr/index.php
+++ b/app/i18n/tr/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => 'Hata raporu',
-		'credits' => 'Tanıtım',
-		'credits_content' => 'Bu frameworkü kullanmamasına rağmen FreshRSS bazı tasarım ögelerini <a href="http://twitter.github.io/bootstrap/">Bootstrap</a> dan almıştır. <a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">İkonlar</a> <a href="https://www.gnome.org/">GNOME projesinden</a> alınmıştır. <em>Open Sans</em> yazı tipi <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a> tarafından oluşturulmuştur. FreshRSS bir PHP framework olan <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a> i temel alır.',
 		'documentation' => 'Dökümantasyon',
 		'freshrss_description' => 'FreshRSS kendi hostunuzda çalışan bir RSS akış toplayıcısıdır. Güçlü ve yapılandırılabilir araçlarıyla basit ve kullanımı kolay bir uygulamadır.',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">GitHub sayfası</a>',

--- a/app/i18n/zh-cn/index.php
+++ b/app/i18n/zh-cn/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => '报告错误',
-		'credits' => '致谢',
-		'credits_content' => '某些设计元素来自于 <a href="http://twitter.github.io/bootstrap/">Bootstrap</a> ，尽管 FreshRSS 并没有使用此框架。<a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">图标</a> 来自于 <a href="https://www.gnome.org/">GNOME 项目</a>。<em>Open Sans</em> 字体出自 <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a> 之手。FreshRSS 基于 PHP 框架 <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>。',
 		'documentation' => '文档',
 		'freshrss_description' => 'FreshRSS 是一个自托管的 RSS 聚合服务。 它不仅轻快易用，并且强大又易于配置。',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">GitHub Issues</a>',

--- a/app/i18n/zh-tw/index.php
+++ b/app/i18n/zh-tw/index.php
@@ -26,8 +26,6 @@ return array(
 			),
 		),
 		'bugs_reports' => '報告錯誤',
-		'credits' => '致謝',
-		'credits_content' => '某些設計元素來自於 <a href="http://twitter.github.io/bootstrap/">Bootstrap</a> ，盡管 FreshRSS 並沒有使用此框架。<a href="https://gitlab.gnome.org/Archive/gnome-icon-theme-symbolic">圖標</a> 來自於 <a href="https://www.gnome.org/">GNOME 項目</a>。<em>Open Sans</em> 字體出自 <a href="https://fonts.google.com/specimen/Open+Sans">Steve Matteson</a> 之手。FreshRSS 基於 PHP 框架 <a href="https://framagit.org/marienfressinaud/MINZ">Minz</a>。',
 		'documentation' => 'Documentation',	// TODO
 		'freshrss_description' => 'FreshRSS 是一個自托管的 RSS 聚合服務。 它不僅輕快又易用，而且強大又易於配置。',
 		'github' => '<a href="https://github.com/FreshRSS/FreshRSS/issues">GitHub Issues</a>',

--- a/app/views/index/about.phtml
+++ b/app/views/index/about.phtml
@@ -66,9 +66,6 @@
 		}
 	}
 	?>
-
-	<h2><?= _t('index.about.credits') ?></h2>
-	<p><?= _t('index.about.credits_content') ?></p>
 </main>
 
 <?php if (!FreshRSS_Auth::hasAccess()) { ?>


### PR DESCRIPTION
MINZ (archived, read-only) is not a dependency of FreshRSS, which would be very concerning.

Instead, FreshRSS copied MINZ and has evolved it since then under the same license.

Ref: https://github.com/FreshRSS/FreshRSS/discussions/7425

## Move credits

This PR moves the credits from the web UI to the README.