### PR TITLE
Document mounting own CA on FreshRSS container

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -194,6 +194,7 @@ People are sorted by name so please keep this order.
 * [Nainor](https://github.com/Nainor): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Nainor)
 * [nanhualyq](https://github.com/nanhualyq): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:nanhualyq)
 * [Natalie Stroud](https://github.com/natastro): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:natastro)
+* [netsho](https://github.com/netsho): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:netsho)
 * [nhirokinet](https://github.com/nhirokinet): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:nhirokinet)
 * [Nick Cross](https://github.com/rnc): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:rnc)
 * [Nico B](https://github.com/youknow0): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:youknow0)

--- a/docs/en/admins/16_OpenID-Connect-Authentik.md
+++ b/docs/en/admins/16_OpenID-Connect-Authentik.md
@@ -26,6 +26,7 @@ Without the port number, Authentik will give a `redirect_url` error.
 You will need to choose a signing key.
 If you don’t have one, generate one under *System > Certificates*.
 The default `authentik Self-Signed Certificate` will also work.
+If using a self-signed certificate issued by your own CA, you will need to mount the following file to the FreshRSS container: `/etc/ssl/certs/ca-certificates.crt:ro`. *Note: The `ca-certificates.crt` need to be mounted as read-only `:ro` to avoid any unwanted modification.*
 
 Under *Advanced Protocol Settings > Scopes* you will see that email, openid and profile are selected by default.
 These are the scopes you will set later in the docker config file.
@@ -125,6 +126,7 @@ services:
     volumes:
       - freshrss-data:/var/www/FreshRSS/data
       - freshrss-extensions:/var/www/FreshRSS/extensions
+	  - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro # If using self-signed authentik signing-key issued by your own CA
     # # Portainer defines the env file as show below, but not needed if using the default `.env`
     # env_file:
     #   - ../stack.env


### PR DESCRIPTION
Closes #8405

Changes proposed in this pull request:

- Add documentation on how to trust own CA that issued self-signed certificate as authentik signing key
- Add example in Docker Example

How to test the feature manually:

1. Create your own CA
2. Issue a certificate
3. Use the issued certificate as a signing-key in authentik when configuring FreshRSS provider
4. Add created CA on host's CA store by running `update-ca-certificates`
5. Mount the `/etc/ssl/certs/ca-certificates.crt` file on FreshRSS container
6. Start the container
7. Navigate to FreshRSS in the browser
8. Authentik login form should be displayed and work as normal.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
