### PR TITLE
Keep scroll state of page when closing the slider

### DIFF
--- a/app/views/configure/queries.phtml
+++ b/app/views/configure/queries.phtml
@@ -79,6 +79,6 @@
 		?>
 	</div>
 </aside>
-<a href="#" id="close-slider">
+<a href="#close" id="close-slider">
 	<?= _i('close') ?>
 </a>

--- a/app/views/extension/index.phtml
+++ b/app/views/extension/index.phtml
@@ -91,6 +91,6 @@
 		?>
 	</div>
 </aside>
-<a href="#" id="close-slider">
+<a href="#close" id="close-slider">
 	<?= _i('close') ?>
 </a>

--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -190,7 +190,7 @@ $today = @strtotime('today');
 		<div id="slider-content">
 		</div>
 </aside>
-<a href="#" id="close-slider" class="<?= $class ?>">
+<a href="#close" id="close-slider" class="<?= $class ?>">
 	<?= _i('close') ?>
 </a>
 

--- a/app/views/index/reader.phtml
+++ b/app/views/index/reader.phtml
@@ -66,6 +66,6 @@ $useKeepUnreadImportant = !FreshRSS_Context::isImportant() && !FreshRSS_Context:
 	<div id="slider-content">
 	</div>
 </aside>
-<a href="#" id="close-slider" class="<?= $class ?>">
+<a href="#close" id="close-slider" class="<?= $class ?>">
 	<?= _i('close') ?>
 </a>

--- a/app/views/stats/idle.phtml
+++ b/app/views/stats/idle.phtml
@@ -70,6 +70,6 @@
 		?>
 	</div>
 </aside>
-<a href="#" id="close-slider" class="<?= $class ?>">
+<a href="#close" id="close-slider" class="<?= $class ?>">
 	<?= _i('close') ?>
 </a>

--- a/app/views/subscription/index.phtml
+++ b/app/views/subscription/index.phtml
@@ -102,6 +102,6 @@
 		?>
 	</div>
 </aside>
-<a href="#" id="close-slider">
+<a href="#close" id="close-slider">
 	<?= _i('close') ?>
 </a>

--- a/app/views/tag/index.phtml
+++ b/app/views/tag/index.phtml
@@ -47,6 +47,6 @@
 		?>
 	</div>
 </aside>
-<a href="#" id="close-slider">
+<a href="#close" id="close-slider">
 	<?= _i('close') ?>
 </a>

--- a/app/views/user/manage.phtml
+++ b/app/views/user/manage.phtml
@@ -135,6 +135,6 @@
 		?>
 	</div>
 </aside>
-<a href="#" id="close-slider">
+<a href="#close" id="close-slider">
 	<?= _i('close') ?>
 </a>


### PR DESCRIPTION
When closing a slider (tested extension slider and configure feed slider), the page would scroll to the top which is unexpected.