### PR TITLE
Docker CMD compatibility

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -64,6 +64,6 @@ ENTRYPOINT ["./Docker/entrypoint.sh"]
 
 EXPOSE 80
 # hadolint ignore=DL3025
-CMD ([ -z "$CRON_MIN" ] || cron) && \
+CMD [ -z "$CRON_MIN" ] || cron && \
 	. /etc/apache2/envvars && \
 	exec apache2 -D FOREGROUND $([ "${OIDC_ENABLED:-0}" -ne 0 ] && echo "-D OIDC_ENABLED")

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -63,6 +63,7 @@ ENV TRUSTED_PROXY=''
 ENTRYPOINT ["./Docker/entrypoint.sh"]
 
 EXPOSE 80
-
 # hadolint ignore=DL3025
-CMD sh -c '([ -z "$CRON_MIN" ] || cron) && . /etc/apache2/envvars && if [ "${OIDC_ENABLED:-0}" -ne 0 ]; then exec apache2 -D FOREGROUND -D OIDC_ENABLED; else exec apache2 -D FOREGROUND; fi'
+CMD ([ -z "$CRON_MIN" ] || cron) && \
+	. /etc/apache2/envvars && \
+	exec apache2 -D FOREGROUND $([ "${OIDC_ENABLED:-0}" -ne 0 ] && echo "-D OIDC_ENABLED")

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -66,4 +66,4 @@ EXPOSE 80
 # hadolint ignore=DL3025
 CMD ([ -z "$CRON_MIN" ] || cron) && \
 	. /etc/apache2/envvars && \
-	exec apache2 -D FOREGROUND $([ -n "$OIDC_ENABLED" ] && [ "$OIDC_ENABLED" -ne 0 ]&& echo "-D OIDC_ENABLED")
+	exec apache2 -D FOREGROUND $([ -n "$OIDC_ENABLED" ] && [ "$OIDC_ENABLED" -ne 0 ] && echo "-D OIDC_ENABLED")

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -66,4 +66,4 @@ EXPOSE 80
 # hadolint ignore=DL3025
 CMD ([ -z "$CRON_MIN" ] || cron) && \
 	. /etc/apache2/envvars && \
-	exec apache2 -D FOREGROUND $([ "${OIDC_ENABLED:-0}" -ne 0 ] && echo "-D OIDC_ENABLED")
+	exec apache2 -D FOREGROUND $([ -n "$OIDC_ENABLED" ] && [ "$OIDC_ENABLED" -ne 0 ]&& echo "-D OIDC_ENABLED")

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -65,4 +65,4 @@ ENTRYPOINT ["./Docker/entrypoint.sh"]
 EXPOSE 80
 
 # hadolint ignore=DL3025
-CMD sh -c '[ -z "$CRON_MIN" ] || cron; . /etc/apache2/envvars; if [ "${OIDC_ENABLED:-0}" -ne 0 ]; then exec apache2 -D FOREGROUND -D OIDC_ENABLED; else exec apache2 -D FOREGROUND; fi'
+CMD sh -c '([ -z "$CRON_MIN" ] || cron) && . /etc/apache2/envvars && if [ "${OIDC_ENABLED:-0}" -ne 0 ]; then exec apache2 -D FOREGROUND -D OIDC_ENABLED; else exec apache2 -D FOREGROUND; fi'

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -63,7 +63,6 @@ ENV TRUSTED_PROXY=''
 ENTRYPOINT ["./Docker/entrypoint.sh"]
 
 EXPOSE 80
+
 # hadolint ignore=DL3025
-CMD ([ -z "$CRON_MIN" ] || cron) && \
-	. /etc/apache2/envvars && \
-	exec apache2 -D FOREGROUND $([ -n "$OIDC_ENABLED" ] && [ "$OIDC_ENABLED" -ne 0 ] && echo '-D OIDC_ENABLED')
+CMD sh -c '[ -z "$CRON_MIN" ] || cron; . /etc/apache2/envvars; if [ "${OIDC_ENABLED:-0}" -ne 0 ]; then exec apache2 -D FOREGROUND -D OIDC_ENABLED; else exec apache2 -D FOREGROUND; fi'

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -64,6 +64,6 @@ ENTRYPOINT ["./Docker/entrypoint.sh"]
 
 EXPOSE 80
 # hadolint ignore=DL3025
