### PR TITLE
Fix fetching OPML url with special characters

### DIFF
--- a/app/Controllers/categoryController.php
+++ b/app/Controllers/categoryController.php
@@ -59,7 +59,7 @@ class FreshRSS_category_Controller extends FreshRSS_ActionController {
 				Minz_Request::bad(_t('feedback.tag.name_exists', $cat->name()), $url_redirect);
 			}
 
-			$opml_url = checkUrl(Minz_Request::paramString('opml_url'));
+			$opml_url = checkUrl(Minz_Request::paramString('opml_url', plaintext: true));
 			if ($opml_url != '') {
 				$cat->_kind(FreshRSS_Category::KIND_DYNAMIC_OPML);
 				$cat->_attribute('opml_url', $opml_url);
@@ -137,7 +137,7 @@ class FreshRSS_category_Controller extends FreshRSS_ActionController {
 			$position = Minz_Request::paramInt('position') ?: null;
 			$category->_attribute('position', $position);
 
-			$opml_url = checkUrl(Minz_Request::paramString('opml_url'));
+			$opml_url = checkUrl(Minz_Request::paramString('opml_url', plaintext: true));
 			if ($opml_url != '') {
 				$category->_kind(FreshRSS_Category::KIND_DYNAMIC_OPML);
 				$category->_attribute('opml_url', $opml_url);

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -182,7 +182,7 @@ class FreshRSS_Category extends Minz_Model {
 	}
 
 	public function refreshDynamicOpml(): bool {
-		$url = htmlspecialchars_decode($this->attributeString('opml_url') ?? '', ENT_QUOTES);
+		$url = $this->attributeString('opml_url');
 		if ($url == null) {
 			return false;
 		}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -182,7 +182,7 @@ class FreshRSS_Category extends Minz_Model {
 	}
 
 	public function refreshDynamicOpml(): bool {
-		$url = htmlspecialchars_decode($this->attributeString('opml_url'));
+		$url = htmlspecialchars_decode($this->attributeString('opml_url') ?? '', ENT_QUOTES);
 		if ($url == null) {
 			return false;
 		}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -182,7 +182,7 @@ class FreshRSS_Category extends Minz_Model {
 	}
 
 	public function refreshDynamicOpml(): bool {
-		$url = $this->attributeString('opml_url');
+		$url = htmlspecialchars_decode($this->attributeString('opml_url'));
 		if ($url == null) {
 			return false;
 		}

--- a/app/views/helpers/category/update.phtml
+++ b/app/views/helpers/category/update.phtml
@@ -51,7 +51,7 @@
 					<label class="group-name" for="opml_url"><?= _t('sub.category.opml_url') ?></label>
 					<div class="group-controls">
 						<div class="stick">
-							<input id="opml_url" name="opml_url" type="url" autocomplete="off" class="long" data-disable-update="refreshOpml" value="<?= $this->category->attributeString('opml_url') ?>" />
+							<input id="opml_url" name="opml_url" type="url" autocomplete="off" class="long" data-disable-update="refreshOpml" value="<?= htmlspecialchars($this->category->attributeString('opml_url') ?? '', ENT_COMPAT, 'UTF-8') ?>" />
 							<button type="submit" class="btn" id="refreshOpml" formmethod="post" formaction="<?= _url('category', 'refreshOpml', 'id', $this->category->id()) ?>">
 								<?= _i('refresh') ?> <?= _t('gen.action.refresh_opml') ?>
 							</button>


### PR DESCRIPTION
Add dynamic OPML with url `http://freshrss2.local/api/query.php?user=X&t=X&f=opml`

Expect to see in server logs:
```
172.18.0.2 - - [20/Aug/2025:02:25:38 +0000] "GET /api/query.php?user=X&t=X&f=opml HTTP/1.1" 200 1591 "-" "FreshRSS/1.27.1-dev (Linux; https://freshrss.org)"
```

Instead this happens:
```
172.18.0.2 - - [20/Aug/2025:02:20:41 +0000] "GET /api/query.php?user=X&amp;t=X&amp;f=opml HTTP/1.1" 422 18 "-" "FreshRSS/1.27.1-dev (Linux; https://freshrss.org)"
```

<img width="967" height="77" alt="image" src="https://github.com/user-attachments/assets/398e2530-4ac2-4069-9372-9fffd2ce09a1" />

