### PR TITLE
fix: add default values on stat processing

### DIFF
--- a/app/views/stats/index.phtml
+++ b/app/views/stats/index.phtml
@@ -112,7 +112,7 @@ function generateColorPalette(int $count): array {
 }
 
 // 1. Get all unique category labels and sort them
-$allLabels = array_unique(array_merge($this->feedByCategory['label'], $this->entryByCategory['label']));
+$allLabels = array_unique(array_merge($this->feedByCategory['label'] ?? [], $this->entryByCategory['label'] ?? []));
 sort($allLabels); // Ensure consistent order
 
 // 2. Generate a color palette based on the number of unique categories
@@ -123,11 +123,11 @@ $colorMap = array_combine($allLabels, $colorPalette);
 
 // 4. Align data and labels for both charts
 $feedData = array_fill_keys($allLabels, 0); // Initialize data with all categories
-foreach ($this->feedByCategory['label'] as $index => $label) {
+foreach ($this->feedByCategory['label'] ?? [] as $index => $label) {
 	$feedData[$label] = $this->feedByCategory['data'][$index];
 }
 $entryData = array_fill_keys($allLabels, 0); // Initialize data with all categories
-foreach ($this->entryByCategory['label'] as $index => $label) {
+foreach ($this->entryByCategory['label'] ?? [] as $index => $label) {
 	$entryData[$label] = $this->entryByCategory['data'][$index];
 }
 


### PR DESCRIPTION
Before, there was an error when retrieving stats for a user without feeds. Now, there are default values to display empty stats instead of an exception.

See #7884

Closes #7884

Changes proposed in this pull request:

- add default values when retrieving stat data

How to test the feature manually:

1. create a new user
2. connect as the new user
3. display stats
4. validate that there is no errors

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