-CMD [ -z "$CRON_MIN" ] || cron && \
+CMD ([ -z "$CRON_MIN" ] || cron) && \
 	. /etc/apache2/envvars && \
 	exec apache2 -D FOREGROUND $([ "${OIDC_ENABLED:-0}" -ne 0 ] && echo "-D OIDC_ENABLED")

--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -60,5 +60,5 @@ ENTRYPOINT ["./Docker/entrypoint.sh"]
 
 EXPOSE 80
 # hadolint ignore=DL3025
-CMD [ -z "$CRON_MIN" ] || crond -d 6 && \
+CMD ([ -z "$CRON_MIN" ] || crond -d 6) && \
 	exec httpd -D FOREGROUND $([ "${OIDC_ENABLED:-0}" -ne 0 ] && echo "-D OIDC_ENABLED")

--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -59,6 +59,6 @@ ENV TRUSTED_PROXY=''
 ENTRYPOINT ["./Docker/entrypoint.sh"]
 
 EXPOSE 80
-
 # hadolint ignore=DL3025
-CMD sh -c '([ -z "$CRON_MIN" ] || crond -d 6) && if [ "${OIDC_ENABLED:-0}" -ne 0 ]; then exec httpd -D FOREGROUND -D OIDC_ENABLED; else exec httpd -D FOREGROUND; fi'
+CMD ([ -z "$CRON_MIN" ] || crond -d 6) && \
+	exec httpd -D FOREGROUND $([ "${OIDC_ENABLED:-0}" -ne 0 ] && echo "-D OIDC_ENABLED")

--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -59,6 +59,6 @@ ENV TRUSTED_PROXY=''
 ENTRYPOINT ["./Docker/entrypoint.sh"]
 
 EXPOSE 80
+
 # hadolint ignore=DL3025
-CMD ([ -z "$CRON_MIN" ] || crond -d 6) && \
-	exec httpd -D FOREGROUND $([ -n "$OIDC_ENABLED" ] && [ "$OIDC_ENABLED" -ne 0 ] && echo '-D OIDC_ENABLED')
+CMD sh -c '[ -z "$CRON_MIN" ] || crond -d 6; if [ "${OIDC_ENABLED:-0}" -ne 0 ]; then exec httpd -D FOREGROUND -D OIDC_ENABLED; else exec httpd -D FOREGROUND; fi'

--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -61,4 +61,4 @@ ENTRYPOINT ["./Docker/entrypoint.sh"]
 EXPOSE 80
 
 # hadolint ignore=DL3025
-CMD sh -c '[ -z "$CRON_MIN" ] || crond -d 6; if [ "${OIDC_ENABLED:-0}" -ne 0 ]; then exec httpd -D FOREGROUND -D OIDC_ENABLED; else exec httpd -D FOREGROUND; fi'
+CMD sh -c '([ -z "$CRON_MIN" ] || crond -d 6) && if [ "${OIDC_ENABLED:-0}" -ne 0 ]; then exec httpd -D FOREGROUND -D OIDC_ENABLED; else exec httpd -D FOREGROUND; fi'

--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -61,4 +61,4 @@ ENTRYPOINT ["./Docker/entrypoint.sh"]
 EXPOSE 80
 # hadolint ignore=DL3025
 CMD ([ -z "$CRON_MIN" ] || crond -d 6) && \
-	exec httpd -D FOREGROUND $([ "${OIDC_ENABLED:-0}" -ne 0 ] && echo "-D OIDC_ENABLED")
+	exec httpd -D FOREGROUND $([ -n "$OIDC_ENABLED" ] && [ "$OIDC_ENABLED" -ne 0 ] && echo "-D OIDC_ENABLED")

--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -60,5 +60,5 @@ ENTRYPOINT ["./Docker/entrypoint.sh"]
 
 EXPOSE 80
 # hadolint ignore=DL3025
-CMD ([ -z "$CRON_MIN" ] || crond -d 6) && \
+CMD [ -z "$CRON_MIN" ] || crond -d 6 && \
 	exec httpd -D FOREGROUND $([ "${OIDC_ENABLED:-0}" -ne 0 ] && echo "-D OIDC_ENABLED")

--- a/Docker/Dockerfile-Newest
+++ b/Docker/Dockerfile-Newest
@@ -62,6 +62,6 @@ ENV TRUSTED_PROXY=''
 ENTRYPOINT ["./Docker/entrypoint.sh"]
 
 EXPOSE 80
+
 # hadolint ignore=DL3025
