### PR TITLE
PHP 8.5: Remove ReflectionProperty::setAccessible

### DIFF
--- a/tests/cli/i18n/I18nCompletionValidatorTest.php
+++ b/tests/cli/i18n/I18nCompletionValidatorTest.php
@@ -20,13 +20,11 @@ final class I18nCompletionValidatorTest extends \PHPUnit\Framework\TestCase {
 		self::assertSame("There is no data.\n", $validator->displayReport());
 
 		$reflectionTotalEntries = new ReflectionProperty(I18nCompletionValidator::class, 'totalEntries');
-		$reflectionTotalEntries->setAccessible(true);
 		$reflectionTotalEntries->setValue($validator, 100);
 
 		self::assertSame("Translation is   0.0% complete.\n", $validator->displayReport());
 
 		$reflectionPassEntries = new ReflectionProperty(I18nCompletionValidator::class, 'passEntries');
-		$reflectionPassEntries->setAccessible(true);
 		$reflectionPassEntries->setValue($validator, 25);
 
 		self::assertSame("Translation is  25.0% complete.\n", $validator->displayReport());

--- a/tests/cli/i18n/I18nUsageValidatorTest.php
+++ b/tests/cli/i18n/I18nUsageValidatorTest.php
@@ -20,13 +20,11 @@ final class I18nUsageValidatorTest extends \PHPUnit\Framework\TestCase {
 		self::assertSame("There is no data.\n", $validator->displayReport());
 
 		$reflectionTotalEntries = new ReflectionProperty(I18nUsageValidator::class, 'totalEntries');
-		$reflectionTotalEntries->setAccessible(true);
 		$reflectionTotalEntries->setValue($validator, 100);
 
 		self::assertSame("  0.0% of translation keys are unused.\n", $validator->displayReport());
 
 		$reflectionFailedEntries = new ReflectionProperty(I18nUsageValidator::class, 'failedEntries');
-		$reflectionFailedEntries->setAccessible(true);
 		$reflectionFailedEntries->setValue($validator, 25);
 
 		self::assertSame(" 25.0% of translation keys are unused.\n", $validator->displayReport());

--- a/tests/cli/i18n/I18nValueTest.php
+++ b/tests/cli/i18n/I18nValueTest.php
@@ -58,7 +58,6 @@ final class I18nValueTest extends \PHPUnit\Framework\TestCase {
 
 	public static function testStates(): void {
 		$reflectionProperty = new ReflectionProperty(I18nValue::class, 'state');
-		$reflectionProperty->setAccessible(true);
 
 		$value = new I18nValue('some value');
 		self::assertNull($reflectionProperty->getValue($value));


### PR DESCRIPTION
https://php.net/reflectionproperty.setaccessible
> As of PHP 8.1.0, calling this method has no effect; all properties are accessible by default.
> This function has been DEPRECATED as of PHP 8.5.0.
