### PR TITLE
Fix critical GHA vulnerability

### DIFF
--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -16,8 +16,7 @@ jobs:
       github.event.comment.body == '/fix-all' &&
       (
         github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'MEMBER' ||
-        (github.event.comment.user != null && github.event.comment.user.login == github.event.issue.user.login)
+        github.event.comment.author_association == 'MEMBER'
       )
     runs-on: ubuntu-latest
 
@@ -63,6 +62,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ fromJSON(steps.pr.outputs.result).repo.full_name }}
           ref: ${{ fromJSON(steps.pr.outputs.result).ref }}
+          persist-credentials: false
 
       - name: Use Composer cache
         id: composer-cache


### PR DESCRIPTION
See https://github.com/FreshRSS/FreshRSS/pull/8099

The commands action is currently disabled, needs some more improvement.
We need to make sure that the code within the PR cannot access `GITHUB_TOKEN`.

I am not happy with having to grant `contents: write` permission so that commits can be added into the current PR, so some workaround is needed if possible. Otherwise it is safer to restrict permissions to just owner/member, and check PR contents before running `/fix-all`.

Current zizmor output:
```
info[template-injection]: code injection via template expansion
   --> ./commands.yml:140:37
    |
136 |         uses: actions/github-script@v8
    |         ------------------------------ action accepts arbitrary code
...
139 |           script: |
    |           ------ via this input
140 |             const makeFailed = '${{ steps.fix.outputs.make_failed }}' === 'true';
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → Low

info[template-injection]: code injection via template expansion
   --> ./commands.yml:141:36
    |
136 |         uses: actions/github-script@v8
    |         ------------------------------ action accepts arbitrary code
...
139 |           script: |
    |           ------ via this input
140 |             const makeFailed = '${{ steps.fix.outputs.make_failed }}' === 'true';
141 |             const noChanges = '${{ steps.commit.outputs.no_changes || 'false' }}' === 'true';
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → Low

info[template-injection]: code injection via template expansion
   --> ./commands.yml:142:33
    |
136 |         uses: actions/github-script@v8
    |         ------------------------------ action accepts arbitrary code
...
139 |           script: |
    |           ------ via this input
...
142 |             const pushed = '${{ steps.commit.outputs.pushed || 'false' }}' === 'true';
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → Low

info[template-injection]: code injection via template expansion
   --> ./commands.yml:143:36
    |
136 |         uses: actions/github-script@v8
    |         ------------------------------ action accepts arbitrary code
...
139 |           script: |
    |           ------ via this input
...
143 |             const commitSha = '${{ steps.commit.outputs.commit_sha }}';
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → Low

info[template-injection]: code injection via template expansion
   --> ./commands.yml:144:36
    |
136 |         uses: actions/github-script@v8
    |         ------------------------------ action accepts arbitrary code
...
139 |           script: |
    |           ------ via this input
...
144 |             const jobStatus = '${{ job.status }}';
    |                                    ^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → Low

15 findings (10 suppressed): 5 informational, 0 low, 0 medium, 0 high
```

