### PR TITLE
Docker: Debian 13 RC with PHP 8.4

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12-slim
+FROM debian:trixie-slim
 
 ENV TZ=UTC
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
Debian 13 Trixie is now in full freeze. Help final testing before the release (9 August).
PHP 8.4.10, Apache 2.4.64
I will make another PR after the release to update to `debian:13-slim` when it gets available.
* https://wiki.debian.org/DebianTrixie
* https://www.debian.org/releases/testing/release-notes/whats-new.en.html
* https://downloads.apache.org/httpd/CHANGES_2.4
