### PR TITLE
Change omnivore help URL

### DIFF
--- a/app/shares.php
+++ b/app/shares.php
@@ -152,7 +152,7 @@ return [
 	'omnivore' => [
 		'url' => '~URL~/api/save?url=~LINK~',
 		'transform' => ['urlencode'],
-		'help' => 'https://omnivore.app/',
+		'help' => 'https://github.com/omnivore-app/omnivore',
 		'form' => 'advanced',
 		'method' => 'GET',
 	],


### PR DESCRIPTION
Fix #7105

Closes #7105

Changes proposed in this pull request:

- Change omnivore help URL

How to test the feature manually:

1. add omnivore sharing service
2. validate that the help URL link to omnivore github page

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
