### PR TITLE
Fix no registration limit setting

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -503,7 +503,7 @@ class FreshRSS_configure_Controller extends FreshRSS_ActionController {
 
 		if (Minz_Request::isPost()) {
 			$limits = FreshRSS_Context::systemConf()->limits;
-			$limits['max_registrations'] = Minz_Request::paramInt('max-registrations') ?: 1;
+			$limits['max_registrations'] = Minz_Request::paramIntNull('max-registrations') ?? 1;
 			$limits['max_feeds'] = Minz_Request::paramInt('max-feeds') ?: 16384;
 			$limits['max_categories'] = Minz_Request::paramInt('max-categories') ?: 16384;
 			$limits['cookie_duration'] = Minz_Request::paramInt('cookie-duration') ?: FreshRSS_Auth::DEFAULT_COOKIE_DURATION;


### PR DESCRIPTION
Regression introduced in #5267

When trying to set the value to 0, the setting reverted back to 1 (registration disabled instead of no registration limit):

https://github.com/FreshRSS/FreshRSS/blob/e6540335caa0b6d39c213a9a11ca77ad1eebe504/app/views/configure/system.phtml#L77-L81

I probably ran into this bug too when I first started using FreshRSS a few months ago but forgot about it