### PR TITLE
Create a new user: placeholder username "demo"

### DIFF
--- a/app/views/user/manage.phtml
+++ b/app/views/user/manage.phtml
@@ -42,7 +42,7 @@
 			<label class="group-name" for="new_user_name"><?= _t('admin.user.username') ?></label>
 			<div class="group-controls">
 				<input id="new_user_name" name="new_user_name" type="text" size="16" required="required" autocomplete="off"
-					pattern="<?= FreshRSS_user_Controller::USERNAME_PATTERN ?>" placeholder="demo" />
+					pattern="<?= FreshRSS_user_Controller::USERNAME_PATTERN ?>">
 			</div>
 		</div>
 


### PR DESCRIPTION
I think that the placeholder for new user names should not be "demo". An empty field is good enough IMHO

<img width="825" height="533" alt="grafik" src="https://github.com/user-attachments/assets/e2bde73b-4472-4bf7-ac4e-81138f3d9a3f" />


<img width="866" height="516" alt="grafik" src="https://github.com/user-attachments/assets/f7586470-d0e8-4962-9e5f-5aa6912670d3" />
