### PR TITLE
Call DOMNode::insertBefore() on the parent of it's $child

### DIFF
--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -535,7 +535,7 @@ function enforceHtmlBase(string $html, string $href): string {
 		if ($head instanceof DOMElement) {
 			$head->insertBefore($base, $head->firstChild);
 		} else {
-			$doc->insertBefore($base, $doc->documentElement->firstChild);
+			$doc->documentElement->insertBefore($base, $doc->documentElement->firstChild);
 		}
 	}
 	return $doc->saveHTML() ?: $html;


### PR DESCRIPTION
Follow-up to #7654

Changes proposed in this pull request:

- `DOMNode::insertBefore()` needs to be called on an element that is the parent of the `$child` param being passed
- Update code to call this on `$doc->documentElement` instead of directly on the `$doc` (`DOMDocument`)

How to test the feature manually:

1. Set up an HTML + XPath feed for a URL that contains partial HTML content (eg. https://victoria.citified.ca/modules/blog/news.php?n=7&c=8)
1. Observe that the feed is processed successfully without error, and that the `<base>` is still inserted

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
