### PR TITLE
Fix navigation bullet points being cut off in docs on Chromium

### DIFF
--- a/docs/_includes/docs.css
+++ b/docs/_includes/docs.css
@@ -44,7 +44,7 @@ aside > nav.docs > ul {
 }
 
 aside > nav.docs ul {
-	padding-left: 1rem;
+	padding-left: 1.1rem;
 	margin-right: 1rem;
 }
 


### PR DESCRIPTION
Before:

<img width="279" height="342" alt="" src="https://github.com/user-attachments/assets/84d77add-4cc1-4632-b142-5ad059bfee31" />

After:


<img width="285" height="338" alt="" src="https://github.com/user-attachments/assets/89575aa6-b87a-4aec-9832-2472778c15a3" />
