### PR TITLE
Change make help output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,7 @@ else
 	DOCKERFILE=Dockerfile
 endif
 
-############
-## Docker ##
-############
+##@ Docker
 .PHONY: build
 build: ## Build a Docker image
 	docker build \
@@ -55,9 +53,7 @@ stop: ## Stop FreshRSS container if any
 	docker stop freshrss-dev || true
 	docker network rm $(NETWORK) || true
 
-######################
-## Tests and linter ##
-######################
+##@ Tests and linter
 .PHONY: test
 test: bin/phpunit ## Run the test suite
 	$(PHP) bin/phpunit --bootstrap ./tests/bootstrap.php ./tests
@@ -98,9 +94,7 @@ node_modules/.bin/eslint:
 node_modules/.bin/rtlcss:
 	npm install
 
-##########
-## I18N ##
-##########
+##@ I18n
 .PHONY: i18n-format
 i18n-format: ## Format I18N files
 	@$(PHP) ./cli/manipulate.translation.php -a format
@@ -170,9 +164,7 @@ ifndef key
 endif
 	@$(PHP) ./cli/manipulate.translation.php -a exist -k $(key)
 
-###########
-## TOOLS ##
-###########
+##@ Tools
 .PHONY: rtl
 rtl: node_modules/.bin/rtlcss ## Generate RTL CSS files
 	npm run-script rtlcss
@@ -218,10 +210,7 @@ test-all: composer-test npm-test typos-test
 .PHONY: fix-all
 fix-all: composer-fix npm-fix
 
-
-##########
-## HELP ##
-##########
+##@ Help
 .PHONY: help
-help:
-	@grep --extended-regexp '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+help: ## Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)


### PR DESCRIPTION
The new output allows to categorize the targets.

Changes proposed in this pull request:

- add target categories in the make output

How to test the feature manually:

1. in the terminal, launch the `make` command
2. validate that targets are categorized

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).

# Before
```
build                          Build a Docker image
i18n-add-key                   Add a translation key to all supported languages
i18n-add-language              Add a new supported language
i18n-format                    Format I18N files
i18n-ignore-key                Ignore a translation key for the selected language
i18n-ignore-unmodified-keys    Ignore all unmodified translation keys for the selected language
i18n-key-exists                Check if a translation key exists
i18n-remove-key                Remove a translation key from all supported languages
i18n-update-key                Update a translation key in all supported languages
lint                           Run the linter on the PHP files
lint-fix                       Fix the errors detected by the linter
pot                            Generate POT templates for docs
refresh                        Refresh feeds by fetching new messages
rtl                            Generate RTL CSS files
start                          Start the development environment (use Docker)
stop                           Stop FreshRSS container if any
test                           Run the test suite
```
# After
```
Usage:
  make <target>

Docker
  build                           Build a Docker image
  start                           Start the development environment (use Docker)
  stop                            Stop FreshRSS container if any

Tests and linter
  test                            Run the test suite
  lint                            Run the linter on the PHP files
  lint-fix                        Fix the errors detected by the linter

I18n
  i18n-format                     Format I18N files
  i18n-add-language               Add a new supported language
  i18n-add-key                    Add a translation key to all supported languages
  i18n-remove-key                 Remove a translation key from all supported languages
  i18n-update-key                 Update a translation key in all supported languages
  i18n-ignore-key                 Ignore a translation key for the selected language
  i18n-ignore-unmodified-keys     Ignore all unmodified translation keys for the selected language
  i18n-key-exists                 Check if a translation key exists

Tools
  rtl                             Generate RTL CSS files
  pot                             Generate POT templates for docs
  refresh                         Refresh feeds by fetching new messages

Help
  help                            Display this help
```