### PR TITLE
Web scraping forbid security headers in cURL

### DIFF
--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -823,6 +823,9 @@
 							$httpHeaders = [];
 						}
 						$httpHeaders = array_filter($httpHeaders, 'is_string');
+						// Remove headers problematic for security
+						$httpHeaders = array_filter($httpHeaders,
+							fn(string $header) => !preg_match('/^(Remote-User|X-WebAuth-User)\\s*:/i', $header));
 					?>
 					<textarea class="valid-json" id="http_headers" name="http_headers" rows="3" cols="64" spellcheck="false"><?php
 						foreach ($httpHeaders as $header) {


### PR DESCRIPTION
Prevent using `Remote-User`, `X-WebAuth-User` during Web scraping.
