### PR TITLE
Fix multiple auth headers bug

### DIFF
--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -857,7 +857,7 @@ function checkTrustedIP(): bool {
 
 function httpAuthUser(bool $onlyTrusted = true): string {
 	$check_array = array_intersect_key($_SERVER, array_flip(['REMOTE_USER', 'REDIRECT_REMOTE_USER', 'HTTP_REMOTE_USER', 'HTTP_X_WEBAUTH_USER']));
-	$auths = array_filter(array_unique($check_array));
+	$auths = array_unique($check_array);
 	if (count($auths) > 1) {
 		Minz_Log::warning('Multiple HTTP authentication headers!');
 		return '';

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -856,7 +856,8 @@ function checkTrustedIP(): bool {
 }
 
 function httpAuthUser(bool $onlyTrusted = true): string {
-	$auths = array_intersect_key(array_unique($_SERVER), ['REMOTE_USER' => '', 'REDIRECT_REMOTE_USER' => '', 'HTTP_REMOTE_USER' => '', 'HTTP_X_WEBAUTH_USER' => '']);
+	$check_array = array_intersect_key($_SERVER, array_flip(['REMOTE_USER', 'REDIRECT_REMOTE_USER', 'HTTP_REMOTE_USER', 'HTTP_X_WEBAUTH_USER']));
+	$auths = array_filter(array_unique($check_array));
 	if (count($auths) > 1) {
 		Minz_Log::warning('Multiple HTTP authentication headers!');
 		return '';

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -856,7 +856,7 @@ function checkTrustedIP(): bool {
 }
 
 function httpAuthUser(bool $onlyTrusted = true): string {
-	$auths = array_intersect_key($_SERVER, ['REMOTE_USER' => '', 'REDIRECT_REMOTE_USER' => '', 'HTTP_REMOTE_USER' => '', 'HTTP_X_WEBAUTH_USER' => '']);
+	$auths = array_intersect_key(array_unique($_SERVER), ['REMOTE_USER' => '', 'REDIRECT_REMOTE_USER' => '', 'HTTP_REMOTE_USER' => '', 'HTTP_X_WEBAUTH_USER' => '']);
 	if (count($auths) > 1) {
 		Minz_Log::warning('Multiple HTTP authentication headers!');
 		return '';

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -856,8 +856,7 @@ function checkTrustedIP(): bool {
 }
 
 function httpAuthUser(bool $onlyTrusted = true): string {
-	$check_array = array_intersect_key($_SERVER, array_flip(['REMOTE_USER', 'REDIRECT_REMOTE_USER', 'HTTP_REMOTE_USER', 'HTTP_X_WEBAUTH_USER']));
-	$auths = array_unique($check_array);
+	$auths = array_unique(array_intersect_key($_SERVER, ['REMOTE_USER' => '', 'REDIRECT_REMOTE_USER' => '', 'HTTP_REMOTE_USER' => '', 'HTTP_X_WEBAUTH_USER' => '']));
 	if (count($auths) > 1) {
 		Minz_Log::warning('Multiple HTTP authentication headers!');
 		return '';


### PR DESCRIPTION
Closes #7699

for example when we have `HTTP_REMOTE_USER` and `REMOTE_USER` set to the same value, we don't want to treat them as separate headers