### PR TITLE
Add support for extension priority

### DIFF
--- a/docs/en/developers/03_Backend/05_Extensions.md
+++ b/docs/en/developers/03_Backend/05_Extensions.md
@@ -135,6 +135,9 @@ The `Minz_Extension` abstract class defines another set of methods that should n
 ### The "hooks" system
 
 You can register at the FreshRSS event system in an extensions `init()` method, to manipulate data when some of the core functions are executed.
+The last parameter is the priority of the hook when triggered.
+The hook with the lowest priority value are triggered first.
+The default priority is 0.
 
 ```php
 final class HelloWorldExtension extends Minz_Extension
@@ -143,8 +146,8 @@ final class HelloWorldExtension extends Minz_Extension
 	public function init(): void {
 		parent::init();
 
-		$this->registerHook(Minz_HookType::EntryBeforeDisplay, [$this, 'renderEntry']);
-		$this->registerHook(Minz_HookType::CheckUrlBeforeAdd, [self::class, 'checkUrl']);
+		$this->registerHook(Minz_HookType::EntryBeforeDisplay, [$this, 'renderEntry'], 10);
+		$this->registerHook(Minz_HookType::CheckUrlBeforeAdd, [self::class, 'checkUrl'], -10);
 	}
 
 	public function renderEntry(FreshRSS_Entry $entry): FreshRSS_Entry {

--- a/docs/fr/developers/03_Backend/05_Extensions.md
+++ b/docs/fr/developers/03_Backend/05_Extensions.md
@@ -189,6 +189,9 @@ Your class will benefit from four methods to redefine:
 
 You can register at the FreshRSS event system in an extensions `init()`
 method, to manipulate data when some of the core functions are executed.
+Le dernier paramètre représente la priorité du *hook* quand celui-ci est déclenché.
+Le *hook* avec la priorité la plus basse sera déclenché en premier.
+La priorité par défaut est 0.
 
 ```php
 final class HelloWorldExtension extends Minz_Extension
@@ -197,8 +200,8 @@ final class HelloWorldExtension extends Minz_Extension
 	public function init(): void {
 		parent::init();
 
-		$this->registerHook(Minz_HookType::EntryBeforeDisplay, [$this, 'renderEntry']);
-		$this->registerHook(Minz_HookType::CheckUrlBeforeAdd, [self::class, 'checkUrl']);
+		$this->registerHook(Minz_HookType::EntryBeforeDisplay, [$this, 'renderEntry'], 10);
+		$this->registerHook(Minz_HookType::CheckUrlBeforeAdd, [self::class, 'checkUrl'], -10);
 	}
 
 	public function renderEntry(FreshRSS_Entry $entry): FreshRSS_Entry {

--- a/lib/Minz/Extension.php
+++ b/lib/Minz/Extension.php
@@ -258,9 +258,10 @@ abstract class Minz_Extension {
 	 *
 	 * @param string $hook_name the hook name (must exist).
 	 * @param callable $hook_function the function name to call (must be callable).
+	 * @param int $priority the priority of the hook, default priority is 0, the higher the value the lower the priority
 	 */
-	final protected function registerHook(string $hook_name, $hook_function): void {
-		Minz_ExtensionManager::addHook($hook_name, $hook_function);
+	final protected function registerHook(string $hook_name, $hook_function, int $priority = Minz_Hook::DEFAULT_PRIORITY): void {
+		Minz_ExtensionManager::addHook($hook_name, $hook_function, $priority);
 	}
 
 	/** @param 'system'|'user' $type */

--- a/lib/Minz/Hook.php
+++ b/lib/Minz/Hook.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+class Minz_Hook {
+	public const DEFAULT_PRIORITY = 0;
+
+	public function __construct(
+		private readonly \Closure $function,
+		private readonly int $priority,
+	) {
+	}
+
+	public function getFunction(): \Closure {
+		return $this->function;
+	}
+
+	public function getPriority(): int {
+		return $this->priority;
+	}
+}


### PR DESCRIPTION
Extension can now define their hook priority. This will allow to define the order in which hooks are triggered.

See #7110

Closes #7110

Changes proposed in this pull request:

- Add support for extension priority

How to test the feature manually:

1. Create an extension with 2 hooks on the same hook type but different priority
2. The hooks must be prepending the title with different values
3. Validate that changing the hook priority changes the final title accordingly.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
