### PR TITLE
Redirect to the login page from bookmarklet instead of 403

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -21,6 +21,13 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 			$token_is_ok = ($token != '' && $token == $token_param);
 			$action = Minz_Request::actionName();
 			$allow_anonymous_refresh = FreshRSS_Context::systemConf()->allow_anonymous_refresh;
+
+			// Likely coming from bookmarklet, redirect to the login page
+			if ($action === 'add') {
+				Minz_Request::forward(['c' => 'auth', 'a' => 'login']);
+				return;
+			}
+
 			if ($action !== 'actualize' ||
 					!($allow_anonymous_refresh || $token_is_ok)) {
 				Minz_Error::error(403);


### PR DESCRIPTION
Makes it easier than having to sign in then go back to the website I clicked the bookmarklet on.