### PR TITLE
Disallow iframe srcdoc for now

### DIFF
--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -350,7 +350,7 @@ function customSimplePie(array $attributes = [], array $curl_options = []): \Sim
 	$simplePie->strip_attributes(array_merge($simplePie->strip_attributes, [
 		'autoplay', 'class', 'onload', 'onunload', 'onclick', 'ondblclick', 'onmousedown', 'onmouseup',
 		'onmouseover', 'onmousemove', 'onmouseout', 'onfocus', 'onblur',
-		'onkeypress', 'onkeydown', 'onkeyup', 'onselect', 'onchange', 'seamless', 'sizes', 'srcset']));
+		'onkeypress', 'onkeydown', 'onkeyup', 'onselect', 'onchange', 'seamless', 'sizes', 'srcdoc', 'srcset']));
 	$simplePie->add_attributes([
 		'audio' => ['controls' => 'controls', 'preload' => 'none'],
 		'iframe' => [


### PR DESCRIPTION
We do not sanitize this attribute well enough, so striped for now.
It is rarely used: I have not seen any use of it in any of my many test feeds.
Can be added back when we can handle its inherent security issues better.
