### PR TITLE
Update the Apache configuration in Dockerfile-Alpine file

### DIFF
--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -32,9 +32,9 @@ LABEL \
 
 RUN \
 	# Disable unwanted Apache modules and configurations
-	rm -f /etc/apache2/conf.d/languages.conf /etc/apache2/conf.d/info.conf \
+	rm -f /etc/apache2/conf.d/info.conf \
 		/etc/apache2/conf.d/status.conf /etc/apache2/conf.d/userdir.conf && \
-	sed -r -i "/^\s*LoadModule .*mod_(alias|autoindex|negotiation|status).so$/s/^/#/" \
+	sed -r -i "/^\s*LoadModule .*mod_(alias|autoindex|status).so$/s/^/#/" \
 		/etc/apache2/httpd.conf && \
 	sed -r -i "/^\s*(CustomLog|ErrorLog|Listen) /s/^/#/" \
 		/etc/apache2/httpd.conf && \


### PR DESCRIPTION
This pull request makes a minor adjustment to the Apache configuration in the `Docker/Dockerfile-Alpine` file. The change removes the disabling of the `languages.conf` configuration and the `mod_negotiation` module, which were previously included.

* Dockerfile Apache configuration: Stopped removing `/etc/apache2/conf.d/languages.conf` and no longer disables the `mod_negotiation` module in `httpd.conf`.Closes #

Changes proposed in this pull request:

-
-
-

How to test the feature manually:

1.
2.
3.

Pull request checklist:

- [ ] clear commit messages
- [ ] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
