### PR TITLE
Fix link to Minz docs in 05_Extensions.md

### DIFF
--- a/docs/en/developers/03_Backend/05_Extensions.md
+++ b/docs/en/developers/03_Backend/05_Extensions.md
@@ -24,7 +24,7 @@ Note: it is quite conceivable that the functionalities of an extension can later
 
 ## Minz Framework
 
-see [Minz documentation](/docs/en/developers/Minz/index.md)
+see [Minz documentation](../Minz/index.md)
 
 ## Write an extension for FreshRSS
 


### PR DESCRIPTION
The link to the Minz docs works on GitHub but 404's on the [live site](https://freshrss.github.io/FreshRSS/en/developers/03_Backend/05_Extensions.html). Replacing the absolute path with a relative path should correct the 404.

Changes proposed in this pull request:
-

How to test the feature manually:
1. Build GitHub Pages site
2. Confirm hyperlink under "Minz Framework" on ["Writing extensions for FreshRSS"](https://freshrss.github.io/FreshRSS/en/developers/03_Backend/05_Extensions.html) heading links to ["Minz Framework"](https://freshrss.github.io/FreshRSS/en/developers/Minz/)

Pull request checklist:

- [x] clear commit messages
- [ ] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

