### PR TITLE
Move PHP minimum version check

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -35,6 +35,10 @@ const CORE_EXTENSIONS_PATH = LIB_PATH . '/core-extensions';
 const TESTS_PATH = FRESHRSS_PATH . '/tests';
 //</Not customisable>
 
+if (version_compare(PHP_VERSION, FRESHRSS_MIN_PHP_VERSION, '<')) {
+	die(sprintf('Error: FreshRSS requires PHP %s+ but was invoked with PHP %s!', FRESHRSS_MIN_PHP_VERSION, PHP_VERSION));
+}
+
 if (file_exists(__DIR__ . '/constants.local.php')) {
 	//Include custom / local settings:
 	include(__DIR__ . '/constants.local.php');

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -1,10 +1,6 @@
 <?php
 declare(strict_types=1);
 
-if (version_compare(PHP_VERSION, FRESHRSS_MIN_PHP_VERSION, '<')) {
-	die(sprintf('FreshRSS error: FreshRSS requires PHP %s+!', FRESHRSS_MIN_PHP_VERSION));
-}
-
 if (!function_exists('mb_strcut')) {
 	function mb_strcut(string $str, int $start, ?int $length = null, string $encoding = 'UTF-8'): string {
 		return substr($str, $start, $length) ?: '';


### PR DESCRIPTION
It is too late to check for minimum version check in `lib_rss.php` because that file already contains some relatively new PHP language constructs, which will lead to a syntax error - when running with an old PHP version - instead of the expected error message.
Moved to `constants.php` for now.

Example of syntax error with PHP 7.4:
```
PHP Parse error:  syntax error, unexpected '|', expecting '{' in /var/www/FreshRSS/lib/lib_rss.php on line 166
```

Should help users like in:
* https://github.com/FreshRSS/FreshRSS/discussions/7539
* https://github.com/FreshRSS/FreshRSS/issues/7557
