### PR TITLE
Add more time options to Mark as Read dropdown

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -226,13 +226,13 @@ Voir le [dépôt dédié à ces extensions](https://github.com/FreshRSS/Extensio
 
 | Langage | Progression | |
 | - | - | - |
-| Čeština (cs) | ￭￭￭￭￭￭￭￭･･ 84% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fcs+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Čeština (cs) | ￭￭￭￭￭￭￭￭･･ 83% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fcs+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Deutsch (de) | ￭￭￭￭￭￭￭￭￭･ 94% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fde+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Ελληνικά (el) | ￭￭￭･･･････ 38% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fel+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (en) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen+%2F%28TODO%7CDIRTY%29%24%2F) |
-| English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |
+| English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Español (es) | ￭￭￭￭￭￭￭￭･･ 87% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
-| فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 93% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
+| فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 92% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Suomi (fi) | ￭￭￭￭￭￭￭￭￭･ 95% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffi+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Français (fr) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | עברית (he) | ￭￭￭￭･･････ 42% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhe+%2F%28TODO%7CDIRTY%29%24%2F) |
@@ -240,19 +240,19 @@ Voir le [dépôt dédié à ces extensions](https://github.com/FreshRSS/Extensio
 | Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭￭･ 92% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Italiano (it) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fit+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 日本語 (ja) | ￭￭￭￭￭￭￭￭￭･ 90% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fja+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 한국어 (ko) | ￭￭￭￭￭￭￭￭･･ 84% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fko+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Latviešu (lv) | ￭￭￭￭￭￭￭･･･ 78% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Flv+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Nederlands (nl) | ￭￭￭￭￭￭￭￭￭･ 95% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fnl+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 한국어 (ko) | ￭￭￭￭￭￭￭￭･･ 83% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fko+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Latviešu (lv) | ￭￭￭￭￭￭￭･･･ 77% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Flv+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Nederlands (nl) | ￭￭￭￭￭￭￭￭￭･ 94% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fnl+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Occitan (oc) | ￭￭￭￭￭￭￭･･･ 76% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Foc+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Polski (pl) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpl+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Português (Brasil) (pt-BR) | ￭￭￭￭￭￭￭￭･･ 83% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-BR+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Português (Portugal) (pt-PT) | ￭￭￭￭￭￭￭￭･･ 83% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-PT+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Русский (ru) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fru+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Slovenčina (sk) | ￭￭￭￭￭￭￭￭･･ 84% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fsk+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Slovenčina (sk) | ￭￭￭￭￭￭￭￭･･ 83% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fsk+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Türkçe (tr) | ￭￭￭￭￭￭￭￭￭･ 91% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ftr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Українська (uk) | ￭￭￭￭￭￭￭￭￭･ 94% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fuk+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 简体中文 (zh-CN) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-CN+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 正體中文 (zh-TW) | ￭￭￭￭￭￭￭￭･･ 84% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-TW+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 正體中文 (zh-TW) | ￭￭￭￭￭￭￭￭･･ 83% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-TW+%2F%28TODO%7CDIRTY%29%24%2F) |
 
 </translations>
 

