### PR TITLE
add allowfullscreen to iframe

### DIFF
--- a/app/Models/SimplePieCustom.php
+++ b/app/Models/SimplePieCustom.php
@@ -220,7 +220,7 @@ final class FreshRSS_SimplePieCustom extends \SimplePie\SimplePie
 			'iframe' => [
 				'allow' => 'accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share',
 				'sandbox' => 'allow-scripts allow-same-origin',
-				'allowfullscreen' = > 'allowfullscreen',			  
+				'allowfullscreen' => 'allowfullscreen',			  
 			],
 			'video' => ['controls' => 'controls', 'preload' => 'none'],
 		]);

--- a/app/Models/SimplePieCustom.php
+++ b/app/Models/SimplePieCustom.php
@@ -114,7 +114,7 @@ final class FreshRSS_SimplePieCustom extends \SimplePie\SimplePie
 			'hgroup' => [],
 			'hr' => ['align', 'noshade', 'size', 'width'],
 			'i' => [],
-			'iframe' => ['src', 'align', 'frameborder', 'longdesc', 'marginheight', 'marginwidth', 'scrolling'],
+			'iframe' => ['src', 'align', 'frameborder', 'longdesc', 'marginheight', 'marginwidth', 'scrolling', 'allowfullscreen'],
 			'image' => ['src', 'alt', 'width', 'height', 'align', 'border', 'hspace', 'longdesc', 'vspace'],
 			'img' => ['src', 'alt', 'width', 'height', 'align', 'border', 'hspace', 'longdesc', 'vspace'],
 			'ins' => ['cite', 'datetime'],
@@ -220,6 +220,7 @@ final class FreshRSS_SimplePieCustom extends \SimplePie\SimplePie
 			'iframe' => [
 				'allow' => 'accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share',
 				'sandbox' => 'allow-scripts allow-same-origin',
+				'allowfullscreen' = > 'allowfullscreen',			  
 			],
 			'video' => ['controls' => 'controls', 'preload' => 'none'],
 		]);

--- a/app/Models/SimplePieCustom.php
+++ b/app/Models/SimplePieCustom.php
@@ -220,7 +220,7 @@ final class FreshRSS_SimplePieCustom extends \SimplePie\SimplePie
 			'iframe' => [
 				'allow' => 'accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share',
 				'sandbox' => 'allow-scripts allow-same-origin',
-				'allowfullscreen' => 'allowfullscreen',			  
+				'allowfullscreen' => 'allowfullscreen',
 			],
 			'video' => ['controls' => 'controls', 'preload' => 'none'],
 		]);


### PR DESCRIPTION
With the "allowfullscreen" attribute it's possible to view an embedded video in full screen.

When a feed has an embedded video that's rendered in an iframe, without the allowfullscreen attribute it's not possible to toggle the video to full screen, adding the attribute makes it possible.

I'm not sure it's necessary to add it to both places, but I tested manually with a couple of feeds and now I can see youtoube videos in full screen without having to go to youtube.

See also [here](https://github.com/FreshRSS/FreshRSS/issues/8175#issuecomment-3790152826)