### PR TITLE
Better SQL auto-update f.kind

### DIFF
--- a/app/Models/CategoryDAO.php
+++ b/app/Models/CategoryDAO.php
@@ -94,6 +94,12 @@ class FreshRSS_CategoryDAO extends Minz_ModelPdo {
 		if (isset($errorInfo[0])) {
 			if ($errorInfo[0] === FreshRSS_DatabaseDAO::ER_BAD_FIELD_ERROR || $errorInfo[0] === FreshRSS_DatabaseDAOPGSQL::UNDEFINED_COLUMN) {
 				$errorLines = explode("\n", $errorInfo[2], 2);	// The relevant column name is on the first line, other lines are noise
+				if (str_contains($errorLines[0], 'f.')) {	// Coming from a feed sub-query
+					$feedDao = FreshRSS_Factory::createFeedDao();
+					if ($feedDao->autoUpdateDb($errorInfo)) {
+						return true;
+					}
+				}
 				foreach (['kind', 'lastUpdate', 'error', 'attributes'] as $column) {
 					if (str_contains($errorLines[0], $column)) {
 						return $this->addColumn($column);

--- a/app/Models/CategoryDAOSQLite.php
+++ b/app/Models/CategoryDAOSQLite.php
@@ -11,6 +11,15 @@ class FreshRSS_CategoryDAOSQLite extends FreshRSS_CategoryDAO {
 	/** @param array{0:string,1:int,2:string} $errorInfo */
 	#[\Override]
 	protected function autoUpdateDb(array $errorInfo): bool {
+		if (isset($errorInfo[0])) {
+			$errorLines = explode("\n", $errorInfo[2], 2);	// The relevant column name is on the first line, other lines are noise
+			if (str_contains($errorLines[0], 'f.')) {	// Coming from a feed sub-query
+				$feedDao = FreshRSS_Factory::createFeedDao();
+				if ($feedDao->autoUpdateDb($errorInfo)) {
+					return true;
+				}
+			}
+		}
 		if (($tableInfo = $this->pdo->query("PRAGMA table_info('category')")) !== false) {
 			$columns = $tableInfo->fetchAll(PDO::FETCH_COLUMN, 1);
 			foreach (['kind', 'lastUpdate', 'error', 'attributes'] as $column) {

--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -23,7 +23,7 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo {
 	}
 
 	/** @param array{0:string,1:int,2:string} $errorInfo */
-	protected function autoUpdateDb(array $errorInfo): bool {
+	public function autoUpdateDb(array $errorInfo): bool {
 		if (isset($errorInfo[0])) {
 			if ($errorInfo[0] === FreshRSS_DatabaseDAO::ER_BAD_FIELD_ERROR || $errorInfo[0] === FreshRSS_DatabaseDAOPGSQL::UNDEFINED_COLUMN) {
 				$errorLines = explode("\n", $errorInfo[2], 2);	// The relevant column name is on the first line, other lines are noise

--- a/app/Models/FeedDAOSQLite.php
+++ b/app/Models/FeedDAOSQLite.php
@@ -10,10 +10,10 @@ class FreshRSS_FeedDAOSQLite extends FreshRSS_FeedDAO {
 
 	/** @param array{0:string,1:int,2:string} $errorInfo */
 	#[\Override]
-	protected function autoUpdateDb(array $errorInfo): bool {
+	public function autoUpdateDb(array $errorInfo): bool {
 		if (($tableInfo = $this->pdo->query("PRAGMA table_info('feed')")) !== false) {
 			$columns = $tableInfo->fetchAll(PDO::FETCH_COLUMN, 1);
-			foreach (['attributes', 'kind'] as $column) {
+			foreach (['kind'] as $column) {
 				if (!in_array($column, $columns, true)) {
 					return $this->addColumn($column);
 				}


### PR DESCRIPTION
Add a little help to make sure that feed.kind gets added during the first call.
Tested that replacing the DB with a backup from Febuary 2020 just works, automatically adding new columns since FreshRSS 1.20.0.
