### PR TITLE
Fix curl response parsing

### DIFF
--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -539,20 +539,6 @@ function enforceHtmlBase(string $html, string $href): string {
 }
 
 /**
- * @param string $response Result from curl_exec() with CURLOPT_HEADER option enabled
- * @return ?\SimplePie\HTTP\Parser<false>
- */
-function parse_curl_response(string $response): ?\SimplePie\HTTP\Parser {
-	$parser = new \SimplePie\HTTP\Parser($response);
-	if (!$parser->parse()) return null;
-	while ($is_redirect = ($parser->status_code >= 300 && $parser->status_code <= 399)) {
-		$parser = new \SimplePie\HTTP\Parser($parser->body);
-		if (!$parser->parse()) return null;
-	}
-	return $parser;
-}
-
-/**
  * @param string $type {html,ico,json,opml,xml}
  * @param array<string,mixed> $attributes
  * @param array<int,mixed> $curl_options
@@ -657,13 +643,16 @@ function httpGet(string $url, string $cachePath, string $type = 'html', array $a
 	$c_redirect_count = curl_getinfo($ch, CURLINFO_REDIRECT_COUNT);
 	$c_error = curl_error($ch);
 
-	$parser = parse_curl_response(is_string($response) ? $response : '');
-	if ($parser !== null) {
-		$headers = $parser->headers;
-		$body = $parser->body;
-	} else {
-		$headers = [];
-		$body = false;
+	$body = false;
+	$headers = [];
+	if ($c_error == '') {
+		assert($c_redirect_count >= 0);
+		$response = \SimplePie\HTTP\Parser::prepareHeaders(is_string($response) ? $response : '', $c_redirect_count + 1);
+		$parser = new \SimplePie\HTTP\Parser($response);
+		if ($parser->parse()) {
+			$headers = $parser->headers;
+			$body = $parser->body;
+		}
 	}
 
 	$fail = $c_status != 200 || $c_error != '' || $body === false;

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -642,10 +642,11 @@ function httpGet(string $url, string $cachePath, string $type = 'html', array $a
 	$c_effective_url = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
 	$c_redirect_count = curl_getinfo($ch, CURLINFO_REDIRECT_COUNT);
 	$c_error = curl_error($ch);
+	$c_errno = curl_errno($ch);
 
 	$body = false;
 	$headers = [];
-	if ($c_error == '') {
+	if ($response !== false && $c_errno === 0) {
 		assert($c_redirect_count >= 0);
 		$response = \SimplePie\HTTP\Parser::prepareHeaders(is_string($response) ? $response : '', $c_redirect_count + 1);
 		$parser = new \SimplePie\HTTP\Parser($response);

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -539,6 +539,20 @@ function enforceHtmlBase(string $html, string $href): string {
 }
 
 /**
+ * @param string $response Result from curl_exec() with CURLOPT_HEADER option enabled
+ * @return ?\SimplePie\HTTP\Parser<false>
+ */
+function parse_curl_response(string $response): ?\SimplePie\HTTP\Parser {
+	$parser = new \SimplePie\HTTP\Parser($response);
+	if (!$parser->parse()) return null;
+	while ($is_redirect = ($parser->status_code >= 300 && $parser->status_code <= 399)) {
+		$parser = new \SimplePie\HTTP\Parser($parser->body);
+		if (!$parser->parse()) return null;
+	}
+	return $parser;
+}
+
+/**
  * @param string $type {html,ico,json,opml,xml}
  * @param array<string,mixed> $attributes
  * @param array<int,mixed> $curl_options
@@ -643,8 +657,8 @@ function httpGet(string $url, string $cachePath, string $type = 'html', array $a
 	$c_redirect_count = curl_getinfo($ch, CURLINFO_REDIRECT_COUNT);
 	$c_error = curl_error($ch);
 
-	$parser = new \SimplePie\HTTP\Parser(is_string($response) ? $response : '');
-	if ($parser->parse()) {
+	$parser = parse_curl_response(is_string($response) ? $response : '');
+	if ($parser !== null) {
 		$headers = $parser->headers;
 		$body = $parser->body;
 	} else {

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -642,11 +642,10 @@ function httpGet(string $url, string $cachePath, string $type = 'html', array $a
 	$c_effective_url = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
 	$c_redirect_count = curl_getinfo($ch, CURLINFO_REDIRECT_COUNT);
 	$c_error = curl_error($ch);
-	$c_errno = curl_errno($ch);
 
 	$body = false;
 	$headers = [];
-	if ($response !== false && $c_errno === 0) {
+	if ($response !== false) {
 		assert($c_redirect_count >= 0);
 		$response = \SimplePie\HTTP\Parser::prepareHeaders(is_string($response) ? $response : '', $c_redirect_count + 1);
 		$parser = new \SimplePie\HTTP\Parser($response);


### PR DESCRIPTION
Regression from #7760 

After curl followed any redirects there would incorrectly be HTTP headers from the next response in the parsed response body.

Test feeds:
* https://research.securitum.com/feed/
   * FreshRSS tried to fetch `/favicon.ico` to download the icon, got redirected and the default WordPress icon didn't download correctly due to `isImgMime()` failing when seeing HTTP headers at the beginning
* https://turnoff.us/feed.xml
   * Set `html` as the CSS selector and click preview, see headers:
       
<img width="1463" height="316" alt="image" src="https://github.com/user-attachments/assets/12f19352-f803-4553-b402-946ecb9d5c94" />

* https://blog.thea.codes/feed.xml
     * Same as above
