### PR TITLE
Add ClawCloud Run button

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ If you want a rolling release with the newest features, or want to help testing 
 * [![PikaPods](https://www.pikapods.com/static/run-button-34.svg)](https://www.pikapods.com/pods?run=freshrss)
 * [![Deploy on Elestio](https://elest.io/images/logos/deploy-to-elestio-btn.png)](https://elest.io/open-source/freshrss)
 * [![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/MD4TRW)
+* [![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?openapp=system-fastdeploy%3FtemplateName%3Dfreshrss)
 
 ## Manual install
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Add ClawCloud Run button to Readme

How to test the feature manually:

1. Click the button to deploy FreshRSS on ClawCloud Run.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] documentation updated
