### PR TITLE
Add default parameter on int parameters

### DIFF
--- a/lib/Minz/Request.php
+++ b/lib/Minz/Request.php
@@ -124,11 +124,11 @@ class Minz_Request {
 		return is_numeric(self::$params[$key] ?? null) ? (int)self::$params[$key] : null;
 	}
 
-	public static function paramInt(string $key): int {
+	public static function paramInt(string $key, int $default = 0): int {
 		if (!empty(self::$params[$key]) && is_numeric(self::$params[$key])) {
 			return (int)self::$params[$key];
 		}
-		return 0;
+		return $default;
 	}
 
 	/**


### PR DESCRIPTION
Before, the method had a default value of 0 when retrieving an int parameter on the request. Which is not always what we want.
Now, the default value can be overridden when needed. If no value is provided, the default value is still 0.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
