### PR TITLE
Fix JS error when navigating to last article with keyboard

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -592,7 +592,7 @@ function prev_feed() {
 			adjacent = feed;
 		}
 	}
-	if (found) {
+	if (found && adjacent) {
 		delayedClick(adjacent.querySelector('a.item-title'));
 	} else {
 		last_feed();
@@ -622,7 +622,7 @@ function next_feed() {
 			adjacent = feed;
 		}
 	}
-	if (found) {
+	if (found && adjacent) {
 		delayedClick(adjacent.querySelector('a.item-title'));
 	} else {
 		first_feed();


### PR DESCRIPTION
This error would print in the console if navigating to last article with <kbd>J</kbd> or <kbd>K</kbd> key:

<img width="836" height="173" alt="image" src="https://github.com/user-attachments/assets/0ae88d1c-26eb-4ebe-8d15-4bf03c24cef6" />

---

To reproduce the bug:
<ol>
<li>Select unread + read view, while having all articles marked as read</li>
<li>Mark two as unread and go to unread only view</li>
<li>Navigate with either <kbd>J</kbd> or <kbd>K</kbd> until you go past the last article or before first article</li>
<li>See error in console and no navigation with <code>first_feed()</code> or <code>last_feed()</code></li>
</ol>

note: I'm not sure if the fix is what the expected behavior is supposed to be
