### PR TITLE
Fix MySQL / MariaDB database size calculation

### DIFF
--- a/app/Models/DatabaseDAO.php
+++ b/app/Models/DatabaseDAO.php
@@ -254,7 +254,7 @@ SQL;
 		$values = [':table_schema' => $db['base']];
 		if (!$all) {
 			$sql .= ' AND table_name LIKE :table_name';
-			$values[':table_name'] = $this->pdo->prefix() . '%';
+			$values[':table_name'] = addcslashes($this->pdo->prefix(), '%_') . '%';
 		}
 		$res = $this->fetchColumn($sql, 0, $values);
 		return isset($res[0]) ? (int)($res[0]) : -1;


### PR DESCRIPTION
The `_` is a special character in the SQL `LIKE` expression and was not escaped, leading to users counting for other users size.
Stats for `freshrss` user included users `freshrss1` and `freshrss2` (but not vice versa).
Discovered during https://github.com/FreshRSS/FreshRSS/pull/8277
