### PR TITLE
frame-ancestors CSP

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -1150,6 +1150,7 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 
 		$this->_csp([
 			'default-src' => "'self'",
+			'frame-ancestors' => "'self'",
 			'frame-src' => '*',
 			'img-src' => '* data:',
 			'media-src' => '*',

--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -50,6 +50,7 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 			'default-src' => "'self'",
 			'frame-src' => '*',
 			'img-src' => '* data:',
+			'frame-ancestors' => "'none'",
 			'media-src' => '*',
 		]);
 
@@ -138,6 +139,7 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 			'default-src' => "'self'",
 			'frame-src' => '*',
 			'img-src' => '* data:',
+			'frame-ancestors' => "'none'",
 			'media-src' => '*',
 		]);
 	}

--- a/app/Controllers/statsController.php
+++ b/app/Controllers/statsController.php
@@ -29,6 +29,7 @@ class FreshRSS_stats_Controller extends FreshRSS_ActionController {
 
 		$this->_csp([
 			'default-src' => "'self'",
+			'frame-ancestors' => "'none'",
 			'img-src' => '* data:',
 			'style-src' => "'self' 'unsafe-inline'",
 		]);

--- a/app/install.php
+++ b/app/install.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 if (function_exists('opcache_reset')) {
 	opcache_reset();
 }
-header("Content-Security-Policy: default-src 'self'");
+header("Content-Security-Policy: default-src 'self'; frame-ancestors 'none'");
 header('Referrer-Policy: same-origin');
 
 require(LIB_PATH . '/lib_install.php');

--- a/lib/Minz/ActionController.php
+++ b/lib/Minz/ActionController.php
@@ -14,6 +14,7 @@ abstract class Minz_ActionController {
 	/** @var array<string,string> */
 	private static array $csp_default = [
 		'default-src' => "'self'",
+		'frame-ancestors' => "'none'",
 	];
 
 	/** @var array<string,string> */
@@ -66,7 +67,7 @@ abstract class Minz_ActionController {
 	 * @param array<string,string> $policies An array where keys are directives and values are sources.
 	 */
 	public static function _defaultCsp(array $policies): void {
-		if (!isset($policies['default-src'])) {
+		if (!isset($policies['default-src']) || !isset($policies['frame-ancestors'])) {
 			Minz_Log::warning('Default CSP policy is not declared', ADMIN_LOG);
 		}
 		self::$csp_default = $policies;

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -1010,7 +1010,7 @@ function errorMessageInfo(string $errorTitle, string $error = ''): string {
 		$details = "<pre>{$details}</pre>";
 	}
 
-	header("Content-Security-Policy: default-src 'self'");
+	header("Content-Security-Policy: default-src 'self'; frame-ancestors 'none'");
 	header('Referrer-Policy: same-origin');
 
 	return <<<MSG

--- a/p/f.php
+++ b/p/f.php
@@ -48,7 +48,7 @@ if ($ico_mtime == false || $ico_mtime < $txt_mtime || ($ico_mtime < time() - (mt
 	}
 }
 
-header("Content-Security-Policy: default-src 'none'; img-src 'self'; style-src 'self';");
+header("Content-Security-Policy: default-src 'none'; frame-ancestors 'none'; img-src 'self'; style-src 'self';");
 if (!httpConditional($ico_mtime, mt_rand(14, 21) * 86400, 2)) {
 	$ico_content_type = contentType($ico);
 	header('Content-Type: ' . $ico_content_type);

--- a/p/themes/.htaccess
+++ b/p/themes/.htaccess
@@ -26,6 +26,6 @@
 
 <IfModule mod_headers.c>
 	<FilesMatch "\.svg$">
-		Header	set Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'"
+		Header	set Content-Security-Policy "default-src 'self'; frame-ancestors 'none'; style-src 'self' 'unsafe-inline'"
 	</FilesMatch>
 </IfModule>


### PR DESCRIPTION
Related: #6302 #3649

We only need `frame-ancestors 'self'` in the content preview action, everywhere else we can put `frame-ancestors 'none'` and later override if needed.