### PR TITLE
do not show dot, if no unread number is shown

### DIFF
--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -149,7 +149,7 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 		if (FreshRSS_Context::$get_unread > 0) {
 			$title = '(' . FreshRSS_Context::$get_unread . ') ' . $title;
 		}
-		if (strlen($title)) {
+		if (strlen($title) > 0) {
 			FreshRSS_View::prependTitle($title . ' · ');
 		}
 

--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -149,7 +149,9 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 		if (FreshRSS_Context::$get_unread > 0) {
 			$title = '(' . FreshRSS_Context::$get_unread . ') ' . $title;
 		}
-		FreshRSS_View::prependTitle($title . ' · ');
+		if (strlen($title)) {
+			FreshRSS_View::prependTitle($title . ' · ');
+		}
 
 		if (FreshRSS_Context::$id_max === '0') {
 			FreshRSS_Context::$id_max = uTimeString();


### PR DESCRIPTION
Closes #8616

Open for discussion: Is the dot really needed to separate the unread number (f.e. `(12)`) from the `FreshRSS` string? A simple `(12) FreshRSS` would do the same job, wouldn't?

