### PR TITLE
Feed list hook traversable

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -474,9 +474,13 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 			$feeds = [];
 		}
 
+		$firstFeed = null;
 		foreach ($feeds as $feed) {
 			if (!($feed instanceof FreshRSS_Feed)) {
 				continue;
+			}
+			if (null === $firstFeed) {
+				$firstFeed = $feed;
 			}
 			$feed = Minz_ExtensionManager::callHook(Minz_HookType::FeedBeforeActualize, $feed);
 			if (!($feed instanceof FreshRSS_Feed)) {
@@ -812,7 +816,7 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 				break;
 			}
 		}
-		return [$nbUpdatedFeeds, reset($feeds) ?: null, $nbNewArticles, $feedsCacheToRefresh];
+		return [$nbUpdatedFeeds, $firstFeed, $nbNewArticles, $feedsCacheToRefresh];
 	}
 
 	/**

--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -470,13 +470,14 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 		$categoriesEntriesTitle = [];
 
 		$feeds = Minz_ExtensionManager::callHook(Minz_HookType::FeedsListBeforeActualize, $feeds);
-		if (is_array($feeds)) {
-			$feeds = array_filter($feeds, static fn($feed): bool => $feed instanceof FreshRSS_Feed);
-		} else {
+		if (!is_array($feeds) && !($feeds instanceof Traversable)) {
 			$feeds = [];
 		}
 
 		foreach ($feeds as $feed) {
+			if (!($feed instanceof FreshRSS_Feed)) {
+				continue;
+			}
 			$feed = Minz_ExtensionManager::callHook(Minz_HookType::FeedBeforeActualize, $feed);
 			if (!($feed instanceof FreshRSS_Feed)) {
 				continue;

--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -472,7 +472,7 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 		$categoriesEntriesGuid = [];
 
 		$feeds = Minz_ExtensionManager::callHook(Minz_HookType::FeedsListBeforeActualize, $feeds);
-		if (!is_array($feeds) && !($feeds instanceof Traversable)) {
+		if (!is_iterable($feeds)) {
 			$feeds = [];
 		}
 

--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -573,10 +573,12 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 			} catch (FreshRSS_Feed_Exception $e) {
 				Minz_Log::warning($e->getMessage());
 				$feedDAO->updateLastError($feed->id());
+				$feed->_error(time());
 				if ($e->getCode() === 410) {
 					// HTTP 410 Gone
 					Minz_Log::warning('Muting gone feed: ' . $feed->url(false));
 					$feedDAO->mute($feed->id(), true);
+					$feed->_ttl(-abs($feed->ttl())); // Replicate behavior of line above which acts directly into the DB
 				}
 				$feed->unlock();
 				continue;
@@ -727,11 +729,13 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 
 			if ($simplePiePush === null) {	// Not WebSub
 				$feedDAO->updateLastUpdate($feed->id(), $mtime);
+				$feed->_lastUpdate($mtime);
 				// Do not call for WebSub events, as we do not know the list of articles still on the upstream feed.
 				$needFeedCacheRefresh |= ($feed->markAsReadUponGone($feedIsEmpty, $mtime) != false);
 			} elseif ($feed->inError()) {
 				// Reset feed error state in case of successful WebSub push
 				$feedDAO->updateLastError($feed->id(), 0);
+				$feed->_error(0);
 			}
 			if ($needFeedCacheRefresh) {
 				$feedsCacheToRefresh[] = $feed;
@@ -792,9 +796,11 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 			if (!empty($feedProperties) || $feedIsNew) {
 				$feedProperties['attributes'] = $feed->attributes();
 				$ok = $feedDAO->updateFeed($feed->id(), $feedProperties);
+				// No need to update $feed object, since $feedProperties are taken from the object itself
 				if (!$ok && $feedIsNew) {
 					//Cancel adding new feed in case of database error at first actualize
 					$feedDAO->deleteFeed($feed->id());
+					// TODO: Reflect in the $feed object the feed has been deleted.
 					$feed->unlock();
 					break;
 				}


### PR DESCRIPTION
Improvements to changes in #8655  

I found some cases where returning an array doesn't provide the desired result using the extension to solve the use case mentioned in #8650 (I'll update this issue with more information).  

Changes proposed in this pull request:  

- Accept a Traversable object as the response from `Minz_HookType::FeedsListBeforeActualize` to provide more control on the order the feeds are updated.  
- Update the `$feed` object with some changes that were being made directly to the DB via `$feedDAO`.  

How to test the feature manually:

1. Have several feeds from a couple of sites (e.g. YT, reddit)  
2. Have an extension that registers to the hook.  
  https://github.com/pe1uca/xExtension-Declumping works as an example on the branch `main` for an array, and `traversable` for the Traversable object.  
3. Call `php app/actualize_script.php` to update feeds with a different order.  

A log like this one is needed to properly see the behavior.  
```php
foreach ($feeds as $key => $value) {
    syslog(LOG_INFO, "$key: {$value->name()} ({$value->url()})");
}
```

Pull request checklist:

- [ ] clear commit messages
- [ ] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
