### PR TITLE
Switch to using CURLOPT_ACCEPT_ENCODING instead of the deprecated CURLOPT_ENCODING

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -1415,7 +1415,7 @@ class FreshRSS_Feed extends Minz_Model {
 				CURLOPT_USERAGENT => FRESHRSS_USERAGENT,
 				CURLOPT_MAXREDIRS => 10,
 				CURLOPT_FOLLOWLOCATION => true,
-				CURLOPT_ENCODING => '',	//Enable all encodings
+				CURLOPT_ACCEPT_ENCODING => '',	//Enable all encodings
 				//CURLOPT_VERBOSE => 1,	// To debug sent HTTP headers
 			]);
 			$response = curl_exec($ch);

--- a/app/Utils/httpUtil.php
+++ b/app/Utils/httpUtil.php
@@ -339,7 +339,7 @@ final class FreshRSS_http_Util {
 			CURLOPT_MAXREDIRS => 4,
 			CURLOPT_RETURNTRANSFER => true,
 			CURLOPT_FOLLOWLOCATION => true,
-			CURLOPT_ENCODING => '',	//Enable all encodings
+			CURLOPT_ACCEPT_ENCODING => '',	//Enable all encodings
 			//CURLOPT_VERBOSE => 1,	// To debug sent HTTP headers
 		]);
 

--- a/cli/health.php
+++ b/cli/health.php
@@ -17,7 +17,7 @@ if ($ch === false) {
 curl_setopt_array($ch, [
 	CURLOPT_CONNECTTIMEOUT => is_numeric($options['connect_timeout'] ?? null) ? (int)$options['connect_timeout'] : 3,
 	CURLOPT_TIMEOUT => is_numeric($options['timeout'] ?? null) ? (int)$options['timeout'] : 5,
-	CURLOPT_ENCODING => '',	//Enable all encodings
+	CURLOPT_ACCEPT_ENCODING => '',	//Enable all encodings
 	CURLOPT_HTTPHEADER => [
 		'Connection: close',
 	],

--- a/lib/composer.json
+++ b/lib/composer.json
@@ -14,7 +14,7 @@
 		"marienfressinaud/lib_opml": "0.5.1",
 		"phpgt/cssxpath": "v1.4.0",
 		"phpmailer/phpmailer": "7.0.1",
-		"simplepie/simplepie": "dev-freshrss#e7b26b4f01d377dc8174d5d4aee961604534d065"
+		"simplepie/simplepie": "dev-merge-mmeier86"
 	},
 	"config": {
 		"sort-packages": true,

--- a/lib/composer.json
+++ b/lib/composer.json
@@ -14,7 +14,7 @@
 		"marienfressinaud/lib_opml": "0.5.1",
 		"phpgt/cssxpath": "v1.4.0",
 		"phpmailer/phpmailer": "7.0.1",
-		"simplepie/simplepie": "dev-merge-mmeier86"
+		"simplepie/simplepie": "dev-freshrss#02d08ffe43b7e93239f90f7d700475891cefcef8"
 	},
 	"config": {
 		"sort-packages": true,

--- a/lib/simplepie/simplepie/src/File.php
+++ b/lib/simplepie/simplepie/src/File.php
@@ -122,7 +122,7 @@ class File implements Response
                     unset($curl_options[CURLOPT_HTTPHEADER]);
                 }
                 if (version_compare(\SimplePie\Misc::get_curl_version(), '7.10.5', '>=')) {
-                    curl_setopt($fp, CURLOPT_ENCODING, '');
+                    curl_setopt($fp, CURLOPT_ACCEPT_ENCODING, '');
                 }
                 curl_setopt($fp, CURLOPT_URL, $url);
                 curl_setopt($fp, CURLOPT_RETURNTRANSFER, 1);
@@ -147,7 +147,7 @@ class File implements Response
                     $this->error = 'cURL error ' . curl_errno($fp) . ': ' . curl_error($fp); // FreshRSS
                     $this->on_http_response($responseBody === false ? false : $responseHeaders . $responseBody, $curl_options);
                     $this->error = null; // FreshRSS
-                    curl_setopt($fp, CURLOPT_ENCODING, 'none');
+                    curl_setopt($fp, CURLOPT_ACCEPT_ENCODING, '');
                     $responseHeaders = '';
                     $responseBody = curl_exec($fp);
                     $responseHeaders .= "\r\n";

--- a/lib/simplepie/simplepie/src/File.php
+++ b/lib/simplepie/simplepie/src/File.php
@@ -121,8 +121,10 @@ class File implements Response
                     }
                     unset($curl_options[CURLOPT_HTTPHEADER]);
                 }
