### PR TITLE
Enhance navigation bar

### DIFF
--- a/app/layout/nav_entries.phtml
+++ b/app/layout/nav_entries.phtml
@@ -3,6 +3,8 @@
 ?>
 <nav id="nav_entries">
 	<button class="previous_entry" title="<?= _t('gen.action.nav_buttons.prev') ?>"><?= _i('prev') ?></button>
+	<button class="link" title="<?= _t('gen.action.nav_buttons.link') ?>"><?= _i('link') ?></button>
 	<button class="up" title="<?= _t('gen.action.nav_buttons.up') ?>"><?= _i('up') ?></button>
+	<button class="favourite" title="<?= _t('gen.action.nav_buttons.favourite') ?>"><?= _i('non-starred') ?></button>
 	<button class="next_entry" title="<?= _t('gen.action.nav_buttons.next') ?>"><?= _i('next') ?></button>
 </nav>

--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -90,6 +90,7 @@ $today = @strtotime('today');
 		?>" data-entry="<?= $this->entry->id()
 		?>" data-feed="<?= $this->feed->id()
 		?>" data-priority="<?= $this->feed->priority()
+		?>" data-link="<?= $this->entry->link()
 		?>"><?php
 			$this->renderHelper('index/normal/entry_header');
 			if ($this->feed === null || $this->entry === null) {

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1531,6 +1531,16 @@ function init_nav_entries() {
 			document.scrollingElement.scrollTop = windowTop > item_top ? item_top - nav_menu_height : 0 - nav_menu_height;
 			return false;
 		};
+		nav_entries.querySelector('.favourite').onclick = function (e) {
+			const active_item = (document.querySelector('.flux.current') || document.querySelector('.flux'));
+			mark_favorite(active_item);
+			return false;
+		};
+		nav_entries.querySelector('.link').onclick = function (e) {
+			const active_item = (document.querySelector('.flux.current') || document.querySelector('.flux'));
+			window.open(active_item.dataset.link, '_blank');
+			return false;
+		};
 	}
 }
 

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1889,7 +1889,7 @@ a.website:hover .favicon {
 #nav_entries button {
 	background-color: transparent;
 	display: table-cell;
-	width: 33.3%;
+	width: 20%;
 	height: 3rem;
 	border: 0;
 	cursor: pointer;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1889,7 +1889,7 @@ a.website:hover .favicon {
 #nav_entries button {
 	background-color: transparent;
 	display: table-cell;
-	width: 33.3%;
+	width: 20%;
 	height: 3rem;
 	border: 0;
 	cursor: pointer;


### PR DESCRIPTION
Now, it includes a button to open the current article in a new window and a button to toggle the current article favourite flag.

See #7912

Closes #7912

Changes proposed in this pull request:

- Add 2 buttons in the navbar to ease mobile navigation

How to test the feature manually:

1. use the 2 new buttons and validate that they behave properly

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).


# The new navbar
<img width="300" height="49" alt="Screen Shot 2025-09-04 at 08 26 15" src="https://github.com/user-attachments/assets/b36bdf72-79f9-4fd9-924a-8235ebff79d3" />
