### PR TITLE
Fix MariaDB updateCachedValues

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -66,7 +66,7 @@ FreshRSS n’est fourni avec aucune garantie.
 	* Extensions requises : [cURL](https://www.php.net/curl), [DOM](https://www.php.net/dom), [JSON](https://www.php.net/json), [XML](https://www.php.net/xml), [session](https://www.php.net/session), [ctype](https://www.php.net/ctype)
 	* Extensions recommandées : [PDO_SQLite](https://www.php.net/pdo-sqlite) (pour l’export/import), [GMP](https://www.php.net/gmp) (pour accès API sur plateformes < 64 bits), [IDN](https://www.php.net/intl.idn) (pour les noms de domaines internationalisés), [mbstring](https://www.php.net/mbstring) (pour le texte Unicode), [iconv](https://www.php.net/iconv) (pour conversion d’encodages), [ZIP](https://www.php.net/zip) (pour import/export), [zlib](https://www.php.net/zlib) (pour les flux compressés)
 	* Extension pour base de données : [PDO_PGSQL](https://www.php.net/pdo-pgsql) ou [PDO_SQLite](https://www.php.net/pdo-sqlite) ou [PDO_MySQL](https://www.php.net/pdo-mysql)
-* PostgreSQL 10+ ou SQLite ou MariaDB 10.0.5+ ou MySQL 8.0+
+* PostgreSQL 10+ ou SQLite ou MariaDB 10.6+ ou MySQL 8.0+
 
 # [Installation](https://freshrss.github.io/FreshRSS/fr/users/01_Installation.html)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ FreshRSS comes with absolutely no warranty.
 	* Required extensions: [cURL](https://www.php.net/curl), [DOM](https://www.php.net/dom), [JSON](https://www.php.net/json), [XML](https://www.php.net/xml), [session](https://www.php.net/session), [ctype](https://www.php.net/ctype)
 	* Recommended extensions: [PDO_SQLite](https://www.php.net/pdo-sqlite) (for export/import), [GMP](https://www.php.net/gmp) (for API access on 32-bit platforms), [IDN](https://www.php.net/intl.idn) (for Internationalized Domain Names), [mbstring](https://www.php.net/mbstring) (for Unicode strings), [iconv](https://www.php.net/iconv) (for charset conversion), [ZIP](https://www.php.net/zip) (for import/export), [zlib](https://www.php.net/zlib) (for compressed feeds)
 	* Extension for database: [PDO_PGSQL](https://www.php.net/pdo-pgsql) or [PDO_SQLite](https://www.php.net/pdo-sqlite) or [PDO_MySQL](https://www.php.net/pdo-mysql)
-* PostgreSQL 10+ or SQLite or MariaDB 10.0.5+ or MySQL 8.0+
+* PostgreSQL 10+ or SQLite or MariaDB 10.6+ or MySQL 8.0+
 
 # [Installation](https://freshrss.github.io/FreshRSS/en/admins/03_Installation.html)
 

--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -487,7 +487,8 @@ SQL;
 			$whereEntryIdFeeds = 'id_feed IN (' . str_repeat('?,', count($feedIds) - 1) . '?)';
 		}
 		$sql = <<<SQL
-			WITH entry_counts AS (
+			UPDATE `_feed`
+			LEFT JOIN (
 				SELECT
 					id_feed,
 					COUNT(*) AS total_entries,
@@ -495,9 +496,7 @@ SQL;
 				FROM `_entry`
 				WHERE $whereEntryIdFeeds
 				GROUP BY id_feed
-			)
-			UPDATE `_feed`
-			LEFT JOIN entry_counts ON entry_counts.id_feed = `_feed`.id
+			) AS entry_counts ON entry_counts.id_feed = `_feed`.id
 			SET `cache_nbEntries` = COALESCE(entry_counts.total_entries, 0),
 				`cache_nbUnreads` = COALESCE(entry_counts.unread_entries, 0)
 			WHERE $whereFeedIds

--- a/app/Models/FeedDAOPGSQL.php
+++ b/app/Models/FeedDAOPGSQL.php
@@ -13,6 +13,7 @@ SQL;
 
 	#[\Override]
 	public function updateCachedValues(int ...$feedIds): int|false {
+		// Compatible PostgreSQL, SQLite, MySQL 8.0+, but not MariaDB as of version 12.2.
 		if (empty($feedIds)) {
 			$whereFeedIds = 'true';
 			$whereEntryIdFeeds = 'true';

--- a/docs/en/admins/02_Prerequisites.md
+++ b/docs/en/admins/02_Prerequisites.md
@@ -9,7 +9,7 @@ You need to verify that your server can run FreshRSS before installing it. If yo
 | Web server    | **Apache 2.4**          | nginx, lighttpd |
 | PHP           | **PHP 8.1+**            | FreshRSS 1.24.3: PHP 7.4+<br />FreshRSS 1.22.1: PHP 7.2+ |
 | PHP modules   | Required: libxml, cURL, JSON, PDO_MySQL, PCRE and ctype.<br />Required (32-bit only): GMP <br />Recommended: Zlib, mbstring, iconv, ZipArchive<br />*For the whole modules list see [Dockerfile](https://github.com/FreshRSS/FreshRSS/blob/edge/Docker/Dockerfile-Alpine#L9-L11)* | |
-| Database      | **PostgreSQL 10+**      | SQLite, MariaDB 10.0.5+, MySQL 8.0+ |
+| Database      | **PostgreSQL 10+**      | SQLite, MariaDB 10.6+, MySQL 8.0+ |
 | Browser       | **Firefox**             | Chrome, Opera, Safari, or Edge       |
 
 ## Getting the appropriate version of FreshRSS

--- a/docs/fr/users/01_Installation.md
+++ b/docs/fr/users/01_Installation.md
@@ -9,7 +9,7 @@ Il est toutefois de votre responsabilité de vérifier que votre hébergement pe
 | Serveur web      | **Apache 2.4+**    | nginx, lighttpd |
 | PHP              | **PHP 8.1+**       | FreshRSS 1.24.3 : PHP 7.4+<br />FreshRSS 1.22.1 : PHP 7.2+ |
 | Modules PHP      | Requis : libxml, cURL, JSON, PDO_MySQL, PCRE et ctype<br />Requis (32 bits seulement) : GMP<br />Recommandé : Zlib, mbstring et iconv, ZipArchive<br />*Pour une liste complète des modules nécessaires voir le [Dockerfile](https://github.com/FreshRSS/FreshRSS/blob/edge/Docker/Dockerfile-Alpine#L9-L11)* |                                |
-| Base de données  | **PostgreSQL 10+** | SQLite, MariaDB 10.0.5+, MySQL 8.0+ |
+| Base de données  | **PostgreSQL 10+** | SQLite, MariaDB 10.6+, MySQL 8.0+ |
 | Navigateur       | **Firefox**        | Chrome, Opera, Safari, or Edge   |
 
 ## Choisir la bonne version de FreshRSS


### PR DESCRIPTION
Changed syntax for an even wider compatibility.
Follow-up of https://github.com/FreshRSS/FreshRSS/pull/8254
Regression from https://github.com/FreshRSS/FreshRSS/pull/6957
MariaDB images on Docker Hub go back to 10.6, so changed documentation to indicate support from that version, as I cannot easily test even older versions.
