### PR TITLE
Fix redirect to wrong view after mark as read

### DIFF
--- a/app/Controllers/entryController.php
+++ b/app/Controllers/entryController.php
@@ -200,7 +200,7 @@ class FreshRSS_entry_Controller extends FreshRSS_ActionController {
 				$is_read ? _t('feedback.sub.articles.marked_read') : _t('feedback.sub.articles.marked_unread'),
 				[
 					'c' => 'index',
-					'a' => 'index',
+					'a' => Minz_Request::paramStringNull('from') ?? 'index',
 					'params' => $params,
 				],
 				notificationName: 'readAction ',

--- a/app/layout/nav_menu.phtml
+++ b/app/layout/nav_menu.phtml
@@ -125,6 +125,7 @@
 				'state' => FreshRSS_Context::$state,
 				'sort' => FreshRSS_Context::$sort,
 				'order' => FreshRSS_Context::$order,
+				'from' => Minz_Request::actionName(),
 			],
 		];
 

--- a/app/views/helpers/stream-footer.phtml
+++ b/app/views/helpers/stream-footer.phtml
@@ -22,6 +22,7 @@
 			'state' => FreshRSS_Context::$state,
 			'sort' => FreshRSS_Context::$sort,
 			'order' => FreshRSS_Context::$order,
+			'from' => Minz_Request::paramStringNull('from') ?? Minz_Request::actionName(),
 		],
 	];
 

--- a/app/views/index/global.phtml
+++ b/app/views/index/global.phtml
@@ -42,6 +42,7 @@
 	$params = array_filter($_GET, 'is_string', ARRAY_FILTER_USE_KEY);
 	unset($params['c']);
 	unset($params['a']);
+	$params['from'] = 'global';
 	$url_base = [
 		'c' => 'index',
 		'a' => 'normal',


### PR DESCRIPTION
Closes #6509

A wrong redirect (to normal view) happened in case of both the big mark as read button on the bottom and the navbar one, for reader and global views.
