### PR TITLE
delete sub.title.rename_label

### DIFF
--- a/app/i18n/cs/sub.php
+++ b/app/i18n/cs/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPML category name',	// TODO
 		'delete_label' => 'Odstranit popisek',
 		'feed_management' => 'Správa kanálů RSS',
-		'rename_label' => 'Přejmenovat popisek',
 		'subscription_tools' => 'Nástroje odběrů',
 	),
 );

--- a/app/i18n/de/sub.php
+++ b/app/i18n/de/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPML Kategoriename',
 		'delete_label' => 'Label löschen',
 		'feed_management' => 'RSS-Feeds verwalten',
-		'rename_label' => 'Label umbenennen',
 		'subscription_tools' => 'Abonnement-Tools',
 	),
 );

--- a/app/i18n/el/sub.php
+++ b/app/i18n/el/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPML category name',	// TODO
 		'delete_label' => 'Delete this label',	// TODO
 		'feed_management' => 'RSS feeds management',	// TODO
-		'rename_label' => 'Rename a label',	// TODO
 		'subscription_tools' => 'Subscription tools',	// TODO
 	),
 );

--- a/app/i18n/en-us/sub.php
+++ b/app/i18n/en-us/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPML category name',	// IGNORE
 		'delete_label' => 'Delete this label',	// IGNORE
 		'feed_management' => 'RSS feeds management',	// IGNORE
-		'rename_label' => 'Rename a label',	// IGNORE
 		'subscription_tools' => 'Subscription tools',	// IGNORE
 	),
 );

--- a/app/i18n/en/sub.php
+++ b/app/i18n/en/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPML category name',
 		'delete_label' => 'Delete this label',
 		'feed_management' => 'RSS feeds management',
-		'rename_label' => 'Rename a label',
 		'subscription_tools' => 'Subscription tools',
 	),
 );

--- a/app/i18n/es/sub.php
+++ b/app/i18n/es/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPML category name',	// TODO
 		'delete_label' => 'Eliminar una etiqueta',
 		'feed_management' => 'Administración de fuentes RSS',
-		'rename_label' => 'Cambiar el nombre de una etiqueta',
 		'subscription_tools' => 'Herramientas de suscripción',
 	),
 );

--- a/app/i18n/fa/sub.php
+++ b/app/i18n/fa/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'نام دسته OPML',
 		'delete_label' => ' یک برچسب را حذف کنید',
 		'feed_management' => ' فیدهای RSS را مدیریت می کندment',
-		'rename_label' => ' نام یک برچسب را تغییر دهید',
 		'subscription_tools' => 'ابزارهای اشتراک',
 	),
 );

--- a/app/i18n/fi/sub.php
+++ b/app/i18n/fi/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPML category name',	// TODO
 		'delete_label' => 'Poista tunniste',
 		'feed_management' => 'RSS-syötteiden hallinta',
-		'rename_label' => 'Nimeä tunniste uudelleen',
 		'subscription_tools' => 'Tilaustyökalut',
 	),
 );

--- a/app/i18n/fr/sub.php
+++ b/app/i18n/fr/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'Nom de la catégorie OPML',
 		'delete_label' => 'Supprimer l’étiquette',
 		'feed_management' => 'Gestion des flux RSS',
-		'rename_label' => 'Renommer l’étiquette',
 		'subscription_tools' => 'Outils d’abonnement',
 	),
 );

--- a/app/i18n/he/sub.php
+++ b/app/i18n/he/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPML category name',	// TODO
 		'delete_label' => 'Delete this label',	// TODO
 		'feed_management' => 'ניהול הזנות RSS',
-		'rename_label' => 'Rename a label',	// TODO
 		'subscription_tools' => 'Subscription tools',	// TODO
 	),
 );

--- a/app/i18n/hu/sub.php
+++ b/app/i18n/hu/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPML kategória név',
 		'delete_label' => 'Címke törlése',
 		'feed_management' => 'RSS hírforrások kezelése',
-		'rename_label' => 'Címke átnevezése',
 		'subscription_tools' => 'Feliratkozási eszközök',
 	),
 );

--- a/app/i18n/id/sub.php
+++ b/app/i18n/id/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'Nama kategori OPML',
 		'delete_label' => 'Hapus label',
 		'feed_management' => 'Pengelolaan umpan RSS',
-		'rename_label' => 'Ubah nama label',
 		'subscription_tools' => 'Alat langganan',
 	),
 );

--- a/app/i18n/it/sub.php
+++ b/app/i18n/it/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'Nome categoria OPML',
 		'delete_label' => 'Cancella un’etichetta',
 		'feed_management' => 'Gestione feed RSS',
-		'rename_label' => 'Rinomina un’etichetta',
 		'subscription_tools' => 'Strumenti di sottoscrizione',
 	),
 );

