### PR TITLE
Fix duplicate HTTP header for POST

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -215,6 +215,7 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 			$headers = array_filter(array_map('trim', $headers));
 			if (!empty($headers)) {
 				$opts[CURLOPT_HTTPHEADER] = array_merge($headers, $opts[CURLOPT_HTTPHEADER] ?? []);
+				$opts[CURLOPT_HTTPHEADER] = array_unique($opts[CURLOPT_HTTPHEADER]);
 			}
 
 			$attributes = [

--- a/app/Controllers/subscriptionController.php
+++ b/app/Controllers/subscriptionController.php
@@ -197,6 +197,7 @@ class FreshRSS_subscription_Controller extends FreshRSS_ActionController {
 			$headers = array_filter(array_map('trim', $headers));
 			if (!empty($headers)) {
 				$opts[CURLOPT_HTTPHEADER] = array_merge($headers, $opts[CURLOPT_HTTPHEADER] ?? []);
+				$opts[CURLOPT_HTTPHEADER] = array_unique($opts[CURLOPT_HTTPHEADER]);
 			}
 
 			$feed->_attribute('curl_params', empty($opts) ? null : $opts);


### PR DESCRIPTION
Using POST with JSON would add `Content-Type: application/json` again and again everytime the feed's settings were saved
