### PR TITLE
Prevent logout CSRFs

### DIFF
--- a/app/Controllers/authController.php
+++ b/app/Controllers/authController.php
@@ -70,7 +70,7 @@ class FreshRSS_auth_Controller extends FreshRSS_ActionController {
 	 * the user is already connected.
 	 */
 	public function loginAction(): void {
-		if (FreshRSS_Auth::hasAccess() && Minz_Request::paramString('u') === '') {
+		if (FreshRSS_Auth::hasAccess() && !(FreshRSS_Context::systemConf()->unsafe_autologin_enabled && Minz_Request::paramString('u') !== '')) {
 			Minz_Request::forward(['c' => 'index', 'a' => 'index'], true);
 		}
 

--- a/app/Controllers/javascriptController.php
+++ b/app/Controllers/javascriptController.php
@@ -66,16 +66,16 @@ class FreshRSS_javascript_Controller extends FreshRSS_ActionController {
 		header('Cache-Control: private, no-cache, no-store, must-revalidate');
 		header('Pragma: no-cache');
 
-		$user = $_GET['user'] ?? '';
-		if (!is_string($user) || $user === '') {
+		$user = Minz_Request::paramString('user');
+		if ($user === '') {
 			Minz_Error::error(400);
 			return;
 		}
-		FreshRSS_Context::initUser($user);
-		if (FreshRSS_Context::hasUserConf()) {
+		$user_conf = get_user_configuration($user);
+		if ($user_conf !== null) {
 			try {
 				$salt = FreshRSS_Context::systemConf()->salt;
-				$s = FreshRSS_Context::userConf()->passwordHash;
+				$s = $user_conf->passwordHash;
 				if (strlen($s) >= 60) {
 					//CRYPT_BLOWFISH Salt: "$2a$", a two digit cost parameter, "$", and 22 characters from the alphabet "./0-9A-Za-z".
 					$this->view->salt1 = substr($s, 0, 29);


### PR DESCRIPTION
By avoiding `FreshRSS_Context::initUser()` calls
