### PR TITLE
Remove wrong deprecation

### DIFF
--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -267,7 +267,6 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 		header('Content-Type: application/rss+xml; charset=utf-8');
 	}
 
-	#[Deprecated('See user query OPML sharing instead')]
 	public function opmlAction(): void {
 		$allow_anonymous = FreshRSS_Context::systemConf()->allow_anonymous;
 


### PR DESCRIPTION
This OPML method is the one used when exporting a single feed as OPML. Not deprecated.
