### PR TITLE
gitignore: Ignore all the installed extensions

### DIFF
--- a/extensions/.gitignore
+++ b/extensions/.gitignore
@@ -1,1 +1,6 @@
 [xX]*
+*
+!.gitignore
+!.htaccess
+!index.html
+!README.md

--- a/extensions/.gitignore
+++ b/extensions/.gitignore
@@ -1,4 +1,3 @@
-[xX]*
 *
 !.gitignore
 !.htaccess


### PR DESCRIPTION
Closes N/A

Changes proposed in this pull request:

- Have the `extensions/.gitignore` ignore all installed extensions so that they don't show up in `git status`
- Keep the existing files present

How to test the feature manually:

1. Check out the branch
2. Install an extension, like https://github.com/Niehztog/freshrss-af-readability# so it appears at `extensions/af_readability`
3. Do a `git status`, expect to no longer see the extension appear in the diff

Pull request checklist:

- [ ] clear commit messages
- [ ] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
