### PR TITLE
Rename Extensions branch from master to main

### DIFF
--- a/app/Controllers/extensionController.php
+++ b/app/Controllers/extensionController.php
@@ -45,7 +45,7 @@ class FreshRSS_extension_Controller extends FreshRSS_ActionController {
 	 * @phpstan-return list<ExtensionFullMetadata>
 	 */
 	protected function getAvailableExtensionList(): array {
-		$extensionListUrl = 'https://raw.githubusercontent.com/FreshRSS/Extensions/master/extensions.json';
+		$extensionListUrl = 'https://raw.githubusercontent.com/FreshRSS/Extensions/refs/heads/main/extensions.json';
 
 		$cacheFile = CACHE_PATH . '/extension_list.json';
 		if (FreshRSS_Context::userConf()->retrieve_extension_list === true) {


### PR DESCRIPTION
For uniformity with other repos
https://github.com/FreshRSS/Extensions/commit/dd20c6003e9c4fbcfb7b8e96317aa6e17ec120ea
I made a tag https://github.com/FreshRSS/Extensions/releases/tag/master for back compatibility
