### PR TITLE
Fix wrong navigation buttons layout on Chromium

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1938,7 +1938,7 @@ a.website:hover .favicon {
 
 #nav_entries button {
 	background-color: transparent;
-	width: 33.3%;
+	flex: 1;
 	height: 3rem;
 	border: 0;
 	cursor: pointer;

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1924,11 +1924,11 @@ a.website:hover .favicon {
 
 /*=== Navigation menu (for articles) */
 #nav_entries {
-	display: table;
+	display: flex;
+	justify-content: space-evenly;
 	position: fixed;
 	bottom: 0; left: 0;
 	width: 300px;
-	table-layout: fixed;
 	padding-bottom: env(safe-area-inset-bottom);
 	z-index: 50;
 }
@@ -1939,7 +1939,6 @@ a.website:hover .favicon {
 
 #nav_entries button {
 	background-color: transparent;
-	display: table-cell;
 	width: 33.3%;
 	height: 3rem;
 	border: 0;

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1925,7 +1925,6 @@ a.website:hover .favicon {
 /*=== Navigation menu (for articles) */
 #nav_entries {
 	display: flex;
-	justify-content: space-evenly;
 	position: fixed;
 	bottom: 0; left: 0;
 	width: 300px;

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2768,7 +2768,7 @@ html.slider-active {
 	}
 
 	#nav_entries {
-		display: table !important;
+		display: flex !important;
 		width: 100%;
 	}
 

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1938,7 +1938,7 @@ a.website:hover .favicon {
 
 #nav_entries button {
 	background-color: transparent;
-	width: 33.3%;
+	flex: 1;
 	height: 3rem;
 	border: 0;
 	cursor: pointer;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1924,11 +1924,11 @@ a.website:hover .favicon {
 
 /*=== Navigation menu (for articles) */
 #nav_entries {
-	display: table;
+	display: flex;
+	justify-content: space-evenly;
 	position: fixed;
 	bottom: 0; right: 0;
 	width: 300px;
-	table-layout: fixed;
 	padding-bottom: env(safe-area-inset-bottom);
 	z-index: 50;
 }
@@ -1939,7 +1939,6 @@ a.website:hover .favicon {
 
 #nav_entries button {
 	background-color: transparent;
-	display: table-cell;
 	width: 33.3%;
 	height: 3rem;
 	border: 0;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2768,7 +2768,7 @@ html.slider-active {
 	}
 
 	#nav_entries {
-		display: table !important;
+		display: flex !important;
 		width: 100%;
 	}
 

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1925,7 +1925,6 @@ a.website:hover .favicon {
 /*=== Navigation menu (for articles) */
 #nav_entries {
 	display: flex;
-	justify-content: space-evenly;
 	position: fixed;
 	bottom: 0; right: 0;
 	width: 300px;


### PR DESCRIPTION
Closes #8605

Since Chromium Canary 146.0.7669.0 (and Stable 146.0.7680.71) there is some sort of bug that broke this layout:
<img width="1050" height="704" alt="image" src="https://github.com/user-attachments/assets/03903658-9a01-43b6-aed9-eed90b8736c0" />

So instead of using `display: table`, we now use `display: flex`, to also modernize the CSS aside from fixing this.
