### PR TITLE
Add remote user in Apache logs, also for API

### DIFF
--- a/Docker/FreshRSS.Apache.conf
+++ b/Docker/FreshRSS.Apache.conf
@@ -14,7 +14,7 @@ ErrorLog /dev/stderr
 	RemoteIPInternalProxy 10.0.0.1/8 172.16.0.1/12 192.168.0.1/16
 </IfModule>
 
-LogFormat "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined_proxy
+LogFormat "%a %l %{REMOTE_USER}e %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined_proxy
 CustomLog "|/var/www/FreshRSS/cli/sensitive-log.sh" combined_proxy
 
 <IfDefine OIDC_ENABLED>

--- a/Docker/FreshRSS.Apache.conf
+++ b/Docker/FreshRSS.Apache.conf
@@ -14,7 +14,11 @@ ErrorLog /dev/stderr
 	RemoteIPInternalProxy 10.0.0.1/8 172.16.0.1/12 192.168.0.1/16
 </IfModule>
 
-LogFormat "%a %l %{REMOTE_USER}e %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined_proxy
+# Default, will be overridden by p/.htaccess and p/api/.htaccess
+SetEnvIfExpr "reqenv('LOG_REMOTE_USER') == ''" LOG_REMOTE_USER=-
+SetEnvIfExpr "reqenv('LOG_REMOTE_USER') == '-' && reqenv('REMOTE_USER') =~ /(.+)/" LOG_REMOTE_USER=$1
+
+LogFormat "%a %l %{LOG_REMOTE_USER}e %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined_proxy
 CustomLog "|/var/www/FreshRSS/cli/sensitive-log.sh" combined_proxy
 
 <IfDefine OIDC_ENABLED>

--- a/p/.htaccess
+++ b/p/.htaccess
@@ -57,3 +57,12 @@ AddDefaultCharset	UTF-8
 		SetEnvIfExpr "%{CONN_REMOTE_ADDR} =~ /(.*)/" CONN_REMOTE_ADDR=$1
 	</IfModule>
 </IfModule>
+
+# Log remote user with same priority as FreshRSS_http_Util::httpAuthUser(). See also api/.htaccess
+<IfModule mod_setenvif.c>
+	SetEnvIfExpr "reqenv('LOG_REMOTE_USER') == ''" LOG_REMOTE_USER=-
+	SetEnvIfExpr "reqenv('LOG_REMOTE_USER') == '-' && reqenv('REMOTE_USER') =~ /(.+)/" LOG_REMOTE_USER=$1
+	SetEnvIfExpr "reqenv('LOG_REMOTE_USER') == '-' && reqenv('REDIRECT_REMOTE_USER') =~ /(.+)/" LOG_REMOTE_USER=$1
+	SetEnvIfExpr "reqenv('LOG_REMOTE_USER') == '-' && req('Remote-User') =~ /(.+)/" LOG_REMOTE_USER=$1
+	SetEnvIfExpr "reqenv('LOG_REMOTE_USER') == '-' && req('X-WebAuth-User') =~ /(.+)/" LOG_REMOTE_USER=$1
+</IfModule>

--- a/p/api/.htaccess
+++ b/p/api/.htaccess
@@ -1,5 +1,6 @@
 <IfModule mod_setenvif.c>
 	SetEnvIfNoCase "Authorization" "(.*)" HTTP_AUTHORIZATION=$1
+	SetEnvIfNoCase "Authorization" "GoogleLogin auth=([^/]+)" REMOTE_USER=$1
 </IfModule>
 <IfModule !mod_setenvif.c>
 	<IfModule mod_rewrite.c>

--- a/p/api/.htaccess
+++ b/p/api/.htaccess
@@ -6,5 +6,7 @@
 	<IfModule mod_rewrite.c>
 		RewriteEngine on
 		RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+		RewriteCond %{HTTP:Authorization} "^GoogleLogin auth=([^/]+)" [NC]
+		RewriteRule .* - [E=REMOTE_USER:%1]
 	</IfModule>
 </IfModule>

--- a/p/api/.htaccess
+++ b/p/api/.htaccess
@@ -1,6 +1,6 @@
 <IfModule mod_setenvif.c>
 	SetEnvIfNoCase "Authorization" "(.*)" HTTP_AUTHORIZATION=$1
-	SetEnvIfNoCase "Authorization" "GoogleLogin auth=([^/]+)" REMOTE_USER=$1
+	SetEnvIfNoCase "Authorization" "^GoogleLogin auth=([^/]+)" REMOTE_USER=$1
 </IfModule>
 <IfModule !mod_setenvif.c>
 	<IfModule mod_rewrite.c>

--- a/p/api/.htaccess
+++ b/p/api/.htaccess
@@ -1,12 +1,12 @@
 <IfModule mod_setenvif.c>
 	SetEnvIfNoCase "Authorization" "(.*)" HTTP_AUTHORIZATION=$1
-	SetEnvIfNoCase "Authorization" "^GoogleLogin auth=([^/]+)" REMOTE_USER=$1
+	SetEnvIfNoCase "Authorization" "^GoogleLogin auth=([^/]+)" REMOTE_USER=$1 LOG_REMOTE_USER=$1
 </IfModule>
 <IfModule !mod_setenvif.c>
 	<IfModule mod_rewrite.c>
 		RewriteEngine on
 		RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 		RewriteCond %{HTTP:Authorization} "^GoogleLogin auth=([^/]+)" [NC]
-		RewriteRule .* - [E=REMOTE_USER:%1]
+		RewriteRule .* - [E=REMOTE_USER:%1,E=LOG_REMOTE_USER:%1]
 	</IfModule>
 </IfModule>


### PR DESCRIPTION
fix https://github.com/FreshRSS/FreshRSS/discussions/8385

Example:
```
2026-01-01T18:38:28.645486326Z 0.0.0.0 - alex [01/Jan/2026:19:38:28 +0100] "GET /api/greader.php/reader/api/0/subscription/list?output=json HTTP/1.1" 200 9798 "-" "curl/8.14.1"
```