-CMD ([ -z "$CRON_MIN" ] || crond -d 6) && \
-	exec httpd -D FOREGROUND $([ -n "$OIDC_ENABLED" ] && [ "$OIDC_ENABLED" -ne 0 ] && echo '-D OIDC_ENABLED')
+CMD sh -c '[ -z "$CRON_MIN" ] || crond -d 6; if [ "${OIDC_ENABLED:-0}" -ne 0 ]; then exec httpd -D FOREGROUND -D OIDC_ENABLED; else exec httpd -D FOREGROUND; fi'

--- a/Docker/Dockerfile-Newest
+++ b/Docker/Dockerfile-Newest
@@ -63,5 +63,5 @@ ENTRYPOINT ["./Docker/entrypoint.sh"]
 
 EXPOSE 80
 # hadolint ignore=DL3025
-CMD ([ -z "$CRON_MIN" ] || crond -d 6) && \
+CMD [ -z "$CRON_MIN" ] || crond -d 6 && \
 	exec httpd -D FOREGROUND $([ "${OIDC_ENABLED:-0}" -ne 0 ] && echo "-D OIDC_ENABLED")

--- a/Docker/Dockerfile-Newest
+++ b/Docker/Dockerfile-Newest
@@ -64,4 +64,4 @@ ENTRYPOINT ["./Docker/entrypoint.sh"]
 EXPOSE 80
 # hadolint ignore=DL3025
 CMD ([ -z "$CRON_MIN" ] || crond -d 6) && \
-	exec httpd -D FOREGROUND $([ "${OIDC_ENABLED:-0}" -ne 0 ] && echo "-D OIDC_ENABLED")
+	exec httpd -D FOREGROUND $([ -n "$OIDC_ENABLED" ] && [ "$OIDC_ENABLED" -ne 0 ] && echo "-D OIDC_ENABLED")

--- a/Docker/Dockerfile-Newest
+++ b/Docker/Dockerfile-Newest
@@ -64,4 +64,4 @@ ENTRYPOINT ["./Docker/entrypoint.sh"]
 EXPOSE 80
 
 # hadolint ignore=DL3025
-CMD sh -c '[ -z "$CRON_MIN" ] || crond -d 6; if [ "${OIDC_ENABLED:-0}" -ne 0 ]; then exec httpd -D FOREGROUND -D OIDC_ENABLED; else exec httpd -D FOREGROUND; fi'
+CMD sh -c '([ -z "$CRON_MIN" ] || crond -d 6) && if [ "${OIDC_ENABLED:-0}" -ne 0 ]; then exec httpd -D FOREGROUND -D OIDC_ENABLED; else exec httpd -D FOREGROUND; fi'

--- a/Docker/Dockerfile-Newest
+++ b/Docker/Dockerfile-Newest
@@ -62,6 +62,6 @@ ENV TRUSTED_PROXY=''
 ENTRYPOINT ["./Docker/entrypoint.sh"]
 
 EXPOSE 80
-
 # hadolint ignore=DL3025
-CMD sh -c '([ -z "$CRON_MIN" ] || crond -d 6) && if [ "${OIDC_ENABLED:-0}" -ne 0 ]; then exec httpd -D FOREGROUND -D OIDC_ENABLED; else exec httpd -D FOREGROUND; fi'
+CMD ([ -z "$CRON_MIN" ] || crond -d 6) && \
+	exec httpd -D FOREGROUND $([ "${OIDC_ENABLED:-0}" -ne 0 ] && echo "-D OIDC_ENABLED")

--- a/Docker/Dockerfile-Newest
+++ b/Docker/Dockerfile-Newest
@@ -63,5 +63,5 @@ ENTRYPOINT ["./Docker/entrypoint.sh"]
 
 EXPOSE 80
 # hadolint ignore=DL3025
-CMD [ -z "$CRON_MIN" ] || crond -d 6 && \
+CMD ([ -z "$CRON_MIN" ] || crond -d 6) && \
 	exec httpd -D FOREGROUND $([ "${OIDC_ENABLED:-0}" -ne 0 ] && echo "-D OIDC_ENABLED")

--- a/Docker/Dockerfile-Oldest
+++ b/Docker/Dockerfile-Oldest
@@ -62,4 +62,4 @@ ENTRYPOINT ["./Docker/entrypoint.sh"]
 EXPOSE 80
 
 # hadolint ignore=DL3025
