### PR TITLE
Updated docker-compose.yml to meet 1.28.0 folder structure changes

### DIFF
--- a/Docker/freshrss/docker-compose.yml
+++ b/Docker/freshrss/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       options:
         max-size: 10m
     volumes:
-      - data:/var/www/FreshRSS/data
-      - extensions:/var/www/FreshRSS/extensions
+      - data:/config/www/freshrss/data
+      - extensions:/config/www/freshrss/extensions
     environment:
       TZ: Europe/Paris
       CRON_MIN: '3,33'


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

Updated docker-compose.yml to meet 1.28.0 folder structure changes

How to test the feature manually:

1. Compared FreshRSS docker folder structure and confirmed that config files were changed from `/var/www/FreshRSS/` to `/config/www/freshrss`

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
