### PR TITLE
Include remaining tags/attributes for lazy loading

### DIFF
--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -368,11 +368,11 @@ function customSimplePie(array $attributes = [], array $curl_options = []): \Sim
 		'iframe' => 'src',
 		'img' => [
 			'longdesc',
-			'src'
+			'src',
 		],
 		'image' => [
 			'longdesc',
-			'src'
+			'src',
 		],
 		'input' => 'src',
 		'ins' => 'cite',

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -370,6 +370,10 @@ function customSimplePie(array $attributes = [], array $curl_options = []): \Sim
 			'longdesc',
 			'src'
 		],
+		'image' => [
+			'longdesc',
+			'src'
+		],
 		'input' => 'src',
 		'ins' => 'cite',
 		'q' => 'cite',
@@ -632,16 +636,20 @@ function validateEmailAddress(string $email): bool {
 
 /**
  * Add support of image lazy loading
- * Move content from src attribute to data-original
+ * Move content from src/poster attribute to data-original
  * @param string $content is the text we want to parse
  */
 function lazyimg(string $content): string {
 	return preg_replace([
-			'/<((?:img|iframe)[^>]+?)src="([^"]+)"([^>]*)>/i',
-			"/<((?:img|iframe)[^>]+?)src='([^']+)'([^>]*)>/i",
+			'/<((?:img|image|iframe)[^>]+?)src="([^"]+)"([^>]*)>/i',
+			"/<((?:img|image|iframe)[^>]+?)src='([^']+)'([^>]*)>/i",
+			'/<((?:video)[^>]+?)poster="([^"]+)"([^>]*)>/i',
+			"/<((?:video)[^>]+?)poster='([^']+)'([^>]*)>/i",
 		], [
 			'<$1src="' . Minz_Url::display('/themes/icons/grey.gif') . '" data-original="$2"$3>',
 			"<$1src='" . Minz_Url::display('/themes/icons/grey.gif') . "' data-original='$2'$3>",
+			'<$1poster="' . Minz_Url::display('/themes/icons/grey.gif') . '" data-original="$2"$3>',
+			"<$1poster='" . Minz_Url::display('/themes/icons/grey.gif') . "' data-original='$2'$3>",
 		],
 		$content
 	) ?? '';

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -431,8 +431,12 @@ const freshrssOpenArticleEvent = document.createEvent('Event');
 freshrssOpenArticleEvent.initEvent('freshrss:openArticle', true, true);
 
 function loadLazyImages(rootElement) {
-	rootElement.querySelectorAll('img[data-original], iframe[data-original]').forEach(function (el) {
-		el.src = el.getAttribute('data-original');
+	rootElement.querySelectorAll('img[data-original], iframe[data-original], video[data-original]').forEach(function (el) {
+		if (el.tagName === 'VIDEO') {
+			el.poster = el.getAttribute('data-original');
+		} else {
+			el.src = el.getAttribute('data-original');
+		}
 		el.removeAttribute('data-original');
 	});
 }


### PR DESCRIPTION
- Now including:
	- `<video poster>` attribute, used as a preview image for the video
	- `<image>` tag, browsers map it to `<img>` automatically for [some reason](https://stackoverflow.com/questions/11928566/img-vs-image-tag-in-html)