-CMD sh -c '[ -z "$CRON_MIN" ] || crond -d 6; if [ "${OIDC_ENABLED:-0}" -ne 0 ]; then exec httpd -D FOREGROUND -D OIDC_ENABLED; else exec httpd -D FOREGROUND; fi'
+CMD sh -c '([ -z "$CRON_MIN" ] || crond -d 6) && if [ "${OIDC_ENABLED:-0}" -ne 0 ]; then exec httpd -D FOREGROUND -D OIDC_ENABLED; else exec httpd -D FOREGROUND; fi'

--- a/Docker/Dockerfile-Oldest
+++ b/Docker/Dockerfile-Oldest
@@ -61,5 +61,5 @@ ENTRYPOINT ["./Docker/entrypoint.sh"]
 
 EXPOSE 80
 # hadolint ignore=DL3025
-CMD [ -z "$CRON_MIN" ] || crond -d 6 && \
+CMD ([ -z "$CRON_MIN" ] || crond -d 6) && \
 	exec httpd -D FOREGROUND $([ "${OIDC_ENABLED:-0}" -ne 0 ] && echo "-D OIDC_ENABLED")

--- a/Docker/Dockerfile-Oldest
+++ b/Docker/Dockerfile-Oldest
@@ -60,6 +60,6 @@ ENV TRUSTED_PROXY=''
 ENTRYPOINT ["./Docker/entrypoint.sh"]
 
 EXPOSE 80
+
 # hadolint ignore=DL3025
-CMD ([ -z "$CRON_MIN" ] || crond -d 6) && \
-	exec httpd -D FOREGROUND $([ -n "$OIDC_ENABLED" ] && [ "$OIDC_ENABLED" -ne 0 ] && echo '-D OIDC_ENABLED')
+CMD sh -c '[ -z "$CRON_MIN" ] || crond -d 6; if [ "${OIDC_ENABLED:-0}" -ne 0 ]; then exec httpd -D FOREGROUND -D OIDC_ENABLED; else exec httpd -D FOREGROUND; fi'

--- a/Docker/Dockerfile-Oldest
+++ b/Docker/Dockerfile-Oldest
@@ -61,5 +61,5 @@ ENTRYPOINT ["./Docker/entrypoint.sh"]
 
 EXPOSE 80
 # hadolint ignore=DL3025
-CMD ([ -z "$CRON_MIN" ] || crond -d 6) && \
+CMD [ -z "$CRON_MIN" ] || crond -d 6 && \
 	exec httpd -D FOREGROUND $([ "${OIDC_ENABLED:-0}" -ne 0 ] && echo "-D OIDC_ENABLED")

--- a/Docker/Dockerfile-Oldest
+++ b/Docker/Dockerfile-Oldest
@@ -62,4 +62,4 @@ ENTRYPOINT ["./Docker/entrypoint.sh"]
 EXPOSE 80
 # hadolint ignore=DL3025
 CMD ([ -z "$CRON_MIN" ] || crond -d 6) && \
-	exec httpd -D FOREGROUND $([ "${OIDC_ENABLED:-0}" -ne 0 ] && echo "-D OIDC_ENABLED")
+	exec httpd -D FOREGROUND $([ -n "$OIDC_ENABLED" ] && [ "$OIDC_ENABLED" -ne 0 ] && echo "-D OIDC_ENABLED")

--- a/Docker/Dockerfile-Oldest
+++ b/Docker/Dockerfile-Oldest
@@ -60,6 +60,6 @@ ENV TRUSTED_PROXY=''
 ENTRYPOINT ["./Docker/entrypoint.sh"]
 
 EXPOSE 80
-
 # hadolint ignore=DL3025
-CMD sh -c '([ -z "$CRON_MIN" ] || crond -d 6) && if [ "${OIDC_ENABLED:-0}" -ne 0 ]; then exec httpd -D FOREGROUND -D OIDC_ENABLED; else exec httpd -D FOREGROUND; fi'
+CMD ([ -z "$CRON_MIN" ] || crond -d 6) && \
+	exec httpd -D FOREGROUND $([ "${OIDC_ENABLED:-0}" -ne 0 ] && echo "-D OIDC_ENABLED")


### PR DESCRIPTION
Some caller systems do not seem to obey the [SHELL instruction](https://docs.docker.com/reference/dockerfile/#shell) (or may be wrongly escaping quotes)
fix https://github.com/FreshRSS/FreshRSS/issues/7859#issuecomment-3225691432
fix https://github.com/FreshRSS/FreshRSS/discussions/5611
fix https://github.com/FreshRSS/FreshRSS/discussions/7267
