### PR TITLE
Fix some PHP 8.5 deprecations

### DIFF
--- a/app/Controllers/updateController.php
+++ b/app/Controllers/updateController.php
@@ -222,7 +222,6 @@ class FreshRSS_update_Controller extends FreshRSS_ActionController {
 			$result = curl_exec($curlResource);
 			$curlGetinfo = curl_getinfo($curlResource, CURLINFO_HTTP_CODE);
 			$curlError = curl_error($curlResource);
-			curl_close($curlResource);
 
 			if ($curlGetinfo !== 200) {
 				Minz_Log::warning(

--- a/app/views/importExport/sqlite.phtml
+++ b/app/views/importExport/sqlite.phtml
@@ -5,6 +5,6 @@ declare(strict_types=1);
 header('Content-Type: application/vnd.sqlite3');
 header('Content-Disposition: attachment; filename="' . basename($this->sqlitePath) . '"');
 header('Cache-Control: private, no-store, max-age=0');
-header('Last-Modified: ' . gmdate(DateTimeInterface::RFC7231, @filemtime($this->sqlitePath) ?: 0));
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s \\G\\M\\T', @filemtime($this->sqlitePath) ?: 0));
 header('Content-Length: ' . (@filesize($this->sqlitePath) ?: 0));
 readfile($this->sqlitePath);

--- a/lib/favicons.php
+++ b/lib/favicons.php
@@ -18,7 +18,6 @@ function isImgMime(string $content): bool {
 	}
 	$content = finfo_buffer($fInfo, $content);
 	$isImage = str_contains($content ?: '', 'image');
-	finfo_close($fInfo);
 	return $isImage;
 }
 

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -642,7 +642,6 @@ function httpGet(string $url, string $cachePath, string $type = 'html', array $a
 	$c_effective_url = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
 	$c_redirect_count = curl_getinfo($ch, CURLINFO_REDIRECT_COUNT);
 	$c_error = curl_error($ch);
-	curl_close($ch);
 
 	$parser = new \SimplePie\HTTP\Parser(is_string($response) ? $response : '');
 	if ($parser->parse()) {


### PR DESCRIPTION
https://github.com/php/php-src/blob/php-8.5.0beta1/NEWS

https://php.net/function.curl-close
> This function has no effect. Prior to PHP 8.0.0, this function was used to close the resource.
