### PR TITLE
Update OIDCRedirectURI to use BASE_URL variable

### DIFF
--- a/Docker/FreshRSS.Apache.conf
+++ b/Docker/FreshRSS.Apache.conf
@@ -31,6 +31,8 @@ CustomLog "|/var/www/FreshRSS/cli/sensitive-log.sh" combined_proxy
 	Define VStart "${"
 	Define VEnd "}"
 
+	OIDCXForwardedHeaders X-Forwarded-Proto X-Forwarded-Port X-Forwarded-Host
+
 	OIDCProviderMetadataURL ${OIDC_PROVIDER_METADATA_URL}
 	OIDCClientID ${OIDC_CLIENT_ID}
 	OIDCClientSecret ${OIDC_CLIENT_SECRET}
@@ -39,7 +41,7 @@ CustomLog "|/var/www/FreshRSS/cli/sensitive-log.sh" combined_proxy
 	OIDCSessionMaxDuration ${OIDC_SESSION_MAX_DURATION}
 	OIDCSessionType ${OIDC_SESSION_TYPE}
 
-	OIDCRedirectURI /i/oidc/
+	OIDCRedirectURI ${BASE_URL}/i/oidc/
 	OIDCCryptoPassphrase ${OIDC_CLIENT_CRYPTO_KEY}
 
 	Define "Test_${OIDC_REMOTE_USER_CLAIM}"

--- a/Docker/FreshRSS.Apache.conf
+++ b/Docker/FreshRSS.Apache.conf
@@ -31,8 +31,6 @@ CustomLog "|/var/www/FreshRSS/cli/sensitive-log.sh" combined_proxy
 	Define VStart "${"
 	Define VEnd "}"
 
-	OIDCXForwardedHeaders X-Forwarded-Proto X-Forwarded-Port X-Forwarded-Host
-
 	OIDCProviderMetadataURL ${OIDC_PROVIDER_METADATA_URL}
 	OIDCClientID ${OIDC_CLIENT_ID}
 	OIDCClientSecret ${OIDC_CLIENT_SECRET}


### PR DESCRIPTION
Closes #8407 

Changes proposed in this pull request:

- This PR sets OIDC to allow FORWARDED-FOR headers and use BASE_URL to fix a scenario in which OIDC can't use `https` callback URLs behind a reverse proxy

How to test the feature manually:

1. Setup FreshRSS with docker
2. Setup a Reverse Proxy (eg. Traefik) to serve FreshRSS over `https`
3. Setup an OIDC provider (eg. PocketID)
4. Set FreshRSS to use OIDC
5. You will notice that despite being served over `https` FreshRSS will insist in using OIDC over `http`

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
