### PR TITLE
i18n: complete Spanish translation (100%)

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -232,7 +232,7 @@ Voir le [dépôt dédié à ces extensions](https://github.com/FreshRSS/Extensio
 | Ελληνικά (el) | ￭￭￭･･･････ 37% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fel+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (en) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Español (es) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Español (es) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
 | فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 91% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Suomi (fi) | ￭￭￭￭￭￭￭￭￭･ 93% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffi+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Français (fr) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ See the [repository dedicated to those extensions](https://github.com/FreshRSS/E
 | Ελληνικά (el) | ￭￭￭･･･････ 37% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fel+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (en) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Español (es) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Español (es) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
 | فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 91% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Suomi (fi) | ￭￭￭￭￭￭￭￭￭･ 93% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffi+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Français (fr) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |

--- a/app/i18n/es/conf.php
+++ b/app/i18n/es/conf.php
@@ -54,7 +54,7 @@ return array(
 			'timeout' => 'Notificación de fin de espera HTML5',
 		),
 		'show_nav_buttons' => 'Mostrar los botones de navegación',
-		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO
+		'sidebar_hidden_by_default' => 'Ocultar barra lateral por defecto',
 		'theme' => array(
 			'_' => 'Tema',
 			'deprecated' => array(
@@ -107,7 +107,7 @@ return array(
 		'small' => 'Pequeño',
 	),
 	'notification' => array(
-		'html5_enable_notif' => 'Enable notification',	// TODO
+		'html5_enable_notif' => 'Activar notificaciones',
 	),
 	'notification_timeout' => array(
 		'bad' => array(

--- a/app/i18n/es/gen.php
+++ b/app/i18n/es/gen.php
@@ -228,7 +228,7 @@ return array(
 		'categories' => 'Categorías',
 		'content' => 'Contenido',
 		'date_from' => 'Desde',
-		'date_modified' => 'Server Modification Date',	// TODO
+		'date_modified' => 'Fecha de modificación del servidor',
 		'date_past' => 'En el pasado',
 		'date_published' => 'Fecha de publicación',
 		'date_range' => 'Rango de fechas',

--- a/app/i18n/es/index.php
+++ b/app/i18n/es/index.php
@@ -85,14 +85,14 @@ return array(
 		'rss_view' => 'Fuente RSS',
 		'search_short' => 'Buscar',
 		'sort' => array(
-			'asc' => 'Ascending',	// TODO
+			'asc' => 'Ascendente',
 			'c' => array(
 				'name_asc' => 'Categoría, títulos de fuentes A→Z',
 				'name_desc' => 'Categoría, títulos de fuentes Z→A',
 			),
 			'date_asc' => 'Fecha de publicación 1→9',
 			'date_desc' => 'Fecha de publicación 9→1',
-			'desc' => 'Descending',	// TODO
+			'desc' => 'Descendente',
 			'f' => array(
 				'name_asc' => 'Título de fuente A→Z',
 				'name_desc' => 'Título de fuente Z→A',
@@ -104,13 +104,13 @@ return array(
 			'link_asc' => 'Enlace A→Z',
 			'link_desc' => 'Enlace Z→A',
 			'primary' => array(
-				'_' => 'Sorting criterion',	// TODO
-				'help' => 'Sorting by <em>received</em> date is recommended in most cases, for consistency and performance',	// TODO
+				'_' => 'Criterio de ordenación principal',
+				'help' => 'El orden por fecha de <em>recepción</em> es recomendado en la mayoría de casos, para mantener la consistencia y el rendimiento',
 			),
 			'rand' => 'Orden aleatorio',
 			'secondary' => array(
-				'_' => 'Secondary sorting criterion',	// TODO
-				'help' => 'Only relevant when the primary sorting criterion is categories or feeds titles',	// TODO
+				'_' => 'Criterio de ordenación secundario',
+				'help' => 'Solo relevante cuando el criterio de ordenación principal es categorías o títulos de fuentes',
 			),
 			'title_asc' => 'Título A→Z',
 			'title_desc' => 'Título Z→A',

--- a/app/i18n/es/install.php
+++ b/app/i18n/es/install.php
@@ -51,18 +51,18 @@ return array(
 			'ok' => 'Los permisos del directorio data son correctos.',
 		),
 		'database-connection' => array(
-			'nok' => 'Database connection error.',	// TODO
-			'ok' => 'Database connection is good.',	// TODO
+			'nok' => 'Error de conexión a la base de datos.',	
+			'ok' => 'La conexión a la base de datos es correcta.',	
 		),
 		'database-table' => array(
-			'nok' => 'Database table "%s" is incomplete.',	// TODO
-			'ok' => 'Database table "%s" is good.',	// TODO
+			'nok' => 'La tabla de la base de datos "%s" está incompleta.',	
+			'ok' => 'La tabla de la base de datos "%s" es correcta.',	
 		),
 		'database-tables' => array(
-			'nok' => 'Some database tables are missing.',	// TODO
-			'ok' => 'All database tables exist.',	// TODO
+			'nok' => 'Algunas tablas de la base de datos están ausentes.',	
+			'ok' => 'Todas las tablas de la base de datos existen.',	
 		),
-		'database-title' => 'Database',	// TODO
+		'database-title' => 'Base de datos',	
 		'dom' => array(
 			'nok' => 'No se ha podido localizar la librería necesaria para explorar la DOM.',
 			'ok' => 'Dispones de la librería necesaria para explorar la DOM.',

--- a/app/i18n/es/install.php
+++ b/app/i18n/es/install.php
@@ -51,18 +51,18 @@ return array(
 			'ok' => 'Los permisos del directorio data son correctos.',
 		),
 		'database-connection' => array(
-			'nok' => 'Error de conexión a la base de datos.',	
-			'ok' => 'La conexión a la base de datos es correcta.',	
+			'nok' => 'Error de conexión a la base de datos.',
+			'ok' => 'La conexión a la base de datos es correcta.',
 		),
 		'database-table' => array(
-			'nok' => 'La tabla de la base de datos "%s" está incompleta.',	
-			'ok' => 'La tabla de la base de datos "%s" es correcta.',	
+			'nok' => 'La tabla de la base de datos "%s" está incompleta.',
+			'ok' => 'La tabla de la base de datos "%s" es correcta.',
 		),
 		'database-tables' => array(
-			'nok' => 'Algunas tablas de la base de datos están ausentes.',	
-			'ok' => 'Todas las tablas de la base de datos existen.',	
+			'nok' => 'Algunas tablas de la base de datos están ausentes.',
+			'ok' => 'Todas las tablas de la base de datos existen.',
 		),
-		'database-title' => 'Base de datos',	
+		'database-title' => 'Base de datos',
 		'dom' => array(
 			'nok' => 'No se ha podido localizar la librería necesaria para explorar la DOM.',
 			'ok' => 'Dispones de la librería necesaria para explorar la DOM.',


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

- Updated and completed Spanish translation (100%) in app/i18n/es/
- Removed obsolete // TODO

How to test the feature manually:

1. Switch the interface language to "Español" in the user settings.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
