### PR TITLE
GReader API: fix incorrect favicon URL

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -438,7 +438,7 @@ class FreshRSS_Feed extends Minz_Model {
 		@unlink($path . '.ico');
 		@unlink($path . '.txt');
 	}
-	public function favicon(): string {
+	public function favicon(bool $absolute = false): string {
 		$hash = $this->hashFavicon();
 		$url = '/f.php?h=' . $hash;
 		if ($this->customFavicon()
@@ -446,7 +446,7 @@ class FreshRSS_Feed extends Minz_Model {
 			&& !$this->attributeBoolean('customFaviconDisallowDel')) {
 			$url .= '&t=' . @filemtime(DATA_PATH . '/favicons/' . $hash . '.ico');
 		}
-		return Minz_Url::display($url);
+		return Minz_Url::display($url, absolute: $absolute);
 	}
 
 	public function _id(int $value): void {

--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -332,7 +332,7 @@ final class GReaderAPI {
 			self::internalServerError();
 		}
 		header('Content-Type: application/json; charset=UTF-8');
-		$faviconsUrl = Minz_Url::display('/f.php?', '', true);
+		$faviconsUrl = Minz_Url::display('/f.php?h=', '', true);
 		$faviconsUrl = str_replace('/api/greader.php/reader/api/0/subscription', '', $faviconsUrl);	//Security if base_url is not set properly
 		$subscriptions = [];
 

--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -332,8 +332,6 @@ final class GReaderAPI {
 			self::internalServerError();
 		}
 		header('Content-Type: application/json; charset=UTF-8');
-		$faviconsUrl = Minz_Url::display('/f.php?h=', '', true);
-		$faviconsUrl = str_replace('/api/greader.php/reader/api/0/subscription', '', $faviconsUrl);	//Security if base_url is not set properly
 		$subscriptions = [];
 
 		$categoryDAO = FreshRSS_Factory::createCategoryDao();
@@ -352,7 +350,9 @@ final class GReaderAPI {
 					//'firstitemmsec' => 0,
 					'url' => htmlspecialchars_decode($feed->url(), ENT_QUOTES),
 					'htmlUrl' => htmlspecialchars_decode($feed->website(), ENT_QUOTES),
-					'iconUrl' => $faviconsUrl . $feed->hashFavicon(),
+					'iconUrl' => str_replace(
+						'/api/greader.php/reader/api/0/subscription', '',	// Security if base_url is not set properly
+						$feed->favicon(absolute: true)),
 				];
 			}
 		}


### PR DESCRIPTION
Since 7915abd833e1ab7a72ad27b3ec52020ac9ab7051, `f.php?<iconHash>` is no longer correct and should be replaced with `f.php?q=<iconHash>`. This was done in the commit everywhere except in the GReader API as far as I can tell. This pull request fixes this inconsistency.

How to test this fix (thanks to CarelessCaution in #7570 for this useful test case for a different bug):

Obtain GReader API credentials:

    curl -X POST -d "Email=apiuser&Passwd=apipasswd" 'HOST/api/greader.php/accounts/ClientLogin'

Check feed icon URLs:

    curl -s -H "Authorization:GoogleLogin auth=AUTH_TOKEN" 'HOST/api/greader.php/reader/api/0/subscription/list?output=json'

Let me know if anything is wrong, this is a first time contribution. Thanks for the software :)