### PR TITLE
Fix SQL bind bug when adding tag

### DIFF
--- a/app/Models/TagDAO.php
+++ b/app/Models/TagDAO.php
@@ -37,7 +37,9 @@ SQL;
 			$valuesTmp['attributes'] = [];
 		}
 		if ($stm !== false) {
-			$stm->bindValue(':id', empty($valuesTmp['id']) ? null : $valuesTmp['id'], PDO::PARAM_INT);
+			if (!empty($valuesTmp['id'])) {
+				$stm->bindValue(':id', $valuesTmp['id'], PDO::PARAM_INT);
+			}
 			$stm->bindValue(':name1', $valuesTmp['name'], PDO::PARAM_STR);
 			$stm->bindValue(':name2', $valuesTmp['name'], PDO::PARAM_STR);
 			$stm->bindValue(':attributes', is_string($valuesTmp['attributes']) ? $valuesTmp['attributes'] :


### PR DESCRIPTION
Error in SQLite: `SQL error FreshRSS_TagDAO::addTag["HY000",25,"column index out of range"]`
