### PR TITLE
Fix dropdown menus in sidebar going under the navigation bar

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1112,9 +1112,10 @@ function init_column_categories() {
 			window.addEventListener('hashchange', () => {
 				const dropdownBottom = dropdownMenu.getBoundingClientRect().bottom;
 				const toggleHeight = a.getBoundingClientRect().height;
+				const navbarHeight = document.querySelector('nav#nav_entries')?.getBoundingClientRect()?.height || 0;
 
 				// If there is no space to display the dropdown below, display it above
-				if (dropdownBottom > window.innerHeight) {
+				if (dropdownBottom > window.innerHeight - navbarHeight) {
 					dropdownMenu.style.bottom = `${toggleHeight + 2}px`;
 					dropdownMenu.classList.add('arrow-bottom');
 				}


### PR DESCRIPTION
Missed in #8335 because I was testing without having the navigation bar enabled.

<img width="674" height="198" alt="image" src="https://github.com/user-attachments/assets/a1db7f95-f1d9-47e5-a572-20892e6c7abc" />
