### PR TITLE
Update Japanese translation for "Duration to keep logged in"

### DIFF
--- a/app/i18n/ja/admin.php
+++ b/app/i18n/ja/admin.php
@@ -167,7 +167,7 @@ return array(
 		),
 		'cookie-duration' => array(
 			'help' => '秒',
-			'number' => 'ログを残す間隔',
+			'number' => 'ログイン状態維持時間',
 		),
 		'force_email_validation' => 'Eメールアドレスの検証を強制します',
 		'instance-name' => 'インスタンス名',


### PR DESCRIPTION
If this corresponds to "Duration to keep logged in", then current Japanese text says different thing: "Time to store log (not login)".

There are multiple choices for translation of this one and I thought a bit which one is the best, and I'm not sure this is the best, but at least this explains "the time after user logged in until user is logged out", not "the time the log is stored".

How to test the feature manually:

Just a translation and no test

Pull request checklist:

- [X] clear commit messages
- [ ] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
