### PR TITLE
Fix cancellation of slider exit

### DIFF
--- a/p/scripts/extra.js
+++ b/p/scripts/extra.js
@@ -348,10 +348,9 @@ function close_slider_listener(ev) {
 	if (data_leave_validation(slider) || confirm(context.i18n.confirmation_default)) {
 		slider.querySelectorAll('form').forEach(function (f) { f.reset(); });
 		document.documentElement.classList.remove('slider-active');
-		return true;
-	} else {
-		return false;
+		return;
 	}
+	ev.preventDefault();
 }
 // </slider>
 


### PR DESCRIPTION
Previously when you clicked the "Cancel" button inside of the confirm dialog, the slider would close anyway.

How to test the feature manually:

1. Go into `Extensions`
2. Open the manage slider of an extension that uses `data-leave-validation` correctly, change one setting and try closing the slider
3. You will see the confirm dialog, then press `Cancel` and the slider doesn't close anymore as intended