### PR TITLE
Fix log CRLF injection

### DIFF
--- a/app/Models/Log.php
+++ b/app/Models/Log.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 class FreshRSS_Log extends Minz_Model {
 
 	private string $date;
+	/** @property 'error'|'warning'|'notice'|'debug'|'info' $level */
 	private string $level;
 	private string $information;
 
@@ -20,6 +21,10 @@ class FreshRSS_Log extends Minz_Model {
 		$this->date = $date;
 	}
 	public function _level(string $level): void {
+		if (!in_array($level, ['error', 'warning', 'notice', 'debug', 'info'], true)) {
+			$this->level = 'info';
+			return;
+		}
 		$this->level = $level;
 	}
 	public function _info(string $information): void {

--- a/lib/Minz/Log.php
+++ b/lib/Minz/Log.php
@@ -56,7 +56,7 @@ class Minz_Log {
 					$level_label = 'info';
 			}
 
-			$log = '[' . date('r') . '] [' . $level_label . '] --- ' . str_replace(["\r", "\n"], '', $information) . "\n";
+			$log = '[' . date('r') . '] [' . $level_label . '] --- ' . str_replace(["\r", "\n"], ' ', $information) . "\n";
 
 			if (defined('COPY_LOG_TO_SYSLOG') && COPY_LOG_TO_SYSLOG) {
 				syslog($level, '[' . $username . '] ' . trim($log));

--- a/lib/Minz/Log.php
+++ b/lib/Minz/Log.php
@@ -56,7 +56,7 @@ class Minz_Log {
 					$level_label = 'info';
 			}
 
-			$log = '[' . date('r') . '] [' . $level_label . '] --- ' . $information . "\n";
+			$log = '[' . date('r') . '] [' . $level_label . '] --- ' . str_replace(["\r", "\n"], '', $information) . "\n";
 
 			if (defined('COPY_LOG_TO_SYSLOG') && COPY_LOG_TO_SYSLOG) {
 				syslog($level, '[' . $username . '] ' . trim($log));


### PR DESCRIPTION
Can inject new lines into `Minz_Request::paramString('challenge')` f.e. by logging in with challenge `x%0D%0A[Sat, 30 Aug 2025 21:39:50 +0000] [warning] --- something`
https://github.com/FreshRSS/FreshRSS/blob/200eafb352f807bd70592b2ccc06745017328a85/app/Controllers/authController.php#L181
<img width="816" height="113" alt="image" src="https://github.com/user-attachments/assets/47808d0c-fca1-4660-ae1b-25b04e791988" />

If it were `Minz_Request::paramString('challenge', plaintext: true)` or somewhere else, HTML could be injected into `level`
https://github.com/FreshRSS/FreshRSS/blob/200eafb352f807bd70592b2ccc06745017328a85/app/views/index/logs.phtml#L27

which is why its values are restricted now
