### PR TITLE
Restrict allowed curl parameters

### DIFF
--- a/app/Services/ImportService.php
+++ b/app/Services/ImportService.php
@@ -275,7 +275,8 @@ class FreshRSS_Import_Service {
 				$curl_params[CURLOPT_COOKIE] = $feed_elt['frss:CURLOPT_COOKIE'];
 			}
 			if (isset($feed_elt['frss:CURLOPT_COOKIEFILE'])) {
-				$curl_params[CURLOPT_COOKIEFILE] = $feed_elt['frss:CURLOPT_COOKIEFILE'];
+				// Allow only an empty value just to enable the libcurl cookie engine
+				$curl_params[CURLOPT_COOKIEFILE] = '';
 			}
 			if (isset($feed_elt['frss:CURLOPT_FOLLOWLOCATION'])) {
 				$curl_params[CURLOPT_FOLLOWLOCATION] = (bool)$feed_elt['frss:CURLOPT_FOLLOWLOCATION'];

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -319,8 +319,27 @@ function customSimplePie(array $attributes = [], array $curl_options = []): \Sim
 		}
 	}
 	if (!empty($attributes['curl_params']) && is_array($attributes['curl_params'])) {
+		$safe_params = [
+			CURLOPT_COOKIE,
+			CURLOPT_COOKIEFILE,
+			CURLOPT_FOLLOWLOCATION,
+			CURLOPT_HTTPHEADER,
+			CURLOPT_MAXREDIRS,
+			CURLOPT_POST,
+			CURLOPT_POSTFIELDS,
+			CURLOPT_PROXY,
+			CURLOPT_PROXYTYPE,
+			CURLOPT_USERAGENT,
+		];
 		foreach ($attributes['curl_params'] as $co => $v) {
 			if (is_int($co)) {
+				if (!in_array($co, $safe_params, true)) {
+					continue;
+				}
+				if ($co === CURLOPT_COOKIEFILE) {
+					// Allow only an empty value just to enable the libcurl cookie engine
+					$v = '';
+				}
 				$curl_options[$co] = $v;
 			}
 		}


### PR DESCRIPTION
For additional safety, also making sure in this PR that [`CURLOPT_COOKIEFILE`](https://curl.se/libcurl/c/CURLOPT_COOKIEFILE.html) is only allowed as an empty string during import.