### PR TITLE
Fix SQL request for user labels with custom sort

### DIFF
--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -1318,7 +1318,9 @@ SQL;
 
 		return [array_merge($values, $searchValues), 'SELECT '
 			. ($type === 'T' ? 'DISTINCT ' : '')
-			. 'e.id FROM `_entry` e '
+			. 'e.id'
+			. ($type === 'T' && $orderBy !== 'e.id' ? ', ' . $orderBy : '') // SELECT DISTINCT, ORDER BY expressions must appear in SELECT
+			. ' FROM `_entry` e '
 			. 'INNER JOIN `_feed` f ON e.id_feed = f.id '
 			. ($type === 't' || $type === 'T' ? 'INNER JOIN `_entrytag` et ON et.id_entry = e.id ' : '')
 			. 'WHERE ' . $where


### PR DESCRIPTION
The list or articles with a user label with a custom sort was broken when using PostgreSQL

Example: `https://freshrss.example.net/i/?a=normal&get=T&sort=title&order=ASC`

```
SQL error FreshRSS_EntryDAO::listWhereRaw["42P10",7,"ERROR: for SELECT DISTINCT, ORDER BY expressions must appear in select list\nLINE 3: ...d_entry = e.id WHERE 1=1 AND e.id <= $1 ORDER BY e.title DE...\n ^"]
```
