### PR TITLE
Fix/config dropdown menu mobile view

### DIFF
--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -1174,6 +1174,10 @@ a:hover .icon {
 		margin-bottom: 3rem;
 	}
 
+	.item.configure .dropdown .dropdown-menu {
+		border-radius: 0;
+	}
+
 	#nav_menu_read_all .btn {
 		border-left: 1px solid var(--border-color-shadow-side);
 		border-radius: 3px;

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -1174,6 +1174,10 @@ a:hover .icon {
 		margin-bottom: 3rem;
 	}
 
+	.item.configure .dropdown .dropdown-menu {
+		border-radius: 0;
+	}
+
 	#nav_menu_read_all .btn {
 		border-right: 1px solid var(--border-color-shadow-side);
 		border-radius: 3px;

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2643,9 +2643,9 @@ html.slider-active {
 		width: 90%;
 		height: 100vh;
 		top: 0;
-		right: 0;
+		right: 0 !important;
 		bottom: 0;
-		left: auto;
+		left: auto !important;
 		position: fixed;
 		padding-top: 0;
 		margin-top: 0;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2643,9 +2643,9 @@ html.slider-active {
 		width: 90%;
 		height: 100vh;
 		top: 0;
-		left: 0;
+		left: 0 !important;
 		bottom: 0;
-		right: auto;
+		right: auto !important;
 		position: fixed;
 		padding-top: 0;
 		margin-top: 0;


### PR DESCRIPTION
Before:
<img width="534" height="394" alt="grafik" src="https://github.com/user-attachments/assets/63cbf645-2380-448f-9e96-11cf454f9a13" />

1: menu is not right hand side aligned
2: rounded corner (Origine theme specific)

After:
<img width="533" height="359" alt="grafik" src="https://github.com/user-attachments/assets/bfb8fd79-3190-4d40-bba1-ef5fadb81f01" />

Menu is aligned on the right hand side
Sharp corner



Changes proposed in this pull request:

- CSS


How to test the feature manually:

1. small screen for mobile view
2. open config menu right top corner

Negative check:
other dropdown menus should not be touched (f.e. User Queries menu, search, article labels menu)
