### PR TITLE
JavaScript: new event to detect context loaded

### DIFF
--- a/docs/en/developers/03_Backend/05_Extensions.md
+++ b/docs/en/developers/03_Backend/05_Extensions.md
@@ -183,6 +183,24 @@ The following events are available:
 
 > ℹ️ Note: the `simplepie_*` hooks are only fired for feeds using SimplePie via pull, i.e. normal RSS/Atom feeds. This excludes WebSub (push), and the various HTML or JSON Web scraping methods.
 
+### The JavaScript events
+
+```javascript
+function use_context() {
+	// Something that refers to the window.context
+}
+
+if (document.readyState && document.readyState !== 'loading' && typeof window.context !== 'undefined' && typeof window.context.extensions !== 'undefined') {
+	use_context();
+} else {
+	document.addEventListener('freshrss:globalContextLoaded', use_context, false);
+}
+```
+
+The following events are available:
+
+* `freshrss:globalContextLoaded`: will be dispatched after load the global `context` variable, useful for referencing variables injected with the `js_vars` hook.
+
 ### Injecting CDN content
 
 When using the `init` method, it is possible to inject scripts from CDN using the `Minz_View::appendScript` directive.

--- a/docs/en/developers/03_Backend/05_Extensions.md
+++ b/docs/en/developers/03_Backend/05_Extensions.md
@@ -183,7 +183,7 @@ The following events are available:
 
 > ℹ️ Note: the `simplepie_*` hooks are only fired for feeds using SimplePie via pull, i.e. normal RSS/Atom feeds. This excludes WebSub (push), and the various HTML or JSON Web scraping methods.
 
-### The JavaScript events
+### JavaScript events
 
 ```javascript
 function use_context() {

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -53,6 +53,9 @@ var context;
 	context.icons.unread = decodeURIComponent(context.icons.unread);
 	context.extensions = json.extensions;
 }());
+
+const freshrssGlobalContextLoadedEvent = new Event('freshrss:globalContextLoaded');
+document.dispatchEvent(freshrssGlobalContextLoadedEvent);
 // </Global context>
 
 function badAjax(reload) {


### PR DESCRIPTION
Closes #7451

I considered including `freshrss:load-more` (#1278) in the document, but held off after struggling with how to write it since it is dispatched to a different location.

How to test the feature manually:

1. I confirmed that I can trigger the `add_load_more_listener` of https://github.com/FreshRSS/Extensions/pull/300 .

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).