--- a/app/i18n/ja/sub.php
+++ b/app/i18n/ja/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPMLカテゴリ名',
 		'delete_label' => 'ラベルの削除',
 		'feed_management' => 'RSSフィードの管理',
-		'rename_label' => 'ラベルの名前変更',
 		'subscription_tools' => '購読ツール',
 	),
 );

--- a/app/i18n/ko/sub.php
+++ b/app/i18n/ko/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPML category name',	// TODO
 		'delete_label' => '라벨 삭제',
 		'feed_management' => 'RSS 피드 관리',
-		'rename_label' => '라벨 이름 바꾸기',
 		'subscription_tools' => '구독 도구',
 	),
 );

--- a/app/i18n/lv/sub.php
+++ b/app/i18n/lv/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPML category name',	// TODO
 		'delete_label' => 'Noņemt birku',
 		'feed_management' => 'RSS barotņu pārvalde',
-		'rename_label' => 'Birkas vārda maiņa',
 		'subscription_tools' => 'Abonamentu rīki',
 	),
 );

--- a/app/i18n/nl/sub.php
+++ b/app/i18n/nl/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPML categorienaam',
 		'delete_label' => 'Label verwijderen',
 		'feed_management' => 'RSS-feedbeheer',
-		'rename_label' => 'Label hernoemen',
 		'subscription_tools' => 'Hulpmiddelen voor abonnementen',
 	),
 );

--- a/app/i18n/oc/sub.php
+++ b/app/i18n/oc/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPML category name',	// TODO
 		'delete_label' => 'Suprimir una etiqueta',
 		'feed_management' => 'Gestion dels fluxes RSS',
-		'rename_label' => 'Renomenar una etiqueta',
 		'subscription_tools' => 'Aisinas d’abonament',
 	),
 );

--- a/app/i18n/pl/sub.php
+++ b/app/i18n/pl/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'Nazwa kategorii OPML',
 		'delete_label' => 'Usuń etykietę',
 		'feed_management' => 'Zarządzanie kanałami RSS',
-		'rename_label' => 'Zmień nazwę etykiety',
 		'subscription_tools' => 'Narzędzia subskrypcji',
 	),
 );

--- a/app/i18n/pt-br/sub.php
+++ b/app/i18n/pt-br/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPML category name',	// TODO
 		'delete_label' => 'Deletar uma etiqueta',
 		'feed_management' => 'Gerenciamento dos RSS feeds',
-		'rename_label' => 'Renomear uma etiqueta',
 		'subscription_tools' => 'Ferramentas de inscrição',
 	),
 );

--- a/app/i18n/pt-pt/sub.php
+++ b/app/i18n/pt-pt/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPML category name',	// TODO
 		'delete_label' => 'Apagar uma etiqueta',
 		'feed_management' => 'Gerir dos RSS feeds',
-		'rename_label' => 'Renomear uma etiqueta',
 		'subscription_tools' => 'Ferramentas de inscrição',
 	),
 );

--- a/app/i18n/ru/sub.php
+++ b/app/i18n/ru/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPML category name',	// TODO
 		'delete_label' => 'Удалить метку',
 		'feed_management' => 'Управление RSS-лентами',
-		'rename_label' => 'Переименовать метку',
 		'subscription_tools' => 'Инструменты подписки',
 	),
 );

--- a/app/i18n/sk/sub.php
+++ b/app/i18n/sk/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPML category name',	// TODO
 		'delete_label' => 'Zmazať štítok',
 		'feed_management' => 'Správa RSS kanálov',
-		'rename_label' => 'Premenovať štítok',
 		'subscription_tools' => 'Nástroje na odoberanie kanálov',
 	),
 );

--- a/app/i18n/tr/sub.php
+++ b/app/i18n/tr/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPML kategori adı',
 		'delete_label' => 'Etiketi sil',
 		'feed_management' => 'RSS besleme yönetimi',
-		'rename_label' => 'Etiketi yeniden adlandır',
 		'subscription_tools' => 'Abonelik araçları',
 	),
 );

--- a/app/i18n/zh-cn/sub.php
+++ b/app/i18n/zh-cn/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPML category name',	// TODO
 		'delete_label' => '删除标签',
 		'feed_management' => '订阅源管理',
-		'rename_label' => '重命名标签',
 		'subscription_tools' => '订阅工具',
 	),
 );

--- a/app/i18n/zh-tw/sub.php
+++ b/app/i18n/zh-tw/sub.php
@@ -301,7 +301,6 @@ return array(
 		'add_opml_category' => 'OPML category name',	// TODO
 		'delete_label' => '刪除標籤',
 		'feed_management' => '訂閱源管理',
-		'rename_label' => '重命名標籤',
 		'subscription_tools' => '訂閱工具',
 	),
 );


### PR DESCRIPTION
Ref #7871 
Ref #5954

Changes proposed in this pull request:

- `sub.title.rename_label ` has been not used anymore since #5954 (Version V1.24.0)
- `sub.title.rename_label ` deleted

