### PR TITLE
Remove Apache 2.2 (only support Apache 2.4+)

### DIFF
--- a/docs/en/admins/02_Prerequisites.md
+++ b/docs/en/admins/02_Prerequisites.md
@@ -6,7 +6,7 @@ You need to verify that your server can run FreshRSS before installing it. If yo
 
 | Software      | Recommended             | Also Works With         |
 | ------------- | ----------------------- | ----------------------- |
-| Web server    | **Apache 2.4**          | nginx, lighttpd<br />Minimal compatibility with Apache 2.2 |
+| Web server    | **Apache 2.4**          | nginx, lighttpd |
 | PHP           | **PHP 8.1+**            | FreshRSS 1.24.3: PHP 7.4+<br />FreshRSS 1.22.1: PHP 7.2+ |
 | PHP modules   | Required: libxml, cURL, JSON, PDO_MySQL, PCRE and ctype.<br />Required (32-bit only): GMP <br />Recommended: Zlib, mbstring, iconv, ZipArchive<br />*For the whole modules list see [Dockerfile](https://github.com/FreshRSS/FreshRSS/blob/edge/Docker/Dockerfile-Alpine#L9-L11)* | |
 | Database      | **PostgreSQL 10+**      | SQLite, MariaDB 10.0.5+, MySQL 8.0+ |

--- a/docs/fr/users/01_Installation.md
+++ b/docs/fr/users/01_Installation.md
@@ -6,7 +6,7 @@ Il est toutefois de votre responsabilité de vérifier que votre hébergement pe
 
 | Logiciel         | Recommandé         | Fonctionne aussi avec          |
 | --------         | -----------        | ---------------------          |
-| Serveur web      | **Apache 2.4+**    | nginx, lighttpd<br />Compatibilité minimale avec Apache 2.2 |
+| Serveur web      | **Apache 2.4+**    | nginx, lighttpd |
 | PHP              | **PHP 8.1+**       | FreshRSS 1.24.3 : PHP 7.4+<br />FreshRSS 1.22.1 : PHP 7.2+ |
 | Modules PHP      | Requis : libxml, cURL, JSON, PDO_MySQL, PCRE et ctype<br />Requis (32 bits seulement) : GMP<br />Recommandé : Zlib, mbstring et iconv, ZipArchive<br />*Pour une liste complète des modules nécessaires voir le [Dockerfile](https://github.com/FreshRSS/FreshRSS/blob/edge/Docker/Dockerfile-Alpine#L9-L11)* |                                |
 | Base de données  | **PostgreSQL 10+** | SQLite, MariaDB 10.0.5+, MySQL 8.0+ |

--- a/p/.htaccess
+++ b/p/.htaccess
@@ -39,7 +39,6 @@ AddDefaultCharset	UTF-8
 <IfModule mod_headers.c>
 	<FilesMatch "\.(css|gif|html|ico|js|png|svg|woff|woff2)$">
 		Header	merge Cache-Control "public"
-		# If you run an old Apache 2.2-, comment out the following <If> section
 		<If "%{QUERY_STRING} =~ /^[0-9]+$/">
 			# For requests like `frss.css?1746304092`
 			Header merge Cache-Control "immutable"
@@ -55,7 +54,6 @@ AddDefaultCharset	UTF-8
 </IfModule>
 <IfModule !mod_rewrite.c>
 	<IfModule mod_setenvif.c>
-		# If you run an old Apache 2.2-, disable mod_setenvif and enable mod_rewrite, or comment out next line
 		SetEnvIfExpr "%{CONN_REMOTE_ADDR} =~ /(.*)/" CONN_REMOTE_ADDR=$1
 	</IfModule>
 </IfModule>


### PR DESCRIPTION
Follow-up of https://github.com/FreshRSS/FreshRSS/pull/7552
I cannot find any distribution still supporting Apache 2.2
