### PR TITLE
Running FreshRSS in a rootless Docker container

### DIFF
--- a/Docker/Dockerfile-Newest
+++ b/Docker/Dockerfile-Newest
@@ -3,20 +3,34 @@ FROM alpine:edge
 
 ENV TZ=UTC
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+ARG TARGETARCH
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories && \
 	apk add --no-cache \
-	tzdata \
+	tzdata sed \
 	apache2 php85-apache2 \
 	apache-mod-auth-openidc \
 	php85 php85-curl php85-gmp php85-intl php85-mbstring php85-xml php85-zip \
 	php85-ctype php85-dom php85-fileinfo php85-iconv php85-json php85-openssl php85-phar php85-session php85-simplexml php85-xmlreader php85-xmlwriter php85-xml php85-tokenizer php85-zlib \
-	php85-pdo_sqlite php85-pdo_mysql php85-pdo_pgsql
+	php85-pdo_sqlite php85-pdo_mysql php85-pdo_pgsql && \
+	# Install supercronic for rootless cron
+	wget -q -O /usr/local/bin/supercronic https://github.com/aptible/supercronic/releases/download/v0.2.33/supercronic-linux-${TARGETARCH} && \
+	chmod +x /usr/local/bin/supercronic
 
-RUN mkdir -p /var/www/FreshRSS /run/apache2/
+# Create non-root user
+RUN adduser -D -u 1000 -G apache freshrss && \
+	mkdir -p /var/www/FreshRSS /run/apache2/ && \
+	chown -R freshrss:apache /run/apache2/
 WORKDIR /var/www/FreshRSS
 
