### PR TITLE
fix validator url update

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -289,6 +289,7 @@ People are sorted by name so please keep this order.
 * [tonitonae](https://github.com/tonitonae): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:tonitonae)
 * [Troy Engel](https://github.com/troyengel): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:troyengel)
 * [TryAllTheThings](https://github.com/tryallthethings): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:tryallthethings)
+* [Tsung-Han Yu](https://github.com/johan456789): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:johan456789), [Web](https://tsunghanyu.com/)
 * [Twilek-de](https://github.com/Twilek-de): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Twilek-de)
 * [Uncovery](https://github.com/uncovery): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:uncovery)
 * [upskaling](https://github.com/upskaling): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:upskaling)

--- a/app/views/feed/add.phtml
+++ b/app/views/feed/add.phtml
@@ -50,7 +50,7 @@
 						<a class="btn open-url" target="_blank" rel="noreferrer" href="<?= $this->feed->url() ?>" data-input="url" title="<?= _t('gen.action.open_url') ?>"><?= _i('link') ?></a>
 					</div>
 					<br />
-					<a class="btn open-validator" target="_blank" rel="noreferrer" data-input="url" data-prefix="https://validator.w3.org/feed/check.cgi?url=" href="https://validator.w3.org/feed/check.cgi?url=<?= $this->feed->url() ?>"><?= _t('sub.feed.validator') ?></a>
+					<a class="btn open-url" target="_blank" rel="noreferrer" data-input="url" data-prefix="https://validator.w3.org/feed/check.cgi?url=" data-encode="1" href="https://validator.w3.org/feed/check.cgi?url=<?= $this->feed->url() ?>"><?= _t('sub.feed.validator') ?></a>
 				</div>
 			</div>
 			<div class="form-group">

--- a/app/views/feed/add.phtml
+++ b/app/views/feed/add.phtml
@@ -50,7 +50,7 @@
 						<a class="btn open-url" target="_blank" rel="noreferrer" href="<?= $this->feed->url() ?>" data-input="url" title="<?= _t('gen.action.open_url') ?>"><?= _i('link') ?></a>
 					</div>
 					<br />
-					<a class="btn" target="_blank" rel="noreferrer" href="https://validator.w3.org/feed/check.cgi?url=<?= $this->feed->url() ?>"><?= _t('sub.feed.validator') ?></a>
+					<a class="btn open-validator" target="_blank" rel="noreferrer" data-input="url" data-prefix="https://validator.w3.org/feed/check.cgi?url=" href="https://validator.w3.org/feed/check.cgi?url=<?= $this->feed->url() ?>"><?= _t('sub.feed.validator') ?></a>
 				</div>
 			</div>
 			<div class="form-group">

--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -95,7 +95,7 @@
 						<input type="url" name="url" id="url" value="<?= $this->feed->url() ?>" required="required" />
 						<a class="btn open-url" target="_blank" rel="noreferrer" href="<?= $this->feed->url() ?>" data-input="url" title="<?= _t('gen.action.open_url') ?>"><?= _i('link') ?></a>
 					</div>
-					<a class="btn" target="_blank" rel="noreferrer" href="https://validator.w3.org/feed/check.cgi?url=<?=
+					<a class="btn open-validator" target="_blank" rel="noreferrer" data-input="url" data-prefix="https://validator.w3.org/feed/check.cgi?url=" href="https://validator.w3.org/feed/check.cgi?url=<?=
 						rawurlencode(htmlspecialchars_decode($this->feed->url(), ENT_QUOTES)) ?>"><?= _t('sub.feed.validator') ?></a>
 				</div>
 			</div>

--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -95,7 +95,7 @@
 						<input type="url" name="url" id="url" value="<?= $this->feed->url() ?>" required="required" />
 						<a class="btn open-url" target="_blank" rel="noreferrer" href="<?= $this->feed->url() ?>" data-input="url" title="<?= _t('gen.action.open_url') ?>"><?= _i('link') ?></a>
 					</div>
-					<a class="btn open-validator" target="_blank" rel="noreferrer" data-input="url" data-prefix="https://validator.w3.org/feed/check.cgi?url=" href="https://validator.w3.org/feed/check.cgi?url=<?=
+					<a class="btn open-url" target="_blank" rel="noreferrer" data-input="url" data-prefix="https://validator.w3.org/feed/check.cgi?url=" data-encode="1" href="https://validator.w3.org/feed/check.cgi?url=<?=
 						rawurlencode(htmlspecialchars_decode($this->feed->url(), ENT_QUOTES)) ?>"><?= _t('sub.feed.validator') ?></a>
 				</div>
 			</div>

--- a/p/scripts/extra.js
+++ b/p/scripts/extra.js
@@ -398,29 +398,15 @@ function close_slider_listener(ev) {
 // overwrites the href attribute from the url input
 function updateHref(ev) {
 	const urlField = document.getElementById(this.getAttribute('data-input'));
-	const url = urlField.value;
-	if (url.length > 0) {
+	const rawUrl = urlField.value;
+	const prefix = this.getAttribute('data-prefix') || '';
+	const shouldEncode = this.getAttribute('data-encode') === '1';
+	const url = prefix + (shouldEncode ? encodeURIComponent(rawUrl) : rawUrl);
+	if (rawUrl.length > 0) {
 		this.href = url;
 		return true;
 	} else {
 		urlField.focus();
-		this.removeAttribute('href');
-		ev.preventDefault();
-		return false;
-	}
-}
-
-function updateValidatorHref(ev) {
-	const urlField = document.getElementById(this.getAttribute('data-input'));
-	const url = urlField ? urlField.value : '';
-	if (url.length > 0) {
-		const prefix = this.getAttribute('data-prefix') || '';
-		this.href = prefix + encodeURIComponent(url);
-		return true;
-	} else {
-		if (urlField) {
-			urlField.focus();
-		}
 		this.removeAttribute('href');
 		ev.preventDefault();
 		return false;
@@ -432,13 +418,6 @@ function init_url_observers(parent) {
 	parent.querySelectorAll('.open-url').forEach(function (btn) {
 		btn.addEventListener('mouseover', updateHref);
 		btn.addEventListener('click', updateHref);
-	});
-}
-
-function init_validator_observers(parent) {
-	parent.querySelectorAll('.open-validator').forEach(function (btn) {
-		btn.addEventListener('mouseover', updateValidatorHref);
-		btn.addEventListener('click', updateValidatorHref);
 	});
 }
 
@@ -634,12 +613,10 @@ function init_extra_afterDOM() {
 			init_slider(slider);
 			init_archiving(slider);
 			init_url_observers(slider);
-			init_validator_observers(slider);
 		} else {
 			init_display(document.body);
 			init_archiving(document.body);
 			init_url_observers(document.body);
-			init_validator_observers(document.body);
 		}
 	}
 

--- a/p/scripts/extra.js
+++ b/p/scripts/extra.js
@@ -410,11 +410,35 @@ function updateHref(ev) {
 	}
 }
 
+function updateValidatorHref(ev) {
+	const urlField = document.getElementById(this.getAttribute('data-input'));
+	const url = urlField ? urlField.value : '';
+	if (url.length > 0) {
+		const prefix = this.getAttribute('data-prefix') || '';
+		this.href = prefix + encodeURIComponent(url);
+		return true;
+	} else {
+		if (urlField) {
+			urlField.focus();
+		}
+		this.removeAttribute('href');
+		ev.preventDefault();
+		return false;
+	}
+}
+
 // set event listener on "show url" buttons
 function init_url_observers(parent) {
 	parent.querySelectorAll('.open-url').forEach(function (btn) {
 		btn.addEventListener('mouseover', updateHref);
 		btn.addEventListener('click', updateHref);
+	});
+}
+
+function init_validator_observers(parent) {
+	parent.querySelectorAll('.open-validator').forEach(function (btn) {
+		btn.addEventListener('mouseover', updateValidatorHref);
+		btn.addEventListener('click', updateValidatorHref);
 	});
 }
 
@@ -610,10 +634,12 @@ function init_extra_afterDOM() {
 			init_slider(slider);
 			init_archiving(slider);
 			init_url_observers(slider);
+			init_validator_observers(slider);
 		} else {
 			init_display(document.body);
 			init_archiving(document.body);
 			init_url_observers(document.body);
+			init_validator_observers(document.body);
 		}
 	}
 

--- a/p/scripts/extra.js
+++ b/p/scripts/extra.js
@@ -395,7 +395,7 @@ function close_slider_listener(ev) {
 }
 // </slider>
 
-// overwrites the href attribute from the url input
+// updates href from the input value, with optional prefix/encoding
 function updateHref(ev) {
 	const urlField = document.getElementById(this.getAttribute('data-input'));
 	const rawUrl = urlField.value;

--- a/p/scripts/feed.js
+++ b/p/scripts/feed.js
@@ -1,6 +1,6 @@
 // @license magnet:?xt=urn:btih:0b31508aeb0634b347b8270c7bee4d411b5d4109&dn=agpl-3.0.txt AGPL-3.0
 'use strict';
-/* globals init_archiving, init_configuration_alert, init_password_observers, init_slider, init_url_observers, init_validator_observers */
+/* globals init_archiving, init_configuration_alert, init_password_observers, init_slider, init_url_observers */
 
 // <popup>
 let popup = null;
@@ -148,7 +148,6 @@ function init_feed_afterDOM() {
 			init_disable_elements_on_update(slider);
 			init_password_observers(slider);
 			init_url_observers(slider);
-			init_validator_observers(slider);
 			init_valid_xpath(slider);
 		});
 		init_slider(slider);

--- a/p/scripts/feed.js
+++ b/p/scripts/feed.js
@@ -1,6 +1,6 @@
 // @license magnet:?xt=urn:btih:0b31508aeb0634b347b8270c7bee4d411b5d4109&dn=agpl-3.0.txt AGPL-3.0
 'use strict';
-/* globals init_archiving, init_configuration_alert, init_password_observers, init_slider, init_url_observers */
+/* globals init_archiving, init_configuration_alert, init_password_observers, init_slider, init_url_observers, init_validator_observers */
 
 // <popup>
 let popup = null;
@@ -148,6 +148,7 @@ function init_feed_afterDOM() {
 			init_disable_elements_on_update(slider);
 			init_password_observers(slider);
 			init_url_observers(slider);
+			init_validator_observers(slider);
 			init_valid_xpath(slider);
 		});
 		init_slider(slider);


### PR DESCRIPTION
Closes #8435

  Changes proposed in this pull request:

  - update validator links to use the same open-url handler with prefix + encoding
  - ensure the validator link reflects the current #url field value before opening
  - keep existing open-url behavior for other links unchanged

  How to test the feature manually:

  1. Open feed edit (or add feed) form.
  2. Change the feed URL in the URL field.
  3. Click “Check the validity of the feed” and verify it opens the validator with the updated URL.

  Pull request checklist:

  - [x] clear commit messages
  - [x] code manually tested
  - [ ] unit tests written (optional if too hard)
  - [ ] documentation updated