### PR TITLE
Mark as read 1 or 7 days based on publication date

### DIFF
--- a/app/Controllers/entryController.php
+++ b/app/Controllers/entryController.php
@@ -40,7 +40,8 @@ class FreshRSS_entry_Controller extends FreshRSS_ActionController {
 	 *   - id (default: false)
 	 *   - get (default: false) /(c_\d+|f_\d+|s|a)/
 	 *   - nextGet (default: $get)
-	 *   - idMax (default: 0)
+	 *   - idMax (default: '0')
+	 *   - maxPubDate (default: 0)
 	 *   - is_read (default: true)
 	 */
 	public function readAction(): void {
@@ -52,6 +53,12 @@ class FreshRSS_entry_Controller extends FreshRSS_ActionController {
 		}
 		$is_read = Minz_Request::paramTernary('is_read') ?? true;
 		FreshRSS_Context::$search = new FreshRSS_BooleanSearch(Minz_Request::paramString('search'));
+		$maxPubDate = Minz_Request::paramInt('maxPubDate');
+		if ($maxPubDate > 0) {
+			$search = new FreshRSS_Search('');
+			$search->setMaxPubdate($maxPubDate);
+			FreshRSS_Context::$search->prepend($search);
+		}
 
 		FreshRSS_Context::$state = Minz_Request::paramInt('state');
 		if (FreshRSS_Context::isStateEnabled(FreshRSS_Entry::STATE_FAVORITE)) {

--- a/app/Models/BooleanSearch.php
+++ b/app/Models/BooleanSearch.php
@@ -422,6 +422,11 @@ class FreshRSS_BooleanSearch implements \Stringable {
 	}
 
 	/** @param FreshRSS_BooleanSearch|FreshRSS_Search $search */
+	public function prepend(FreshRSS_BooleanSearch|FreshRSS_Search $search): void {
+		array_unshift($this->searches, $search);
+	}
+
+	/** @param FreshRSS_BooleanSearch|FreshRSS_Search $search */
 	public function add(FreshRSS_BooleanSearch|FreshRSS_Search $search): void {
 		$this->searches[] = $search;
 	}

--- a/app/Models/Search.php
+++ b/app/Models/Search.php
@@ -274,6 +274,9 @@ class FreshRSS_Search implements \Stringable {
 	public function getNotMaxPubdate(): ?int {
 		return $this->not_max_pubdate ?: null;
 	}
+	public function setMaxPubdate(int $value): void {
+		$this->max_pubdate = $value;
+	}
 
 	public function getMinUserdate(): ?int {
 		return $this->min_userdate ?: null;

--- a/app/layout/nav_menu.phtml
+++ b/app/layout/nav_menu.phtml
@@ -152,12 +152,20 @@
 						type="submit"><?= $string_mark ?></button>
 				</li>
 <?php
-	$mark_read_enabled = FreshRSS_Context::$sort === 'id';
+	$mark_read_enabled = in_array(FreshRSS_Context::$sort, ['id', 'date'], true);
 	$today = @strtotime('today');
 	$mark_before_today = $mark_read_url;
-	$mark_before_today['params']['idMax'] = $today . '000000';
 	$mark_before_one_week = $mark_read_url;
-	$mark_before_one_week['params']['idMax'] = ($today - 604800) . '000000';
+	switch (FreshRSS_Context::$sort) {
+		case 'id':
+			$mark_before_today['params']['idMax'] = $today . '000000';
+			$mark_before_one_week['params']['idMax'] = ($today - 604800) . '000000';
+			break;
+		case 'date':
+			$mark_before_today['params']['maxPubDate'] = $today;
+			$mark_before_one_week['params']['maxPubDate'] = $today - 604800;
+			break;
+	}
 	$mark_unread_enabled = FreshRSS_Context::isStateEnabled(FreshRSS_Entry::STATE_READ) ||
 		(!FreshRSS_Context::isStateEnabled(FreshRSS_Entry::STATE_NOT_READ) && !FreshRSS_Context::isStateEnabled(FreshRSS_Entry::STATE_OR_NOT_READ));
 ?>

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,1 +1,2 @@
+*.sqlite
 phpunit.phar


### PR DESCRIPTION
Allow the UI for marking as read articles older than 1 or 7 days to also work when sorting by publication date (in which case, the publication date is used).

<img width="382" height="229" alt="image" src="https://github.com/user-attachments/assets/a630dec8-1e18-4766-8392-59fb593dd73d" />
