### PR TITLE
add target to generate the translation progress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,17 +165,21 @@ endif
 	@$(PHP) ./cli/manipulate.translation.php -a exist -k $(key)
 
 ##@ Tools
-.PHONY: rtl
-rtl: node_modules/.bin/rtlcss ## Generate RTL CSS files
-	npm run-script rtlcss
-
 .PHONY: pot
 pot: ## Generate POT templates for docs
 	cd docs && ../cli/translation-update.sh
 
+.PHONY: readme
+readme: ## Generate translation progress in README file
+	@$(PHP) ./cli/check.translation.php --generate-readme
+
 .PHONY: refresh
 refresh: ## Refresh feeds by fetching new messages
 	@$(PHP) ./app/actualize_script.php
+
+.PHONY: rtl
+rtl: node_modules/.bin/rtlcss ## Generate RTL CSS files
+	npm run-script rtlcss
 
 ###############################
 ## New commands aligned on CI #

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ node_modules/.bin/rtlcss:
 ##@ I18n
 .PHONY: i18n-format
 i18n-format: ## Format I18N files
-	@$(PHP) ./cli/manipulate.translation.php -a format
+	@$(PHP) ./cli/manipulate.translation.php --action format
 	@echo Files formatted.
 
 .PHONY: i18n-add-language
@@ -105,7 +105,7 @@ i18n-add-language: ## Add a new supported language
 ifndef lang
 	$(error To add a new language, you need to provide one in the "lang" variable)
 endif
-	$(PHP) ./cli/manipulate.translation.php -a add -l $(lang) -o $(ref)
+	$(PHP) ./cli/manipulate.translation.php --action add --language $(lang) --origin-language $(ref)
 	@echo Language added.
 
 .PHONY: i18n-add-key
@@ -116,7 +116,7 @@ endif
 ifndef value
 	$(error To add a key, you need to provide its value in the "value" variable)
 endif
-	@$(PHP) ./cli/manipulate.translation.php -a add -k $(key) -v "$(value)"
+	@$(PHP) ./cli/manipulate.translation.php --action add --key $(key) --value "$(value)"
 	@echo Key added.
 
 .PHONY: i18n-remove-key
@@ -124,7 +124,7 @@ i18n-remove-key: ## Remove a translation key from all supported languages
 ifndef key
 	$(error To remove a key, you need to provide one in the "key" variable)
 endif
-	@$(PHP) ./cli/manipulate.translation.php -a delete -k $(key)
+	@$(PHP) ./cli/manipulate.translation.php --action delete --key $(key)
 	@echo Key removed.
 
 .PHONY: i18n-update-key
@@ -135,7 +135,7 @@ endif
 ifndef value
 	$(error To update a key, you need to provide its value in the "value" variable)
 endif
-	@$(PHP) ./cli/manipulate.translation.php -a add -k $(key) -v "$(value)" -l en
+	@$(PHP) ./cli/manipulate.translation.php --action add --key $(key) --value "$(value)" --language en
 	@echo Key updated.
 
 .PHONY: i18n-ignore-key
@@ -146,7 +146,7 @@ endif
 ifndef key
 	$(error To ignore a key, you need to provide one in the "key" variable)
 endif
-	@$(PHP) ./cli/manipulate.translation.php -a ignore -k $(key) -l $(lang)
+	@$(PHP) ./cli/manipulate.translation.php --action ignore --key $(key) --language $(lang)
 	@echo Key ignored.
 
 .PHONY: i18n-ignore-unmodified-keys
@@ -154,7 +154,7 @@ i18n-ignore-unmodified-keys: ## Ignore all unmodified translation keys for the s
 ifndef lang
 	$(error To ignore unmodified keys, you need to provide a language in the "lang" variable)
 endif
-	@$(PHP) ./cli/manipulate.translation.php -a ignore_unmodified -l $(lang)
+	@$(PHP) ./cli/manipulate.translation.php --action ignore_unmodified --language $(lang)
 	@echo Unmodified keys ignored.
 
 .PHONY: i18n-key-exists
@@ -162,7 +162,7 @@ i18n-key-exists: ## Check if a translation key exists
 ifndef key
 	$(error To check if a key exists, you need to provide one in the "key" variable)
 endif
-	@$(PHP) ./cli/manipulate.translation.php -a exist -k $(key)
+	@$(PHP) ./cli/manipulate.translation.php --action exist --key $(key)
 
 ##@ Tools
 .PHONY: pot

--- a/Makefile
+++ b/Makefile
@@ -95,19 +95,6 @@ node_modules/.bin/rtlcss:
 	npm install
 
 ##@ I18n
