### PR TITLE
Fix Docker for PostgreSQL

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -188,7 +188,7 @@ docker network connect freshrss-network postgres
 
 # Otherwise, start a new PostgreSQL instance, remembering to change the passwords:
 docker run -d --restart unless-stopped --log-opt max-size=10m \
-  -v pgsql_data:/var/lib/postgresql/data \
+  -v pgsql_data:/var/lib/postgresql \
   -e POSTGRES_DB=freshrss \
   -e POSTGRES_USER=freshrss \
   -e POSTGRES_PASSWORD=freshrss \

--- a/Docker/freshrss/docker-compose-db.yml
+++ b/Docker/freshrss/docker-compose-db.yml
@@ -11,7 +11,7 @@ services:
       options:
         max-size: 10m
     volumes:
-      - db:/var/lib/postgresql/18/docker
+      - db:/var/lib/postgresql
     environment:
       POSTGRES_DB: ${DB_BASE:-freshrss}
       POSTGRES_USER: ${DB_USER:-freshrss}


### PR DESCRIPTION
Better fix instead of https://github.com/FreshRSS/FreshRSS/pull/8216
Based on error message:

Error: in 18+, these Docker images are configured to store database data in a
format which is compatible with "pg_ctlcluster" (specifically, using
major-version-specific directory names).  This better reflects how
PostgreSQL itself works, and how upgrades are to be performed.

See also https://github.com/docker-library/postgres/pull/1259

Counter to that, there appears to be PostgreSQL data in:
 /var/lib/postgresql/data (unused mount/volume)

This is usually the result of upgrading the Docker image without
upgrading the underlying database using "pg_upgrade" (which requires both
versions).

The suggested container configuration for 18+ is to place a single mount
at /var/lib/postgresql which will then place PostgreSQL data in a
subdirectory, allowing usage of "pg_upgrade --link" without mount point
boundary issues.

See https://github.com/docker-library/postgres/issues/37 for a (long)
discussion around this process, and suggestions for how to do so.