### PR TITLE
Handle fetch of text/plain as <pre>

### DIFF
--- a/app/Utils/httpUtil.php
+++ b/app/Utils/httpUtil.php
@@ -407,7 +407,12 @@ final class FreshRSS_http_Util {
 				$body = self::enforceHttpEncoding($body, $c_content_type);
 			}
 			if (in_array($type, ['html'], true)) {
-				$body = self::enforceHtmlBase($body, $c_effective_url);
+				if (stripos($c_content_type, 'text/plain') !== false) {
+					// Plain text to be displayed as preformatted text. Prefixed with UTF-8 BOM
+					$body = "\xEF\xBB\xBF" . '<pre>' . htmlspecialchars($body, ENT_NOQUOTES, 'UTF-8') . '</pre>';
+				} else {
+					$body = self::enforceHtmlBase($body, $c_effective_url);
+				}
 			}
 		}
 

--- a/app/Utils/httpUtil.php
+++ b/app/Utils/httpUtil.php
@@ -409,7 +409,7 @@ final class FreshRSS_http_Util {
 			if (in_array($type, ['html'], true)) {
 				if (stripos($c_content_type, 'text/plain') !== false) {
 					// Plain text to be displayed as preformatted text. Prefixed with UTF-8 BOM
-					$body = "\xEF\xBB\xBF" . '<pre>' . htmlspecialchars($body, ENT_NOQUOTES, 'UTF-8') . '</pre>';
+					$body = "\xEF\xBB\xBF" . '<pre class="text-plain">' . htmlspecialchars($body, ENT_NOQUOTES, 'UTF-8') . '</pre>';
 				} else {
 					$body = self::enforceHtmlBase($body, $c_effective_url);
 				}


### PR DESCRIPTION
fix https://github.com/FreshRSS/FreshRSS/issues/8328

Wrap `text/plain` Web scraping in a `<pre>...</pre>`

<img width="1012" height="706" alt="image" src="https://github.com/user-attachments/assets/02ca5190-0740-4cfc-b233-e410bd9b6f06" />
