### PR TITLE
Avoid styling `<code>` inside of `<pre>`

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -108,6 +108,7 @@ People are sorted by name so please keep this order.
 * [Jackson Culbreth](https://github.com/culbrethj): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:culbrethj)
 * [jaden](https://github.com/jaden): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:jaden)
 * [Jake Mannens](https://github.com/jakem72360): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:jakem72360)
+* [James Frost](https://github.com/Fraetor): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Fraetor), [Web](https://www.frost.cx/)
 * [Jamie Slome](https://github.com/JamieSlome): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:JamieSlome), [Web](https://418sec.com/)
 * [Jan Lukas Gernert](https://github.com/jangernert): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:jangernert)
 * [Jan van den Berg](https://github.com/jan-vandenberg): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:jan-vandenberg), [Web](https://j11g.com/)

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -505,7 +505,9 @@ button.as-link[disabled] {
 }
 
 .content pre code {
+	background: transparent;
 	color: var(--dark-font-colorA);
+	border: none;
 }
 
 .content blockquote {

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -505,7 +505,9 @@ button.as-link[disabled] {
 }
 
 .content pre code {
+	background: transparent;
 	color: var(--dark-font-colorA);
+	border: none;
 }
 
 .content blockquote {

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -871,7 +871,10 @@ li.item.active {
 .content pre {
 	border: 1px solid var(--accent);
 	border-radius: 6px;
+}
 
+.content pre code {
+	border: none;
 }
 
 .content blockquote {

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -871,7 +871,10 @@ li.item.active {
 .content pre {
 	border: 1px solid var(--accent);
 	border-radius: 6px;
+}
 
+.content pre code {
+	border: none;
 }
 
 .content blockquote {

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -921,6 +921,12 @@ a:hover .icon {
 	border-radius: 3px;
 }
 
+.content pre code {
+	background: transparent;
+	color: var(--font-color);
+	border: none;
+}
+
 .content code {
 	background-color: var(--background-color-light-shadowed);
 	color: var(--error-feed-color);

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -921,6 +921,12 @@ a:hover .icon {
 	border-radius: 3px;
 }
 
+.content pre code {
+	background: transparent;
+	color: var(--font-color);
+	border: none;
+}
+
 .content code {
 	background-color: var(--background-color-light-shadowed);
 	color: var(--error-feed-color);


### PR DESCRIPTION
Closes #7796

Changes proposed in this pull request:

- The background of `.content pre code` is set to transparent, so the `<pre>` background can show through.
- Any border around the `<code>` within the `<pre>` is removed.

How to test the feature manually:

1. Open an article with a code block (such as the one suggested in the issue.)
2. Check it renders correctly in the Origine, Origine-compact, Dark, and Nord themes.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] ~~unit tests written (optional if too hard)~~ Styling change, not sure how to test.
- [ ] ~~documentation updated~~ N/A

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
