### PR TITLE
Convert feed view into grid where appropriate

### DIFF
--- a/app/views/helpers/index/normal/entry_header.phtml
+++ b/app/views/helpers/index/normal/entry_header.phtml
@@ -12,10 +12,17 @@
 	$topline_date = FreshRSS_Context::userConf()->topline_date;
 	$topline_link = FreshRSS_Context::userConf()->topline_link;
 	$lazyload = FreshRSS_Context::userConf()->lazyload;
+	$headerClasses = ['horizontal-list', 'flux_header', 'website' . $topline_website];
+	if ($topline_thumbnail !== 'none') {
+		$headerClasses[] = 'has-thumbnail';
+	}
+	if ($topline_summary) {
+		$headerClasses[] = 'has-summary';
+	}
 	if ($this->feed === null || $this->entry === null) {
 		return;
 	}
-?><ul class="horizontal-list flux_header website<?= $topline_website ?>" data-website-name="<?= $this->feed->name() ?>" data-article-authors="<?= implode(' · ', $this->entry->authors()) ?>"><?php
+?><ul class="<?= implode(' ', $headerClasses) ?>" data-website-name="<?= $this->feed->name() ?>" data-article-authors="<?= implode(' · ', $this->entry->authors()) ?>"><?php
 	if (FreshRSS_Auth::hasAccess()) {
 		if ($topline_read) {
 			?><li class="item manage"><?php

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2549,7 +2549,6 @@ html.slider-active {
 			"website   website manage-read  manage-bookmark  manage-share  manage-labels  link"
 			"thumbnail content content      content          content       content        content";
 		align-items: start;
-		gap: 8px;
 		list-style: none;
 	}
 	/** Show feed name */

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2541,7 +2541,7 @@ html.slider-active {
 		padding-right: 1rem;
 	}
 
-	.flux .flux_header:has(.thumbnail):has(.summary) {
+	.flux .flux_header.has-thumbnail.has-summary {
 		display: grid;
 		grid-template-columns: auto 1fr auto auto auto;
 		grid-template-rows: auto auto;
@@ -2551,42 +2551,42 @@ html.slider-active {
 		list-style: none;
 	}
 
-	.flux .flux_header:has(.thumbnail):has(.summary) li.website .websiteName {
+	.flux .flux_header.has-thumbnail.has-summary li.website .websiteName {
 		display: inline;
 	}
 
 	/** place all the elements in their respective template areas */
-	.flux .flux_header:has(.thumbnail):has(.summary) li.website {
+	.flux .flux_header.has-thumbnail.has-summary li.website {
 		grid-area: website;
 		/** Show feed name */
 		width: auto;
 	}
 
-	.flux .flux_header:has(.thumbnail):has(.summary) li.thumbnail {
+	.flux .flux_header.has-thumbnail.has-summary li.thumbnail {
 		grid-area: thumbnail;
 	}
 
-	.flux .flux_header:has(.thumbnail):has(.summary) li.titleAuthorSummaryDate {
+	.flux .flux_header.has-thumbnail.has-summary li.titleAuthorSummaryDate {
 		grid-area: content;
 	}
 
-	.flux .flux_header:has(.thumbnail):has(.summary) li.manage:has(.read) {
+	.flux .flux_header.has-thumbnail.has-summary li.manage:has(.read) {
 		grid-area: manage-read;
 	}
 
-	.flux .flux_header:has(.thumbnail):has(.summary) li.manage:has(.bookmark) {
+	.flux .flux_header.has-thumbnail.has-summary li.manage:has(.bookmark) {
 		grid-area: manage-bookmark;
 	}
 
-	.flux .flux_header:has(.thumbnail):has(.summary) li.link {
+	.flux .flux_header.has-thumbnail.has-summary li.link {
 		grid-area: link;
 	}
 
-	.flux .flux_header:has(.thumbnail):has(.summary) li.labels {
+	.flux .flux_header.has-thumbnail.has-summary li.labels {
 		grid-area: manage-labels
 	}
 
-	.flux .flux_header:has(.thumbnail):has(.summary) li.share {
+	.flux .flux_header.has-thumbnail.has-summary li.share {
 		grid-area: manage-share
 	}
 

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2545,8 +2545,8 @@ html.slider-active {
 		display: grid;
 		grid-template-columns: auto 1fr auto auto auto;
 		grid-template-rows: auto auto;
-		grid-template-areas: "website   website manage-read  manage-bookmark  manage-share  manage-labels  link"
-			"thumbnail content content      content          content       content        content";
+		grid-template-areas: "website website manage-read manage-bookmark manage-share manage-labels link"
+			"thumbnail content content content content content content";
 		align-items: start;
 		list-style: none;
 	}

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2545,42 +2545,48 @@ html.slider-active {
 		display: grid;
 		grid-template-columns: auto 1fr auto auto auto;
 		grid-template-rows: auto auto;
-		grid-template-areas:
-			"website   website manage-read  manage-bookmark  manage-share  manage-labels  link"
+		grid-template-areas: "website   website manage-read  manage-bookmark  manage-share  manage-labels  link"
 			"thumbnail content content      content          content       content        content";
 		align-items: start;
 		list-style: none;
 	}
-	/** Show feed name */
-	.flux .flux_header:has(.thumbnail):has(.summary) li.website {
-		width: auto;
-	}
-	.flux .flux_header:has(.thumbnail):has(.summary) li.website .websiteName   {
+
+	.flux .flux_header:has(.thumbnail):has(.summary) li.website .websiteName {
 		display: inline;
 	}
+
 	/** place all the elements in their respective template areas */
-	.flux .flux_header:has(.thumbnail):has(.summary) li.website    {
+	.flux .flux_header:has(.thumbnail):has(.summary) li.website {
 		grid-area: website;
+		/** Show feed name */
+		width: auto;
 	}
-	.flux .flux_header:has(.thumbnail):has(.summary) li.thumbnail  {
+
+	.flux .flux_header:has(.thumbnail):has(.summary) li.thumbnail {
 		grid-area: thumbnail;
 	}
+
 	.flux .flux_header:has(.thumbnail):has(.summary) li.titleAuthorSummaryDate {
 		grid-area: content;
 	}
+
 	.flux .flux_header:has(.thumbnail):has(.summary) li.manage:has(.read) {
 		grid-area: manage-read;
 	}
+
 	.flux .flux_header:has(.thumbnail):has(.summary) li.manage:has(.bookmark) {
 		grid-area: manage-bookmark;
 	}
-	.flux .flux_header:has(.thumbnail):has(.summary) li.link       {
+
+	.flux .flux_header:has(.thumbnail):has(.summary) li.link {
 		grid-area: link;
 	}
-	.flux .flux_header:has(.thumbnail):has(.summary) li.labels     {
+
+	.flux .flux_header:has(.thumbnail):has(.summary) li.labels {
 		grid-area: manage-labels
 	}
-	.flux .flux_header:has(.thumbnail):has(.summary) li.share     {
+
+	.flux .flux_header:has(.thumbnail):has(.summary) li.share {
 		grid-area: manage-share
 	}
 

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2541,6 +2541,50 @@ html.slider-active {
 		padding-right: 1rem;
 	}
 
+	.flux .flux_header:has(.thumbnail):has(.summary) {
+		display: grid;
+		grid-template-columns: auto 1fr auto auto auto;
+		grid-template-rows: auto auto;
+		grid-template-areas:
+			"website   website manage-read  manage-bookmark  manage-share  manage-labels  link"
+			"thumbnail content content      content          content       content        content";
+		align-items: start;
+		gap: 8px;
+		list-style: none;
+	}
+	/** Show feed name */
+	.flux .flux_header:has(.thumbnail):has(.summary) li.website {
+		width: auto;
+	}
+	.flux .flux_header:has(.thumbnail):has(.summary) li.website .websiteName   {
+		display: inline;
+	}
+	/** place all the elements in their respective template areas */
+	.flux .flux_header:has(.thumbnail):has(.summary) li.website    {
+		grid-area: website;
+	}
+	.flux .flux_header:has(.thumbnail):has(.summary) li.thumbnail  {
+		grid-area: thumbnail;
+	}
+	.flux .flux_header:has(.thumbnail):has(.summary) li.titleAuthorSummaryDate {
+		grid-area: content;
+	}
+	.flux .flux_header:has(.thumbnail):has(.summary) li.manage:has(.read) {
+		grid-area: manage-read;
+	}
+	.flux .flux_header:has(.thumbnail):has(.summary) li.manage:has(.bookmark) {
+		grid-area: manage-bookmark;
+	}
+	.flux .flux_header:has(.thumbnail):has(.summary) li.link       {
+		grid-area: link;
+	}
+	.flux .flux_header:has(.thumbnail):has(.summary) li.labels     {
+		grid-area: manage-labels
+	}
+	.flux .flux_header:has(.thumbnail):has(.summary) li.share     {
+		grid-area: manage-share
+	}
+
 	#overlay .close {
 		position: relative;
 	}

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2549,7 +2549,6 @@ html.slider-active {
 			"website   website manage-read  manage-bookmark  manage-share  manage-labels  link"
 			"thumbnail content content      content          content       content        content";
 		align-items: start;
-		gap: 8px;
 		list-style: none;
 	}
 	/** Show feed name */

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2545,8 +2545,8 @@ html.slider-active {
 		display: grid;
 		grid-template-columns: auto 1fr auto auto auto;
 		grid-template-rows: auto auto;
-		grid-template-areas: "website   website manage-read  manage-bookmark  manage-share  manage-labels  link"
-			"thumbnail content content      content          content       content        content";
+		grid-template-areas: "website website manage-read manage-bookmark manage-share manage-labels link"
+			"thumbnail content content content content content content";
 		align-items: start;
 		list-style: none;
 	}

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2545,42 +2545,48 @@ html.slider-active {
 		display: grid;
 		grid-template-columns: auto 1fr auto auto auto;
 		grid-template-rows: auto auto;
-		grid-template-areas:
-			"website   website manage-read  manage-bookmark  manage-share  manage-labels  link"
+		grid-template-areas: "website   website manage-read  manage-bookmark  manage-share  manage-labels  link"
 			"thumbnail content content      content          content       content        content";
 		align-items: start;
 		list-style: none;
 	}
-	/** Show feed name */
-	.flux .flux_header:has(.thumbnail):has(.summary) li.website {
-		width: auto;
-	}
-	.flux .flux_header:has(.thumbnail):has(.summary) li.website .websiteName   {
+
+	.flux .flux_header:has(.thumbnail):has(.summary) li.website .websiteName {
 		display: inline;
 	}
+
 	/** place all the elements in their respective template areas */
-	.flux .flux_header:has(.thumbnail):has(.summary) li.website    {
+	.flux .flux_header:has(.thumbnail):has(.summary) li.website {
 		grid-area: website;
+		/** Show feed name */
+		width: auto;
 	}
-	.flux .flux_header:has(.thumbnail):has(.summary) li.thumbnail  {
+
+	.flux .flux_header:has(.thumbnail):has(.summary) li.thumbnail {
 		grid-area: thumbnail;
 	}
+
 	.flux .flux_header:has(.thumbnail):has(.summary) li.titleAuthorSummaryDate {
 		grid-area: content;
 	}
+
 	.flux .flux_header:has(.thumbnail):has(.summary) li.manage:has(.read) {
 		grid-area: manage-read;
 	}
+
 	.flux .flux_header:has(.thumbnail):has(.summary) li.manage:has(.bookmark) {
 		grid-area: manage-bookmark;
 	}
-	.flux .flux_header:has(.thumbnail):has(.summary) li.link       {
+
+	.flux .flux_header:has(.thumbnail):has(.summary) li.link {
 		grid-area: link;
 	}
-	.flux .flux_header:has(.thumbnail):has(.summary) li.labels     {
+
+	.flux .flux_header:has(.thumbnail):has(.summary) li.labels {
 		grid-area: manage-labels
 	}
-	.flux .flux_header:has(.thumbnail):has(.summary) li.share     {
+
+	.flux .flux_header:has(.thumbnail):has(.summary) li.share {
 		grid-area: manage-share
 	}
 

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2541,6 +2541,50 @@ html.slider-active {
 		padding-left: 1rem;
 	}
 
+	.flux .flux_header:has(.thumbnail):has(.summary) {
+		display: grid;
+		grid-template-columns: auto 1fr auto auto auto;
+		grid-template-rows: auto auto;
+		grid-template-areas:
+			"website   website manage-read  manage-bookmark  manage-share  manage-labels  link"
+			"thumbnail content content      content          content       content        content";
+		align-items: start;
+		gap: 8px;
+		list-style: none;
+	}
+	/** Show feed name */
+	.flux .flux_header:has(.thumbnail):has(.summary) li.website {
+		width: auto;
+	}
+	.flux .flux_header:has(.thumbnail):has(.summary) li.website .websiteName   {
+		display: inline;
+	}
+	/** place all the elements in their respective template areas */
+	.flux .flux_header:has(.thumbnail):has(.summary) li.website    {
+		grid-area: website;
+	}
+	.flux .flux_header:has(.thumbnail):has(.summary) li.thumbnail  {
+		grid-area: thumbnail;
+	}
+	.flux .flux_header:has(.thumbnail):has(.summary) li.titleAuthorSummaryDate {
+		grid-area: content;
+	}
+	.flux .flux_header:has(.thumbnail):has(.summary) li.manage:has(.read) {
+		grid-area: manage-read;
+	}
+	.flux .flux_header:has(.thumbnail):has(.summary) li.manage:has(.bookmark) {
+		grid-area: manage-bookmark;
+	}
+	.flux .flux_header:has(.thumbnail):has(.summary) li.link       {
+		grid-area: link;
+	}
+	.flux .flux_header:has(.thumbnail):has(.summary) li.labels     {
+		grid-area: manage-labels
+	}
+	.flux .flux_header:has(.thumbnail):has(.summary) li.share     {
+		grid-area: manage-share
+	}
+
 	#overlay .close {
 		position: relative;
 	}

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2541,7 +2541,7 @@ html.slider-active {
 		padding-left: 1rem;
 	}
 
-	.flux .flux_header:has(.thumbnail):has(.summary) {
+	.flux .flux_header.has-thumbnail.has-summary {
 		display: grid;
 		grid-template-columns: auto 1fr auto auto auto;
 		grid-template-rows: auto auto;
@@ -2551,42 +2551,42 @@ html.slider-active {
 		list-style: none;
 	}
 
-	.flux .flux_header:has(.thumbnail):has(.summary) li.website .websiteName {
+	.flux .flux_header.has-thumbnail.has-summary li.website .websiteName {
 		display: inline;
 	}
 
 	/** place all the elements in their respective template areas */
-	.flux .flux_header:has(.thumbnail):has(.summary) li.website {
+	.flux .flux_header.has-thumbnail.has-summary li.website {
 		grid-area: website;
 		/** Show feed name */
 		width: auto;
 	}
 
-	.flux .flux_header:has(.thumbnail):has(.summary) li.thumbnail {
+	.flux .flux_header.has-thumbnail.has-summary li.thumbnail {
 		grid-area: thumbnail;
 	}
 
-	.flux .flux_header:has(.thumbnail):has(.summary) li.titleAuthorSummaryDate {
+	.flux .flux_header.has-thumbnail.has-summary li.titleAuthorSummaryDate {
 		grid-area: content;
 	}
 
-	.flux .flux_header:has(.thumbnail):has(.summary) li.manage:has(.read) {
+	.flux .flux_header.has-thumbnail.has-summary li.manage:has(.read) {
 		grid-area: manage-read;
 	}
 
-	.flux .flux_header:has(.thumbnail):has(.summary) li.manage:has(.bookmark) {
+	.flux .flux_header.has-thumbnail.has-summary li.manage:has(.bookmark) {
 		grid-area: manage-bookmark;
 	}
 
-	.flux .flux_header:has(.thumbnail):has(.summary) li.link {
+	.flux .flux_header.has-thumbnail.has-summary li.link {
 		grid-area: link;
 	}
 
-	.flux .flux_header:has(.thumbnail):has(.summary) li.labels {
+	.flux .flux_header.has-thumbnail.has-summary li.labels {
 		grid-area: manage-labels
 	}
 
-	.flux .flux_header:has(.thumbnail):has(.summary) li.share {
+	.flux .flux_header.has-thumbnail.has-summary li.share {
 		grid-area: manage-share
 	}
 


### PR DESCRIPTION
This makes the feed view prettier on mobile, if thumbnails and summary are shown, as discussed in https://github.com/FreshRSS/FreshRSS/discussions/8629

**Changes proposed in this pull request:**

- Converts Feed Item list into multiple lines
- But only if both thumbnails and summaries are shown

The code is quite different from what I had done in my own hack: There I had used `display: flex` and then counted items, but that only works for my own hack: here we don't know how many items a given user may have, so we use `display:grid` instead with name grid areas.

**How to test the feature manually:**

1. Ensure you enable both thumbnails and summaries
2. Check out the feed view on mobile
3. Play around with enabling and disabling bookmarks, share button, etc.

**Pull request checklist:**

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

**Screenshots:**

<img width="458" height="1173" alt="SCR-20260324-jnte" src="https://github.com/user-attachments/assets/1d5c1615-961a-4953-8157-f9f8a5470545" />
<img width="459" height="1172" alt="SCR-20260324-jnwf" src="https://github.com/user-attachments/assets/96ffcea3-384f-4de9-9c50-3366022713d8" />