-                if (version_compare(\SimplePie\Misc::get_curl_version(), '7.10.5', '>=')) {
+                if (version_compare(\SimplePie\Misc::get_curl_version(), '7.21.6', '>=')) {
                     curl_setopt($fp, CURLOPT_ACCEPT_ENCODING, '');
+                } elseif (version_compare(\SimplePie\Misc::get_curl_version(), '7.10.5', '>=')) {
+                    curl_setopt($fp, CURLOPT_ENCODING, '');
                 }
                 curl_setopt($fp, CURLOPT_URL, $url);
                 curl_setopt($fp, CURLOPT_RETURNTRANSFER, 1);
@@ -147,7 +149,11 @@ class File implements Response
                     $this->error = 'cURL error ' . curl_errno($fp) . ': ' . curl_error($fp); // FreshRSS
                     $this->on_http_response($responseBody === false ? false : $responseHeaders . $responseBody, $curl_options);
                     $this->error = null; // FreshRSS
-                    curl_setopt($fp, CURLOPT_ACCEPT_ENCODING, '');
+                    if (version_compare(\SimplePie\Misc::get_curl_version(), '7.21.6', '>=')) {
+                        curl_setopt($fp, CURLOPT_ACCEPT_ENCODING, null);
+                    } else {
+                        curl_setopt($fp, CURLOPT_ENCODING, null);
+                    }
                     $responseHeaders = '';
                     $responseBody = curl_exec($fp);
                     $responseHeaders .= "\r\n";

--- a/lib/simplepie/simplepie/src/SimplePie.php
+++ b/lib/simplepie/simplepie/src/SimplePie.php
@@ -2240,7 +2240,7 @@ class SimplePie
                             // We need to unset this so that if SimplePie::set_file() has
                             // been called that object is untouched
                             unset($file);
-                            $this->error = "A feed could not be found at `$this->feed_url`; the status code is `$copyStatusCode` and content-type is `$copyContentType`xxxxxxxxxxxxxx`$this->dbg`";
+                            $this->error = "A feed could not be found at `$this->feed_url`; the status code is `$copyStatusCode` and content-type is `$copyContentType`";
                             $this->registry->call(Misc::class, 'error', [$this->error, E_USER_NOTICE, __FILE__, __LINE__]);
                             return false;
                         }

--- a/lib/simplepie/simplepie/src/SimplePie.php
+++ b/lib/simplepie/simplepie/src/SimplePie.php
@@ -2240,7 +2240,7 @@ class SimplePie
                             // We need to unset this so that if SimplePie::set_file() has
                             // been called that object is untouched
                             unset($file);
-                            $this->error = "A feed could not be found at `$this->feed_url`; the status code is `$copyStatusCode` and content-type is `$copyContentType`";
+                            $this->error = "A feed could not be found at `$this->feed_url`; the status code is `$copyStatusCode` and content-type is `$copyContentType`xxxxxxxxxxxxxx`$this->dbg`";
                             $this->registry->call(Misc::class, 'error', [$this->error, E_USER_NOTICE, __FILE__, __LINE__]);
                             return false;
                         }


### PR DESCRIPTION
Closes #8374 

Changes proposed in this pull request:

- Replacing deprecated `CURLOPT_ENCODING` with `CURLOPT_ACCEPT_ENCODING`

As per the [CURLOPT_ACCEPT_ENCODING docs](https://curl.se/libcurl/c/CURLOPT_ACCEPT_ENCODING.html), `CURLOPT_ENCODING` is obsolete since cURL 7.21.6.

How to test the feature manually:

1. Set up a test instance and add any feet
2. Observe that adding feeds still works

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard)
- [x] documentation updated
