### PR TITLE
Configuration → Display → Theme: increase button visibility

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2143,7 +2143,7 @@ html.slider-active {
 	text-align: center;
 	line-height: 2;
 	background-color: var(--frss-background-color-transparent);
-	text-shadow: 0px 0px 15px rgb(119, 119, 119);
+	text-shadow: 0px 0px 15px #000;
 }
 
 .theme-preview-list .properties {
@@ -2165,7 +2165,7 @@ html.slider-active {
 }
 
 .theme-preview-list .preview + .nav label {
-	opacity: 0.5;
+	opacity: 0.8;
 }
 
 .theme-preview-list .nav label:hover {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2143,7 +2143,7 @@ html.slider-active {
 	text-align: center;
 	line-height: 2;
 	background-color: var(--frss-background-color-transparent);
-	text-shadow: 0px 0px 15px rgb(119, 119, 119);
+	text-shadow: 0px 0px 15px #000;
 }
 
 .theme-preview-list .properties {
@@ -2165,7 +2165,7 @@ html.slider-active {
 }
 
 .theme-preview-list .preview + .nav label {
-	opacity: 0.5;
+	opacity: 0.8;
 }
 
 .theme-preview-list .nav label:hover {


### PR DESCRIPTION
Closes #6577.

Maintains a little bit of distinction between hover and non-hover, but the focus is on always making it visible.

### Before
<img width="45%" alt="Image" src="https://github.com/user-attachments/assets/4ebbffa3-e90d-42b2-9cdd-536197eabde3" />

### After
Left not hovered, right left arrow hovered. The distinction is obvious enough to show activation when actually hovering; it doesn't show very well on the screenshot.
<img width="45%" alt="image" src="https://github.com/user-attachments/assets/74e3da4a-7072-4f27-b435-375d6168181a" /> <img width="45%" alt="image" src="https://github.com/user-attachments/assets/8d0016e1-8cb0-4307-b7d0-8a9d0fdec188" />



Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
