### PR TITLE
Improve leave validation

### DIFF
--- a/app/Models/Context.php
+++ b/app/Models/Context.php
@@ -151,6 +151,15 @@ final class FreshRSS_Context {
 		if (!in_array(FreshRSS_Context::$user_conf->display_categories, [ 'active', 'remember', 'all', 'none' ], true)) {
 			FreshRSS_Context::$user_conf->display_categories = FreshRSS_Context::$user_conf->display_categories === true ? 'all' : 'active';
 		}
+
+		// FreshRSS 1.27.0
+		if (array_key_exists('close_dropdown', FreshRSS_Context::$user_conf->shortcuts)) {
+			$shortcuts = FreshRSS_Context::$user_conf->shortcuts;
+			$shortcuts['close_menus'] = $shortcuts['close_dropdown'];
+			unset($shortcuts['close_dropdown']);
+			FreshRSS_Context::$user_conf->shortcuts = $shortcuts;
+			FreshRSS_Context::$user_conf->save();
+		}
 	}
 
 	/**

--- a/app/Models/Context.php
+++ b/app/Models/Context.php
@@ -152,8 +152,8 @@ final class FreshRSS_Context {
 			FreshRSS_Context::$user_conf->display_categories = FreshRSS_Context::$user_conf->display_categories === true ? 'all' : 'active';
 		}
 
-		// FreshRSS 1.27.0
-		if (array_key_exists('close_dropdown', FreshRSS_Context::$user_conf->shortcuts)) {
+		// FreshRSS 1.27.1+
+		if (isset(FreshRSS_Context::$user_conf->shortcuts['close_dropdown'])) {
 			$shortcuts = FreshRSS_Context::$user_conf->shortcuts;
 			$shortcuts['close_menus'] = $shortcuts['close_dropdown'];
 			unset($shortcuts['close_dropdown']);

--- a/app/i18n/cs/conf.php
+++ b/app/i18n/cs/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'Akce článku',
 		'auto_share' => 'Sdílet',
 		'auto_share_help' => 'Pokud je pouze jeden režim sdílení, je použit. Jinak jsou režimy dostupné podle jejich čísla.',
-		'close_dropdown' => 'Zavřít nabídky',
+		'close_menus' => 'Zavřít nabídky',
 		'collapse_article' => 'Sbalit',
 		'first_article' => 'Otevřít první článek',
 		'focus_search' => 'Vstoupit do vyhledávacího pole',

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'Artikel',
 		'auto_share' => 'Teilen',
 		'auto_share_help' => 'Wenn es nur eine Option zum Teilen gibt, wird diese verwendet. Ansonsten sind die Optionen über ihre Nummer erreichbar.',
-		'close_dropdown' => 'Menüs schließen',
+		'close_menus' => 'Menüs schließen',
 		'collapse_article' => 'Einklappen',
 		'first_article' => 'Zum ersten Artikel springen',
 		'focus_search' => 'Auf das Suchfeld zugreifen',

--- a/app/i18n/el/conf.php
+++ b/app/i18n/el/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'Article actions',	// TODO
 		'auto_share' => 'Share',	// TODO
 		'auto_share_help' => 'If there is only one sharing mode, it is used. Otherwise, modes are accessible by their number.',	// TODO
-		'close_dropdown' => 'Close menus',	// TODO
+		'close_menus' => 'Close menus',	// TODO
 		'collapse_article' => 'Collapse',	// TODO
 		'first_article' => 'Open the first article',	// TODO
 		'focus_search' => 'Access search box',	// TODO

--- a/app/i18n/en-us/conf.php
+++ b/app/i18n/en-us/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'Article actions',	// IGNORE
 		'auto_share' => 'Share',	// IGNORE
 		'auto_share_help' => 'If there is only one sharing mode, it is used. Otherwise, modes are accessible by their number.',	// IGNORE
-		'close_dropdown' => 'Close menus',	// IGNORE
+		'close_menus' => 'Close menus',	// IGNORE
 		'collapse_article' => 'Collapse',	// IGNORE
 		'first_article' => 'Open the first article',	// IGNORE
 		'focus_search' => 'Access search box',	// IGNORE

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'Article actions',
 		'auto_share' => 'Share',
 		'auto_share_help' => 'If there is only one sharing mode, it is used. Otherwise, modes are accessible by their number.',
-		'close_dropdown' => 'Close menus',
+		'close_menus' => 'Close menus',
 		'collapse_article' => 'Collapse',
 		'first_article' => 'Open the first article',
 		'focus_search' => 'Access search box',

--- a/app/i18n/es/conf.php
+++ b/app/i18n/es/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'Acciones de artículo',
 		'auto_share' => 'Compartir',
 		'auto_share_help' => 'Si solo hay un modo para compartir, ese será el que se use. En caso contrario los modos quedarán accesibles por su numeración.',
-		'close_dropdown' => 'Cerrar menús',
+		'close_menus' => 'Cerrar menús',
 		'collapse_article' => 'Contraer',
 		'first_article' => 'Saltar al primer artículo',
 		'focus_search' => 'Acceso a la casilla de búsqueda',

--- a/app/i18n/fa/conf.php
+++ b/app/i18n/fa/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => ' اقدامات ماده',
 		'auto_share' => ' اشتراک گذاری',
 		'auto_share_help' => ' اگر فقط یک حالت اشتراک گذاری وجود داشته باشد',
-		'close_dropdown' => ' منوها را ببندید',
+		'close_menus' => ' منوها را ببندید',
 		'collapse_article' => ' فروپاشی',
 		'first_article' => ' اولین مقاله را باز کنید',
 		'focus_search' => ' به کادر جستجو دسترسی پیدا کنید',

--- a/app/i18n/fi/conf.php
+++ b/app/i18n/fi/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'Artikkelitoiminnot',
 		'auto_share' => 'Jaa',
 		'auto_share_help' => 'Jos jakamistapoja on vain yksi, sitä käytetään automaattisesti. Muussa tapauksessa jakamistavan voi valita numerolla.',
-		'close_dropdown' => 'Sulje valikot',
+		'close_menus' => 'Sulje valikot',
 		'collapse_article' => 'Sulje',
 		'first_article' => 'Avaa ensimmäinen artikkeli',
 		'focus_search' => 'Siirry hakukenttään',

--- a/app/i18n/fr/conf.php
+++ b/app/i18n/fr/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'Actions associées à l’article courant',
 		'auto_share' => 'Partager',
 		'auto_share_help' => 'S’il n’y a qu’un mode de partage, celui-ci est utilisé automatiquement. Sinon ils sont accessibles par leur numéro.',
-		'close_dropdown' => 'Fermer les menus',
+		'close_menus' => 'Fermer les menus',
 		'collapse_article' => 'Refermer',
 		'first_article' => 'Passer au premier article',
 		'focus_search' => 'Accéder à la recherche',

--- a/app/i18n/he/conf.php
+++ b/app/i18n/he/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'פעולות על מאמרים',
 		'auto_share' => 'שיתוף',
 		'auto_share_help' => 'אם יש רק מצב שיתוף אחד, הוא מופעל. אחרת המצבים נבחרים על בסיס המספר שלהם.',
-		'close_dropdown' => 'Close menus',	// TODO
+		'close_menus' => 'Close menus',	// TODO
 		'collapse_article' => 'כיווץ',
 		'first_article' => 'דילוג למאמר הראשון',
 		'focus_search' => 'גישה לתיבת החיפוש',

--- a/app/i18n/hu/conf.php
+++ b/app/i18n/hu/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'Cikk műveletek',
 		'auto_share' => 'Megosztás',
 		'auto_share_help' => 'Ha csak egy megosztási mód van, az lesz használva. Egyébként, a megosztási módok a számukkal elérhetőek.',
-		'close_dropdown' => 'Menük bezárása',
+		'close_menus' => 'Menük bezárása',
 		'collapse_article' => 'Összecsuk',
 		'first_article' => 'Első cikk megnyitása',
 		'focus_search' => 'Ugrás a keresődobozra',

--- a/app/i18n/id/conf.php
+++ b/app/i18n/id/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'Tindakan artikel',
 		'auto_share' => 'Berbagi',
 		'auto_share_help' => 'Jika hanya ada satu layanan berbagi, maka itu akan digunakan. Jika tidak, mode dapat diakses dengan nomornya.',
-		'close_dropdown' => 'Tutup menu',
+		'close_menus' => 'Tutup menu',
 		'collapse_article' => 'Tutup',
 		'first_article' => 'Buka artikel pertama',
 		'focus_search' => 'Akses kotak pencarian',

--- a/app/i18n/it/conf.php
+++ b/app/i18n/it/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'Azioni sugli articoli',
 		'auto_share' => 'Condividi',
 		'auto_share_help' => 'Se è presente un solo servizio di condivisione verrà usato quello, altrimenti usare anche il numero associato.',
-		'close_dropdown' => 'Chiudi menù',
+		'close_menus' => 'Chiudi menù',
 		'collapse_article' => 'Collassa articoli',
 		'first_article' => 'Salta al primo articolo',
 		'focus_search' => 'Modulo di ricerca',

--- a/app/i18n/ja/conf.php
+++ b/app/i18n/ja/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => '記事のアクション',
 		'auto_share' => '共有',
 		'auto_share_help' => '共有方法が一つしか設定されていないときにはそれが使われます。そうではなければ、番号によって共有方法にアクセスできます。',
-		'close_dropdown' => 'メニューを閉じる',
+		'close_menus' => 'メニューを閉じる',
 		'collapse_article' => '折りたたむ',
 		'first_article' => '初めの記事を開く',
 		'focus_search' => '検索ボックスにアクセスする',

--- a/app/i18n/ko/conf.php
+++ b/app/i18n/ko/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => '글 관련 동작',
 		'auto_share' => '공유',
 		'auto_share_help' => '공유 옵션이 하나만 설정되어 있다면 해당 공유 옵션을 사용하고, 그렇지 않다면 공유 옵션을 번호로 선택할 수 있습니다.',
-		'close_dropdown' => '메뉴 닫기',
+		'close_menus' => '메뉴 닫기',
 		'collapse_article' => '접기',
 		'first_article' => '첫 글 보기',
 		'focus_search' => '검색창 사용하기',

--- a/app/i18n/lv/conf.php
+++ b/app/i18n/lv/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'Raksta darbības',
 		'auto_share' => 'Dalīties',
 		'auto_share_help' => 'Ja ir tikai viens dalīšanās režīms, tiek izmantots tas režīms. Pretējā gadījumā režīmi ir pieejami pēc to numura If there is only one sharing mode, it is used.',
-		'close_dropdown' => 'Aizvērt izvēlnes',
+		'close_menus' => 'Aizvērt izvēlnes',
 		'collapse_article' => 'Salocīt',
 		'first_article' => 'Atvērt pirmo rakstu',
 		'focus_search' => 'Piekļuve meklēšanas lodziņam',

--- a/app/i18n/nl/conf.php
+++ b/app/i18n/nl/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'Artikelacties',
 		'auto_share' => 'Delen',
 		'auto_share_help' => 'Als er slechts één deelmethode is, dan wordt die gebruikt. Anders zijn ze toegankelijk met hun nummer.',
-		'close_dropdown' => 'Sluit menu',
+		'close_menus' => 'Sluit menu',
 		'collapse_article' => 'Inklappen',
 		'first_article' => 'Spring naar eerste artikel',
 		'focus_search' => 'Toegang zoek venster',

--- a/app/i18n/oc/conf.php
+++ b/app/i18n/oc/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'Accions ligadas a l’article',
 		'auto_share' => 'Partejar',
 		'auto_share_help' => 'S’i a pas qu’un mòde de partatge, aquel serà utilizat. Autrament los mòdes son accessibles per lor numèro.',
-		'close_dropdown' => 'Tampar los menús',
+		'close_menus' => 'Tampar los menús',
 		'collapse_article' => 'Replegar',
 		'first_article' => 'Passar al primièr article',
 		'focus_search' => 'Accedir a la recèrca',

--- a/app/i18n/pl/conf.php
+++ b/app/i18n/pl/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'Akcje wiadomości',
 		'auto_share' => 'Udostępnij',
 		'auto_share_help' => 'Gdy jest dostępna tylko jedna metoda udostępniania jest ona od razu wykorzystywana. W pozostałych przypadkach poszczególne metody są dostępne przez wybranie ich numeru.',
-		'close_dropdown' => 'Zamknięcie menu',
+		'close_menus' => 'Zamknięcie menu',
 		'collapse_article' => 'Zwinięcie',
 		'first_article' => 'Otworzenie pierwszej wiadomości',
 		'focus_search' => 'Przejdź do pola wyszukiwania',

--- a/app/i18n/pt-br/conf.php
+++ b/app/i18n/pt-br/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'Ações no artigo',
 		'auto_share' => 'Compartilhar',
 		'auto_share_help' => 'Se há apenas um modo de compartilhamento, ele é usado. Caso contrário, serão acessíveis pelo seu número.',
-		'close_dropdown' => 'Fechar menus',
+		'close_menus' => 'Fechar menus',
 		'collapse_article' => 'Fechar',
 		'first_article' => 'Ir para o primeiro artigo',
 		'focus_search' => 'Acessar a caixa de busca',

--- a/app/i18n/pt-pt/conf.php
+++ b/app/i18n/pt-pt/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'Ações no artigo',
 		'auto_share' => 'Partilhar',
 		'auto_share_help' => 'Se há apenas um modo de partilha, ele é usado. Caso contrário, serão acessíveis pelo seu número.',
-		'close_dropdown' => 'Fechar menus',
+		'close_menus' => 'Fechar menus',
 		'collapse_article' => 'Fechar',
 		'first_article' => 'Ir para o primeiro artigo',
 		'focus_search' => 'Aceder a caixa de pesquisa',

--- a/app/i18n/ru/conf.php
+++ b/app/i18n/ru/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'Действия со статьями',
 		'auto_share' => 'Обмен',
 		'auto_share_help' => 'Если способ единственный, он будет вызван. Иначе способы доступны по их номеру.',
-		'close_dropdown' => 'Закрыть меню',
+		'close_menus' => 'Закрыть меню',
 		'collapse_article' => 'Схлопнуть',
 		'first_article' => 'Открыть первую статью',
 		'focus_search' => 'К строке поиска',

--- a/app/i18n/sk/conf.php
+++ b/app/i18n/sk/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'Akcie článku',
 		'auto_share' => 'Zdieľať',
 		'auto_share_help' => 'Ak je nastavený iba jeden spôsob zdieľania, použije sa. Inak si spôsoby zdieľania vyberá používateľ podľa čísla.',
-		'close_dropdown' => 'Zavrie menu',
+		'close_menus' => 'Zavrie menu',
 		'collapse_article' => 'Zroluje článok',
 		'first_article' => 'Otvorí prvý článok',
 		'focus_search' => 'Vyhľadávanie',

--- a/app/i18n/tr/conf.php
+++ b/app/i18n/tr/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => 'Makale eylemleri',
 		'auto_share' => 'Paylaş',
 		'auto_share_help' => 'Eğer yalnızca bir paylaşım modu varsa, o kullanılır. Aksi takdirde, modlar numaralarıyla erişilebilir.',
-		'close_dropdown' => 'Menüleri kapat',
+		'close_menus' => 'Menüleri kapat',
 		'collapse_article' => 'Daralt',
 		'first_article' => 'İlk makaleyi aç',
 		'focus_search' => 'Arama kutusuna eriş',

--- a/app/i18n/zh-cn/conf.php
+++ b/app/i18n/zh-cn/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => '文章操作',
 		'auto_share' => '分享',
 		'auto_share_help' => '如果有多种分享方式，则会按照它们的序号依次访问。',
-		'close_dropdown' => '关闭菜单',
+		'close_menus' => '关闭菜单',
 		'collapse_article' => '折叠文章',
 		'first_article' => '打开第一篇文章',
 		'focus_search' => '访问搜索框',

--- a/app/i18n/zh-tw/conf.php
+++ b/app/i18n/zh-tw/conf.php
@@ -321,7 +321,7 @@ return array(
 		'article_action' => '文章操作',
 		'auto_share' => '分享',
 		'auto_share_help' => '如果有多種分享方式，則會按照它們的序號依次訪問。',
-		'close_dropdown' => '關閉菜單',
+		'close_menus' => '關閉菜單',
 		'collapse_article' => '收起文章',
 		'first_article' => '打開第一篇文章',
 		'focus_search' => '聚焦到搜尋框',

--- a/app/views/configure/shortcut.phtml
+++ b/app/views/configure/shortcut.phtml
@@ -199,9 +199,9 @@
 			</div>
 
 			<div class="form-group">
-				<label class="group-name" for="close_dropdown_shortcut"><?= _t('conf.shortcut.close_dropdown') ?></label>
+				<label class="group-name" for="close_menus_shortcut"><?= _t('conf.shortcut.close_menus') ?></label>
 				<div class="group-controls">
-					<input type="text" id="close_dropdown" name="shortcuts[close_dropdown]" list="keys" value="<?= $s['close_dropdown'] ?>" />
+					<input type="text" id="close_menus_shortcut" name="shortcuts[close_menus]" list="keys" value="<?= $s['close_menus'] ?>" />
 				</div>
 			</div>
 

--- a/app/views/helpers/javascript_vars.phtml
+++ b/app/views/helpers/javascript_vars.phtml
@@ -54,7 +54,7 @@ echo json_encode([
 		'focus_search' => @$s['focus_search'],
 		'user_filter' => @$s['user_filter'],
 		'help' => @$s['help'],
-		'close_dropdown' => @$s['close_dropdown'],
+		'close_menus' => @$s['close_menus'],
 		'normal_view' => @$s['normal_view'],
 		'global_view' => @$s['global_view'],
 		'reading_view' => @$s['reading_view'],

--- a/config-user.default.php
+++ b/config-user.default.php
@@ -90,7 +90,7 @@ return array (
 		'focus_search' => 'a',
 		'user_filter' => 'u',
 		'help' => 'f1',
-		'close_dropdown' => 'escape',
+		'close_menus' => 'escape',
 		'normal_view' => '1',
 		'global_view' => '2',
 		'reading_view' => '3',

--- a/p/scripts/extra.js
+++ b/p/scripts/extra.js
@@ -179,6 +179,10 @@ function init_update_feed() {
 		if (resetField) {
 			resetField.remove();
 		}
+		const extBtn = feed_update.querySelector('input#extBtn');
+		if (extBtn) {
+			extBtn.remove();
+		}
 		if (faviconExtBtn) {
 			faviconExtBtn.disabled = false;
 			extension.innerText = extension.dataset.initialExt ?? extension.innerText;
@@ -214,6 +218,10 @@ function init_update_feed() {
 		if (resetField) {
 			resetField.remove();
 		}
+		const extBtn = feed_update.querySelector('input#extBtn');
+		if (extBtn) {
+			extBtn.remove();
+		}
 		resetFavicon.disabled = false;
 		favicon.src = URL.createObjectURL(faviconUpload.files[0]);
 	};
@@ -231,19 +239,16 @@ function init_update_feed() {
 		faviconExt.classList.add('hidden');
 		faviconError.innerHTML = '';
 		clearUploadedIcon();
-		resetFavicon.insertAdjacentHTML('afterend', '<input type="hidden" name="resetFavicon" value="1" />');
+		resetFavicon.insertAdjacentHTML('afterend', '<input type="hidden" name="resetFavicon" value="1" data-leave-validation="" />');
 		resetFavicon.disabled = true;
 
 		favicon.src = favicon.dataset.originalIcon;
 	};
 
-	// Discard the icon change when the "Cancel" button is clicked
-	feed_update.querySelectorAll('[type="reset"]').forEach(cancelBtn => {
-		cancelBtn.addEventListener('click', () => {
-			faviconExt.classList.remove('hidden');
-			faviconError.innerHTML = '';
-			discardIconChange();
-		});
+	feed_update.querySelector('form').addEventListener('reset', () => {
+		faviconExt.classList.remove('hidden');
+		faviconError.innerHTML = '';
+		discardIconChange();
 	});
 
 	if (faviconExtBtn) {
@@ -272,6 +277,7 @@ function init_update_feed() {
 				if (resetField) {
 					resetField.remove();
 				}
+				faviconExtBtn.insertAdjacentHTML('afterend', '<input type="hidden" id="extBtn" value="1" data-leave-validation="" />');
 				resetFavicon.disabled = false;
 				faviconError.innerHTML = '';
 				faviconExt.classList.remove('hidden');
@@ -367,9 +373,12 @@ function close_slider_listener(ev) {
 	if (data_leave_validation(slider) || confirm(context.i18n.confirm_exit_slider)) {
 		slider.querySelectorAll('form').forEach(function (f) { f.reset(); });
 		document.documentElement.classList.remove('slider-active');
-		return;
+		return true;
 	}
-	ev.preventDefault();
+	if (ev) {
+		ev.preventDefault();
+	}
+	return false;
 }
 // </slider>
 

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1185,6 +1185,7 @@ function init_shortcuts() {
 			}
 			return;
 		}
+		const hash = location.hash.substr(1);
 		if (k === s.skip_next_entry) { next_entry(true); ev.preventDefault(); return; }
 		if (k === s.skip_prev_entry) { prev_entry(true); ev.preventDefault(); return; }
 		if (k === s.collapse_entry) { collapse_entry(); ev.preventDefault(); return; }
@@ -1192,7 +1193,11 @@ function init_shortcuts() {
 		if (k === s.auto_share) { auto_share(); ev.preventDefault(); return; }
 		if (k === s.user_filter) { user_filter(); ev.preventDefault(); return; }
 		if (k === s.load_more) { load_more_posts(); ev.preventDefault(); return; }
-		if (k === s.close_dropdown) { location.hash = null; ev.preventDefault(); return; }
+		/* globals close_slider_listener */
+		if (k === s.close_menus && (
+			(hash === 'slider' && close_slider_listener()) ||
+			hash.startsWith('dropdown')
+		)) { location.hash = ''; ev.preventDefault(); return; }
 		if (k === s.help) { window.open(context.urls.help); ev.preventDefault(); return; }
 		if (k === s.focus_search) { document.getElementById('search').focus(); ev.preventDefault(); return; }
 		if (k === s.normal_view) { delayedClick(document.querySelector('#nav_menu_views .view-normal')); ev.preventDefault(); return; }


### PR DESCRIPTION
fix: no confirmation popup was shown when exiting slider with shortcut (ESC)
fix: no confirmation popup was shown after exiting slider and having reset the icon to default or set by extension
fix: input for `close_dropdown` wasn't named correctly for label to work
refactor: `close_dropdown` was renamed to `close_menus`

TODO for later PR: move custom favicon code to `feed.js` instead of `extra.js`

