### PR TITLE
Docblock update for getFileUrl

### DIFF
--- a/lib/Minz/Extension.php
+++ b/lib/Minz/Extension.php
@@ -207,7 +207,7 @@ abstract class Minz_Extension {
 	 *
 	 * @param string $filename The name of the file.
 	 * @param string $type Optional. The type of file (e.g., 'css', 'js'), used as a URL parameter. Defaults to an empty string.
-	 * @param bool $add_version Optional. Add a version parameter to prevent caching. `true` by default.
+	 * @param bool   $isStatic indicates if the file is a static file or a user file. Default is static.
 	 * @return string The URL of the extension file.
 	 */
 	final public function getFileUrl(string $filename, string $type = '', bool $isStatic = true): string {

--- a/lib/Minz/Extension.php
+++ b/lib/Minz/Extension.php
@@ -203,12 +203,12 @@ abstract class Minz_Extension {
 	}
 
 	/**
-	 * Return the url for a given file.
+	 * Return the URL of a file in the current extension.
 	 *
-	 * @param string $filename name of the file to serve.
-	 * @param '' $type MIME type of the file to serve. Deprecated: always use the file extension.
-	 * @param bool $isStatic indicates if the file is a static file or a user file. Default is static.
-	 * @return string url corresponding to the file.
+	 * @param string $filename The name of the file.
+	 * @param string $type Optional. The type of file (e.g., 'css', 'js'), used as a URL parameter. Defaults to an empty string.
+	 * @param bool $add_version Optional. Add a version parameter to prevent caching. `true` by default.
+	 * @return string The URL of the extension file.
 	 */
 	final public function getFileUrl(string $filename, string $type = '', bool $isStatic = true): string {
 		if ($isStatic) {


### PR DESCRIPTION
# Changes proposed in this pull request:

PHPStan was complaining about my code, although it should be correct due to my understanding:

```php
Minz_View::appendStyle($this->getFileUrl('style.css', 'css')); 
Minz_View::appendScript($this->getFileUrl('script.js', 'js'), false, true, false);
```

```phpstan
 ------ ----------------------------------------------------------------------- 
  Line   extension.php                                                          
 ------ ----------------------------------------------------------------------- 
  80     Parameter #2 $type of method Minz_Extension::getFileUrl() expects '',  
         'css' given.                                                           
         🪪 argument.type                                                       
  81     Parameter #2 $type of method Minz_Extension::getFileUrl() expects '',  
         'js' given.                                                            
         🪪 argument.type                                                       
  82     Parameter #2 $type of method Minz_Extension::getFileUrl() expects '',  
         'js' given.                                                            
         🪪 argument.type                                                       
 ------ ----------------------------------------------------------------------- 
```

# How to test the feature manually:

1. Run PHPStan on PHP code containing the above calls

# Pull request checklist:

- [X] clear commit messages
- [ ] code manually tested
 -> No idea how to do that. PHPStan is new to me
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated