### PR TITLE
fix: add validation when creating a new tag

### DIFF
--- a/app/Controllers/tagController.php
+++ b/app/Controllers/tagController.php
@@ -153,14 +153,21 @@ class FreshRSS_tag_Controller extends FreshRSS_ActionController {
 			Minz_Error::error(405);
 		}
 
+		$url_redirect = ['c' => 'tag', 'a' => 'index'];
 		$name = Minz_Request::paramString('name');
-		$tagDAO = FreshRSS_Factory::createTagDao();
-		if (strlen($name) > 0 && null === $tagDAO->searchByName($name)) {
-			$tagDAO->addTag(['name' => $name]);
-			Minz_Request::good(_t('feedback.tag.created', $name), ['c' => 'tag', 'a' => 'index']);
+
+		$catDAO = FreshRSS_Factory::createCategoryDao();
+		if ($catDAO->searchByName($name) !== null) {
+			Minz_Request::bad(_t('feedback.sub.category.name_exists'), $url_redirect);
 		}
 
-		Minz_Request::bad(_t('feedback.tag.name_exists', $name), ['c' => 'tag', 'a' => 'index']);
+		$tagDAO = FreshRSS_Factory::createTagDao();
+		if ($tagDAO->searchByName($name) !== null) {
+			Minz_Request::bad(_t('feedback.tag.name_exists', $name), $url_redirect);
+		}
+
+		$tagDAO->addTag(['name' => $name]);
+		Minz_Request::good(_t('feedback.tag.created', $name), $url_redirect);
 	}
 
 	/**


### PR DESCRIPTION
A tag name must be unique and can't be used as a category. There were no error message when creating a tag identical to an existing category. Now, this is addressed.

See #7686

Closes #7686

Changes proposed in this pull request:

- add validation on tag creation

How to test the feature manually:

1. create a new category (ex: `HW`)
2. create a new tag with the same name as the new category (ex: `HW`)
3. validate that the appropriate error message is displayed

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
