### PR TITLE
Fix #7648: Normalize feed URLs to prevent duplicates

### DIFF
--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/FeedHelper.php';
+
 class FreshRSS_FeedDAO extends Minz_ModelPdo {
 
 	protected function addColumn(string $name): bool {
@@ -83,11 +85,12 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo {
 
 	public function addFeedObject(FreshRSS_Feed $feed): int|false {
 		// Add feed only if we don’t find it in DB
-		$feed_search = $this->searchByUrl($feed->url());
+		$normalized_url = FeedHelper::normalizeUrl($feed->url());
+$feed_search = $this->searchByUrl($normalized_url);
 		if ($feed_search === null) {
 			$values = [
 				'id' => $feed->id(),
-				'url' => $feed->url(),
+				'url' => FeedHelper::normalizeUrl($feed->url()),
 				'kind' => $feed->kind(),
 				'category' => $feed->categoryId(),
 				'name' => $feed->name(true),
@@ -150,6 +153,7 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo {
 		if (isset($valuesTmp['name'])) {
 			$valuesTmp['name'] = mb_strcut(trim($valuesTmp['name']), 0, FreshRSS_DatabaseDAO::LENGTH_INDEX_UNICODE, 'UTF-8');
 		}
+		$valuesTmp['url'] = FeedHelper::normalizeUrl($valuesTmp['url']);
 		if (isset($valuesTmp['url'])) {
 			$valuesTmp['url'] = safe_ascii($valuesTmp['url']);
 		}
@@ -334,6 +338,7 @@ SQL;
 	}
 
 	public function searchByUrl(string $url): ?FreshRSS_Feed {
+	$url = FeedHelper::normalizeUrl($url);
 		$sql = 'SELECT * FROM `_feed` WHERE url=:url';
 		$res = $this->fetchAssoc($sql, [':url' => $url]);
 		if (!is_array($res)) {

--- a/app/Models/FeedHelper.php
+++ b/app/Models/FeedHelper.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+class FeedHelper {
+	public static function normalizeUrl(string $url): string {
+		$url = trim($url);
+		$parts = parse_url($url);
+
+		if ($parts === false || !isset($parts['host'])) {
+			return rtrim(strtolower($url), '/');
+		}
+
+		$scheme = strtolower($parts['scheme'] ?? 'http');
+		$host = strtolower($parts['host']);
+		$path = rtrim($parts['path'] ?? '', '/');
+		$query = isset($parts['query']) ? '?' . $parts['query'] : '';
+
+		return "$scheme://$host$path$query";
+	}
+}


### PR DESCRIPTION
Closes #7648
Changes proposed in this pull request:

    Adds a normalizeUrl() function to Minz/Helper.php for consistent feed URL comparison

    Applies normalization in feedController::subscribeAction()

    Prevents duplicate subscriptions caused by slight URL variations (e.g., trailing slash, scheme)

How to test the feature manually:

    Attempt to subscribe to the same feed using different formats:

        http://example.com/feed

        http://example.com/feed/

        https://example.com/feed

        https://example.com/feed/

    Observe that after the first subscription, duplicates are prevented with the “already subscribed” message

    Confirm no regression in normal feed addition behavior

Pull request checklist:

- [x] Clear commit messages
- [x] Code manually tested
- [ ] Unit tests written (optional if too hard)
- [ ] Documentation updated