### PR TITLE
fix: anonym. mode: label management link

### DIFF
--- a/app/layout/aside_feed.phtml
+++ b/app/layout/aside_feed.phtml
@@ -66,11 +66,15 @@
 					foreach ($this->tags as $tag):
 				?>
 				<li id="t_<?= $tag->id() ?>" class="item feed<?= FreshRSS_Context::isCurrentGet('t_' . $tag->id()) ? ' active' : '' ?>" data-unread="<?= $tag->nbUnread() ?>">
-					<div class="dropdown no-mobile">
-						<div id="dropdown-t-<?= $tag->id() ?>" class="dropdown-target"></div>
-						<a class="dropdown-toggle" href="#dropdown-t-<?= $tag->id() ?>"><?= _i('configure') ?></a>
-						<?php /* tag_config_template */ ?>
-					</div>
+					<?php if (FreshRSS_Auth::hasAccess()) { ?>
+						<div class="dropdown no-mobile">
+							<div id="dropdown-t-<?= $tag->id() ?>" class="dropdown-target"></div>
+							<a class="dropdown-toggle" href="#dropdown-t-<?= $tag->id() ?>"><?= _i('configure') ?></a>
+							<?php /* tag_config_template */ ?>
+						</div>
+					<?php } else { ?>
+						<div class="no-dropdown-toggle"></div>
+					<?php } ?>
 					<a class="item-title" data-unread="<?= format_number($tag->nbUnread()) ?>" href="<?=
 						_url('index', $actual_view, 'get', 't_' . $tag->id()) . $state_filter_manual ?>"><?= _i('label') ?> <?= $tag->name() ?></a>
 				</li>

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1367,6 +1367,11 @@ input[type="search"] {
 	opacity: 1;
 }
 
+.aside_feed .tree-folder-items .item .no-dropdown-toggle {
+	display: inline-block;
+	width: 2.25rem;
+}
+
 .aside_feed .tree-folder-items .item .dropdown-target:target ~ .dropdown-toggle > .icon,
 .aside_feed .tree-folder-items .item:hover .dropdown-toggle > .icon,
 .aside_feed .tree-folder-items .item.active .dropdown-toggle > .icon {
@@ -2471,7 +2476,8 @@ html.slider-active {
 	.flux_header .item.website span,
 	.item .date, .day .date,
 	.dropdown-menu > .no-mobile,
-	.no-mobile {
+	.no-mobile,
+	.aside_feed .tree-folder-items .item .no-dropdown-toggle {
 		display: none;
 	}
 

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1367,6 +1367,11 @@ input[type="search"] {
 	opacity: 1;
 }
 
+.aside_feed .tree-folder-items .item .no-dropdown-toggle {
+	display: inline-block;
+	width: 2.25rem;
+}
+
 .aside_feed .tree-folder-items .item .dropdown-target:target ~ .dropdown-toggle > .icon,
 .aside_feed .tree-folder-items .item:hover .dropdown-toggle > .icon,
 .aside_feed .tree-folder-items .item.active .dropdown-toggle > .icon {
@@ -2471,7 +2476,8 @@ html.slider-active {
 	.flux_header .item.website span,
 	.item .date, .day .date,
 	.dropdown-menu > .no-mobile,
-	.no-mobile {
+	.no-mobile,
+	.aside_feed .tree-folder-items .item .no-dropdown-toggle {
 		display: none;
 	}
 


### PR DESCRIPTION
Ref: #8001

Changes proposed in this pull request:

- do not show the "manage" dropdown menu for labels in anonym. mode (normal view)

Before:
<img width="304" height="139" alt="grafik" src="https://github.com/user-attachments/assets/2aff0299-febe-41b0-a99a-450559393cd6" />


After:
<img width="281" height="121" alt="grafik" src="https://github.com/user-attachments/assets/69ad334e-0a31-4546-9939-9b72306db046" />

