### PR TITLE
Fix only the title being highlighted after hovering a bit on an article

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -777,10 +777,6 @@ kbd {
 	background: var(--background-color-hover);
 }
 
-.flux:not(.current):hover .item .title {
-	background: var(--background-color-hover);
-}
-
 .flux.current:not(.active) {
 	background: var(--background-color-hover);
 }

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -777,10 +777,6 @@ kbd {
 	background: var(--background-color-hover);
 }
 
-.flux:not(.current):hover .item .title {
-	background: var(--background-color-hover);
-}
-
 .flux.current:not(.active) {
 	background: var(--background-color-hover);
 }

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -853,7 +853,6 @@ button:hover .icon,
 }
 
 .flux .flux_header:not(.current):hover .flux_header,
-.flux:not(.current):hover .flux_header .title,
 .flux.current .flux_header {
 	background-color: var(--background-color-hover);
 }

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -853,7 +853,6 @@ button:hover .icon,
 }
 
 .flux .flux_header:not(.current):hover .flux_header,
-.flux:not(.current):hover .flux_header .title,
 .flux.current .flux_header {
 	background-color: var(--background-color-hover);
 }

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -797,7 +797,6 @@ a.signin {
 }
 
 .flux .flux_header:hover,
-.flux:not(.current):hover .flux_header .title,
 .flux.current .flux_header {
 	background-color: var(--background-color-grey-hover);
 }

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -797,7 +797,6 @@ a.signin {
 }
 
 .flux .flux_header:hover,
-.flux:not(.current):hover .flux_header .title,
 .flux.current .flux_header {
 	background-color: var(--background-color-grey-hover);
 }


### PR DESCRIPTION
Before:

![before](https://github.com/user-attachments/assets/cafbbe8d-bad9-40fc-bb85-f825a2c16003)

After:

![after](https://github.com/user-attachments/assets/ca5f8736-66e0-4634-bf97-fe03e9633a63)

Affected themes were:

* Alternative Dark
* Origine
* Pafat
