### PR TITLE
force correct index for MySQL when listing entries

### DIFF
--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -1443,11 +1443,14 @@ SQL;
 		[$searchValues, $search] = $this->sqlListEntriesWhere(alias: 'e.', state: $state, filters: $filters, id_min: $id_min, id_max: $id_max,
 			sort: $sort, order: $order, continuation_id: $continuation_id, continuation_values: $continuation_values);
 
+		// Help MySQL/MariaDB's optimizer with the query plan:
+		$useEntryIndex = $this->pdo->dbType() === 'mysql' ? 'USE INDEX (entry_feed_read_index) ' : '';
+
 		return [array_merge($values, $searchValues), 'SELECT '
 			. ($type === 'T' ? 'DISTINCT ' : '')
 			. 'e.id'
 			. ($type === 'T' && $sort !== 'id' ? ', ' . $orderBy : '') // SELECT DISTINCT, ORDER BY expressions must appear in SELECT
-			. ' FROM `_entry` e FORCE INDEX (`entry_feed_read_index`) '
+			. ' FROM `_entry` e ' . $useEntryIndex
 			. 'INNER JOIN `_feed` f ON f.id = e.id_feed '
 			. ($sort === 'c.name' ? 'INNER JOIN `_category` c ON c.id = f.category ' : '')
 			. ($type === 't' || $type === 'T' ? 'INNER JOIN `_entrytag` et ON et.id_entry = e.id ' : '')

--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -1447,7 +1447,7 @@ SQL;
 			. ($type === 'T' ? 'DISTINCT ' : '')
 			. 'e.id'
 			. ($type === 'T' && $sort !== 'id' ? ', ' . $orderBy : '') // SELECT DISTINCT, ORDER BY expressions must appear in SELECT
-			. ' FROM `_entry` e '
+			. ' FROM `_entry` e FORCE INDEX (`entry_feed_read_index`) '
 			. 'INNER JOIN `_feed` f ON f.id = e.id_feed '
 			. ($sort === 'c.name' ? 'INNER JOIN `_category` c ON c.id = f.category ' : '')
 			. ($type === 't' || $type === 'T' ? 'INNER JOIN `_entrytag` et ON et.id_entry = e.id ' : '')


### PR DESCRIPTION
# Issue

I have 700k+ entries in my `_entry` table and the performance is abysmal (10+ seconds) when querying the overview (front page) and having the "unread" filter set. I dug into the code and enabled the slow query log which pointed me at the `\FreshRSS_EntryDAO::sqlListWhere` method taking an absurd amount of time.

# Cause

The query it's producing is
```sql
SELECT
	e0.id
  , e0.guid
  , e0.title
  , e0.author
  , UNCOMPRESS( e0.content_bin ) content
  , e0.link
  , e0.date
  , e0.`lastSeen`
  , e0.`lastUserModified`
  , HEX( e0.hash ) hash
  , e0.is_read
  , e0.is_favorite
  , e0.id_feed
  , e0.tags
  , e0.attributes
FROM
	`user_entry` e0
		INNER JOIN (
			           SELECT
				           e.id
			           FROM
				           `user_entry` e
					           INNER JOIN `user_feed` f
					           ON f.id = e.id_feed
			           WHERE f.priority >= 10 AND ( e.is_read = 0 ) AND e.id <= '1763210336616787'
			           ORDER BY e.id DESC
			           LIMIT 201
		           ) e2
		ON e2.id = e0.id
ORDER BY e0.id DESC;
```

An `EXPLAIN` shows the issue:

| id | select\_type | table | partitions | type | possible\_keys | key | key\_len | ref | rows | filtered | Extra |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 1 | PRIMARY | &lt;derived2&gt; | null | ALL | null | null | null | null | 201 | 100 | Using temporary; Using filesort |
| 1 | PRIMARY | e0 | null | eq\_ref | PRIMARY | PRIMARY | 8 | e2.id | 1 | 100 | null |
| 2 | DERIVED | f | null | range | PRIMARY,priority | priority | 1 | null | 96 | 100 | Using where; Using index; Using temporary; Using filesort |
| 2 | DERIVED | e | null | ref | PRIMARY,id\_feed,is\_read,entry\_feed\_read\_index,user\_entry\_id\_feed\_index | id\_feed | 3 | freshrss.f.id | 476 | 50 | Using index condition; Using where |

Its using the wrong index (on the PK), which means it's basically doing a full table scan.

So having exactly 737_141 entries in my table, the query takes (using PhpStorm)
```
100 rows retrieved starting from 1 in 11 s 258 ms (execution: 10 s 796 ms, fetching: 462 ms)
```

Because MySQL is bad at picking the "right" index, this needs to be fixed.

Forcing the better suiting index manually, results in the query

```sql
SELECT
	e0.id
  , e0.guid
  , e0.title
  , e0.author
  , UNCOMPRESS( e0.content_bin ) content
  , e0.link
  , e0.date
  , e0.`lastSeen`
  , e0.`lastUserModified`
  , HEX( e0.hash ) hash
  , e0.is_read
  , e0.is_favorite
  , e0.id_feed
  , e0.tags
  , e0.attributes
FROM
	`user_entry` e0
		INNER JOIN (
			           SELECT
				           e.id
			           FROM
				           `user_entry` e FORCE INDEX (`entry_feed_read_index`)
					           INNER JOIN `user_feed` f
					           ON f.id = e.id_feed
			           WHERE f.priority >= 10 AND ( e.is_read = 0 ) AND e.id <= '1763210336616787'
			           ORDER BY e.id DESC
			           LIMIT 201
		           ) e2
		ON e2.id = e0.id
ORDER BY e0.id DESC;
```

which now isn't even taking a single second.

```
100 rows retrieved starting from 1 in 440 ms (execution: 17 ms, fetching: 423 ms)
```

The `EXPLAIN` shows the resulting query plan:

| id | select\_type | table | partitions | type | possible\_keys | key | key\_len | ref | rows | filtered | Extra |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 1 | PRIMARY | &lt;derived2&gt; | null | ALL | null | null | null | null | 201 | 100 | Using temporary; Using filesort |
| 1 | PRIMARY | e0 | null | eq\_ref | PRIMARY | PRIMARY | 8 | e2.id | 1 | 100 | null |
| 2 | DERIVED | f | null | range | PRIMARY,priority | priority | 1 | null | 96 | 100 | Using where; Using index; Using temporary; Using filesort |
| 2 | DERIVED | e | null | ref | entry\_feed\_read\_index | entry\_feed\_read\_index | 4 | freshrss.f.id,const | 8677 | 33.33 | Using where; Using index |

# Bugfix

`\FreshRSS_EntryDAO::sqlListWhere` needs an update which forces MySQL to pick the right index

```
...
. ' FROM `_entry` e FORCE INDEX (`entry_feed_read_index`) '
...
```

# Result

The front page with the "unread" filter is now instantly available.
