### PR TITLE
Fix feeds encoded in UTF-16LE

### DIFF
--- a/lib/composer.json
+++ b/lib/composer.json
@@ -14,7 +14,7 @@
         "marienfressinaud/lib_opml": "0.5.1",
         "phpgt/cssxpath": "v1.3.0",
         "phpmailer/phpmailer": "6.10.0",
-        "simplepie/simplepie": "dev-freshrss#370de7c2a6402a00aff7af53c9bf9cfe5faae006"
+        "simplepie/simplepie": "dev-freshrss#2f0417355a702c678c237eac5ffc273863301a80"
     },
     "config": {
         "sort-packages": true,

--- a/lib/composer.json
+++ b/lib/composer.json
@@ -14,7 +14,7 @@
         "marienfressinaud/lib_opml": "0.5.1",
         "phpgt/cssxpath": "v1.3.0",
         "phpmailer/phpmailer": "6.10.0",
-        "simplepie/simplepie": "dev-freshrss#f644950102ef4d4ab6e811db6ee9416d7151484a"
+        "simplepie/simplepie": "dev-freshrss#370de7c2a6402a00aff7af53c9bf9cfe5faae006"
     },
     "config": {
         "sort-packages": true,

--- a/lib/simplepie/simplepie/src/File.php
+++ b/lib/simplepie/simplepie/src/File.php
@@ -162,7 +162,7 @@ class File implements Response
                     $parser = new \SimplePie\HTTP\Parser($responseHeaders, true);
                     if ($parser->parse()) {
                         $this->set_headers($parser->headers);
-                        $this->body = trim($parser->body);
+                        $this->body = trim($parser->body, " \n\r\t\v"); // Do not trim \x00 to avoid breaking BOM or multibyte characters
                         $this->status_code = $parser->status_code;
                         if ((in_array($this->status_code, [300, 301, 302, 303, 307]) || $this->status_code > 307 && $this->status_code < 400) && ($locationHeader = $this->get_header_line('location')) !== '' && $this->redirects < $redirects) {
                             $this->redirects++;


### PR DESCRIPTION
Fix https://github.com/FreshRSS/FreshRSS/issues/7690
https://github.com/FreshRSS/simplepie/pull/40
The final character `>` of a feed is encoded as `3E 00` in UTF-16LE, so calling `trim()` was removing the `\x00`, breaking the multibyte encoding and making the feed invalid.

Upstream PR https://github.com/simplepie/simplepie/pull/916
