### PR TITLE
Add `data:` to CSP in `subscriptionController`

### DIFF
--- a/app/Controllers/subscriptionController.php
+++ b/app/Controllers/subscriptionController.php
@@ -49,7 +49,7 @@ class FreshRSS_subscription_Controller extends FreshRSS_ActionController {
 		$this->_csp([
 			'default-src' => "'self'",
 			'frame-ancestors' => FreshRSS_Context::systemConf()->attributeString('csp.frame-ancestors') ?? "'none'",
-			'img-src' => "'self' blob:",
+			'img-src' => "'self' data: blob:",
 		]);
 
 		$this->view->onlyFeedsWithError = Minz_Request::paramBoolean('error');
@@ -119,7 +119,7 @@ class FreshRSS_subscription_Controller extends FreshRSS_ActionController {
 		$this->_csp([
 			'default-src' => "'self'",
 			'frame-ancestors' => FreshRSS_Context::systemConf()->attributeString('csp.frame-ancestors') ?? "'none'",
-			'img-src' => "'self' blob:",
+			'img-src' => "'self' data: blob:",
 		]);
 
 		if (Minz_Request::isPost()) {


### PR DESCRIPTION
Quick fix for https://github.com/FreshRSS/FreshRSS/issues/8250
Regression from https://github.com/FreshRSS/FreshRSS/pull/7646

It seems the CSP is too permissive on some pages though (`img-src *`), so should fix that too later