-.PHONY: i18n-format
-i18n-format: ## Format I18N files
-	@$(PHP) ./cli/manipulate.translation.php --action format
-	@echo Files formatted.
-
-.PHONY: i18n-add-language
-i18n-add-language: ## Add a new supported language
-ifndef lang
-	$(error To add a new language, you need to provide one in the "lang" variable)
-endif
-	$(PHP) ./cli/manipulate.translation.php --action add --language $(lang) --origin-language $(ref)
-	@echo Language added.
-
 .PHONY: i18n-add-key
 i18n-add-key: ## Add a translation key to all supported languages
 ifndef key
@@ -119,24 +106,18 @@ endif
 	@$(PHP) ./cli/manipulate.translation.php --action add --key $(key) --value "$(value)"
 	@echo Key added.
 
-.PHONY: i18n-remove-key
-i18n-remove-key: ## Remove a translation key from all supported languages
-ifndef key
-	$(error To remove a key, you need to provide one in the "key" variable)
+.PHONY: i18n-add-language
+i18n-add-language: ## Add a new supported language
+ifndef lang
+	$(error To add a new language, you need to provide one in the "lang" variable)
 endif
-	@$(PHP) ./cli/manipulate.translation.php --action delete --key $(key)
-	@echo Key removed.
+	$(PHP) ./cli/manipulate.translation.php --action add --language $(lang) --origin-language $(ref)
+	@echo Language added.
 
-.PHONY: i18n-update-key
-i18n-update-key: ## Update a translation key in all supported languages
-ifndef key
-	$(error To update a key, you need to provide one in the "key" variable)
-endif
-ifndef value
-	$(error To update a key, you need to provide its value in the "value" variable)
-endif
-	@$(PHP) ./cli/manipulate.translation.php --action add --key $(key) --value "$(value)" --language en
-	@echo Key updated.
+.PHONY: i18n-format
+i18n-format: ## Format I18N files
+	@$(PHP) ./cli/manipulate.translation.php --action format
+	@echo Files formatted.
 
 .PHONY: i18n-ignore-key
 i18n-ignore-key: ## Ignore a translation key for the selected language
@@ -163,6 +144,25 @@ ifndef key
 	$(error To check if a key exists, you need to provide one in the "key" variable)
 endif
 	@$(PHP) ./cli/manipulate.translation.php --action exist --key $(key)
+
+.PHONY: i18n-remove-key
+i18n-remove-key: ## Remove a translation key from all supported languages
+ifndef key
+	$(error To remove a key, you need to provide one in the "key" variable)
+endif
+	@$(PHP) ./cli/manipulate.translation.php --action delete --key $(key)
+	@echo Key removed.
+
+.PHONY: i18n-update-key
+i18n-update-key: ## Update a translation key in all supported languages
+ifndef key
+	$(error To update a key, you need to provide one in the "key" variable)
+endif
+ifndef value
+	$(error To update a key, you need to provide its value in the "value" variable)
+endif
+	@$(PHP) ./cli/manipulate.translation.php --action add --key $(key) --value "$(value)" --language en
+	@echo Key updated.
 
 ##@ Tools
 .PHONY: pot

--- a/Makefile
+++ b/Makefile
@@ -54,17 +54,17 @@ stop: ## Stop FreshRSS container if any
 	docker network rm $(NETWORK) || true
 
 ##@ Tests and linter
-.PHONY: test
-test: bin/phpunit ## Run the test suite
-	$(PHP) bin/phpunit --bootstrap ./tests/bootstrap.php ./tests
-
 .PHONY: lint
-lint: bin/phpcs ## Run the linter on the PHP files
+lint: bin/phpcs ## Run the linter on PHP files
 	$(PHP) bin/phpcs . -p -s
 
 .PHONY: lint-fix
 lint-fix: bin/phpcbf ## Fix the errors detected by the linter
 	$(PHP) bin/phpcbf . -p -s
+
+.PHONY: test
+test: bin/phpunit ## Run the test suite
+	$(PHP) bin/phpunit --bootstrap ./tests/bootstrap.php ./tests
 
 bin/composer:
 	mkdir -p bin/

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "phpstan": "phpstan analyse .",
         "phpstan-next": "phpstan analyse -c phpstan-next.neon .",
         "phpunit": "phpunit --bootstrap ./tests/bootstrap.php --display-notices --display-phpunit-deprecations ./tests",
-        "translations": "cli/manipulate.translation.php -a format && cli/check.translation.php -g",
+        "translations": "cli/manipulate.translation.php --action format && cli/check.translation.php --generate-readme",
         "test": [
             "@php-lint",
             "@phtml-lint",


### PR DESCRIPTION
Changes proposed in this pull request:

- sort make targets
- replace short options by long options
- add target to generate `README` file

How to test the feature manually:

1. in a terminal, launch `make`.
2. validate that the targets are sorted.
3. launch `make` with a target.
4. validate that the target still works.
5. launch `make` with the `readme` target.
6. validate that the `README` file is updated.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
