### PR TITLE
Remove pocket sharing service

### DIFF
--- a/app/shares.php
+++ b/app/shares.php
@@ -170,12 +170,6 @@ return [
 		'form' => 'simple',
 		'method' => 'GET',
 	],
-	'pocket' => [
-		'url' => 'https://getpocket.com/save?url=~LINK~&amp;title=~TITLE~',
-		'transform' => ['rawurlencode'],
-		'form' => 'simple',
-		'method' => 'GET',
-	],
 	'print' => [
 		'HTMLtag' => 'button',
 		'url' => '#',


### PR DESCRIPTION
It has been discontinued.

See #8125

Closes #8125

Changes proposed in this pull request:

- Remove pocket sharing service

How to test the feature manually:

1. Go to the sharing page
2. Validate that pocket is not in the list anymore

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
