### PR TITLE
Regenerate cookie ID after logging out

### DIFF
--- a/app/Controllers/authController.php
+++ b/app/Controllers/authController.php
@@ -226,6 +226,12 @@ class FreshRSS_auth_Controller extends FreshRSS_ActionController {
 		if (Minz_Request::isPost()) {
 			invalidateHttpCache();
 			FreshRSS_Auth::removeAccess();
+
+			ini_set('session.use_cookies', '1');
+			Minz_Session::lock();
+			Minz_Session::regenerateID();
+			Minz_Session::unlock();
+
 			Minz_Request::good(_t('feedback.auth.logout.success'), [ 'c' => 'index', 'a' => 'index' ]);
 		} else {
 			Minz_Error::error(403);


### PR DESCRIPTION
To make the session cookie no longer usable if hijacked and put in another browser after user logs out