### PR TITLE
Allow negative category sort numbers

### DIFF
--- a/app/views/helpers/category/update.phtml
+++ b/app/views/helpers/category/update.phtml
@@ -31,7 +31,7 @@
 			<div class="form-group">
 				<label class="group-name" for="position"><?= _t('sub.category.position') ?></label>
 				<div class="group-controls">
-					<input type="number" name="position" id="position" min="1" value="<?= $this->category->attributeInt('position') ?>" />
+					<input type="number" name="position" id="position" value="<?= $this->category->attributeInt('position') ?>" />
 					<p class="help"><?= _i('help') ?> <?= _t('sub.category.position_help') ?></p>
 				</div>
 			</div>


### PR DESCRIPTION
Closes #8304 

Changes proposed in this pull request:

- Remove the min=1 attribute so negative numbers can be used to force categories to the bottom