### PR TITLE
Add CLI tool for clearing the cache of all feeds

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -101,6 +101,9 @@ cd /usr/share/FreshRSS
 #  and the number of: 5) categories, 6) feeds, 7) read articles, 8) unread articles, 9) favourites, 10) tags,
 #  11) language, 12) e-mail.
 
+./cli/clear-all-cache.php [--user=<user>] [--all-users]
+# Clear the cache of all feeds for a specific user or all users.
+
 ./cli/import-for-user.php --user username --filename /path/to/file.ext
 # The extension of the file { .json, .opml, .xml, .zip } is used to detect the type of import.
 

--- a/cli/clear-all-cache.php
+++ b/cli/clear-all-cache.php
@@ -1,0 +1,81 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+require(__DIR__ . '/_cli.php');
+
+performRequirementCheck(FreshRSS_Context::systemConf()->db['type'] ?? '');
+
+$cliOptions = new class extends CliOptionsParser {
+	public string $user = '';
+	public bool $allUsers;
+
+	public function __construct() {
+		$this->addOption('user', new CliOption('user'));
+		$this->addOption('allUsers', (new CliOption('all-users'))->withValueNone());
+		parent::__construct();
+	}
+};
+
+if (!empty($cliOptions->errors)) {
+	fail('FreshRSS error: ' . array_shift($cliOptions->errors) . "\n" . $cliOptions->usage);
+}
+
+$username = $cliOptions->user;
+
+if ($username === '' && !$cliOptions->allUsers) {
+    fail($cliOptions->usage);
+}
+
+function clearCacheForUser(string $username) {
+    echo "Clearing cache for user $username.\n";
+    
+    $feedDAO = FreshRSS_Factory::createFeedDao($username);
+    $ids = $feedDAO->listFeedsIds();
+
+	if (count($ids) === 0) {
+		echo "No feeds found.\n";
+		return;
+	}
+
+    $maxId = max($ids);
+    
+    foreach ($ids as $feedId) {
+        echo "\rfor feed ID: $feedId/$maxId";
+            
+        $feed = $feedDAO->searchById($feedId);
+        if ($feed === null) {
+            echo "\nFeed with ID $feedId not found. Continuing.\n";
+            continue;
+        }
+            
+        $feed->clearCache();
+    }
+        
+    invalidateHttpCache($username);
+    echo "\nDone.\n";
+}
+
+if ($cliOptions->allUsers) {
+    $users = listUsers();
+    sort($users);
+    if (FreshRSS_Context::systemConf()->default_user !== ''
+    	&& in_array(FreshRSS_Context::systemConf()->default_user, $users, true)) {
+    	array_unshift($users, FreshRSS_Context::systemConf()->default_user);
+    	$users = array_unique($users);
+    }
+    
+    foreach ($users as $username) {
+        clearCacheForUser($username);
+    }
+
+    die();
+}
+
+if (!FreshRSS_user_Controller::checkUsername($username)) {
+	fail('FreshRSS error: invalid username: ' . $username . "\n");
+}
+if (!FreshRSS_user_Controller::userExists($username)) {
+	fail('FreshRSS error: user not found: ' . $username . "\n");
+}
+
+clearCacheForUser($username);

--- a/cli/clear-all-cache.php
+++ b/cli/clear-all-cache.php
@@ -23,52 +23,52 @@ if (!empty($cliOptions->errors)) {
 $username = $cliOptions->user;
 
 if ($username === '' && !$cliOptions->allUsers) {
-    fail($cliOptions->usage);
+	fail($cliOptions->usage);
 }
 
 function clearCacheForUser(string $username) {
-    echo "Clearing cache for user $username.\n";
-    
-    $feedDAO = FreshRSS_Factory::createFeedDao($username);
-    $ids = $feedDAO->listFeedsIds();
+	echo "Clearing cache for user $username.\n";
+
+	$feedDAO = FreshRSS_Factory::createFeedDao($username);
+	$ids = $feedDAO->listFeedsIds();
 
 	if (count($ids) === 0) {
 		echo "No feeds found.\n";
 		return;
 	}
 
-    $maxId = max($ids);
-    
-    foreach ($ids as $feedId) {
-        echo "\rfor feed ID: $feedId/$maxId";
-            
-        $feed = $feedDAO->searchById($feedId);
-        if ($feed === null) {
-            echo "\nFeed with ID $feedId not found. Continuing.\n";
-            continue;
-        }
-            
-        $feed->clearCache();
-    }
-        
-    invalidateHttpCache($username);
-    echo "\nDone.\n";
+	$maxId = max($ids);
+
+	foreach ($ids as $feedId) {
+		echo "\rfor feed ID: $feedId/$maxId";
+
+		$feed = $feedDAO->searchById($feedId);
+		if ($feed === null) {
+			echo "\nFeed with ID $feedId not found. Continuing.\n";
+			continue;
+		}
+
+		$feed->clearCache();
+	}
+
+	invalidateHttpCache($username);
+	echo "\nDone.\n";
 }
 
 if ($cliOptions->allUsers) {
-    $users = listUsers();
-    sort($users);
-    if (FreshRSS_Context::systemConf()->default_user !== ''
-    	&& in_array(FreshRSS_Context::systemConf()->default_user, $users, true)) {
-    	array_unshift($users, FreshRSS_Context::systemConf()->default_user);
-    	$users = array_unique($users);
-    }
-    
-    foreach ($users as $username) {
-        clearCacheForUser($username);
-    }
+	$users = listUsers();
+	sort($users);
+	if (FreshRSS_Context::systemConf()->default_user !== ''
+		&& in_array(FreshRSS_Context::systemConf()->default_user, $users, true)) {
+		array_unshift($users, FreshRSS_Context::systemConf()->default_user);
+		$users = array_unique($users);
+	}
 
-    die();
+	foreach ($users as $username) {
+		clearCacheForUser($username);
+	}
+
+	die();
 }
 
 if (!FreshRSS_user_Controller::checkUsername($username)) {

--- a/cli/clear-all-cache.php
+++ b/cli/clear-all-cache.php
@@ -1,6 +1,9 @@
 #!/usr/bin/env php
 <?php
 declare(strict_types=1);
+
+define("COPY_SYSLOG_TO_STDERR", false);
+
 require(__DIR__ . '/_cli.php');
 
 performRequirementCheck(FreshRSS_Context::systemConf()->db['type'] ?? '');

--- a/cli/clear-all-cache.php
+++ b/cli/clear-all-cache.php
@@ -26,7 +26,7 @@ if ($username === '' && !$cliOptions->allUsers) {
 	fail($cliOptions->usage);
 }
 
-function clearCacheForUser(string $username) {
+function clearCacheForUser(string $username): void {
 	echo "Clearing cache for user $username.\n";
 
 	$feedDAO = FreshRSS_Factory::createFeedDao($username);
@@ -64,8 +64,8 @@ if ($cliOptions->allUsers) {
 		$users = array_unique($users);
 	}
 
-	foreach ($users as $username) {
-		clearCacheForUser($username);
+	foreach ($users as $user) {
+		clearCacheForUser($user);
 	}
 
 	die();


### PR DESCRIPTION
After switching my FreshRSS installation from the `latest` branch to the `edge` branch, all of my feed favicons disappeared and I could only restore them by going manually through every feed and clearing the cache on it.

But it didn't feel like the best way to do it, so I did that with this tool.

