### PR TITLE
Update documentation in regards to CSP warnings

### DIFF
--- a/docs/en/admins/10_ServerConfig.md
+++ b/docs/en/admins/10_ServerConfig.md
@@ -125,7 +125,7 @@ Debug your own CSP header:
 * With DevTools network tab: press F12
 * [CSP Evaluator](https://csp-evaluator.withgoogle.com/)
 
-If you’re aware of the risks or haven’t overwritten the CSP header and want to ignore the warning shown to admin users, change the `suppress_csp_warning` setting to `true` in `./data/config.php`.
+If you’re aware of the risks and want to ignore the warning shown to admin users, change the `suppress_csp_warning` setting to `true` in `./data/config.php`.
 
 Note that FreshRSS already ships with a secure CSP configuration, therefore it’s not necessary to make any adjustments to CSP unless you’re writing an extension.
 

--- a/docs/en/admins/10_ServerConfig.md
+++ b/docs/en/admins/10_ServerConfig.md
@@ -115,17 +115,17 @@ server {
 
 ## Security
 
-Avoid overwriting the [`Content-Security-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) header with directives such as `more_set_headers "Content-Security-Policy: ..."`
+Avoid overwriting the [`Content-Security-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) header with directives such as `more_set_headers "Content-Security-Policy: ..."` or `add_header 'Content-Security-Policy' '...'`.
 
 ✅ Example of good CSP: `default-src 'self'; frame-ancestors 'self'`
 
 ❌ Bad CSP: `upgrade-insecure-requests`
 
-Debug CSP header:
+Debug your own CSP header:
 * With DevTools network tab: press F12
 * [CSP Evaluator](https://csp-evaluator.withgoogle.com/)
 
-If you're aware of the risks and want to ignore the warning shown to admin users, change the `suppress_csp_warning` setting to `true` in `./data/config.php`
+If you're aware of the risks or haven't overwritten the CSP header and want to ignore the warning shown to admin users, change the `suppress_csp_warning` setting to `true` in `./data/config.php`.
 
 Note that FreshRSS already ships with a secure CSP configuration, therefore it's not necessary to make any adjustments to CSP unless you're writing an extension.
 

--- a/docs/en/admins/10_ServerConfig.md
+++ b/docs/en/admins/10_ServerConfig.md
@@ -125,8 +125,8 @@ Debug your own CSP header:
 * With DevTools network tab: press F12
 * [CSP Evaluator](https://csp-evaluator.withgoogle.com/)
 
-If you're aware of the risks or haven't overwritten the CSP header and want to ignore the warning shown to admin users, change the `suppress_csp_warning` setting to `true` in `./data/config.php`.
+If you’re aware of the risks or haven’t overwritten the CSP header and want to ignore the warning shown to admin users, change the `suppress_csp_warning` setting to `true` in `./data/config.php`.
 
-Note that FreshRSS already ships with a secure CSP configuration, therefore it's not necessary to make any adjustments to CSP unless you're writing an extension.
+Note that FreshRSS already ships with a secure CSP configuration, therefore it’s not necessary to make any adjustments to CSP unless you’re writing an extension.
 
 For that, look into the [`Minz_ActionController::_csp`](https://github.com/FreshRSS/FreshRSS/blob/d9197d7e32a97f29829ffd4cf4371b1853e51fa2/lib/Minz/ActionController.php#L76-L96) function and use it in individual actions.

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -2327,7 +2327,8 @@ function init_csp_alert() {
 		Function();
 	} catch (_) {
 		// Exit if 'script-src' is set and 'unsafe-eval' isn't set in CSP
-		console.info("If you see a 'unsafe-eval' warning, everything is working as intended.\nSee https://freshrss.github.io/FreshRSS/en/admins/10_ServerConfig.html#security");
+		console.info(`If you see a 'unsafe-eval' warning, everything is working as intended:
+see https://freshrss.github.io/FreshRSS/en/admins/10_ServerConfig.html#security`);
 		return;
 	}
 

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -2325,9 +2325,9 @@ function init_csp_alert() {
 	try {
 		// eslint-disable-next-line no-new-func
 		Function();
-		// See https://github.com/FreshRSS/FreshRSS/blob/edge/docs/en/admins/10_ServerConfig.md#security
 	} catch (_) {
 		// Exit if 'script-src' is set and 'unsafe-eval' isn't set in CSP
+		console.info("If you see a 'unsafe-eval' warning, everything is working as intended.\nSee https://github.com/FreshRSS/FreshRSS/blob/edge/docs/en/admins/10_ServerConfig.md#security");
 		return;
 	}
 

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -2327,7 +2327,7 @@ function init_csp_alert() {
 		Function();
 	} catch (_) {
 		// Exit if 'script-src' is set and 'unsafe-eval' isn't set in CSP
-		console.info("If you see a 'unsafe-eval' warning, everything is working as intended.\nSee https://github.com/FreshRSS/FreshRSS/blob/edge/docs/en/admins/10_ServerConfig.md#security");
+		console.info("If you see a 'unsafe-eval' warning, everything is working as intended.\nSee https://freshrss.github.io/FreshRSS/en/admins/10_ServerConfig.html#security");
 		return;
 	}
 

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -2325,6 +2325,7 @@ function init_csp_alert() {
 	try {
 		// eslint-disable-next-line no-new-func
 		Function();
+		// See https://github.com/FreshRSS/FreshRSS/blob/edge/docs/en/admins/10_ServerConfig.md#security
 	} catch (_) {
 		// Exit if 'script-src' is set and 'unsafe-eval' isn't set in CSP
 		return;


### PR DESCRIPTION
Closes #8438

Changes proposed in this pull request:
- Add a (documentation) reference to the CSP warning caused by the CSP correctness check to the relevant documentation
- Update the documentation to reflect that this browser warning is triggered also by correct CSP configuration

How to test the feature manually:
1. Login as admin into FreshRSS instance
2. View developer console (CTRL + SHIFT + I) and look at console warnings
~~3. Clicking on the code that tirggered the warning should now also have the documentation link~~
3. Additional console information should be printed (on valid installs) towards the documentation

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
