### PR TITLE
Fix file serving for symlinked extensions

### DIFF
--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -922,6 +922,14 @@ function recursive_unlink(string $dir): bool {
 		return true;
 	}
 
+	if (is_link($dir)) {
+		if (PHP_OS_FAMILY === "Windows") {
+			return rmdir($dir);
+		}
+
+		return unlink($dir);
+	}
+
 	$files = array_diff(scandir($dir) ?: [], ['.', '..']);
 	foreach ($files as $filename) {
 		$filename = $dir . '/' . $filename;

--- a/p/ext.php
+++ b/p/ext.php
@@ -11,7 +11,7 @@ function get_absolute_filename(string $file_name): string {
 
 	$third_party_extension = realpath(THIRDPARTY_EXTENSIONS_PATH . '/' . $file_name);
 	if (false !== $third_party_extension) {
-		$original_dir = THIRDPARTY_EXTENSIONS_PATH . '/' . explode("/", $file_name)[0];
+		$original_dir = THIRDPARTY_EXTENSIONS_PATH . '/' . explode('/', $file_name)[0];
 		if (is_link($original_dir)) {
 			return THIRDPARTY_EXTENSIONS_PATH . '/' . $file_name;
 		}

--- a/p/ext.php
+++ b/p/ext.php
@@ -11,6 +11,11 @@ function get_absolute_filename(string $file_name): string {
 
 	$third_party_extension = realpath(THIRDPARTY_EXTENSIONS_PATH . '/' . $file_name);
 	if (false !== $third_party_extension) {
+		$original_dir = THIRDPARTY_EXTENSIONS_PATH . '/' . explode("/", $file_name)[0];
+		if (is_link($original_dir)) {
+			return THIRDPARTY_EXTENSIONS_PATH . '/' . $file_name;
+		}
+
 		return $third_party_extension;
 	}
 


### PR DESCRIPTION
Fixes #6040, in addition to not recursively deleting symlink contents, but instead just the symlink.
