### PR TITLE
Fix `console.log()` spam due to lack of `window.bcrypt` object

### DIFF
--- a/p/scripts/extra.js
+++ b/p/scripts/extra.js
@@ -17,6 +17,11 @@ function forgetOpenCategories() {
 }
 
 function init_crypto_forms() {
+	const crypto_forms = document.querySelectorAll('.crypto-form');
+	if (crypto_forms.length === 0) {
+		return;
+	}
+
 	if (!(window.bcrypt)) {
 		if (window.console) {
 			console.log('FreshRSS waiting for bcrypt.js…');
@@ -26,7 +31,6 @@ function init_crypto_forms() {
 	}
 
 	/* globals bcrypt */
-	const crypto_forms = document.querySelectorAll('.crypto-form');
 	crypto_forms.forEach(crypto_form => {
 		const submit_button = crypto_form.querySelector('[type="submit"]');
 		if (submit_button) {


### PR DESCRIPTION
Harmless bug introduced in https://github.com/FreshRSS/FreshRSS/pull/7877

Before:
<img width="1580" height="96" alt="image" src="https://github.com/user-attachments/assets/eaebd4fc-fb40-49ec-83af-43bde3009b00" />

(load *Archiving* page for example, `init_crypto_forms()` is not called on view pages)