### PR TITLE
Create dynamic favicons from SVG instead of PNG canvas

### DIFF
--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -36,7 +36,7 @@
 		</script>
 		<?= FreshRSS_View::headScript() ?>
 		<link rel="manifest" href="<?= Minz_Url::display('/themes/manifest.json') ?>" />
-		<link rel="shortcut icon" id="favicon" type="image/x-icon" sizes="16x16 64x64" href="<?= Minz_Url::display('/favicon.ico') ?>" />
+		<link rel="icon" id="favicon" type="image/svg+xml" href="<?= Minz_Url::display('/themes/icons/favicon.svg') ?>" />
 		<link rel="icon msapplication-TileImage apple-touch-icon" type="image/png" sizes="256x256" href="<?= Minz_Url::display('/themes/icons/favicon-256.png') ?>" />
 		<link rel="apple-touch-icon" href="<?= Minz_Url::display('/themes/icons/apple-touch-icon.png') ?>" />
 		<meta name="apple-mobile-web-app-capable" content="yes" />

--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -14,6 +14,10 @@ $useKeepUnreadImportant = !FreshRSS_Context::isImportant() && !FreshRSS_Context:
 $today = @strtotime('today');
 ?>
 
+<template id="dynamic_favicon_base">
+	<?= file_get_contents(PUBLIC_PATH . '/themes/icons/favicon.svg') ?>
+</template>
+
 <datalist id="datalist-labels"></datalist>
 
 <template id="share_article_template">

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -2234,39 +2234,45 @@ function faviconNbUnread(n) {
 		const t = document.querySelector('.category.all .title');
 		n = t ? str2int(t.getAttribute('data-unread')) : 0;
 	}
-	// http://remysharp.com/2010/08/24/dynamic-favicons/
-	const canvas = document.createElement('canvas');
+	const svgBase = document.querySelector('template#dynamic_favicon_base').innerHTML;
 	const link = document.getElementById('favicon').cloneNode(true);
-	const ratio = window.devicePixelRatio;
-	if (canvas.getContext && link) {
-		canvas.height = canvas.width = 16 * ratio;
-		const img = document.createElement('img');
-		img.onload = function () {
-			const ctx = canvas.getContext('2d');
-			ctx.drawImage(this, 0, 0, canvas.width, canvas.height);
-			if (n > 0) {
-				let text = '';
-				if (n < 1000) {
-					text = n;
-				} else if (n < 100000) {
-					text = Math.floor(n / 1000) + 'k';
-				} else {
-					text = 'E' + Math.floor(Math.log10(n));
-				}
-				ctx.font = 'bold ' + 9 * ratio + 'px "Arial", sans-serif';
-				ctx.fillStyle = 'rgba(255, 255, 255, 0.8)';
-				ctx.fillRect(0, 7 * ratio, ctx.measureText(text).width, 9 * ratio);
-				ctx.fillStyle = '#F00';
-				ctx.fillText(text, 0, canvas.height - 1);
+	if (link) {
+		let svgOutput = '';
+		if (n > 0) {
+			let text = '';
+			if (n < 1000) {
+				text = n;
+			} else if (n < 100000) {
+				text = Math.floor(n / 1000) + 'k';
+			} else {
+				text = 'E' + Math.floor(Math.log10(n));
 			}
-			link.href = canvas.toDataURL('image/png');
-			// Check if data URI has generated a real favicon and if not, fallback to standard icon
-			if (link.href.length > 180) {
-				document.querySelector('link[rel~=icon]').remove();
-				document.head.appendChild(link);
-			}
-		};
-		img.src = '../favicon.ico';
+
+			const temp = document.createElement('div');
+			temp.innerHTML = svgBase;
+			document.body.append(temp);
+
+			const svg = temp.querySelector('svg');
+			svg.setAttribute('width', 24);
+			svg.setAttribute('height', 24);
+
+			svg.insertAdjacentHTML('beforeend', `
+			<text id="unreadCount" x="0" y="255" font-family="Arial, sans-serif" font-weight="bold" font-size="150" fill="#F00">${text}</text>
+			`);
+
+			const svgHeight = svg.getBBox().height;
+			const uc = svg.querySelector('text#unreadCount');
+			const ucBBox = uc.getBBox(); // note: doesn't contain actual text height, so the rect is slightly higher
+			uc.insertAdjacentHTML('beforebegin', `
+			<rect x="0" y="${svgHeight - ucBBox.height}" width="${ucBBox.width}" height="${ucBBox.height}" fill="rgba(255, 255, 255, 0.8)" />
+			`);
+
+			svgOutput = svg.outerHTML;
+			temp.remove();
+		}
+		link.href = `data:image/svg+xml;base64,${btoa(svgOutput || svgBase)}`;
+		document.querySelector('#favicon').remove();
+		document.head.appendChild(link);
 	}
 }
 


### PR DESCRIPTION
Closes #4091

The dynamic favicon didn't render properly on browsers that have canvas fingerprinting defenses (see before favicon):

<img width="648" height="84" alt="2026-03-07_17-54" src="https://github.com/user-attachments/assets/872e1a27-1d57-4d24-bd28-15aa39979f4c" />

This is the reason for using SVG instead of canvas for rendering the dynamic favicon.

---

Here are larger versions of both canvas and SVG implementations so that it can be compared the 
favicon will still look the same as before:

Old canvas rendering (resolution is low because this is a small PNG):

<img width="133" height="131" alt="2026-03-07_17-52_1" src="https://github.com/user-attachments/assets/740c3eff-d64b-4b13-a608-adaff4893576" />

New SVG rendering:

<img width="85" height="90" alt="2026-03-07_17-52" src="https://github.com/user-attachments/assets/141eb77c-4bce-44d8-b362-fc2548c0b098" />

---

More comparisons

Tab on the left is canvas, tab on the right is SVG

<img width="451" height="41" alt="image" src="https://github.com/user-attachments/assets/09177e3a-59a0-48c2-925f-f319126d9f39" />

<img width="511" height="49" alt="image" src="https://github.com/user-attachments/assets/e06465c6-93e4-47ce-8ba8-255a3d42d601" />

^ If you're wondering why there is spacing between the digits on the first tab - it's because I marked an article as unread, this needs to be fixed too




