### PR TITLE
Reverse arguments to array_merge of cusotm config

### DIFF
--- a/cli/do-install.php
+++ b/cli/do-install.php
@@ -101,7 +101,7 @@ $customConfigPath = DATA_PATH . '/config.custom.php';
 if (file_exists($customConfigPath)) {
 	$customConfig = include $customConfigPath;
 	if (is_array($customConfig) && is_array_keys_string($customConfig)) {
-		$config = array_merge($customConfig, $config);
+		$config = array_merge($config, $customConfig);
 	}
 }
 


### PR DESCRIPTION
The installer was merging the initial configuration into the custom
configuration, which meant that any keys set in the system configuration
would take precedence over custom configuration. Practically, this meant it
was not possible to preconfigure the database connection via
`config.custom.php`.

This commit reverses the order of the arguments to the `array_merge`
function so that keys in the custom configuration will override keys in the
initial configuration.

See also: https://github.com/FreshRSS/FreshRSS/discussions/8030
