### PR TITLE
Provide theme class for CSS

### DIFF
--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -63,7 +63,7 @@
 		<meta name="robots" content="noindex,nofollow" />
 <?php } ?>
 	</head>
-	<body class="<?= Minz_Request::actionName() ?> theme-<?= strtolower(str_replace(' ', '-', FreshRSS_Context::userConf()->theme)) ?>">
+	<body class="<?= Minz_Request::actionName() ?> theme-<?= strtolower(preg_replace('/[\s\._]/', '-', FreshRSS_Context::userConf()->theme)) ?>">
 <?php
 	if (!Minz_Request::paramBoolean('ajax')) {
 		flush();

--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -63,7 +63,7 @@
 		<meta name="robots" content="noindex,nofollow" />
 <?php } ?>
 	</head>
-	<body class="<?= Minz_Request::actionName() ?> theme-<?= strtolower(str_replace([' ', '_', '.', '<', '>', '&', '"', '\''], '-', html_entity_decode(FreshRSS_Context::userConf()->theme))) ?>">
+	<body class="<?= Minz_Request::actionName() ?> theme-<?= strtolower(str_replace([' ', '_', '.', '<', '>', '&', '"', '\''], '-', htmlspecialchars_decode(FreshRSS_Context::userConf()->theme))) ?>">
 <?php
 	if (!Minz_Request::paramBoolean('ajax')) {
 		flush();

--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -63,7 +63,7 @@
 		<meta name="robots" content="noindex,nofollow" />
 <?php } ?>
 	</head>
-	<body class="<?= Minz_Request::actionName() ?> theme-<?= strtolower(preg_replace('/[\s\._]/', '-', FreshRSS_Context::userConf()->theme) ?? '') ?>">
+	<body class="<?= Minz_Request::actionName() ?> theme-<?= htmlspecialchars(strtolower(str_replace([' ', '_', '.'], '-', FreshRSS_Context::userConf()->theme))) ?>">
 <?php
 	if (!Minz_Request::paramBoolean('ajax')) {
 		flush();

--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -63,7 +63,7 @@
 		<meta name="robots" content="noindex,nofollow" />
 <?php } ?>
 	</head>
-	<body class="<?= Minz_Request::actionName() ?>">
+	<body class="<?= Minz_Request::actionName() ?> theme-<?= strtolower(str_replace(' ', '-', FreshRSS_Context::userConf()->theme)) ?>">
 <?php
 	if (!Minz_Request::paramBoolean('ajax')) {
 		flush();

--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -63,7 +63,7 @@
 		<meta name="robots" content="noindex,nofollow" />
 <?php } ?>
 	</head>
-	<body class="<?= Minz_Request::actionName() ?> theme-<?= strtolower(str_replace([' ', '_', '.', '<', '>', '&', '"', '\''], '-', htmlspecialchars_decode(FreshRSS_Context::userConf()->theme))) ?>">
+	<body class="<?= Minz_Request::actionName() ?> theme-<?= strtolower(str_replace([' ', '_', '.', '<', '>', '&', '"', '\'', "\t", "\r", "\n", "\v"], '-', htmlspecialchars_decode(FreshRSS_Context::userConf()->theme))) ?>">
 <?php
 	if (!Minz_Request::paramBoolean('ajax')) {
 		flush();

--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -63,7 +63,7 @@
 		<meta name="robots" content="noindex,nofollow" />
 <?php } ?>
 	</head>
-	<body class="<?= Minz_Request::actionName() ?> theme-<?= htmlspecialchars(strtolower(str_replace([' ', '_', '.'], '-', FreshRSS_Context::userConf()->theme))) ?>">
+	<body class="<?= Minz_Request::actionName() ?> theme-<?= strtolower(str_replace([' ', '_', '.', '<', '>', '&', '"', '\''], '-', html_entity_decode(FreshRSS_Context::userConf()->theme))) ?>">
 <?php
 	if (!Minz_Request::paramBoolean('ajax')) {
 		flush();

--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -8,8 +8,9 @@
 		$dir = ' dir="rtl"';
 		$class = 'rtl ';
 	}
+	$class .= 'theme_' . FreshRSS_Context::userConf()->theme;
 	if (FreshRSS_Context::userConf()->darkMode !== 'no') {
-		$class .= 'darkMode_' . FreshRSS_Context::userConf()->darkMode;
+		$class .= ' darkMode_' . FreshRSS_Context::userConf()->darkMode;
 	}
 ?>
 <!DOCTYPE html>
@@ -63,7 +64,7 @@
 		<meta name="robots" content="noindex,nofollow" />
 <?php } ?>
 	</head>
-	<body class="<?= Minz_Request::actionName() ?> theme-<?= strtolower(str_replace([' ', '_', '.', '<', '>', '&', '"', '\'', "\t", "\r", "\n", "\v", "\f"], '-', htmlspecialchars_decode(FreshRSS_Context::userConf()->theme))) ?>">
+	<body class="<?= Minz_Request::actionName() ?>">
 <?php
 	if (!Minz_Request::paramBoolean('ajax')) {
 		flush();

--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -63,7 +63,7 @@
 		<meta name="robots" content="noindex,nofollow" />
 <?php } ?>
 	</head>
-	<body class="<?= Minz_Request::actionName() ?> theme-<?= strtolower(preg_replace('/[\s\._]/', '-', FreshRSS_Context::userConf()->theme)) ?>">
+	<body class="<?= Minz_Request::actionName() ?> theme-<?= strtolower(preg_replace('/[\s\._]/', '-', FreshRSS_Context::userConf()->theme) ?? '') ?>">
 <?php
 	if (!Minz_Request::paramBoolean('ajax')) {
 		flush();

--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -63,7 +63,7 @@
 		<meta name="robots" content="noindex,nofollow" />
 <?php } ?>
 	</head>
-	<body class="<?= Minz_Request::actionName() ?> theme-<?= strtolower(str_replace([' ', '_', '.', '<', '>', '&', '"', '\'', "\t", "\r", "\n", "\v"], '-', htmlspecialchars_decode(FreshRSS_Context::userConf()->theme))) ?>">
+	<body class="<?= Minz_Request::actionName() ?> theme-<?= strtolower(str_replace([' ', '_', '.', '<', '>', '&', '"', '\'', "\t", "\r", "\n", "\v", "\f"], '-', htmlspecialchars_decode(FreshRSS_Context::userConf()->theme))) ?>">
 <?php
 	if (!Minz_Request::paramBoolean('ajax')) {
 		flush();


### PR DESCRIPTION
Adds a theme class into the HTML to be used inside CSS. Use cases include user-supplied CSS (via UserCSS) and extensions.

For example this is what I'm doing in my User CSS:
```css
	/* toggle sidebar */

	@media (prefers-color-scheme: dark) {
		body:not(.theme-pafat):not(.theme-ansum) {
			.show-sidebar img,
			.close-sidebar img {
				filter: invert(1) brightness(2);
			}
		}
	}
	
	body.theme-nord,
	body.theme-swage,
	body.theme-mapco,
	body.theme-flat,
	body.theme-dark-pink,
	body.theme-dark,
	body.theme-alternative-dark {
		.show-sidebar img,
		.close-sidebar img {
			filter: invert(1) brightness(2);
		}
	}
```
