### PR TITLE
Allow styling entries by category in User CSS

### DIFF
--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -79,6 +79,7 @@ $today = @strtotime('today');
 		?><?= $useKeepUnreadImportant && ($this->feed->priority() >= FreshRSS_Feed::PRIORITY_IMPORTANT) ? ' keep_unread ' : ''
 		?>" id="flux_<?= $this->entry->id()
 		?>" data-entry="<?= $this->entry->id()
+		?>" data-category="<?= $this->feed->categoryId()
 		?>" data-feed="<?= $this->feed->id()
 		?>" data-priority="<?= $this->feed->priority()
 		?>" data-link="<?= $this->entry->link()

--- a/app/views/index/reader.phtml
+++ b/app/views/index/reader.phtml
@@ -37,9 +37,10 @@ $useKeepUnreadImportant = !FreshRSS_Context::isImportant() && !FreshRSS_Context:
 		?><?= $useKeepUnreadImportant && ($this->feed->priority() >= FreshRSS_Feed::PRIORITY_IMPORTANT) ? ' keep_unread ' : ''
 		?>" id="flux_<?= $this->entry->id()
 		?>" data-entry="<?= $this->entry->id()
-		?>" data-feed="<?= $this->feed->id()
 		?>" data-category="<?= $this->feed->categoryId()
+		?>" data-feed="<?= $this->feed->id()
 		?>" data-priority="<?= $this->feed->priority()
+		?>" data-link="<?= $this->entry->link()
 		?>"><?php $this->renderHelper('index/article'); ?>
 	</div><?php
 	endforeach;

--- a/app/views/index/reader.phtml
+++ b/app/views/index/reader.phtml
@@ -38,6 +38,7 @@ $useKeepUnreadImportant = !FreshRSS_Context::isImportant() && !FreshRSS_Context:
 		?>" id="flux_<?= $this->entry->id()
 		?>" data-entry="<?= $this->entry->id()
 		?>" data-feed="<?= $this->feed->id()
+		?>" data-category="<?= $this->feed->categoryId()
 		?>" data-priority="<?= $this->feed->priority()
 		?>"><?php $this->renderHelper('index/article'); ?>
 	</div><?php


### PR DESCRIPTION
Since we have `data-feed`, it is useful to have `data-category` too.

Example of usage to hide titles in all entries that belong to a specific category ID:
```css
[data-category="6"] {
	.title { display: none !important }
	.summary {
		position: relative;
		bottom: 2rem;
	}
}
```