### PR TITLE
Strip more styles attributes

### DIFF
--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -344,10 +344,12 @@ function customSimplePie(array $attributes = [], array $curl_options = []): \Sim
 	]);
 	$simplePie->rename_attributes(['id', 'class']);
 	$simplePie->strip_attributes(array_merge($simplePie->strip_attributes, [
-		'autoplay', 'class', 'form', 'formaction',
-		'onload', 'onunload', 'onclick', 'ondblclick', 'onmousedown', 'onmouseup',
-		'onmouseover', 'onmousemove', 'onmouseout', 'onfocus', 'onblur',
-		'onkeypress', 'onkeydown', 'onkeyup', 'onselect', 'onchange', 'seamless', 'sizes', 'srcdoc', 'srcset']));
+		'alink', 'autoplay', 'background', 'bgcolor', 'class', 'form', 'formaction',
+		'link', 'onblur', 'onchange', 'onclick', 'ondblclick', 'onfocus',
+		'onkeydown', 'onkeypress', 'onkeyup', 'onload', 'onmousedown', 'onmousemove',
+		'onmouseout', 'onmouseover', 'onmouseup', 'onselect', 'onunload',
+		'seamless', 'sizes', 'srcdoc', 'srcset', 'text', 'vlink',
+	]));
 	$simplePie->add_attributes([
 		'audio' => ['controls' => 'controls', 'preload' => 'none'],
 		'iframe' => [


### PR DESCRIPTION
Strip `bgcolor`, `text`, `background`, `link`, `alink`, `vlink` (all are deprecated HTML style attributes)
fix https://github.com/FreshRSS/FreshRSS/issues/7604
