### PR TITLE
[sqlite export] add username and timestamp

### DIFF
--- a/app/Controllers/importExportController.php
+++ b/app/Controllers/importExportController.php
@@ -752,11 +752,13 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 			return;
 		}
 
-		// Format export as for the ZIP file. See Services/ExportService::zip
-		$username = Minz_User::name() ?? '_';
-		$day = date('Y-m-d');
-		$this->view->sqliteName = 'freshrss_' . $username . '_' . $day . '_db.sqlite';
 		$this->view->sqlitePath = $path;
+		$this->view->sqliteName = basename($path);
+		if ($this->view->sqliteName === 'db.sqlite') {
+			$username = Minz_User::name() ?? '_';
+			$date = date('Y-m-d_H-i-s', filemtime($path) ?: time());
+			$this->view->sqliteName = 'freshrss_' . $username . '_' . $date . '_db.sqlite';
+		}
 		$this->view->_layout(null);
 	}
 }

--- a/app/Controllers/importExportController.php
+++ b/app/Controllers/importExportController.php
@@ -751,6 +751,11 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 			Minz_Error::error(404);
 			return;
 		}
+
+		// Format export as for the ZIP file. See Services/ExportService::zip
+		$username = Minz_User::name() ?? '_';
+		$day = date('Y-m-d');
+		$this->view->sqliteName = 'freshrss_' . $username . '_' . $day . '_db.sqlite';
 		$this->view->sqlitePath = $path;
 		$this->view->_layout(null);
 	}

--- a/app/Models/View.php
+++ b/app/Models/View.php
@@ -92,6 +92,7 @@ class FreshRSS_View extends Minz_View {
 	/** @var null|array<array{name:string,size:int,mtime:int}> */
 	public ?array $sqliteArchives = null;
 	public string $sqlitePath;
+	public string $sqliteName;
 
 	// Form login
 	public int $cookie_days;

--- a/app/views/importExport/sqlite.phtml
+++ b/app/views/importExport/sqlite.phtml
@@ -3,7 +3,7 @@ declare(strict_types=1);
 /** @var FreshRSS_View $this */
 @ob_end_clean();	// Ensure no buffer
 header('Content-Type: application/vnd.sqlite3');
-header('Content-Disposition: attachment; filename="' . basename($this->sqlitePath) . '"');
+header('Content-Disposition: attachment; filename="' . $this->sqliteName . '"');
 header('Cache-Control: private, no-store, max-age=0');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s \\G\\M\\T', @filemtime($this->sqlitePath) ?: 0));
 header('Content-Length: ' . (@filesize($this->sqlitePath) ?: 0));


### PR DESCRIPTION
Changes proposed in this pull request:

- add username and timestamp to sqlite user export, similar to the ZIP export. Useful for archiving purposes.

How to test the feature manually:

1. Go to http://localhost:8080/i/?c=importExport
2. Export Sqlite at the end of the page
3. Verify that the filename is `freshrss_[username]_[date exported]_db.sqlite`

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
