### PR TITLE
Bump PHPStan

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -245,11 +245,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.33",
+            "version": "2.1.36",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9e800e6bee7d5bd02784d4c6069b48032d16224f",
-                "reference": "9e800e6bee7d5bd02784d4c6069b48032d16224f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/2132e5e2361d11d40af4c17faa16f043269a4cf3",
+                "reference": "2132e5e2361d11d40af4c17faa16f043269a4cf3",
                 "shasum": ""
             },
             "require": {
@@ -294,7 +294,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-05T10:24:31+00:00"
+            "time": "2026-01-21T13:58:26+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",


### PR DESCRIPTION
~22% faster analysis since 2.1.34+. https://github.com/phpstan/phpstan/releases/tag/2.1.34

Before / after:

```console
$ rm -fr /tmp/phpstan/
$ time composer run-script phpstan
> phpstan analyse --memory-limit 512M .
Note: Using configuration file /home/alex/GitHub/FreshRSS/phpstan.dist.neon.

real    1m2.924s
user    4m54.812s
sys     0m16.494s

$ rm -fr /tmp/phpstan/
$ time composer run-script phpstan
> phpstan analyse --memory-limit 512M .
Note: Using configuration file /home/alex/GitHub/FreshRSS/phpstan.dist.neon.

real    0m49.215s
user    3m40.906s
sys     0m18.413s
```
