### PR TITLE
Fix SQLite paging when sorting by article length

### DIFF
--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -1648,14 +1648,16 @@ SQL;
 			$sql .= ', e0.id ' . $order;
 		}
 		$stm = $this->pdo->prepare($sql);
-		foreach ($values as $index => $value) {
-			$type = PDO::PARAM_STR;
-			if (is_null($value)) {
-				$type = PDO::PARAM_NULL;
-			} elseif (is_int($value) || is_bool($value)) {
-				$type = PDO::PARAM_INT;
+		if ($stm !== false) {
+			foreach ($values as $index => $value) {
+				$paramType = PDO::PARAM_STR;
+				if (is_null($value)) {
+					$paramType = PDO::PARAM_NULL;
+				} elseif (is_int($value) || is_bool($value)) {
+					$paramType = PDO::PARAM_INT;
+				}
+				$stm->bindValue($index + 1, $value, $paramType);
 			}
-			$stm->bindValue($index + 1, $value, $type);
 		}
 		if ($stm !== false && $stm->execute()) {
 			// TODO: Consider adding an option for SQL debugging

--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -1648,7 +1648,19 @@ SQL;
 			$sql .= ', e0.id ' . $order;
 		}
 		$stm = $this->pdo->prepare($sql);
-		if ($stm !== false && $stm->execute($values)) {
+		foreach ($values as $index => $value) {
+			$type = PDO::PARAM_STR;
+			if (is_null($value)) {
+				$type = PDO::PARAM_NULL;
+			} elseif (is_int($value) || is_bool($value)) {
+				$type = PDO::PARAM_INT;
+			}
+			$stm->bindValue($index + 1, $value, $type);
+		}
+		if ($stm !== false && $stm->execute()) {
+			// TODO: Consider adding an option for SQL debugging
+			// Minz_Log::debug('SQL params ' . __METHOD__ . ' ' . json_encode($values));
+			// Minz_Log::debug('SQL query ' . __METHOD__ . ' ' . json_encode($sql));
 			return $stm;
 		} else {
 			$info = $stm === false ? $this->pdo->errorInfo() : $stm->errorInfo();


### PR DESCRIPTION
In the case of SQLite, there was a PDO type problem resulting in buggy paging when sorting by article length.
The problem was located in `LENGTH(e.content) < ?`
Change to explicit typed binding.
