### PR TITLE
Change `Content-Disposition: inline` to `attachment` in `f.php`

### DIFF
--- a/p/f.php
+++ b/p/f.php
@@ -21,7 +21,7 @@ function show_default_favicon(int $cacheSeconds = 3600): void {
 	$default_mtime = @filemtime(DEFAULT_FAVICON) ?: 0;
 	if ($no_cache || !httpConditional($default_mtime, $cacheSeconds, 2)) {
 		header('Content-Type: image/x-icon');
-		header('Content-Disposition: inline; filename="default_favicon.ico"');
+		header('Content-Disposition: attachment; filename="default_favicon.ico"');
 		readfile(DEFAULT_FAVICON);
 	}
 }
@@ -66,7 +66,7 @@ if (($ico_mtime == false || $ico_mtime < $txt_mtime || ($ico_mtime < time() - (r
 if ($no_cache || !httpConditional($ico_mtime, rand(14, 21) * 86400, 2)) {
 	$ico_content_type = contentType($ico);
 	header('Content-Type: ' . $ico_content_type);
-	header('Content-Disposition: inline; filename="' . $id . '.ico"');
+	header('Content-Disposition: attachment; filename="' . $id . '.ico"');
 	if (!$no_cache && isset($_GET['t'])) {
 		header('Cache-Control: immutable');
 	}


### PR DESCRIPTION
Some [misconfigured instances](https://github.com/FreshRSS/FreshRSS/issues/7835) may be stripping out the CSP header that `f.php` sends, which can be mitigated by forcing the browser to download the image instead of displaying it and executing JS code from unsanitized SVGs for example.

Contributes to https://github.com/FreshRSS/FreshRSS/pull/8263 and https://github.com/FreshRSS/FreshRSS/pull/7924
(improving security when CSP is not present)