### PR TITLE
Minor text underline fix in label management

### DIFF
--- a/app/views/tag/index.phtml
+++ b/app/views/tag/index.phtml
@@ -28,10 +28,8 @@
 	<ul id="tagsList" <?= (count($this->tags) > 11) ? 'class="listInColumns"' : '' ?>>
 	<?php foreach ($this->tags as $tag): ?>
 		<li>
-			<a href="<?= _url('tag', 'update', 'id', $tag->id()) ?>" class="configure open-slider" title="<?= _t('gen.action.manage') ?>">
-				<?= _i('configure') ?>
-			</a>
-			<?= $tag->name() ?>
+			<a href="<?= _url('tag', 'update', 'id', $tag->id()) ?>" class="configure open-slider" title="<?= _t('gen.action.manage') ?>"><?= _i('configure') ?></a>
+			<span class="item-name"><?= $tag->name() ?></span>
 		</li>
 	<?php endforeach; ?>
 	</ul>


### PR DESCRIPTION
Before

<img width="255" height="159" alt="image" src="https://github.com/user-attachments/assets/9b80659c-c646-47de-8436-45aa38afd465" />

After

<img width="238" height="161" alt="image" src="https://github.com/user-attachments/assets/27dcb572-5935-405b-9cfc-33eb95d78bf0" />

(ignore CSS in branch name, it's just HTML changes - although this could've been solved with `display: inline-block` too)
