### PR TITLE
Fix custom session.cookie-lifetime

### DIFF
--- a/lib/Minz/Session.php
+++ b/lib/Minz/Session.php
@@ -215,7 +215,8 @@ class Minz_Session {
 			return;
 		}
 		$lifetime = session_get_cookie_params()['lifetime'];
-		setcookie($name, $newId, $lifetime, self::getCookieDir(), '', Minz_Request::isHttps(), true);
+		$expire = $lifetime > 0 ? time() + $lifetime : 0;
+		setcookie($name, $newId, $expire, self::getCookieDir(), '', Minz_Request::isHttps(), true);
 	}
 
 	public static function deleteLongTermCookie(string $name): void {


### PR DESCRIPTION
fix https://github.com/FreshRSS/FreshRSS/issues/8430
Fix case when `session.cookie-lifetime` is not using the default value of 0 in PHP ini.

Co-authored-by: rioky <rioky@users.noreply.github.com>
