### PR TITLE
Fix privacy link not being highlighted in configure

### DIFF
--- a/app/layout/aside_configure.phtml
+++ b/app/layout/aside_configure.phtml
@@ -52,7 +52,7 @@
 				<li class="item<?= Minz_Request::controllerName() === 'extension' ? ' active' : '' ?>">
 					<a href="<?= _url('extension', 'index') ?>"><?= _t('gen.menu.extensions') ?></a>
 				</li>
-				<li class="item<?= Minz_Request::controllerName() === 'privacy' ? ' active' : '' ?>">
+				<li class="item<?= Minz_Request::actionName() === 'privacy' ? ' active' : '' ?>">
 					<a href="<?= _url('configure', 'privacy') ?>"><?= _t('gen.menu.privacy') ?></a>
 				</li>
 				<?php if (!FreshRSS_Auth::hasAccess('admin')) { ?>


### PR DESCRIPTION
<details>
<summary>Before</summary>

<img width="1137" height="634" alt="image" src="https://github.com/user-attachments/assets/451722d7-4653-4091-a09a-1b4b796171ea" />

</details>

<details>
<summary>After</summary>

<img width="1154" height="615" alt="image" src="https://github.com/user-attachments/assets/3f43b357-c11e-484d-a948-114efe3275d1" />

</details>