### PR TITLE
Call cleanCache when refreshing feeds

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -862,6 +862,9 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 		if ($entryDAO->inTransaction()) {
 			$entryDAO->commit();
 		}
+		if (rand(0, 30) === 1) {	// Remove old cache once in a while
+			cleanCache(CLEANCACHE_HOURS);
+		}
 		return [$nbUpdatedFeeds, $feed, $nbNewArticles, $feedsCacheToRefresh];
 	}
 

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -557,7 +557,7 @@ function httpGet(string $url, string $cachePath, string $type = 'html', array $a
 		}
 	}
 
-	if (mt_rand(0, 30) === 1) {	// Remove old entries once in a while
+	if (rand(0, 30) === 1) {	// Remove old cache once in a while
 		cleanCache(CLEANCACHE_HOURS);
 	}
 


### PR DESCRIPTION
Otherwise, it is only called when calling `httpGet()` which can be rare for users not using Web Scraping.
https://github.com/FreshRSS/FreshRSS/discussions/7784#discussioncomment-14109207
