### PR TITLE
Fix email validation and allow error page for unverified email users

### DIFF
--- a/app/Controllers/userController.php
+++ b/app/Controllers/userController.php
@@ -577,6 +577,9 @@ class FreshRSS_user_Controller extends FreshRSS_ActionController {
 		$this->view->_layout('simple');
 
 		$username = Minz_Request::paramString('username');
+		if (FreshRSS_Auth::hasAccess()) {
+			$username = Minz_User::name() ?? '';
+		}
 		$token = Minz_Request::paramString('token');
 
 		if ($username !== '') {

--- a/app/FreshRSS.php
+++ b/app/FreshRSS.php
@@ -165,7 +165,8 @@ class FreshRSS extends Minz_FrontController {
 			Minz_Request::is('user', 'delete') ||
 			Minz_Request::is('auth', 'logout') ||
 			Minz_Request::is('feed', 'actualize') ||
-			Minz_Request::is('javascript', 'nonce')
+			Minz_Request::is('javascript', 'nonce') ||
+			Minz_Request::is('error', 'index')
 		);
 		if ($email_not_verified && !$action_is_allowed) {
 			Minz_Request::forward([


### PR DESCRIPTION
Closes #8581 

Regression caused by commit 26c1102567c095b051b5e1a0aedb45b78713c283 (v1.28.1), `$username` variable was empty and changes that were made to the `FreshRSS_UserDAO::exists()` function revealed this issue.

Additionally users that have unverified emails can properly access error redirects now, so an infinite redirect loop doesn't happen.