### PR TITLE
Fix encoding being corrupted in non-ASCII HTML feeds

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -1035,6 +1035,8 @@ class FreshRSS_Feed extends Minz_Model {
 		$view->rss_url = htmlspecialchars($feedSourceUrl, ENT_COMPAT, 'UTF-8');
 		$view->html_url = $view->rss_url;
 		$view->entries = [];
+		// As DOMDocument is designed for XML rather than HTML, not having this header makes it detect wrong encoding
+		$html = '<?xml version="1.0" encoding="UTF-8" ?>' . $html;
 
 		try {
 			$doc = new DOMDocument();


### PR DESCRIPTION
Even though when fetching the feed all characters are correcly encoded, they are being maligned when passing it to DOMDocument, since it incorrectly detects the content as CP-1252 encoding.

Can be tested on eg. https://www.npc.sk/aktuality

How to test the feature manually:

1. Add https://www.npc.sk/aktuality feed
2. Observe if content loaded has any maligned characters

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard)
- [x] documentation updated
