### PR TITLE
Optimize how much data needs to be `chown`/`chmod`ed on container startup

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
 RUN mkdir -p /var/www/FreshRSS/ /run/apache2/
 WORKDIR /var/www/FreshRSS
 
-COPY --chown=:www-data . /var/www/FreshRSS
+COPY --chown=root:www-data . /var/www/FreshRSS
 COPY ./Docker/*.Apache.conf /etc/apache2/sites-available/
 
 ARG FRESHRSS_VERSION

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
 RUN mkdir -p /var/www/FreshRSS/ /run/apache2/
 WORKDIR /var/www/FreshRSS
 
-COPY . /var/www/FreshRSS
+COPY --chown=:www-data . /var/www/FreshRSS
 COPY ./Docker/*.Apache.conf /etc/apache2/sites-available/
 
 ARG FRESHRSS_VERSION

--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -13,7 +13,7 @@ RUN apk add --no-cache \
 RUN mkdir -p /var/www/FreshRSS /run/apache2/
 WORKDIR /var/www/FreshRSS
 
-COPY --chown=:www-data . /var/www/FreshRSS
+COPY --chown=root:www-data . /var/www/FreshRSS
 COPY ./Docker/*.Apache.conf /etc/apache2/conf.d/
 
 ARG FRESHRSS_VERSION

--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -13,7 +13,7 @@ RUN apk add --no-cache \
 RUN mkdir -p /var/www/FreshRSS /run/apache2/
 WORKDIR /var/www/FreshRSS
 
-COPY . /var/www/FreshRSS
+COPY --chown=:www-data . /var/www/FreshRSS
 COPY ./Docker/*.Apache.conf /etc/apache2/conf.d/
 
 ARG FRESHRSS_VERSION

--- a/Docker/Dockerfile-Newest
+++ b/Docker/Dockerfile-Newest
@@ -14,7 +14,7 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/reposit
 RUN mkdir -p /var/www/FreshRSS /run/apache2/
 WORKDIR /var/www/FreshRSS
 
-COPY . /var/www/FreshRSS
+COPY --chown=:www-data . /var/www/FreshRSS
 COPY ./Docker/*.Apache.conf /etc/apache2/conf.d/
 
 ARG FRESHRSS_VERSION

--- a/Docker/Dockerfile-Newest
+++ b/Docker/Dockerfile-Newest
@@ -14,7 +14,7 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/reposit
 RUN mkdir -p /var/www/FreshRSS /run/apache2/
 WORKDIR /var/www/FreshRSS
 
-COPY --chown=:www-data . /var/www/FreshRSS
+COPY --chown=root:www-data . /var/www/FreshRSS
 COPY ./Docker/*.Apache.conf /etc/apache2/conf.d/
 
 ARG FRESHRSS_VERSION

--- a/Docker/Dockerfile-Oldest
+++ b/Docker/Dockerfile-Oldest
@@ -13,7 +13,7 @@ RUN apk add --no-cache \
 RUN mkdir -p /var/www/FreshRSS /run/apache2/
 WORKDIR /var/www/FreshRSS
 
-COPY --chown=:www-data . /var/www/FreshRSS
+COPY --chown=root:www-data . /var/www/FreshRSS
 COPY ./Docker/*.Apache.conf /etc/apache2/conf.d/
 
 ARG FRESHRSS_VERSION

--- a/Docker/Dockerfile-Oldest
+++ b/Docker/Dockerfile-Oldest
@@ -13,7 +13,7 @@ RUN apk add --no-cache \
 RUN mkdir -p /var/www/FreshRSS /run/apache2/
 WORKDIR /var/www/FreshRSS
 
-COPY . /var/www/FreshRSS
+COPY --chown=:www-data . /var/www/FreshRSS
 COPY ./Docker/*.Apache.conf /etc/apache2/conf.d/
 
 ARG FRESHRSS_VERSION

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -59,6 +59,7 @@ if [ -n "$FRESHRSS_INSTALL" ]; then
 		echo 'ℹ️ FreshRSS already installed; no change performed.'
 	elif [ $EXITCODE -eq 0 ]; then
 		echo '✅ FreshRSS successfully installed.'
+		REAPPLY_PERMISSIONS=:
 	else
 		echo '❌ FreshRSS error during installation!'
 		exit $EXITCODE
@@ -76,12 +77,15 @@ if [ -n "$FRESHRSS_USER" ]; then
 	elif [ $EXITCODE -eq 0 ]; then
 		echo '✅ FreshRSS user successfully created.'
 		./cli/list-users.php | xargs -n1 ./cli/actualize-user.php --user
+		REAPPLY_PERMISSIONS=:
 	else
 		echo '❌ FreshRSS error during the creation of a user!'
 		exit $EXITCODE
 	fi
 fi
 
-./cli/access-permissions.sh --only-userdirs
+if [ -n "$REAPPLY_PERMISSIONS" ]; then
+	./cli/access-permissions.sh --only-userdirs
+fi
 
 exec "$@"

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -49,6 +49,7 @@ fi
 
 php -f ./cli/prepare.php >/dev/null
 
+reapply_permissions=0
 if [ -n "$FRESHRSS_INSTALL" ]; then
 	# shellcheck disable=SC2046
 	php -f ./cli/do-install.php -- \
@@ -59,7 +60,7 @@ if [ -n "$FRESHRSS_INSTALL" ]; then
 		echo 'ℹ️ FreshRSS already installed; no change performed.'
 	elif [ $EXITCODE -eq 0 ]; then
 		echo '✅ FreshRSS successfully installed.'
-		REAPPLY_PERMISSIONS=:
+		reapply_permissions=1
 	else
 		echo '❌ FreshRSS error during installation!'
 		exit $EXITCODE
@@ -77,14 +78,14 @@ if [ -n "$FRESHRSS_USER" ]; then
 	elif [ $EXITCODE -eq 0 ]; then
 		echo '✅ FreshRSS user successfully created.'
 		./cli/list-users.php | xargs -n1 ./cli/actualize-user.php --user
-		REAPPLY_PERMISSIONS=:
+		reapply_permissions=1
 	else
 		echo '❌ FreshRSS error during the creation of a user!'
 		exit $EXITCODE
 	fi
 fi
 
-if [ -n "$REAPPLY_PERMISSIONS" ]; then
+if [ "$reapply_permissions" -ne 0 ]; then
 	./cli/access-permissions.sh --only-userdirs
 fi
 

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -45,7 +45,7 @@ if [ -n "$CRON_MIN" ]; then
 		-r "s#^[^ ]+ #$CRON_MIN #" | crontab -
 fi
 
-./cli/access-permissions.sh
+./cli/access-permissions.sh --only-userdirs
 
 php -f ./cli/prepare.php >/dev/null
 
@@ -82,6 +82,6 @@ if [ -n "$FRESHRSS_USER" ]; then
 	fi
 fi
 
-./cli/access-permissions.sh
+./cli/access-permissions.sh --only-userdirs
 
 exec "$@"

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -49,7 +49,6 @@ fi
 
 php -f ./cli/prepare.php >/dev/null
 
-reapply_permissions=0
 if [ -n "$FRESHRSS_INSTALL" ]; then
 	# shellcheck disable=SC2046
 	php -f ./cli/do-install.php -- \
@@ -60,7 +59,6 @@ if [ -n "$FRESHRSS_INSTALL" ]; then
 		echo 'ℹ️ FreshRSS already installed; no change performed.'
 	elif [ $EXITCODE -eq 0 ]; then
 		echo '✅ FreshRSS successfully installed.'
-		reapply_permissions=1
 	else
 		echo '❌ FreshRSS error during installation!'
 		exit $EXITCODE
@@ -78,15 +76,14 @@ if [ -n "$FRESHRSS_USER" ]; then
 	elif [ $EXITCODE -eq 0 ]; then
 		echo '✅ FreshRSS user successfully created.'
 		./cli/list-users.php | xargs -n1 ./cli/actualize-user.php --user
-		reapply_permissions=1
 	else
 		echo '❌ FreshRSS error during the creation of a user!'
 		exit $EXITCODE
 	fi
 fi
 
-if [ "$reapply_permissions" -ne 0 ]; then
-	./cli/access-permissions.sh --only-userdirs
-fi
+# Fix permissions of data added by prepare.php as well as a potential
+# installation/user setup
+./cli/access-permissions.sh --only-userdirs
 
 exec "$@"

--- a/cli/access-permissions.sh
+++ b/cli/access-permissions.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Apply access permissions
 
 if [ ! -f './constants.php' ] || [ ! -d './cli/' ]; then
@@ -11,19 +11,22 @@ if [ "$(id -u)" -ne 0 ]; then
 	exit 3
 fi
 
-# If specified, only modify the data and extension dirs
+# Always fix permissions on the data and extensions directories
+# Optionally also fix permissions on the entire webapp
+data_path="${DATA_PATH:-./data}"
+to_update=("${data_path}")
 if [ "${1:-}" = "--only-userdirs" ]; then
-	to_update="./data ./extensions"
+	to_update+=("./extensions")
 else
-	to_update="."
+	to_update+=(".")
 fi
 
 # Based on group access
-chown -R :www-data $to_update
+chown -R :www-data "${to_update[@]}"
 
 # Read files, and directory traversal
-chmod -R g+rX $to_update
+chmod -R g+rX "${to_update[@]}"
 
-# Write access
-mkdir -p ./data/users/_/
-chmod -R g+w ./data/
+# Write access to data
+mkdir -p "${data_path}/users/_/"
+chmod -R g+w "${data_path}"

--- a/cli/access-permissions.sh
+++ b/cli/access-permissions.sh
@@ -20,6 +20,8 @@ else
 	to_update="."
 fi
 
+mkdir -p "${data_path}/users/_/"
+
 # Based on group access
 chown -R :www-data "$data_path" "$to_update"
 
@@ -27,5 +29,4 @@ chown -R :www-data "$data_path" "$to_update"
 chmod -R g+rX "$data_path" "$to_update"
 
 # Write access to data
-mkdir -p "${data_path}/users/_/"
 chmod -R g+w "$data_path"

--- a/cli/access-permissions.sh
+++ b/cli/access-permissions.sh
@@ -11,11 +11,18 @@ if [ "$(id -u)" -ne 0 ]; then
 	exit 3
 fi
 
+# If specified, only modify the data and extension dirs
+if [ "${1:-}" = "--only-userdirs" ]; then
+	to_update="./data ./extensions"
+else
+	to_update="."
+fi
+
 # Based on group access
-chown -R :www-data .
+chown -R :www-data $to_update
 
 # Read files, and directory traversal
-chmod -R g+rX .
+chmod -R g+rX $to_update
 
 # Write access
 mkdir -p ./data/users/_/

--- a/cli/access-permissions.sh
+++ b/cli/access-permissions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Apply access permissions
 
 if [ ! -f './constants.php' ] || [ ! -d './cli/' ]; then
@@ -12,21 +12,20 @@ if [ "$(id -u)" -ne 0 ]; then
 fi
 
 # Always fix permissions on the data and extensions directories
-# Optionally also fix permissions on the entire webapp
+# If specified, only fix the data and extensions directories
 data_path="${DATA_PATH:-./data}"
-to_update=("${data_path}")
 if [ "${1:-}" = "--only-userdirs" ]; then
-	to_update+=("./extensions")
+	to_update="./extensions"
 else
-	to_update+=(".")
+	to_update="."
 fi
 
 # Based on group access
-chown -R :www-data "${to_update[@]}"
+chown -R :www-data "$data_path" "$to_update"
 
 # Read files, and directory traversal
-chmod -R g+rX "${to_update[@]}"
+chmod -R g+rX "$data_path" "$to_update"
 
 # Write access to data
 mkdir -p "${data_path}/users/_/"
-chmod -R g+w "${data_path}"
+chmod -R g+w "$data_path"


### PR DESCRIPTION
This works around an issue where `chmod`/`chown` operations inside a container can be extremely slow when using the `overlay2` storage driver, resulting in 10min+ container startup times.

It modifies the owner of the webapp when building the container so that only the `data` and `extensions` directories (which are commonly mapped as volumes into the container) have to be modified by the `access-permissions.sh` script at container startup.

When not running via docker the behaviour of the `access-permissions.sh` script is unchanged.

This reduced the container startup time for me from ~15 minutes to a few seconds.

Closes #7764

Changes proposed in this pull request:

- Uses the `COPY` command in the dockerfiles to set the group of the copied data as `www-data`
- Changes the docker entrypoint script to call `access-permissions.sh --only-userdirs` 
- Changes `access-permissions.sh` to only `chown`/`chmod` the `data` and `extensions` directories instead of the entire webapp if the `--only-userdirs` flag is provided.

How to test the feature manually:

1. Run the container and ensure it starts up quickly and properly.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
