### PR TITLE
[Feature] Push docker image to ghcr

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,7 +10,7 @@ on:
 
 permissions:
   contents: read
-  # packages: write
+  packages: write
 
 jobs:
   build-container-image:
@@ -61,7 +61,7 @@ jobs:
         flavor: ${{ matrix.flavor }}
         images: |
           docker.io/freshrss/freshrss
-      #     ghcr.io/${{ github.repository }}
+          ghcr.io/${{ github.repository }}
         tags: ${{ matrix.tags }}
         labels: |
           org.opencontainers.image.url=https://freshrss.org/
@@ -74,12 +74,13 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    # - name: Login to GitHub Container Registry
-    #   uses: docker/login-action@v4
-    #   with:
-    #     registry: ghcr.io
-    #     username: ${{ github.repository_owner }}
-    #     password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Login to GitHub Container Registry
+      if: github.repository_owner == 'FreshRSS'
+      uses: docker/login-action@v4
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push Docker images
       uses: docker/build-push-action@v7

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -6,7 +6,7 @@
 FreshRSS is a self-hosted RSS feed aggregator.
 
 * Official website: [`freshrss.org`](https://freshrss.org/)
-* Official Docker images: [`hub.docker.com/r/freshrss/freshrss`](https://hub.docker.com/r/freshrss/freshrss/)
+* Official Docker images: [`hub.docker.com/r/freshrss/freshrss`](https://hub.docker.com/r/freshrss/freshrss/) [`ghcr.io/freshrss/freshrss`](https://github.com/FreshRSS/FreshRSS/pkgs/container/freshrss)
 * Repository: [`github.com/FreshRSS/FreshRSS`](https://github.com/FreshRSS/FreshRSS/)
 * Documentation: [`freshrss.github.io/FreshRSS`](https://freshrss.github.io/FreshRSS/)
 * License: [GNU AGPL 3](https://www.gnu.org/licenses/agpl-3.0.html)


### PR DESCRIPTION
Closes #8647

Changes proposed in this pull request:

- add push to ghcr

How to test the feature manually:

1. fork repository
2. setup docker hub secrets
3. create release/tag

My test run:
https://github.com/DenuxPlays/FreshRSS/actions/runs/23903258314/job/69705170205
Which resulted in:
https://github.com/DenuxPlays/FreshRSS/pkgs/container/freshrss
https://hub.docker.com/r/denuxgit/freshrss

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] ~~unit tests written (optional if too hard)~~ Not possible
- [x] documentation updated

I just updated the `docker/README.md` and none of the docker compose yaml files.
This was intentional as they will work as before and ghcr is just a second option and docker hub will remain the "default" image.

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