--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ See the [repository dedicated to those extensions](https://github.com/FreshRSS/E
 
 | Language | Progress | |
 | - | - | - |
-| Čeština (cs) | ￭￭￭￭￭￭￭￭･･ 84% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fcs+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Čeština (cs) | ￭￭￭￭￭￭￭￭･･ 83% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fcs+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Deutsch (de) | ￭￭￭￭￭￭￭￭￭･ 94% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fde+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Ελληνικά (el) | ￭￭￭･･･････ 38% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fel+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (en) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen+%2F%28TODO%7CDIRTY%29%24%2F) |
-| English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |
+| English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Español (es) | ￭￭￭￭￭￭￭￭･･ 87% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
-| فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 93% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
+| فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 92% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Suomi (fi) | ￭￭￭￭￭￭￭￭￭･ 95% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffi+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Français (fr) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | עברית (he) | ￭￭￭￭･･････ 42% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhe+%2F%28TODO%7CDIRTY%29%24%2F) |
@@ -136,19 +136,19 @@ See the [repository dedicated to those extensions](https://github.com/FreshRSS/E
 | Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭￭･ 92% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Italiano (it) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fit+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 日本語 (ja) | ￭￭￭￭￭￭￭￭￭･ 90% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fja+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 한국어 (ko) | ￭￭￭￭￭￭￭￭･･ 84% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fko+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Latviešu (lv) | ￭￭￭￭￭￭￭･･･ 78% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Flv+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Nederlands (nl) | ￭￭￭￭￭￭￭￭￭･ 95% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fnl+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 한국어 (ko) | ￭￭￭￭￭￭￭￭･･ 83% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fko+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Latviešu (lv) | ￭￭￭￭￭￭￭･･･ 77% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Flv+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Nederlands (nl) | ￭￭￭￭￭￭￭￭￭･ 94% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fnl+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Occitan (oc) | ￭￭￭￭￭￭￭･･･ 76% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Foc+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Polski (pl) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpl+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Português (Brasil) (pt-BR) | ￭￭￭￭￭￭￭￭･･ 83% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-BR+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Português (Portugal) (pt-PT) | ￭￭￭￭￭￭￭￭･･ 83% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-PT+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Русский (ru) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fru+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Slovenčina (sk) | ￭￭￭￭￭￭￭￭･･ 84% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fsk+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Slovenčina (sk) | ￭￭￭￭￭￭￭￭･･ 83% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fsk+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Türkçe (tr) | ￭￭￭￭￭￭￭￭￭･ 91% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ftr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Українська (uk) | ￭￭￭￭￭￭￭￭￭･ 94% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fuk+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 简体中文 (zh-CN) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-CN+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 正體中文 (zh-TW) | ￭￭￭￭￭￭￭￭･･ 84% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-TW+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 正體中文 (zh-TW) | ￭￭￭￭￭￭￭￭･･ 83% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-TW+%2F%28TODO%7CDIRTY%29%24%2F) |
 
 </translations>
 

--- a/app/i18n/cs/index.php
+++ b/app/i18n/cs/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'O FreshRSS',
 		'before_one_day' => 'Starší než jeden den',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'Starší než jeden týden',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Uložit aktuální dotaz do záložek',
 		'favorites' => 'Oblíbené (%s)',
 		'global_view' => 'Zobrazení přehledu',

--- a/app/i18n/de/index.php
+++ b/app/i18n/de/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'Über FreshRSS',
 		'before_one_day' => 'Vor einem Tag',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'Vor einer Woche',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Aktuelle Abfrage speichern',
 		'favorites' => 'Favoriten (%s)',
 		'global_view' => 'Globale Ansicht',

--- a/app/i18n/el/index.php
+++ b/app/i18n/el/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'About FreshRSS',	// TODO
 		'before_one_day' => 'Older than one day',	// TODO
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'Older than one week',	// TODO
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Bookmark current query',	// TODO
 		'favorites' => 'Favourites (%s)',	// TODO
 		'global_view' => 'Global view',	// TODO

--- a/app/i18n/en-US/index.php
+++ b/app/i18n/en-US/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'About FreshRSS',	// IGNORE
 		'before_one_day' => 'Older than one day',	// IGNORE
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'Older than one week',	// IGNORE
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Bookmark current query',	// IGNORE
 		'favorites' => 'Favorites (%s)',
 		'global_view' => 'Global view',	// IGNORE

--- a/app/i18n/en/index.php
+++ b/app/i18n/en/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'About FreshRSS',
 		'before_one_day' => 'Older than one day',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'Older than one week',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Bookmark current query',
 		'favorites' => 'Favourites (%s)',
 		'global_view' => 'Global view',

--- a/app/i18n/en/index.php
+++ b/app/i18n/en/index.php
@@ -66,10 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'About FreshRSS',
 		'before_one_day' => 'Older than one day',
-		'before_one_month' => 'Older than one month',	// TODO
-		'before_one_week' => 'Older than one week',
-		'before_three_days' => 'Older than three days',	// TODO
-		'before_two_days' => 'Older than two days',	// TODO
+		'before_one_month' => 'Older than one month',
+'before_one_week' => 'Older than one week',
+		'before_three_days' => 'Older than three days',
+		'before_two_days' => 'Older than two days',
 		'bookmark_query' => 'Bookmark current query',
 		'favorites' => 'Favourites (%s)',
 		'global_view' => 'Global view',

