### PR TITLE
Add option to enable notifications

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -75,6 +75,7 @@ class FreshRSS_configure_Controller extends FreshRSS_ActionController {
 			FreshRSS_Context::userConf()->bottomline_link = Minz_Request::paramBoolean('bottomline_link');
 			FreshRSS_Context::userConf()->show_nav_buttons = Minz_Request::paramBoolean('show_nav_buttons');
 			FreshRSS_Context::userConf()->html5_notif_timeout = max(0, Minz_Request::paramInt('html5_notif_timeout'));
+			FreshRSS_Context::userConf()->html5_enable_notif = Minz_Request::paramBoolean('html5_enable_notif');
 			FreshRSS_Context::userConf()->good_notification_timeout = max(0, Minz_Request::paramInt('good_notification_timeout'));
 			FreshRSS_Context::userConf()->bad_notification_timeout = max(1, Minz_Request::paramInt('bad_notification_timeout'));
 			FreshRSS_Context::userConf()->save();

--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -75,7 +75,8 @@ class FreshRSS_configure_Controller extends FreshRSS_ActionController {
 			FreshRSS_Context::userConf()->bottomline_link = Minz_Request::paramBoolean('bottomline_link');
 			FreshRSS_Context::userConf()->show_nav_buttons = Minz_Request::paramBoolean('show_nav_buttons');
 			FreshRSS_Context::userConf()->html5_notif_timeout = max(0, Minz_Request::paramInt('html5_notif_timeout'));
-			FreshRSS_Context::userConf()->html5_enable_notif = Minz_Request::paramBoolean('html5_enable_notif');
+			// Invert here so default remains same
+			FreshRSS_Context::userConf()->not_html5_enable_notif = !Minz_Request::paramBoolean('html5_enable_notif');
 			FreshRSS_Context::userConf()->good_notification_timeout = max(0, Minz_Request::paramInt('good_notification_timeout'));
 			FreshRSS_Context::userConf()->bad_notification_timeout = max(1, Minz_Request::paramInt('bad_notification_timeout'));
 			FreshRSS_Context::userConf()->save();

--- a/app/Models/UserConfiguration.php
+++ b/app/Models/UserConfiguration.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
  * @property string $feverKey
  * @property bool $hide_read_feeds
  * @property int $html5_notif_timeout
+ * @property bool $html5_enable_notif
  * @property int $good_notification_timeout
  * @property int $bad_notification_timeout
  * @property-read bool $is_admin

--- a/app/Models/UserConfiguration.php
+++ b/app/Models/UserConfiguration.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
  * @property string $feverKey
  * @property bool $hide_read_feeds
  * @property int $html5_notif_timeout
- * @property bool $html5_enable_notif
+ * @property bool $not_html5_enable_notif
  * @property int $good_notification_timeout
  * @property int $bad_notification_timeout
  * @property-read bool $is_admin

--- a/app/i18n/cs/conf.php
+++ b/app/i18n/cs/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'None',	// TODO
 		'small' => 'Small',	// TODO
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Show warning banner',	// TODO

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'Keine',
 		'small' => 'Klein',
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Zeige Warnbanner',

--- a/app/i18n/el/conf.php
+++ b/app/i18n/el/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'None',	// TODO
 		'small' => 'Small',	// TODO
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Show warning banner',	// TODO

--- a/app/i18n/en-US/conf.php
+++ b/app/i18n/en-US/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'None',	// IGNORE
 		'small' => 'Small',	// IGNORE
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Show warning banner',	// IGNORE

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'None',
 		'small' => 'Small',
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Show warning banner',	// TODO

--- a/app/i18n/es/conf.php
+++ b/app/i18n/es/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'None',	// TODO
 		'small' => 'Small',	// TODO
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Show warning banner',	// TODO

--- a/app/i18n/fa/conf.php
+++ b/app/i18n/fa/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'هیچ',
 		'small' => 'کوچک',
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Show warning banner',	// TODO

--- a/app/i18n/fi/conf.php
+++ b/app/i18n/fi/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'Ei mitään',
 		'small' => 'Pieni',
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Näytä varoituspalkki',

--- a/app/i18n/fr/conf.php
+++ b/app/i18n/fr/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'Aucun',
 		'small' => 'Petit',
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Afficher la bannière d’avertissement',

--- a/app/i18n/he/conf.php
+++ b/app/i18n/he/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'None',	// TODO
 		'small' => 'Small',	// TODO
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Show warning banner',	// TODO

--- a/app/i18n/hu/conf.php
+++ b/app/i18n/hu/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'Egyik sem',
 		'small' => 'Kicsi',
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Figyelmeztető sáv megjelenítése',

--- a/app/i18n/id/conf.php
+++ b/app/i18n/id/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'Tidak ditampilkan',
 		'small' => 'Kecil',
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Show warning banner',	// TODO

--- a/app/i18n/it/conf.php
+++ b/app/i18n/it/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'Nessuno',
 		'small' => 'Piccolo',
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Mostra banner con le segnalazioni',

--- a/app/i18n/ja/conf.php
+++ b/app/i18n/ja/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'None',	// TODO
 		'small' => 'Small',	// TODO
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Show warning banner',	// TODO

--- a/app/i18n/ko/conf.php
+++ b/app/i18n/ko/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'None',	// TODO
 		'small' => 'Small',	// TODO
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Show warning banner',	// TODO

--- a/app/i18n/lv/conf.php
+++ b/app/i18n/lv/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'None',	// TODO
 		'small' => 'Small',	// TODO
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Show warning banner',	// TODO

--- a/app/i18n/nl/conf.php
+++ b/app/i18n/nl/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'Geen',
 		'small' => 'Klein',
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Waarschuwingsbalk tonen',

--- a/app/i18n/oc/conf.php
+++ b/app/i18n/oc/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'None',	// TODO
 		'small' => 'Small',	// TODO
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Show warning banner',	// TODO

--- a/app/i18n/pl/conf.php
+++ b/app/i18n/pl/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'Brak',
 		'small' => 'Mały',
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Pokaż baner ostrzeżenia',

--- a/app/i18n/pt-BR/conf.php
+++ b/app/i18n/pt-BR/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'Nenhum',
 		'small' => 'Pequeno',
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Mostrar banner de aviso',

--- a/app/i18n/pt-PT/conf.php
+++ b/app/i18n/pt-PT/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'None',	// TODO
 		'small' => 'Small',	// TODO
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Show warning banner',	// TODO

--- a/app/i18n/ru/conf.php
+++ b/app/i18n/ru/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'Отсутствует',
 		'small' => 'Маленькая',
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Показывать баннер предупреждения',

--- a/app/i18n/sk/conf.php
+++ b/app/i18n/sk/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'None',	// TODO
 		'small' => 'Small',	// TODO
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Show warning banner',	// TODO

--- a/app/i18n/tr/conf.php
+++ b/app/i18n/tr/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'Yok',
 		'small' => 'Küçük',
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Show warning banner',	// TODO

--- a/app/i18n/uk/conf.php
+++ b/app/i18n/uk/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'Не показувати',
 		'small' => 'Мала',
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Show warning banner',	// TODO

--- a/app/i18n/zh-CN/conf.php
+++ b/app/i18n/zh-CN/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => '无',
 		'small' => '小',
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => '显示警告横幅',

--- a/app/i18n/zh-TW/conf.php
+++ b/app/i18n/zh-TW/conf.php
@@ -105,6 +105,9 @@ return array(
 		'none' => 'None',	// TODO
 		'small' => 'Small',	// TODO
 	),
+	'notification' => array(
+		'html5_enable_notif' => 'Enable notification',	// TODO
+	),
 	'notification_timeout' => array(
 		'bad' => array(
 			'label' => 'Show warning banner',	// TODO

--- a/app/views/configure/display.phtml
+++ b/app/views/configure/display.phtml
@@ -232,6 +232,16 @@
 		</div>
 
 		<div class="form-group">
+			<div class="group-controls">
+				<label class="checkbox" for="html5_enable_notif">
+					<input type="checkbox" name="html5_enable_notif" id="html5_enable_notif" value="1"<?=
+						FreshRSS_Context::userConf()->html5_enable_notif ? ' checked="checked"' : '' ?> />
+					<?= _t('conf.notification.html5_enable_notif') ?>
+				</label>
+			</div>
+		</div>
+
+		<div class="form-group">
 			<label class="group-name" for="html5_notif_timeout"><?= _t('conf.display.notif_html5.timeout') ?></label>
 			<div class="group-controls">
 				<input type="number" min="0" max="60" id="html5_notif_timeout" name="html5_notif_timeout" value="<?=

--- a/app/views/configure/display.phtml
+++ b/app/views/configure/display.phtml
@@ -235,7 +235,7 @@
 			<div class="group-controls">
 				<label class="checkbox" for="html5_enable_notif">
 					<input type="checkbox" name="html5_enable_notif" id="html5_enable_notif" value="1"<?=
-						FreshRSS_Context::userConf()->html5_enable_notif ? ' checked="checked"' : '' ?> />
+						!FreshRSS_Context::userConf()->not_html5_enable_notif ? ' checked="checked"' : '' ?> />
 					<?= _t('conf.notification.html5_enable_notif') ?>
 				</label>
 			</div>

--- a/app/views/helpers/javascript_vars.phtml
+++ b/app/views/helpers/javascript_vars.phtml
@@ -24,6 +24,7 @@ echo json_encode([
 		'does_lazyload' => !!FreshRSS_Context::userConf()->lazyload ,
 		'sides_close_article' => !!FreshRSS_Context::userConf()->sides_close_article,
 		'sticky_post' => !!FreshRSS_Context::isStickyPostEnabled(),
+		'html5_enable_notif' => FreshRSS_Context::userConf()->html5_enable_notif,
 		'html5_notif_timeout' => FreshRSS_Context::userConf()->html5_notif_timeout,
 		'closeNotification' => [
 			'good' => FreshRSS_Context::userConf()->good_notification_timeout * 1000,

--- a/app/views/helpers/javascript_vars.phtml
+++ b/app/views/helpers/javascript_vars.phtml
@@ -24,7 +24,7 @@ echo json_encode([
 		'does_lazyload' => !!FreshRSS_Context::userConf()->lazyload ,
 		'sides_close_article' => !!FreshRSS_Context::userConf()->sides_close_article,
 		'sticky_post' => !!FreshRSS_Context::isStickyPostEnabled(),
-		'html5_enable_notif' => FreshRSS_Context::userConf()->html5_enable_notif,
+		'html5_enable_notif' => !FreshRSS_Context::userConf()->not_html5_enable_notif,
 		'html5_notif_timeout' => FreshRSS_Context::userConf()->html5_notif_timeout,
 		'closeNotification' => [
 			'good' => FreshRSS_Context::userConf()->good_notification_timeout * 1000,

--- a/config-user.default.php
+++ b/config-user.default.php
@@ -127,6 +127,8 @@ return array (
 	'queries' => array (
 	),
 	'html5_notif_timeout' => 0,
+	# Had to start with true, if during 1st time user accepts it is ok.
+	'html5_enable_notif' => true,
 	'good_notification_timeout' => 3,
 	'bad_notification_timeout' => 8,
 	'show_nav_buttons' => true,

--- a/config-user.default.php
+++ b/config-user.default.php
@@ -127,8 +127,8 @@ return array (
 	'queries' => array (
 	),
 	'html5_notif_timeout' => 0,
-	# Had to start with true, if during 1st time user accepts it is ok.
-	'html5_enable_notif' => true,
+	# Making not false => true
+	'not_html5_enable_notif' => false,
 	'good_notification_timeout' => 3,
 	'bad_notification_timeout' => 8,
 	'show_nav_buttons' => true,

--- a/p/scripts/extra.js
+++ b/p/scripts/extra.js
@@ -578,6 +578,37 @@ function init_user_stats() {
 	document.querySelectorAll('tr[data-need-ajax]').forEach(row => observer.observe(row));
 }
 
+function init_enable_notify_button() {
+	const notify_button = document.getElementById('html5_enable_notif');
+	if (!notify_button) return;
+	// it means unsupported in browser
+	if (!notifs_html5_is_supported()) {
+		notify_button.checked = false;
+		return;
+	}
+
+	// Not granted, uncheck even if it is saved in server so browser asks for permission
+	if (Notification.permission !== 'granted') {
+		notify_button.checked = false;
+	}
+
+	notify_button.addEventListener('change', function() {
+		if (this.checked) {
+			Notification.requestPermission().then(function(permission) {
+				notifs_html5_permission = permission;
+				// Uncheck if user denied
+				if (permission !== 'granted') {
+					notify_button.checked = false;
+				}
+			});
+		} else {
+			// User disabled notifications
+			notifs_html5_permission = 'denied';
+		}
+	});
+
+}
+
 function init_extra_afterDOM() {
 	if (!window.context) {
 		if (window.console) {
@@ -599,6 +630,7 @@ function init_extra_afterDOM() {
 		init_update_feed();
 		init_details_attributes();
 		init_user_stats();
+		init_enable_notify_button()
 
 		data_auto_leave_validation(document.body);
 

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1972,15 +1972,16 @@ function notifs_html5_is_supported() {
 }
 
 function notifs_html5_ask_permission() {
-	try {
-		window.Notification.requestPermission(function () {
-			notifs_html5_permission = window.Notification.permission;
-		});
-	} catch (e) {
-	}
+	window.Notification.requestPermission(function (permission) {
+		notifs_html5_permission = permission;
+	}).catch(function(e){
+		// User denied
+		notifs_html5_permission = 'denied';
+	});
 }
 
 function notifs_html5_show(nb, nb_new) {
+	if (!context.html5_enable_notif)return;//from config
 	if (notifs_html5_permission !== 'granted') {
 		return;
 	}
@@ -2010,11 +2011,15 @@ function notifs_html5_show(nb, nb_new) {
 }
 
 function init_notifs_html5() {
-	if (!notifs_html5_is_supported()) {
-		return;
+	if (!notifs_html5_is_supported())return;
+	//from config, 1st run this should be true
+	if (!context.html5_enable_notif)return;
+	notifs_html5_permission = Notification.permission;
+	// Only ask if the user hasn't answered yet
+	// else they need to ask from settings > disply
+	if (notifs_html5_permission === 'default') {
+		notifs_html5_ask_permission();
 	}
-
-	notifs_html5_permission = notifs_html5_ask_permission();
 }
 // </notifs html5>
 


### PR DESCRIPTION
Closes #7330

Changes proposed in this pull request:
- Default behaviour is same
- Added FreshRSS_Context::userConf()->html5_enable_notif so that, it determines weather user wants notification. (will not show any even it has permission)
- Added button such that checking it makes it request permission too 
<img width="707" height="119" alt="image" src="https://github.com/user-attachments/assets/a0fdbc4d-9f15-4644-8753-f0e6c979677f" />


- [x] clear commit messages
- [x] code manually tested

Issue:
- for new users the default FreshRSS_Context::userConf()->html5_enable_notif starts with true , so default behaviour will be same
- but old users , this field may be missing in their config,(they will lose notification, need to manually enable it) which may confuse them. is there way to migrate the config file too.

Edit:
- I inverted variable names html5_enable_notif is now not_html5_enable_notif , so default false on file is true.