### PR TITLE
Fix: sharing button in top line when 0 entries

### DIFF
--- a/app/views/helpers/index/normal/entry_header.phtml
+++ b/app/views/helpers/index/normal/entry_header.phtml
@@ -4,7 +4,7 @@
 	$topline_read = FreshRSS_Context::userConf()->topline_read;
 	$topline_favorite = FreshRSS_Context::userConf()->topline_favorite;
 	$topline_myLabels = FreshRSS_Context::userConf()->topline_myLabels;
-	$topline_sharing = FreshRSS_Context::userConf()->topline_sharing;
+	$topline_sharing = FreshRSS_Context::userConf()->topline_sharing && (count(FreshRSS_Context::userConf()->sharing) > 0);;
 	$topline_website = FreshRSS_Context::userConf()->topline_website;
 	$topline_thumbnail = FreshRSS_Context::userConf()->topline_thumbnail;
 	$topline_summary = FreshRSS_Context::userConf()->topline_summary;


### PR DESCRIPTION
ref #8001 

Changes proposed in this pull request:

- count entries, do not show share button when 0 sharing services


How to test the feature manually:

1. having 0 sharing services
2. enable the sharing button in top line (settings -> display>
3. go to normal view -> sharing button should not be displayed in the article entry
4. add 1 sharing service
5. normal view -> sharing button is be displayed

