### PR TITLE
fix: interpolate FRESHRSS_INSTALL and FRESHRSS_USER variables

### DIFF
--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -52,7 +52,7 @@ php -f ./cli/prepare.php >/dev/null
 if [ -n "$FRESHRSS_INSTALL" ]; then
 	# shellcheck disable=SC2046
 	php -f ./cli/do-install.php -- \
-		$(echo "$FRESHRSS_INSTALL" | sed -r 's/[\r\n]+/\n/g' | paste -s -)
+		$(eval "echo \"$FRESHRSS_INSTALL\"" | sed -r 's/[\r\n]+/\n/g' | paste -s -)
 	EXITCODE=$?
 
 	if [ $EXITCODE -eq 3 ]; then
@@ -68,7 +68,7 @@ fi
 if [ -n "$FRESHRSS_USER" ]; then
 	# shellcheck disable=SC2046
 	php -f ./cli/create-user.php -- \
-		$(echo "$FRESHRSS_USER" | sed -r 's/[\r\n]+/\n/g' | paste -s -)
+		$(eval "echo \"$FRESHRSS_USER\"" | sed -r 's/[\r\n]+/\n/g' | paste -s -)
 	EXITCODE=$?
 
 	if [ $EXITCODE -eq 3 ]; then


### PR DESCRIPTION
Closes #7300 

Changes proposed in this pull request:

- Interpolate `FRESHRSS_INSTALL` and `FRESHRSS_USER` at runtime to allow secrets being passed as environment variables

How to test the feature manually:

1. Clone Repo
2. Take simple `compose.yml`:
```yaml
services:
  freshrss:
    build:
      context: ./FreshRSS
      dockerfile: Docker/Dockerfile-Alpine
    container_name: freshrss
    restart: no
    volumes:
      - ./data:/var/www/FreshRSS/data
    ports:
      - "8080:80"
    environment:
      ADMIN_PASSWORD: "password"
      ADMIN_EMAIL: "admin@admin.com"
      ADMIN_API_PASSWORD: "apipassword"
      FRESHRSS_INSTALL: |-
        --api-enabled
        --default-user admin
        --language en
      FRESHRSS_USER: |-
        --api-password $${ADMIN_API_PASSWORD}
        --email $${ADMIN_EMAIL}
        --language en
        --password $${ADMIN_PASSWORD}
        --user admin

```
3. `docker compose up --build`
4. Visit `localhost:8080`
5. Login with credentials passed as environment variables

Alternatively, put the secrets in another file (e.g. `secrets.env`) and pass it as `env_file`.

---

To test the existing behavior.
1. Create `.env` file file:
```env
ADMIN_PASSWORD="password2"
ADMIN_EMAIL="admin2@admin.com"
ADMIN_API_PASSWORD="apipassword2"
```
2. Modify the environment:
```yml 
environment:
      FRESHRSS_INSTALL: |-
        --api-enabled
        --default-user admin
        --language en
      FRESHRSS_USER: |-
        --api-password ${ADMIN_API_PASSWORD}
        --email ${ADMIN_EMAIL}
        --language en
        --password ${ADMIN_PASSWORD}
        --user admin
```
3. Variables will be interpolated directly by docker compose. So existing way continues to work / is backwards compatible.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