-COPY --chown=root:www-data . /var/www/FreshRSS
-COPY ./Docker/*.Apache.conf /etc/apache2/conf.d/
+COPY --chown=freshrss:apache . /var/www/FreshRSS
+COPY --chown=freshrss:apache ./Docker/*.Apache.conf /etc/apache2/conf.d/
+
+# Create data directories with proper permissions
+RUN mkdir -p ./data/cache ./data/extensions-data ./data/favicons ./data/fever \
+	./data/PubSubHubbub/feeds ./data/PubSubHubbub/keys ./data/Retry-After \
+	./data/tokens ./data/users/_ && \
+	chown -R freshrss:apache ./data ./extensions && \
+	chmod -R 775 ./data ./extensions
 
 ARG FRESHRSS_VERSION
 ARG SOURCE_COMMIT
@@ -44,16 +58,15 @@ RUN \
 	# Enable required Apache modules
 	sed -r -i "/^\s*#\s*LoadModule .*mod_(deflate|expires|filter|headers|mime|remoteip|setenvif).so$/s/^\s*#//" \
 		/etc/apache2/httpd.conf && \
-	# PHP configuration
+	# PHP configuration (done at build time for non-root)
 	if [ ! -f /usr/bin/php ]; then ln -s /usr/bin/php85 /usr/bin/php; else true; fi && \
-	echo 'memory_limit = 256M' > /etc/php85/conf.d/10_memory.ini && \
+	echo -e 'memory_limit = 256M\npost_max_size = 32M\nupload_max_filesize = 32M' > /etc/php85/conf.d/10_freshrss.ini && \
 	# Disable built-in FreshRSS updates when using Docker, as the full image is supposed to be updated instead.
 	sed -r -i "\\#disable_update#s#^.*#\t'disable_update' => true,#" ./config.default.php && \
-	# Configure cron job
-	touch /var/www/FreshRSS/Docker/env.txt && \
-	echo "27,57 * * * * . /var/www/FreshRSS/Docker/env.txt; \
-		su apache -s /bin/sh -c 'php /var/www/FreshRSS/app/actualize_script.php' \
-		2>> /proc/1/fd/2 > /tmp/FreshRSS.log" > /etc/crontab.freshrss.default
+	# Configure supercronic crontab (no user field needed, runs as current user)
+	echo '27,57 * * * * php /var/www/FreshRSS/app/actualize_script.php 2>&1' > /var/www/FreshRSS/Docker/crontab.freshrss.default && \
+	chown freshrss:apache /var/www/FreshRSS/Docker/crontab.freshrss.default && \
+	chmod +x /var/www/FreshRSS/Docker/entrypoint-nonroot.sh
 
 ENV COPY_LOG_TO_SYSLOG=On
 ENV COPY_SYSLOG_TO_STDERR=On
@@ -64,9 +77,13 @@ ENV LISTEN=''
 ENV OIDC_ENABLED=''
 ENV TRUSTED_PROXY=''
 
-ENTRYPOINT ["./Docker/entrypoint.sh"]
+ENTRYPOINT ["./Docker/entrypoint-nonroot.sh"]
 
-EXPOSE 80
+EXPOSE 8080
+
+USER freshrss
+
 # hadolint ignore=DL3025
-CMD ([ -z "$CRON_MIN" ] || crond -d 6) && \
+CMD ([ -z "$CRON_MIN" ] || supercronic /var/www/FreshRSS/Docker/crontab.freshrss &) && \
 	exec httpd -D FOREGROUND $([ -n "$OIDC_ENABLED" ] && [ "$OIDC_ENABLED" -ne 0 ] && echo "-D OIDC_ENABLED")
+

--- a/Docker/FreshRSS.Apache.conf
+++ b/Docker/FreshRSS.Apache.conf
@@ -1,5 +1,5 @@
 ServerName freshrss.localhost
-Listen 80
+Listen 8080
 DocumentRoot /var/www/FreshRSS/p/
 AllowEncodedSlashes On
 ServerTokens OS
@@ -90,3 +90,4 @@ CustomLog "|/var/www/FreshRSS/cli/sensitive-log.sh" combined_proxy
 <Directory /var/www/FreshRSS/p/themes>
 	Include /var/www/FreshRSS/p/themes/.htaccess
 </Directory>
+

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -30,7 +30,7 @@ Example running FreshRSS (or scroll down to the [Docker Compose](#docker-compose
 
 ```sh
 docker run -d --restart unless-stopped --log-opt max-size=10m \
-  -p 8080:80 \
+  -p 8080:8080 \
   -e TZ=Europe/Paris \
   -e 'CRON_MIN=1,31' \
   -v freshrss_data:/var/www/FreshRSS/data \
@@ -97,7 +97,7 @@ and with newer packages in general (Apache, PHP).
 * `FRESHRSS_ENV`: (default is `production`) Enables additional development information if set to `development` (increases the level of logging and ensures that errors are displayed) (see below for more development options)
 * `COPY_LOG_TO_SYSLOG`: (default is `On`) Copy all the logs to syslog
 * `COPY_SYSLOG_TO_STDERR`: (default is `On`) Copy syslog to Standard Error so that it is visible in docker logs
-* `LISTEN`: (default is `80`) Modifies the internal Apache listening address and port, e.g. `0.0.0.0:8080` (for advanced users; useful for [Docker host networking](https://docs.docker.com/network/host/))
+* `LISTEN`: (default is `8080`) Modifies the internal Apache listening address and port, e.g. `0.0.0.0:8080` (for advanced users; useful for [Docker host networking](https://docs.docker.com/network/host/))
 * `FRESHRSS_INSTALL`: automatically pass arguments to command line `cli/do-install.php` (for advanced users; see example in Docker Compose section). Only executed at the very first run (so far), so if you make any change, you need to delete your `freshrss` service, `freshrss_data` volume, before running again.
 * `FRESHRSS_USER`: automatically pass arguments to command line `cli/create-user.php` (for advanced users; see example in Docker Compose section). Only executed at the very first run (so far), so if you make any change, you need to delete your `freshrss` service, `freshrss_data` volume, before running again.
 
@@ -138,7 +138,7 @@ while reading the source code from your local (git) directory, like the followin
 ```sh
 cd ./FreshRSS/
 docker run --rm \
-  -p 8080:80 \
+  -p 8080:8080 \
   -e FRESHRSS_ENV=development \
   -e TZ=Europe/Paris \
   -e 'CRON_MIN=1,31' \
@@ -332,7 +332,7 @@ services:
       - ./config-user.custom.php:/var/www/FreshRSS/data/config-user.custom.php
     ports:
       # If you want to open a port 8080 on the local machine:
-      - "8080:80"
+      - "8080:8080"
     environment:
       # A timezone http://php.net/timezones (default is UTC)
       TZ: Europe/Paris
@@ -341,7 +341,7 @@ services:
       # Optional 'development' for additional logs; default is 'production'
       FRESHRSS_ENV: development
       # Optional advanced parameter controlling the internal Apache listening port
-      LISTEN: 0.0.0.0:80
+      LISTEN: 0.0.0.0:8080
       # Optional parameter, remove for automatic settings, set to 0 to disable,
       # or (if you use a proxy) to a space-separated list of trusted IP ranges
       # compatible with https://httpd.apache.org/docs/current/mod/mod_remoteip.html#remoteipinternalproxy
@@ -507,7 +507,7 @@ upstream freshrss {
 }
 
 server {
-	listen 80;
+	listen 8080;
 
 	location / {
 		return 301 https://$host$request_uri;
@@ -557,7 +557,7 @@ upstream freshrss {
 }
 
 server {
-	listen 80;
+	listen 8080;
 
 	location / {
 		return 301 https://$host$request_uri;
@@ -708,3 +708,4 @@ docker compose -f docker-compose.yml -f docker-compose-db.yml \
 # Restart a new FreshRSS container after maintenance
 docker compose -f docker-compose.yml -f docker-compose-db.yml up -d freshrss
 ```
+

--- a/Docker/entrypoint-nonroot.sh
+++ b/Docker/entrypoint-nonroot.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+
+# Non-root entrypoint for FreshRSS
+# Timezone is handled via TZ environment variable (no system file modification needed)
+# PHP configuration is done at build time
+
+while read -r config_path _; do
+	if [ -f "$config_path" ]; then
+		APACHE_CONFIG="$config_path"
+		break
+	fi
+done <<EOF
+/etc/apache2/sites-available/FreshRSS.Apache.conf # Debian
+/etc/apache2/conf.d/FreshRSS.Apache.conf          # Alpine
+/etc/httpd/conf/conf.d/FreshRSS.Apache.conf       # Arch
+EOF
+
+if [ -z "$APACHE_CONFIG" ]; then
+	echo '❌ Apache configuration file not found!'
+	exit 11
+fi
+
+if [ -n "$LISTEN" ]; then
+	sed -r -i "\\#^Listen#s#^.*#Listen $LISTEN#" "$APACHE_CONFIG"
+fi
+
+if [ -n "$TRUSTED_PROXY" ]; then
+	if [ "$TRUSTED_PROXY" = "0" ]; then
+		# Disable RemoteIPHeader and RemoteIPInternalProxy
+		sed -r -i "/^\s*RemoteIP.*$/s/^/#/" "$APACHE_CONFIG"
+	else
+		# Custom list for RemoteIPInternalProxy
+		sed -r -i "\\#^\s*RemoteIPInternalProxy#s#^.*#\tRemoteIPInternalProxy $TRUSTED_PROXY#" "$APACHE_CONFIG"
+	fi
+fi
+
+if [ -n "$OIDC_ENABLED" ] && [ "$OIDC_ENABLED" -ne 0 ]; then
+	# Default values
+	export OIDC_SESSION_INACTIVITY_TIMEOUT="${OIDC_SESSION_INACTIVITY_TIMEOUT:-300}"
+	export OIDC_SESSION_MAX_DURATION="${OIDC_SESSION_MAX_DURATION:-27200}"
+	export OIDC_SESSION_TYPE="${OIDC_SESSION_TYPE:-server-cache}"
+
+	# Alpine - move config back
+	if [ -f /etc/apache2/conf.d/mod-auth-openidc.conf.bak ]; then
+		mv /etc/apache2/conf.d/mod-auth-openidc.conf.bak /etc/apache2/conf.d/mod-auth-openidc.conf
+		echo 'Enabling module auth_openidc.'
+	fi
+
+	if [ -n "$OIDC_SCOPES" ]; then
+		# Compatibility with : as separator instead of space
+		OIDC_SCOPES=$(echo "$OIDC_SCOPES" | tr ':' ' ')
+		export OIDC_SCOPES
+	fi
+fi
+
+if [ -n "$CRON_MIN" ]; then
+	# Generate crontab with custom minute value for supercronic
+	sed -r "s#^[^ ]+ #$CRON_MIN #" /var/www/FreshRSS/Docker/crontab.freshrss.default > /var/www/FreshRSS/Docker/crontab.freshrss
+fi
+
+# Ensure data directories exist (non-root safe)
+data_path="${DATA_PATH:-./data}"
+mkdir -p "${data_path}/users/_/" 2>/dev/null || true
+
+php -f ./cli/prepare.php >/dev/null
+
+if [ -n "$FRESHRSS_INSTALL" ]; then
+	# shellcheck disable=SC2046
+	php -f ./cli/do-install.php -- \
+		$(eval "echo \"$FRESHRSS_INSTALL\"" | sed -r 's/[\r\n]+/\n/g' | paste -s -)
+	EXITCODE=$?
+
+	if [ $EXITCODE -eq 3 ]; then
+		echo 'ℹ️ FreshRSS already installed; no change performed.'
+	elif [ $EXITCODE -eq 0 ]; then
+		echo '✅ FreshRSS successfully installed.'
+	else
+		echo '❌ FreshRSS error during installation!'
+		exit $EXITCODE
+	fi
+fi
+
+if [ -n "$FRESHRSS_USER" ]; then
+	# shellcheck disable=SC2046
+	php -f ./cli/create-user.php -- \
+		$(eval "echo \"$FRESHRSS_USER\"" | sed -r 's/[\r\n]+/\n/g' | paste -s -)
+	EXITCODE=$?
+
+	if [ $EXITCODE -eq 3 ]; then
+		echo 'ℹ️ FreshRSS user already exists; no change performed.'
+	elif [ $EXITCODE -eq 0 ]; then
+		echo '✅ FreshRSS user successfully created.'
+		./cli/list-users.php | xargs -n1 ./cli/actualize-user.php --user
+	else
+		echo '❌ FreshRSS error during the creation of a user!'
+		exit $EXITCODE
+	fi
+fi
+
+exec "$@"
+


### PR DESCRIPTION
Closes #8362 

Changes proposed in this pull request:
  - Create a non-root user `freshrss` (uid 1000) to run Apache
  - Replace system cron with `supercronic` (works without root privileges)
  - Change default listening port from 80 to 8080 (non-privileged port)
  - Add new `entrypoint-nonroot.sh` script adapted for rootless operation
  - Pre-create data directories with proper permissions at build time
  - Update documentation to reflect new port mappings

  ### Benefits
  - Improved container security by not running as root
  - Compatible with rootless Docker and Podman
  - Follows container security best practices

How to test the feature manually:

1. `cd Docker`
2. `docker build -f Dockerfile-Newest .. -t freshrss:nonroot`
3. `docker run -d -p8080:8080 -e 'CRON_MIN=15'  --name freshrss freshrss:nonroot`
4. `docker exec -it freshrss sh -c "netstat -an | grep LISTEN"`
     Expected output:
     `tcp        0      0 :::8080                 :::*                    LISTEN`
5. `docker exec -it freshrss sh -c "ps -a | grep [c]rontab"`
     Expected output:
     `11 freshrss  0:00 supercronic /var/www/FreshRSS/Docker/crontab.freshrss`
6. Surf to http://localhost:8080 and FreshRSS should work as normal.

Pull request checklist:

- [X] clear commit messages
- [X] code manually tested
- [ ] unit tests written (optional if too hard)
- [X] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
