### PR TITLE
SimplePie: Fix Undefined array key "" in get_thumbnail()

### DIFF
--- a/lib/composer.json
+++ b/lib/composer.json
@@ -14,7 +14,7 @@
 		"marienfressinaud/lib_opml": "0.5.1",
 		"phpgt/cssxpath": "v1.4.0",
 		"phpmailer/phpmailer": "7.0.2",
-		"simplepie/simplepie": "dev-freshrss#144f0823f34f6ae2ceb6bfbcc277172bb2d085b3"
+		"simplepie/simplepie": "dev-freshrss#6405099830e5383fc2cb9aa1be7a8f42a18cb21c"
 	},
 	"config": {
 		"sort-packages": true,

--- a/lib/simplepie/simplepie/src/Item.php
+++ b/lib/simplepie/simplepie/src/Item.php
@@ -359,7 +359,7 @@ class Item implements RegistryAware
     {
         if (!isset($this->data['thumbnail'])) {
             if ($return = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'thumbnail')) {
-                $thumbnail = $return[0]['attribs'][''];
+                $thumbnail = $return[0]['attribs'][''] ?? [];
                 if (empty($thumbnail['url'])) {
                     $this->data['thumbnail'] = null;
                 } else {


### PR DESCRIPTION
https://github.com/simplepie/simplepie/pull/970
https://github.com/FreshRSS/simplepie/pull/72
fix https://github.com/FreshRSS/FreshRSS/issues/8614

Solve warning in the case of `<media:thumbnail />`