### PR TITLE
fix: title normalization in duplicate detection (#948)

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -582,7 +582,10 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 					$readWhenSameTitleInFeed = $feed->attributeInt('read_when_same_title_in_feed') ?? 0;
 				}
 				if ($readWhenSameTitleInFeed > 0) {
-					$titlesAsRead = array_fill_keys($feedDAO->listTitles($feed->id(), $readWhenSameTitleInFeed), true);
+					$titlesAsRead = array_fill_keys(
+						array_map([FreshRSS_Entry::class, 'normalizeTitle'], $feedDAO->listTitles($feed->id(), $readWhenSameTitleInFeed)),
+						true
+					);
 				} else {
 					$titlesAsRead = [];
 				}
@@ -590,7 +593,10 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 				$category = $feed->category();
 				if (!isset($categoriesEntriesTitle[$feed->categoryId()]) && $category !== null && $category->hasAttribute('read_when_same_title_in_category')) {
 					$categoriesEntriesTitle[$feed->categoryId()] = array_fill_keys(
-						$catDAO->listTitles($feed->categoryId(), $category->attributeInt('read_when_same_title_in_category') ?? 0),
+						array_map([FreshRSS_Entry::class, 'normalizeTitle'], $catDAO->listTitles(
+							$feed->categoryId(), 
+							$category->attributeInt('read_when_same_title_in_category') ?? 0
+						)),
 						true
 					);
 				}
@@ -634,10 +640,12 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 							// NB: Do not mark updated articles as read based on their title, as the duplicate title maybe be from the same article.
 							$entry->applyFilterActions([]);
 							if ($readWhenSameTitleInFeed > 0) {
-								$titlesAsRead[$entry->title()] = true;
+								$titlesAsRead[FreshRSS_Entry::normalizeTitle($entry->title())] = true;
 							}
 							if (isset($categoriesEntriesTitle[$feed->categoryId()])) {
-								$categoriesEntriesTitle[$feed->categoryId()][$entry->title()] = true;
+								$categoriesEntriesTitle[$feed->categoryId()][
+									FreshRSS_Entry::normalizeTitle($entry->title())
+								] = true;
 							}
 
 							if (!$entry->isRead()) {
@@ -669,10 +677,12 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 
 						$entry->applyFilterActions(array_merge($titlesAsRead, $categoriesEntriesTitle[$feed->categoryId()] ?? []));
 						if ($readWhenSameTitleInFeed > 0) {
-							$titlesAsRead[$entry->title()] = true;
+							$titlesAsRead[FreshRSS_Entry::normalizeTitle($entry->title())] = true;
 						}
 						if (isset($categoriesEntriesTitle[$feed->categoryId()])) {
-							$categoriesEntriesTitle[$feed->categoryId()][$entry->title()] = true;
+							$categoriesEntriesTitle[$feed->categoryId()][
+								FreshRSS_Entry::normalizeTitle($entry->title())
+							] = true;
 						}
 
 						$needFeedCacheRefresh = true;

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -886,7 +886,21 @@ class FreshRSS_Entry extends Minz_Model {
 		}
 		return (bool)$ok;
 	}
-
+	
+	/**
+	 * Normalize entry titles to improve duplicate detection across different feeds.
+	 * Decodes HTML, collapses multiple spaces, and converts to lowercase.
+	 * @param string $title The raw entry title.
+	 * @return string The normalized title for comparison.
+	 */
+	public static function normalizeTitle(string $title): string {
+		$title = html_entity_decode($title, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+		$title = preg_replace('/\s+/u', ' ', $title);
+		$title = trim($title);
+		$title = mb_strtolower($title, 'UTF-8');
+		return $title;
+	}
+	
 	/** @param array<string,bool|int> $titlesAsRead */
 	public function applyFilterActions(array $titlesAsRead = []): void {
 		$feed = $this->feed;
@@ -898,8 +912,9 @@ class FreshRSS_Entry extends Minz_Model {
 				$this->_isRead(true);
 				Minz_ExtensionManager::callHook(Minz_HookType::EntryAutoRead, $this, 'upon_reception');
 			}
-			if (!empty($titlesAsRead[$this->title()])) {
-				Minz_Log::debug('Mark title as read: ' . $this->title());
+			$titleNorm = self::normalizeTitle($this->title());
+			if (!empty($titlesAsRead[$titleNorm])) {
+				Minz_Log::debug('Mark normalized title as read: ' . $titleNorm);
 				$this->_isRead(true);
 				Minz_ExtensionManager::callHook(Minz_HookType::EntryAutoRead, $this, 'same_title_in_feed');
 			}


### PR DESCRIPTION
Standardize entry titles (HTML, case, whitespace) before checking for duplicates in feeds and categories. 
Without these changes, some users reported "hit or miss" behaviour after enabling `Mark an article as read… if an identical title already exists in the top n newest articles of the category` (https://github.com/FreshRSS/FreshRSS/issues/948#issuecomment-4017251935, https://github.com/FreshRSS/FreshRSS/issues/948#issuecomment-4017416773, https://github.com/FreshRSS/FreshRSS/issues/948#issuecomment-4023014183).

Closes #

Changes proposed in this pull request:

- Added `FreshRSS_Entry::normalizeTitle()` to decode HTML entities, collapse whitespace, and lowercase strings.
- Applied this normalization to the `$titlesAsRead` lookup in both Feed and Category scopes.

How to test the feature manually:

1. **Subscription management** > **Add a feed or category** > enter "RNZ" under _Add a category_, click **Add**  
<img width="997" height="473" alt="Image" src="https://github.com/user-attachments/assets/c5ee6d3f-96b6-4137-8f3e-47d5416c818d" />



2. Click the gear icon ⚙️ on the left of the RNZ category, under _Filter actions_ tick _Mark an article as read..._ ☑️ _if an identical title already exists in the top n newest articles of the category_, enter 100, click **Submit**
<img width="450" height="227" alt="Image" src="https://github.com/user-attachments/assets/fd8ff582-c972-4600-b377-c8f211f2fb01" />
<img width="648" height="575" alt="Image" src="https://github.com/user-attachments/assets/3a6e2781-7092-4c8f-9409-64178e1a3687" />



3. Back to RNZ category, click ➕ _Add a feed_
<img width="441" height="245" alt="Image" src="https://github.com/user-attachments/assets/cf6378b8-4d60-4c66-8bb0-55f670297490" /> 

then paste URL of "RNZ World Headlines" feed. Use default settings for _Article unicity criteria_.
Repeat for "RNZ New Zealand Headlines".



4. Back to main page of FreshRSS, click on the _Show read_ button (opened envelope icon) in the nav menu, I can see 1 out of 2 entries of the article "Iranian diaspora form human chain on Wellington waterfront" is correctly marked as as read.
<img width="1450" height="1753" alt="Image" src="https://github.com/user-attachments/assets/e590cbb8-cbec-46fb-bd34-8e073b2d7743" />

5. Need to observe for some time to make sure no more "hit or miss" behaviour.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
