### PR TITLE
Add new file in i18n

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,14 @@ node_modules/.bin/rtlcss:
 	npm install
 
 ##@ I18n
+.PHONY: i18n-add-file
+i18n-add-file: ## Add a new translation file to all supported languages
+ifndef key
+	$(error To add a new file, you need to provide one in the "key" variable)
+endif
+	@$(PHP) ./cli/manipulate.translation.php --action add --key $(key)
+	@echo File added.
+
 .PHONY: i18n-add-key
 i18n-add-key: ## Add a translation key to all supported languages
 ifndef key

--- a/cli/i18n/I18nData.php
+++ b/cli/i18n/I18nData.php
@@ -110,8 +110,15 @@ class I18nData {
 	 * Check if the key is known.
 	 */
 	public function isKnown(string $key): bool {
-		return array_key_exists($this->getFilenamePrefix($key), $this->data[static::REFERENCE_LANGUAGE]) &&
+		return $this->exists($key) &&
 			array_key_exists($key, $this->data[static::REFERENCE_LANGUAGE][$this->getFilenamePrefix($key)]);
+	}
+
+	/**
+	 * Check if the file exists
+	 */
+	public function exists(string $file): bool {
+		return array_key_exists($this->getFilenamePrefix($file), $this->data[static::REFERENCE_LANGUAGE]);
 	}
 
 	/**
@@ -184,6 +191,24 @@ class I18nData {
 		}));
 
 		return count($children) !== 0;
+	}
+
+	/**
+	 * Add a new translation file to all languages
+	 * @throws Exception
+	 */
+	public function addFile(string $file): void {
+		$file = strtolower($file);
+		if (!str_ends_with($file, '.php')) {
+			throw new Exception('The selected file name is not supported.');
+		}
+		if ($this->exists($file)) {
+			throw new Exception('The selected file exists already.');
+		}
+
+		foreach ($this->getAvailableLanguages() as $language) {
+			$this->data[$language][$this->getFilenamePrefix($file)] = [];
+		}
 	}
 
 	/**

--- a/cli/manipulate.translation.php
+++ b/cli/manipulate.translation.php
@@ -43,6 +43,8 @@ switch ($cliOptions->action) {
 			$i18nData->addValue($cliOptions->key, $cliOptions->value, $cliOptions->language);
 		} elseif (isset($cliOptions->key) && isset($cliOptions->value)) {
 			$i18nData->addKey($cliOptions->key, $cliOptions->value);
+		} elseif (isset($cliOptions->key)) {
+			$i18nData->addFile($cliOptions->key);
 		} elseif (isset($cliOptions->language)) {
 			$reference = null;
 			if (isset($cliOptions->originLanguage)) {
@@ -172,6 +174,8 @@ Example 9:	revert ignore on all unmodified keys. Removes IGNORE comments from al
 Example 10:	check if a key exist.
 	php $file -a exist -k my_key
 
+Example 11:	add a new file to all languages
+	php $file -a add -k my_file.php
 HELP;
 	exit();
 }

--- a/tests/cli/i18n/I18nDataTest.php
+++ b/tests/cli/i18n/I18nDataTest.php
@@ -485,6 +485,30 @@ class I18nDataTest extends PHPUnit\Framework\TestCase {
 		self::assertSame($frValue, $enValue);
 	}
 
+	public function testAddFileWhenNotPhpFile(): void {
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('The selected file name is not supported.');
+
+		$data = new I18nData($this->referenceData);
+		$data->addFile('file2');
+	}
+
+	public function testAddFileWhenAlreadyExists(): void {
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('The selected file exists already.');
+
+		$data = new I18nData($this->referenceData);
+		self::assertTrue($data->exists('file2.php'));
+		$data->addFile('file2.php');
+	}
+
+	public function testAddFileWhenNotExists(): void {
+		$data = new I18nData($this->referenceData);
+		self::assertFalse($data->exists('newfile.php'));
+		$data->addFile('newfile.php');
+		self::assertTrue($data->exists('newfile.php'));
+	}
+
 	public function testAddValueWhenLanguageDoesNotExist(): void {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('The selected language does not exist.');


### PR DESCRIPTION
When manipulating I18N files, it is now possible to add a new file to all
languages. This action is available both in the manipulation script and
the makefile.

Changes proposed in this pull request:

- add a new translation file from cli

How to test the feature manually:

1. create a new i18n file from cli or make (ex: `xxx.php`)
2. validate that the `xxx.php` file is created empty.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
