### PR TITLE
Fix displaying of current date in main statistics

### DIFF
--- a/app/Controllers/statsController.php
+++ b/app/Controllers/statsController.php
@@ -85,7 +85,7 @@ class FreshRSS_stats_Controller extends FreshRSS_ActionController {
 		$this->view->topFeed = $statsDAO->calculateTopFeed();
 
 		$last30DaysLabels = [];
-		for ($i = 0; $i < 30; $i++) {
+		for ($i = 0; $i < 31; $i++) {
 			$last30DaysLabels[$i] = date('d.m.Y', strtotime((-30 + $i) . ' days') ?: null);
 		}
 


### PR DESCRIPTION
Before

<img width="1034" height="543" alt="image" src="https://github.com/user-attachments/assets/09408f81-42f1-4613-948b-b2c7e3ff2409" />

After

<img width="1031" height="536" alt="image" src="https://github.com/user-attachments/assets/d4dd3702-c8a5-4f8d-9014-b419a982d9ec" />

The current day is now included within statistics.

The `-1` thing started happening after #7752 but I'm not sure whether the correct solution is to display the current day or just fix it in the JS

For reference here's what the chart used to looked like:

<img width="1027" height="536" alt="image" src="https://github.com/user-attachments/assets/47a27bad-6593-4e84-a04f-e4385f601c6a" />

