### PR TITLE
Global view: use generic CSS class to open panel

### DIFF
--- a/app/views/index/global.phtml
+++ b/app/views/index/global.phtml
@@ -58,7 +58,7 @@
 			$unreadArticles += $cat->nbNotRead();
 ?>
 	<div class="box category" data-unread="<?= $cat->nbNotRead() ?>">
-		<div class="box-title"><a class="title" data-unread="<?= format_number($cat->nbNotRead()) ?>"
+		<div class="box-title"><a class="title open-panel" data-unread="<?= format_number($cat->nbNotRead()) ?>"
 			href="<?= Minz_Url::display($url_base) ?>"><h2><?= $cat->name() ?></h2></a></div>
 
 		<ul class="box-content scrollbar-thin">
@@ -86,7 +86,7 @@
 			<li id="f_<?= $feed->id() ?>" class="item feed<?= $error_class, $empty_class, $mute_class ?>" title="<?= $error_title, $empty_title ?>"
 				data-unread="<?= $feed->nbNotRead() ?>" data-priority="<?= $feed->priority() ?>">
 				<?php if (FreshRSS_Context::userConf()->show_favicons): ?><img class="favicon" src="<?= $feed->favicon() ?>" alt="✇" loading="lazy" /><?php endif; ?>
-				<a class="item-title" data-unread="<?= format_number($feed->nbNotRead()) ?>" href="<?= Minz_Url::display($url_base) ?>"><?= $feed->name() ?></a>
+				<a class="item-title open-panel" data-unread="<?= format_number($feed->nbNotRead()) ?>" href="<?= Minz_Url::display($url_base) ?>"><?= $feed->name() ?></a>
 			</li>
 			<?php } ?>
 		</ul>

--- a/p/scripts/global_view.js
+++ b/p/scripts/global_view.js
@@ -85,7 +85,7 @@ function init_close_panel() {
 
 function init_global_view() {
 	// TODO: should be based on generic classes
-	document.querySelectorAll('.box a').forEach(function (a) {
+	document.querySelectorAll('.open-panel').forEach(function (a) {
 		a.onclick = function (ev) {
 			load_panel(a.href);
 			return false;

--- a/p/scripts/global_view.js
+++ b/p/scripts/global_view.js
@@ -84,7 +84,6 @@ function init_close_panel() {
 }
 
 function init_global_view() {
-	// TODO: should be based on generic classes
 	document.querySelectorAll('.open-panel').forEach(function (a) {
 		a.onclick = function (ev) {
 			load_panel(a.href);


### PR DESCRIPTION
I found this todo and just did it. 😆 

Changes proposed in this pull request:

- use `open-class` instead of `.box a`


How to test the feature manually:

1. go to global view
2. click on a box title link: it will open the whole category in the panel
3. click on a feed name: it will open the feed articles in the panel
4. nothing will be different for the user as before