--- a/app/i18n/en/index.php
+++ b/app/i18n/en/index.php
@@ -67,7 +67,7 @@ return array(
 		'about' => 'About FreshRSS',
 		'before_one_day' => 'Older than one day',
 		'before_one_month' => 'Older than one month',
-'before_one_week' => 'Older than one week',
+		'before_one_week' => 'Older than one week',
 		'before_three_days' => 'Older than three days',
 		'before_two_days' => 'Older than two days',
 		'bookmark_query' => 'Bookmark current query',

--- a/app/i18n/es/index.php
+++ b/app/i18n/es/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'Acerca de FreshRSS',
 		'before_one_day' => 'Con más de 1 día',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'Con más de una semana',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Marcar consulta actual',
 		'favorites' => 'Favoritos (%s)',
 		'global_view' => 'Vista Global',

--- a/app/i18n/fa/index.php
+++ b/app/i18n/fa/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => ' درباره FreshRSS',
 		'before_one_day' => ' بزرگتر از یک روز',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => ' بزرگتر از یک هفته',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => ' درخواست فعلی را نشانک‌گذاری کنید',
 		'favorites' => ' موارد دلخواه (%s)',
 		'global_view' => ' نمای جهانی',

--- a/app/i18n/fi/index.php
+++ b/app/i18n/fi/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'Tietoja FreshRSS-sovelluksesta',
 		'before_one_day' => 'Vanhemmat kuin yksi päivä',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'Vanhemmat kuin yksi viikko',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Tallenna tämä kysely kirjanmerkiksi',
 		'favorites' => 'Suosikit (%s)',
 		'global_view' => 'Yleisnäkymä',

--- a/app/i18n/fr/index.php
+++ b/app/i18n/fr/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'À propos de FreshRSS',
 		'before_one_day' => 'Antérieurs à 1 jour',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'Antérieurs à 1 semaine',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Enregistrer la recherche courante',
 		'favorites' => 'Articles favoris (%s)',
 		'global_view' => 'Vue globale',

--- a/app/i18n/fr/index.php
+++ b/app/i18n/fr/index.php
@@ -66,10 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'À propos de FreshRSS',
 		'before_one_day' => 'Antérieurs à 1 jour',
-		'before_one_month' => 'Older than one month',	// TODO
+		'before_one_month' => 'Antérieurs à 1 mois',
 		'before_one_week' => 'Antérieurs à 1 semaine',
-		'before_three_days' => 'Older than three days',	// TODO
-		'before_two_days' => 'Older than two days',	// TODO
+		'before_three_days' => 'Antérieurs à 3 jours',
+		'before_two_days' => ''Antérieurs à 2 jours',
 		'bookmark_query' => 'Enregistrer la recherche courante',
 		'favorites' => 'Articles favoris (%s)',
 		'global_view' => 'Vue globale',

--- a/app/i18n/fr/index.php
+++ b/app/i18n/fr/index.php
@@ -69,7 +69,7 @@ return array(
 		'before_one_month' => 'Antérieurs à 1 mois',
 		'before_one_week' => 'Antérieurs à 1 semaine',
 		'before_three_days' => 'Antérieurs à 3 jours',
-		'before_two_days' => ''Antérieurs à 2 jours',
+		'before_two_days' => 'Antérieurs à 2 jours',
 		'bookmark_query' => 'Enregistrer la recherche courante',
 		'favorites' => 'Articles favoris (%s)',
 		'global_view' => 'Vue globale',

--- a/app/i18n/he/index.php
+++ b/app/i18n/he/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'אודות FreshRSS',
 		'before_one_day' => 'אתמול',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'לפני שבוע',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Bookmark current query',	// TODO
 		'favorites' => 'מועדפים (%s)',
 		'global_view' => 'תצוגה גלובלית',

--- a/app/i18n/hu/index.php
+++ b/app/i18n/hu/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'FreshRSS névjegy',
 		'before_one_day' => 'Egy napnál régebbiek',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'Egy hétnél régebbiek',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Jelenlegi lekérdezés könyvjelzőzése',
 		'favorites' => 'Kedvencek (%s)',
 		'global_view' => 'Globális nézet',

--- a/app/i18n/id/index.php
+++ b/app/i18n/id/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'Tentang FreshRSS',
 		'before_one_day' => 'Lebih lama dari satu hari',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'Lebih lama dari satu minggu',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Markah pencarian saat ini',
 		'favorites' => 'Favorit (%s)',
 		'global_view' => 'Tampilan Global',

--- a/app/i18n/it/index.php
+++ b/app/i18n/it/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'Informazioni',
 		'before_one_day' => 'Giorno precedente',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'Settimana precedente',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Inserisci la ricerca corrente nei segnalibri',
 		'favorites' => 'Preferiti (%s)',
 		'global_view' => 'Vista globale per categorie',

--- a/app/i18n/ja/index.php
+++ b/app/i18n/ja/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'FreshRSSについて',
 		'before_one_day' => '一日以上前',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => '一週間以上前',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => '現在のブックマーククエリ',
 		'favorites' => 'お気に入り (%s)',
 		'global_view' => 'グローバルビュー',

--- a/app/i18n/ko/index.php
+++ b/app/i18n/ko/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'FreshRSS 정보',
 		'before_one_day' => '하루 전',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => '일주일 전',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => '현재 쿼리 북마크',
 		'favorites' => '즐겨찾기 (%s)',
 		'global_view' => '전체 모드',

--- a/app/i18n/lv/index.php
+++ b/app/i18n/lv/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'Par FreshRSS',
 		'before_one_day' => 'Vecāks par vienu dienu',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'Vecāks par vienu nedēļu',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Pievienot grāmatzīmi pašreizējam pieprasījumam',
 		'favorites' => 'Mīļākie (%s)',
 		'global_view' => 'Globālais skats',

--- a/app/i18n/nl/index.php
+++ b/app/i18n/nl/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'Over FreshRSS',
 		'before_one_day' => 'Ouder dan een dag',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'Ouder dan een week',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Huidige query opslaan',
 		'favorites' => 'Favorieten (%s)',
 		'global_view' => 'Globale weergave',

--- a/app/i18n/oc/index.php
+++ b/app/i18n/oc/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'A prepaus de FreshRSS',
 		'before_one_day' => '1 jorn en arrièr',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => '1 setmana en arrièr',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Marcar aquesta requèsta',
 		'favorites' => 'Favorits (%s)',
 		'global_view' => 'Vista generala',

--- a/app/i18n/pl/index.php
+++ b/app/i18n/pl/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'O oprogramowaniu FreshRSS',
 		'before_one_day' => 'Starsze niż dzień',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'Starsze niż tydzień',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Zapisz bieżące zapytanie',
 		'favorites' => 'Ulubione (%s)',
 		'global_view' => 'Widok globalny',

--- a/app/i18n/pt-BR/index.php
+++ b/app/i18n/pt-BR/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'Sobre o FreshRSS',
 		'before_one_day' => 'Antes de um dia',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'Antes de uma semana',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Salvar pesquisa atual',
 		'favorites' => 'Favoritos (%s)',
 		'global_view' => 'Visualização global',

--- a/app/i18n/pt-PT/index.php
+++ b/app/i18n/pt-PT/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'Sobre o FreshRSS',
 		'before_one_day' => 'Antes de um dia',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'Antes de uma semana',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Salvar pesquisa atual',
 		'favorites' => 'Favoritos (%s)',
 		'global_view' => 'Visualização global',

--- a/app/i18n/ru/index.php
+++ b/app/i18n/ru/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'О FreshRSS',
 		'before_one_day' => 'Старше одного дня',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'Старше одной недели',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Сохранить текущий запрос',
 		'favorites' => 'Избранное (%s)',
 		'global_view' => 'Глобальный вид',

--- a/app/i18n/sk/index.php
+++ b/app/i18n/sk/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'O FreshRSS',
 		'before_one_day' => 'Pred 1 dňom',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'Pred 1 týždňom',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Pridať aktuálny dopyt do obľúbených',
 		'favorites' => 'Obľúbené (%s)',
 		'global_view' => 'Prehľad',

--- a/app/i18n/tr/index.php
+++ b/app/i18n/tr/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'FreshRSS Hakkında',
 		'before_one_day' => 'Bir günden eski',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'Bir haftadan eski',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Geçerli sorguyu yer imlerine ekle',
 		'favorites' => 'Favoriler (%s)',
 		'global_view' => 'Genel görünüm',

--- a/app/i18n/uk/index.php
+++ b/app/i18n/uk/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => 'Про FreshRSS',
 		'before_one_day' => 'Старіші за день',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => 'Старіші за тиждень',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => 'Додати поточний запит у закладки',
 		'favorites' => 'Вподобані (%s)',
 		'global_view' => 'Загальний показ',

--- a/app/i18n/zh-CN/index.php
+++ b/app/i18n/zh-CN/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => '关于 FreshRSS',
 		'before_one_day' => '一天前',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => '一周前',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => '收藏当前查询',
 		'favorites' => '收藏（%s）',
 		'global_view' => '全局视图',

--- a/app/i18n/zh-TW/index.php
+++ b/app/i18n/zh-TW/index.php
@@ -66,7 +66,10 @@ return array(
 	'menu' => array(
 		'about' => '關於 FreshRSS',
 		'before_one_day' => '一天前',
+		'before_one_month' => 'Older than one month',	// TODO
 		'before_one_week' => '一週前',
+		'before_three_days' => 'Older than three days',	// TODO
+		'before_two_days' => 'Older than two days',	// TODO
 		'bookmark_query' => '收藏當前查詢',
 		'favorites' => '收藏（%s）',
 		'global_view' => '全局視圖',

--- a/app/layout/nav_menu.phtml
+++ b/app/layout/nav_menu.phtml
@@ -157,15 +157,24 @@
 	$mark_read_enabled = in_array(FreshRSS_Context::$sort, ['id', 'date'], true);
 	$today = @strtotime('today');
 	$mark_before_today = $mark_read_url;
+	$mark_before_two_days = $mark_read_url;
+	$mark_before_three_days = $mark_read_url;
 	$mark_before_one_week = $mark_read_url;
+	$mark_before_one_month = $mark_read_url;
 	switch (FreshRSS_Context::$sort) {
 		case 'id':
 			$mark_before_today['params']['idMax'] = $today . '000000';
+			$mark_before_two_days['params']['idMax'] = ($today - 172800) . '000000';
+			$mark_before_three_days['params']['idMax'] = ($today - 259200) . '000000';
 			$mark_before_one_week['params']['idMax'] = ($today - 604800) . '000000';
+			$mark_before_one_month['params']['idMax'] = ($today - 2592000) . '000000';
 			break;
 		case 'date':
 			$mark_before_today['params']['maxPubDate'] = $today;
+			$mark_before_two_days['params']['maxPubDate'] = $today - 172800;
+			$mark_before_three_days['params']['maxPubDate'] = $today - 259200;
 			$mark_before_one_week['params']['maxPubDate'] = $today - 604800;
+			$mark_before_one_month['params']['maxPubDate'] = $today - 2592000;
 			break;
 	}
 	$mark_unread_enabled = FreshRSS_Context::isStateEnabled(FreshRSS_Entry::STATE_READ) ||
@@ -180,8 +189,26 @@
 				<li class="item">
 					<button class="as-link <?= $mark_read_enabled ? $confirm : '" disabled="disabled' ?>"
 						form="mark-read-menu"
+						formaction="<?= Minz_Url::display($mark_before_two_days) ?>"
+						type="submit"><?= _t('index.menu.before_two_days') ?></button>
+				</li>
+				<li class="item">
+					<button class="as-link <?= $mark_read_enabled ? $confirm : '" disabled="disabled' ?>"
+						form="mark-read-menu"
+						formaction="<?= Minz_Url::display($mark_before_three_days) ?>"
+						type="submit"><?= _t('index.menu.before_three_days') ?></button>
+				</li>
+				<li class="item">
+					<button class="as-link <?= $mark_read_enabled ? $confirm : '" disabled="disabled' ?>"
+						form="mark-read-menu"
 						formaction="<?= Minz_Url::display($mark_before_one_week) ?>"
 						type="submit"><?= _t('index.menu.before_one_week') ?></button>
+				</li>
+				<li class="item">
+					<button class="as-link <?= $mark_read_enabled ? $confirm : '" disabled="disabled' ?>"
+						form="mark-read-menu"
+						formaction="<?= Minz_Url::display($mark_before_one_month) ?>"
+						type="submit"><?= _t('index.menu.before_one_month') ?></button>
 				</li>
 				<li class="item separator">
 					<button class="as-link <?= $mark_unread_enabled ? $confirm : '" disabled="disabled' ?>"


### PR DESCRIPTION
Adds options for: Older than 2 days, Older than 3 days, Older than 1 month
Implements #6643 (Already closed, but not implemented)

Changes proposed in this pull request:
- Added strings, menu options, logic to the Mark as Read dropdown
- I chose the options based on my own use cases of trying to quickly clean up an unwieldy RSS queue, without resetting it too much

How to test the feature manually:
1. Accumulate RSS entries over 1+ months, ideally with entries each day
2. Select Mark as Read with one of the new entries
3. Mark as Unread to quickly redo the test with the other entries

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated - Did not find this Mark as Read dropdown mentioned in the documentation.
