### PR TITLE
Fix typo in Japanese translation

### DIFF
--- a/app/i18n/ja/sub.php
+++ b/app/i18n/ja/sub.php
@@ -82,7 +82,7 @@ return array(
 			'help' => '1行に1つの検索フィルターを設定してください。演算子は<a href="https://freshrss.github.io/FreshRSS/en/users/10_filter.html#with-the-search-field" target="_blank">ドキュメントを参照してください</a>。',
 		),
 		'http_headers' => 'HTTPヘッダ',
-		'http_headers_help' => 'ヘッダは開業で区切られ、ヘッダの名前と値はコロンで区切られます (例: <kbd><code>Accept: application/atom+xml<br />Authorization: Bearer some-token</code></kbd>).',
+		'http_headers_help' => 'ヘッダは改行で区切られ、ヘッダの名前と値はコロンで区切られます (例: <kbd><code>Accept: application/atom+xml<br />Authorization: Bearer some-token</code></kbd>).',
 		'icon' => 'Icon',	// TODO
 		'information' => 'インフォメーション',
 		'keep_min' => '最小数の記事は保持されます',


### PR DESCRIPTION
Hi, I just found a typo (Kanji conversion mistake) in Japanese translation. This is just fixing typo and just making the patch with editing on GitHub UI.

開業: opening business
改行: newline

How to test the feature manually:

This is tiny patch with only the string changed, I did not test the code.

Pull request checklist:

- [X] clear commit messages
- [ ] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
