### PR TITLE
Potential fix for 404 error when refreshing feeds from an extension providing a view

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -916,7 +916,7 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 			Minz_Request::setGoodNotification(_t('feedback.sub.feed.actualizeds'));
 			// No layout in ajax request.
 			$this->view->_layout(null);
-		} elseif ($feed instanceof FreshRSS_Feed) {
+		} elseif ($feed instanceof FreshRSS_Feed && $id > 0) {
 			// Redirect to the main page with correct notification.
 			Minz_Request::good(_t('feedback.sub.feed.actualized', $feed->name()), [
 				'params' => ['get' => 'f_' . $id]


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix for 404 error when trying to refresh the feeds from a view extension. Without this change, this happens:

1. Starting on the extension view: https://domain.com/i/?c=freshvibes&tab=test&rid=6858299a5c2f0
2. Clicking refresh redirects to https://domain.com/i/?c=feed&a=actualize with status 302
3. Then to https://domain.com/i/?get=f_0&rid=685872529cbe9 with status 302
4. Finally, to https://domain.com/i/?c=error&rid=685872529cbe9 with 404.

How to test the feature manually:

1. Install the Freshvibes extension (https://github.com/tryallthethings/freshvibes)
5. Activate it and switch to the new view provided by the extension
6. Press refresh feeds. With this change, it works as expected and doesn't throw a 404 error.

Pull request checklist:

- [X] clear commit messages
- [X] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated