### PR TITLE
Fix duplicate semicolon in entry_header

### DIFF
--- a/app/views/helpers/index/normal/entry_header.phtml
+++ b/app/views/helpers/index/normal/entry_header.phtml
@@ -4,7 +4,7 @@
 	$topline_read = FreshRSS_Context::userConf()->topline_read;
 	$topline_favorite = FreshRSS_Context::userConf()->topline_favorite;
 	$topline_myLabels = FreshRSS_Context::userConf()->topline_myLabels;
-	$topline_sharing = FreshRSS_Context::userConf()->topline_sharing && (count(FreshRSS_Context::userConf()->sharing) > 0);;
+	$topline_sharing = FreshRSS_Context::userConf()->topline_sharing && (count(FreshRSS_Context::userConf()->sharing) > 0);
 	$topline_website = FreshRSS_Context::userConf()->topline_website;
 	$topline_thumbnail = FreshRSS_Context::userConf()->topline_thumbnail;
 	$topline_summary = FreshRSS_Context::userConf()->topline_summary;

--- a/app/views/helpers/index/normal/entry_header.phtml
+++ b/app/views/helpers/index/normal/entry_header.phtml
@@ -4,7 +4,7 @@
 	$topline_read = FreshRSS_Context::userConf()->topline_read;
 	$topline_favorite = FreshRSS_Context::userConf()->topline_favorite;
 	$topline_myLabels = FreshRSS_Context::userConf()->topline_myLabels;
-	$topline_sharing = FreshRSS_Context::userConf()->topline_sharing && (count(FreshRSS_Context::userConf()->sharing) > 0);
+	$topline_sharing = FreshRSS_Context::userConf()->topline_sharing && count(FreshRSS_Context::userConf()->sharing) > 0;
 	$topline_website = FreshRSS_Context::userConf()->topline_website;
 	$topline_thumbnail = FreshRSS_Context::userConf()->topline_thumbnail;
 	$topline_summary = FreshRSS_Context::userConf()->topline_summary;


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

- Remove duplicate semicolon in entry_header file.

How to test the feature manually:

1. Remove duplicate semicolon in entry_header file.
2. Open the FreshRSS with entries.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
