### PR TITLE
fix linkding documentation link

### DIFF
--- a/app/shares.php
+++ b/app/shares.php
@@ -125,7 +125,7 @@ return [
 	'linkding' => [
 		'url' => '~URL~/bookmarks/new?url=~LINK~&amp;title=~TITLE~&amp;auto_close',
 		'transform' => ['rawurlencode'],
-		'help' => 'https://github.com/sissbruecker/linkding/blob/master/docs/how-to.md',
+		'help' => 'https://linkding.link/how-to/',
 		'form' => 'advanced',
 		'method' => 'GET',
 	],


### PR DESCRIPTION
Closes #7984 

Changes proposed in this pull request:

- fix linkding documentation link

How to test the feature manually:

1. add a linkding sharing method
2. click on the documentation link
3. validate that the link is working

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
