### PR TITLE
add more per-feed ttl options in the web-ui

### DIFF
--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -129,7 +129,7 @@
 				<div class="group-controls">
 					<select class="w50" name="ttl" id="ttl" required="required"><?php
 						$found = false;
-						foreach ([FreshRSS_Feed::TTL_DEFAULT => _t('gen.short.by_default'), 900 => '15min', 1200 => '20min', 1500 => '25min', 1800 => '30min', 2700 => '45min',
+						foreach ([FreshRSS_Feed::TTL_DEFAULT => _t('gen.short.by_default'), 60 => '1min', 180 => '3min', 300 => '5min', 600 => '10min', 900 => '15min', 1200 => '20min', 1500 => '25min', 1800 => '30min', 2700 => '45min',
 								3600 => '1h', 5400 => '1.5h', 7200 => '2h', 10800 => '3h', 14400 => '4h', 18800 => '5h', 21600 => '6h', 25200 => '7h', 28800 => '8h',
 								36000 => '10h', 43200 => '12h', 64800 => '18h',
 								86400 => '1d', 129600 => '1.5d', 172800 => '2d', 259200 => '3d', 345600 => '4d', 432000 => '5d', 518400 => '6d',


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

- add more per-feed ttl options in the web-ui: 1min, 3min, 5min, 10min. This change serves for some feeds that require frequent refresh.

How to test the feature manually:

1. the change is extremely simple.
1. check the per-feed setting in the web-ui, the new ttl options shows.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated. I checked the online docs to find it doesn't require documentation update.

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
