### PR TITLE
Dockerfile: support `h2c` (HTTP/2) protocol on port 80

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -7,7 +7,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
 	apt-get install --no-install-recommends -y \
 	ca-certificates cron \
-	apache2 libapache2-mod-php \
+	apache2 libapache2-mod-fcgid php-fpm \
 	libapache2-mod-auth-openidc \
 	php-curl php-gmp php-intl php-mbstring php-xml php-zip \
 	php-sqlite3 php-mysql php-pgsql && \
@@ -42,7 +42,9 @@ RUN \
 	sed -r -i "/^\s*(CustomLog|ErrorLog|Listen) /s/^/#/" /etc/apache2/apache2.conf && \
 	sed -r -i "/^\s*Listen /s/^/#/" /etc/apache2/ports.conf && \
 	# Enable required Apache modules
-	a2enmod -q deflate expires filter headers mime remoteip setenvif && \
+	a2enmod -q fcgid proxy_fcgi deflate expires filter headers mime remoteip setenvif && \
+	# Enable php-fpm
+	a2enconf -q php8.4-fpm && \
 	# Enable FreshRSS configuration for Apache
 	a2ensite -q 'FreshRSS*' && \
 	# Disable unwanted PHP modules
@@ -69,5 +71,6 @@ ENTRYPOINT ["./Docker/entrypoint.sh"]
 EXPOSE 80
 # hadolint ignore=DL3025
 CMD ([ -z "$CRON_MIN" ] || cron) && \
+	/usr/sbin/php-fpm8.4 -F & \
 	. /etc/apache2/envvars && \
 	exec apache2 -D FOREGROUND $([ -n "$OIDC_ENABLED" ] && [ "$OIDC_ENABLED" -ne 0 ] && echo "-D OIDC_ENABLED")

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -42,7 +42,7 @@ RUN \
 	sed -r -i "/^\s*(CustomLog|ErrorLog|Listen) /s/^/#/" /etc/apache2/apache2.conf && \
 	sed -r -i "/^\s*Listen /s/^/#/" /etc/apache2/ports.conf && \
 	# Enable required Apache modules
-	a2enmod -q fcgid proxy_fcgi deflate expires filter headers mime remoteip setenvif && \
+	a2enmod -q fcgid proxy_fcgi deflate expires filter headers mime remoteip setenvif http2 && \
 	# Enable php-fpm
 	a2enconf -q php8.4-fpm && \
 	# Enable FreshRSS configuration for Apache

--- a/Docker/FreshRSS.Apache.conf
+++ b/Docker/FreshRSS.Apache.conf
@@ -1,5 +1,6 @@
 ServerName freshrss.localhost
 Listen 80
+Protocols http/1.1 h2
 DocumentRoot /var/www/FreshRSS/p/
 AllowEncodedSlashes On
 ServerTokens OS


### PR DESCRIPTION
Closes #8349

Note this depends on #8353, which would need to be merged first. Thus, I'm marking this as draft for now.

Changes proposed in this pull request:

For running inside Docker, support `h2c` (HTTP/2) protocol on port 80.

How to test the feature manually:

1. build and run the Debian docker image, expose port 80
2. use `curl --http1.1 http://localhost:80/` to test for regressions with HTTP/1.1
3. use `curl --http2-prior-knowledge http://localhost:80/` to test  HTTP/2 now works (note the protocol in the access log)
4. use a reverse proxy and forward traffic as `h2c`, e.g. with Traefik use label:
   `- traefik.http.services.freshrss.loadbalancer.server.scheme=h2c`

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
