### PR TITLE
Only display scrollbar everywhere if there's an overflow

### DIFF
--- a/docs/_includes/docs.css
+++ b/docs/_includes/docs.css
@@ -35,7 +35,7 @@ aside {
 }
 
 aside > nav.docs {
-	overflow-y: scroll;
+	overflow-y: auto;
 	max-height: 90vh;
 }
 

--- a/docs/assets/css/highlight.css
+++ b/docs/assets/css/highlight.css
@@ -1,6 +1,6 @@
 pre.highlight {
 	padding: 1rem;
-	overflow-x: scroll;
+	overflow-x: auto;
 }
 
 /* generated with `rougify style github` */

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2502,7 +2502,7 @@ html.slider-active {
 	}
 
 	.aside:not(.aside_feed) {
-		overflow-y: scroll;
+		overflow-y: auto;
 	}
 
 	nav.configure > .dropdown li.item.dropdown-section:last-child,

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2502,7 +2502,7 @@ html.slider-active {
 	}
 
 	.aside:not(.aside_feed) {
-		overflow-y: scroll;
+		overflow-y: auto;
 	}
 
 	nav.configure > .dropdown li.item.dropdown-section:last-child,


### PR DESCRIPTION
Replaces all instances of `overflow-{x,y}: scroll` with `overflow-{x,y}: auto`

Empty scrollbars may appear due to usage of `scroll` instead of `auto` on Chromium, even when there is no overflow. As far as I know this does not happen with Firefox.

<img width="1461" height="405" alt="2026-03-01_14-29" src="https://github.com/user-attachments/assets/0a246823-8ea5-4d50-a1e8-aac33e73df0e" />
<img width="753" height="806" alt="2026-03-01_14-30" src="https://github.com/user-attachments/assets/631b06a5-5008-4ede-a216-bccac4898f85" />
