### PR TITLE
Rework saving of configuration files

### DIFF
--- a/lib/Minz/Configuration.php
+++ b/lib/Minz/Configuration.php
@@ -210,18 +210,21 @@ class Minz_Configuration {
 	 * Save the current configuration in the configuration file.
 	 */
 	public function save(): bool {
+		$tmp_filename = $this->config_filename . '.tmp';
 		$back_filename = $this->config_filename . '.bak.php';
-		@rename($this->config_filename, $back_filename);
 
-		if (file_put_contents($this->config_filename,
+		if (file_put_contents($tmp_filename,
 			"<?php\nreturn " . var_export($this->data, true) . ';', LOCK_EX) === false) {
-			// file_put_contents failed, attempt to restore the backup config
-			if (@copy($back_filename, $this->config_filename) === false) {
-				// to help with second restore process during user context init
-				@unlink($this->config_filename);
-			}
+			@unlink($tmp_filename);
 			return false;
 		}
+
+		if (copy($this->config_filename, $back_filename) === false) {
+			@unlink($tmp_filename);
+			return false;
+		}
+
+		@rename($tmp_filename, $this->config_filename);
 
 		// Clear PHP cache for include
 		if (function_exists('opcache_invalidate')) {

--- a/lib/Minz/Configuration.php
+++ b/lib/Minz/Configuration.php
@@ -213,13 +213,13 @@ class Minz_Configuration {
 		$tmp_filename = $this->config_filename . '.tmp.php';
 		$back_filename = $this->config_filename . '.bak.php';
 
-		if (file_put_contents($tmp_filename,
-			"<?php\nreturn " . var_export($this->data, true) . ';', LOCK_EX) === false) {
+		if (!file_put_contents($tmp_filename,
+"<?php\nreturn " . var_export($this->data, true) . ';', LOCK_EX)) {
 			@unlink($tmp_filename);
 			return false;
 		}
 
-		if (copy($this->config_filename, $back_filename) === false) {
+		if (!copy($this->config_filename, $back_filename)) {
 			@unlink($tmp_filename);
 			return false;
 		}

--- a/lib/Minz/Configuration.php
+++ b/lib/Minz/Configuration.php
@@ -215,6 +215,11 @@ class Minz_Configuration {
 
 		if (file_put_contents($this->config_filename,
 			"<?php\nreturn " . var_export($this->data, true) . ';', LOCK_EX) === false) {
+			// file_put_contents failed, attempt to restore the backup config
+			if (@copy($back_filename, $this->config_filename) === false) {
+				// to help with second restore process during user context init
+				@unlink($this->config_filename);
+			}
 			return false;
 		}
 

--- a/lib/Minz/Configuration.php
+++ b/lib/Minz/Configuration.php
@@ -214,7 +214,7 @@ class Minz_Configuration {
 		$back_filename = $this->config_filename . '.bak.php';
 
 		if (!file_put_contents($tmp_filename,
-"<?php\nreturn " . var_export($this->data, true) . ';', LOCK_EX)) {
+			"<?php\nreturn " . var_export($this->data, true) . ';', LOCK_EX)) {
 			@unlink($tmp_filename);
 			return false;
 		}

--- a/lib/Minz/Configuration.php
+++ b/lib/Minz/Configuration.php
@@ -210,7 +210,7 @@ class Minz_Configuration {
 	 * Save the current configuration in the configuration file.
 	 */
 	public function save(): bool {
-		$tmp_filename = $this->config_filename . '.tmp';
+		$tmp_filename = $this->config_filename . '.tmp.php';
 		$back_filename = $this->config_filename . '.bak.php';
 
 		if (file_put_contents($tmp_filename,


### PR DESCRIPTION
fix https://github.com/FreshRSS/FreshRSS/issues/8022

How to test the feature manually:

1. Execute `dd if=/dev/urandom of=space bs=1M status=progress` and wait until disk is full
2. Try to save the config
3. Instead of it getting overwritten with 0 bytes, the file won't be touched.


