### PR TITLE
fix: Mapco/Ansum theme: read all button in mobile view

### DIFF
--- a/p/themes/Ansum/_mobile.scss
+++ b/p/themes/Ansum/_mobile.scss
@@ -96,6 +96,10 @@
 		}
 	}
 
+	#nav_menu_read_all #nav_menu_read .dropdown-toggle.btn {
+		background-image: none;
+	}
+
 	#stream {
 		.flux {
 			.flux_header {

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -1213,21 +1213,21 @@ main.prompt {
 		padding: 0.5rem 1rem;
 	}
 	.aside .toggle_aside,
-#overlay .close,
-.dropdown-menu .toggle_aside,
-#slider .toggle_aside {
+	#overlay .close,
+	.dropdown-menu .toggle_aside,
+	#slider .toggle_aside {
 		background-color: #ca7227;
 	}
 	.aside .toggle_aside:hover,
-#overlay .close:hover,
-.dropdown-menu .toggle_aside:hover,
-#slider .toggle_aside:hover {
+	#overlay .close:hover,
+	.dropdown-menu .toggle_aside:hover,
+	#slider .toggle_aside:hover {
 		background-color: #b7641d;
 	}
 	.aside .toggle_aside .icon,
-#overlay .close .icon,
-.dropdown-menu .toggle_aside .icon,
-#slider .toggle_aside .icon {
+	#overlay .close .icon,
+	.dropdown-menu .toggle_aside .icon,
+	#slider .toggle_aside .icon {
 		filter: grayscale(100%) brightness(2.5);
 	}
 	.header .item.search {
@@ -1256,16 +1256,16 @@ main.prompt {
 		padding: 0.85rem 1.25rem;
 	}
 	.nav_menu .stick,
-.nav_menu .group {
+	.nav_menu .group {
 		margin: 0.5rem 0.5rem;
 	}
 	.nav_menu .stick .btn,
-.nav_menu .group .btn {
+	.nav_menu .group .btn {
 		margin: 0;
 		padding: 0.85rem 1.25rem;
 	}
 	.nav_menu .stick .btn.read_all,
-.nav_menu .group .btn.read_all {
+	.nav_menu .group .btn.read_all {
 		padding: 0.85rem 1.25rem;
 	}
 	.nav_menu .search .input {

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -1339,3 +1339,5 @@ a, button.as-link {
 	outline: none;
 	color: #ca7227;
 }
+
+/*# sourceMappingURL=ansum.css.map */

--- a/p/themes/Ansum/ansum.css
+++ b/p/themes/Ansum/ansum.css
@@ -1213,21 +1213,21 @@ main.prompt {
 		padding: 0.5rem 1rem;
 	}
 	.aside .toggle_aside,
-	#overlay .close,
-	.dropdown-menu .toggle_aside,
-	#slider .toggle_aside {
+#overlay .close,
+.dropdown-menu .toggle_aside,
+#slider .toggle_aside {
 		background-color: #ca7227;
 	}
 	.aside .toggle_aside:hover,
-	#overlay .close:hover,
-	.dropdown-menu .toggle_aside:hover,
-	#slider .toggle_aside:hover {
+#overlay .close:hover,
+.dropdown-menu .toggle_aside:hover,
+#slider .toggle_aside:hover {
 		background-color: #b7641d;
 	}
 	.aside .toggle_aside .icon,
-	#overlay .close .icon,
-	.dropdown-menu .toggle_aside .icon,
-	#slider .toggle_aside .icon {
+#overlay .close .icon,
+.dropdown-menu .toggle_aside .icon,
+#slider .toggle_aside .icon {
 		filter: grayscale(100%) brightness(2.5);
 	}
 	.header .item.search {
@@ -1256,16 +1256,16 @@ main.prompt {
 		padding: 0.85rem 1.25rem;
 	}
 	.nav_menu .stick,
-	.nav_menu .group {
+.nav_menu .group {
 		margin: 0.5rem 0.5rem;
 	}
 	.nav_menu .stick .btn,
-	.nav_menu .group .btn {
+.nav_menu .group .btn {
 		margin: 0;
 		padding: 0.85rem 1.25rem;
 	}
 	.nav_menu .stick .btn.read_all,
-	.nav_menu .group .btn.read_all {
+.nav_menu .group .btn.read_all {
 		padding: 0.85rem 1.25rem;
 	}
 	.nav_menu .search .input {
@@ -1274,6 +1274,9 @@ main.prompt {
 	}
 	.nav_menu .search .input:focus {
 		width: 400px;
+	}
+	#nav_menu_read_all #nav_menu_read .dropdown-toggle.btn {
+		background-image: none;
 	}
 	#stream .flux .flux_header {
 		padding: 0.5rem 0;
@@ -1336,5 +1339,3 @@ a, button.as-link {
 	outline: none;
 	color: #ca7227;
 }
-
-/*# sourceMappingURL=ansum.css.map */

--- a/p/themes/Ansum/ansum.rtl.css
+++ b/p/themes/Ansum/ansum.rtl.css
@@ -1275,6 +1275,9 @@ main.prompt {
 	.nav_menu .search .input:focus {
 		width: 400px;
 	}
+	#nav_menu_read_all #nav_menu_read .dropdown-toggle.btn {
+		background-image: none;
+	}
 	#stream .flux .flux_header {
 		padding: 0.5rem 0;
 	}

--- a/p/themes/Mapco/_mobile.scss
+++ b/p/themes/Mapco/_mobile.scss
@@ -103,6 +103,10 @@
 		}
 	}
 
+	#nav_menu_read_all #nav_menu_read .dropdown-toggle.btn {
+		background-image: none;
+	}
+
 	#stream {
 		.flux {
 			.flux_header {

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -1225,21 +1225,21 @@ main.prompt {
 		padding: 0.5rem 1rem;
 	}
 	.aside .toggle_aside,
-	#overlay .close,
-	.dropdown-menu .toggle_aside,
-	#slider .toggle_aside {
+#overlay .close,
+.dropdown-menu .toggle_aside,
+#slider .toggle_aside {
 		background-color: #36c;
 	}
 	.aside .toggle_aside:hover,
-	#overlay .close:hover,
-	.dropdown-menu .toggle_aside:hover,
-	#slider .toggle_aside:hover {
+#overlay .close:hover,
+.dropdown-menu .toggle_aside:hover,
+#slider .toggle_aside:hover {
 		background-color: #25c;
 	}
 	.aside .toggle_aside .icon,
-	#overlay .close .icon,
-	.dropdown-menu .toggle_aside .icon,
-	#slider .toggle_aside .icon {
+#overlay .close .icon,
+.dropdown-menu .toggle_aside .icon,
+#slider .toggle_aside .icon {
 		filter: grayscale(100%) brightness(2.5);
 	}
 	.header .item.search {
@@ -1273,16 +1273,16 @@ main.prompt {
 		padding: 0.85rem 1.25rem;
 	}
 	.nav_menu .stick,
-	.nav_menu .group {
+.nav_menu .group {
 		margin: 0.5rem 0.5rem;
 	}
 	.nav_menu .stick .btn,
-	.nav_menu .group .btn {
+.nav_menu .group .btn {
 		margin: 0;
 		padding: 0.85rem 1.25rem;
 	}
 	.nav_menu .stick .btn.read_all,
-	.nav_menu .group .btn.read_all {
+.nav_menu .group .btn.read_all {
 		padding: 0.85rem 1.25rem;
 	}
 	.nav_menu .search .input {
@@ -1291,6 +1291,9 @@ main.prompt {
 	}
 	.nav_menu .search .input:focus {
 		width: 400px;
+	}
+	#nav_menu_read_all #nav_menu_read .dropdown-toggle.btn {
+		background-image: none;
 	}
 	#stream .flux .flux_header {
 		padding: 0.5rem 0;
@@ -1353,5 +1356,3 @@ a, button.as-link {
 	outline: none;
 	color: #36c;
 }
-
-/*# sourceMappingURL=mapco.css.map */

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -1225,21 +1225,21 @@ main.prompt {
 		padding: 0.5rem 1rem;
 	}
 	.aside .toggle_aside,
-#overlay .close,
-.dropdown-menu .toggle_aside,
-#slider .toggle_aside {
+	#overlay .close,
+	.dropdown-menu .toggle_aside,
+	#slider .toggle_aside {
 		background-color: #36c;
 	}
 	.aside .toggle_aside:hover,
-#overlay .close:hover,
-.dropdown-menu .toggle_aside:hover,
-#slider .toggle_aside:hover {
+	#overlay .close:hover,
+	.dropdown-menu .toggle_aside:hover,
+	#slider .toggle_aside:hover {
 		background-color: #25c;
 	}
 	.aside .toggle_aside .icon,
-#overlay .close .icon,
-.dropdown-menu .toggle_aside .icon,
-#slider .toggle_aside .icon {
+	#overlay .close .icon,
+	.dropdown-menu .toggle_aside .icon,
+	#slider .toggle_aside .icon {
 		filter: grayscale(100%) brightness(2.5);
 	}
 	.header .item.search {
@@ -1273,16 +1273,16 @@ main.prompt {
 		padding: 0.85rem 1.25rem;
 	}
 	.nav_menu .stick,
-.nav_menu .group {
+	.nav_menu .group {
 		margin: 0.5rem 0.5rem;
 	}
 	.nav_menu .stick .btn,
-.nav_menu .group .btn {
+	.nav_menu .group .btn {
 		margin: 0;
 		padding: 0.85rem 1.25rem;
 	}
 	.nav_menu .stick .btn.read_all,
-.nav_menu .group .btn.read_all {
+	.nav_menu .group .btn.read_all {
 		padding: 0.85rem 1.25rem;
 	}
 	.nav_menu .search .input {

--- a/p/themes/Mapco/mapco.css
+++ b/p/themes/Mapco/mapco.css
@@ -1356,3 +1356,5 @@ a, button.as-link {
 	outline: none;
 	color: #36c;
 }
+
+/*# sourceMappingURL=mapco.css.map */

--- a/p/themes/Mapco/mapco.rtl.css
+++ b/p/themes/Mapco/mapco.rtl.css
@@ -1292,6 +1292,9 @@ main.prompt {
 	.nav_menu .search .input:focus {
 		width: 400px;
 	}
+	#nav_menu_read_all #nav_menu_read .dropdown-toggle.btn {
+		background-image: none;
+	}
 	#stream .flux .flux_header {
 		padding: 0.5rem 0;
 	}


### PR DESCRIPTION
Closes #7644

Before:
<img width="212" height="153" alt="grafik" src="https://github.com/user-attachments/assets/628034cf-421a-43c1-a762-21906d99d5d9" />


After:
<img width="249" height="186" alt="grafik" src="https://github.com/user-attachments/assets/8414aa34-4936-44e1-84e4-52dad70477b6" />


How to test the feature manually:

1. use Ansum/Mapco theme
2. have a small screen to see it in the mobile view
3. see the read all button in the normal view

