### PR TITLE
feat: Allow feeds to belong to multiple categories (fixes #1989)

### DIFF
--- a/app/Models/CategoryDAO.php
+++ b/app/Models/CategoryDAO.php
@@ -332,7 +332,13 @@ class FreshRSS_CategoryDAO extends Minz_ModelPdo {
 				SELECT c.id AS c_id, c.name AS c_name, c.kind AS c_kind, c.`lastUpdate` AS c_last_update, c.error AS c_error, c.attributes AS c_attributes,
 					{$feedFields}
 				FROM `_category` c
-				LEFT OUTER JOIN `_feed` f ON f.category=c.id
+				LEFT OUTER JOIN (
+					SELECT f.*, fc.category_id AS _joined_category_id FROM `_feed` f
+					JOIN `_feed_category` fc ON fc.feed_id = f.id
+					UNION
+					SELECT f.*, f.category AS _joined_category_id FROM `_feed` f
+					WHERE NOT EXISTS (SELECT 1 FROM `_feed_category` fc2 WHERE fc2.feed_id = f.id)
+				) f ON f._joined_category_id = c.id
 				GROUP BY f.id, c_id
 				ORDER BY c.name, f.name
 				SQL;

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -53,6 +53,7 @@ class FreshRSS_Feed extends Minz_Model {
 	private int $kind = 0;
 	private int $categoryId = 0;
 	private ?FreshRSS_Category $category = null;
+	private array $categoryIds = [];
 	private int $nbEntries = -1;
 	private int $nbNotRead = -1;
 	private string $name = '';
@@ -292,6 +293,15 @@ class FreshRSS_Feed extends Minz_Model {
 		return $this->category?->id() ?: $this->categoryId;
 	}
 
+	/** @return array<int> */
+	public function categoryIds(): array {
+		if (empty($this->categoryIds)) {
+			$primary = $this->categoryId();
+			return $primary > 0 ? [$primary] : [];
+		}
+		return $this->categoryIds;
+	}
+
 	public function name(bool $raw = false): string {
 		return $raw || $this->name != '' ? $this->name : (preg_replace('%^https?://(www[.])?%i', '', $this->url) ?? '');
 	}
@@ -487,6 +497,15 @@ class FreshRSS_Feed extends Minz_Model {
 	public function _categoryId(int|string $id): void {
 		$this->category = null;
 		$this->categoryId = (int)$id;
+	}
+
+	/** @param array<int> $ids */
+	public function _categoryIds(array $ids): void {
+		$this->categoryIds = array_values(array_unique(array_map('intval', $ids)));
+		if (!empty($this->categoryIds)) {
+			$this->category = null;
+			$this->categoryId = $this->categoryIds[0];
+		}
 	}
 
 	public function _name(string $value): void {

--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -477,7 +477,24 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo {
 		}
 		/** @var list<array{id:int,url:string,kind:int,category:int,name:string,website:string,description:string,lastUpdate:int,priority:int,
 		 * 	pathEntries:string,httpAuth:string,error:int,ttl:int,attributes?:string,cache_nbUnreads:int,cache_nbEntries:int}> $res */
-		return self::daoToFeeds($res);
+		$feeds = self::daoToFeeds($res);
+		// Populate categoryIds from join table in one query
+		$sql2 = <<<'SQL'
+			SELECT feed_id, category_id FROM `_feed_category`
+			SQL;
+		$catRows = $this->fetchAssoc($sql2);
+		if (is_array($catRows)) {
+			$catMap = [];
+			foreach ($catRows as $row) {
+				$catMap[(int)$row['feed_id']][] = (int)$row['category_id'];
+			}
+			foreach ($feeds as $feed) {
+				if (isset($catMap[$feed->id()])) {
+					$feed->_categoryIds($catMap[$feed->id()]);
+				}
+			}
+		}
+		return $feeds;
 	}
 
 	/** @return array<string,string> */

--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -101,6 +101,50 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo {
 		}
 	}
 
+
+	/**
+	 * Set the categories for a feed in the feed_category join table.
+	 * @param array<int> $categoryIds
+	 */
+	public function setFeedCategories(int $feedId, array $categoryIds): bool {
+		$ok = true;
+		$sql = <<<'SQL'
+			DELETE FROM `_feed_category` WHERE feed_id=:feed_id
+			SQL;
+		$stm = $this->pdo->prepare($sql);
+		if ($stm === false || !$stm->execute([':feed_id' => $feedId])) {
+			return false;
+		}
+		foreach ($categoryIds as $catId) {
+			$catId = (int)$catId;
+			if ($catId <= 0) {
+				continue;
+			}
+			$sql2 = <<<'SQL'
+				INSERT INTO `_feed_category` (feed_id, category_id) VALUES (:feed_id, :category_id)
+				SQL;
+			$stm2 = $this->pdo->prepare($sql2);
+			if ($stm2 === false) {
+				return false;
+			}
+			$ok = $ok && $stm2->execute([':feed_id' => $feedId, ':category_id' => $catId]);
+		}
+		return $ok;
+	}
+
+	/** @return array<int> */
+	public function getFeedCategoryIds(int $feedId): array {
+		$sql = <<<'SQL'
+			SELECT category_id FROM `_feed_category` WHERE feed_id=:feed_id
+			SQL;
+		$stm = $this->pdo->prepare($sql);
+		if ($stm === false || !$stm->execute([':feed_id' => $feedId])) {
+			return [];
+		}
+		$res = $stm->fetchAll(\PDO::FETCH_COLUMN, 0);
+		return is_array($res) ? array_map('intval', $res) : [];
+	}
+
 	public function addFeedObject(FreshRSS_Feed $feed): int|false {
 		// Add feed only if we don’t find it in DB
 		$feed_search = $this->searchByUrl($feed->url());
@@ -126,6 +170,7 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo {
 			if ($id) {
 				$feed->_id($id);
 				$feed->faviconPrepare();
+				$this->setFeedCategories((int)$id, $feed->categoryIds());
 			}
 
 			return $id;
@@ -154,6 +199,13 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo {
 
 			if (!$this->updateFeed($feed_search->id(), $values)) {
 				return false;
+			}
+
+			// Merge existing categories with new ones
+			if (!empty($feed->categoryIds())) {
+				$existingCatIds = $this->getFeedCategoryIds($feed_search->id());
+				$mergedCatIds = array_unique(array_merge($existingCatIds, $feed->categoryIds()));
+				$this->setFeedCategories($feed_search->id(), array_values($mergedCatIds));
 			}
 
 			return $feed_search->id();
@@ -518,7 +570,9 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo {
 	 */
 	public function listByCategory(int $cat, ?bool $muted = null, ?bool $errored = null): array {
 		$sql = <<<'SQL'
-			SELECT * FROM `_feed` WHERE category=:category
+			SELECT * FROM `_feed` f
+			WHERE EXISTS (SELECT 1 FROM `_feed_category` fc WHERE fc.feed_id=f.id AND fc.category_id=:category)
+			OR (NOT EXISTS (SELECT 1 FROM `_feed_category` fc2 WHERE fc2.feed_id=f.id) AND f.category=:category2)
 			SQL;
 		if ($muted) {
 			$sql .= "\n" . <<<SQL
@@ -530,7 +584,7 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo {
 				AND error <> 0
 				SQL;
 		}
-		$res = $this->fetchAssoc($sql, [':category' => $cat]);
+		$res = $this->fetchAssoc($sql, [':category' => $cat, ':category2' => $cat]);
 		if (!is_array($res)) {
 			return [];
 		}

--- a/app/SQL/install.sql.mysql.php
+++ b/app/SQL/install.sql.mysql.php
@@ -123,6 +123,17 @@ $GLOBALS['ALTER_TABLE_ENTRY_LAST_MODIFIED'] = <<<'SQL'
 ALTER TABLE `_entry`
 	ADD COLUMN IF NOT EXISTS `lastModified` BIGINT,	-- 1.29.0
 	ADD INDEX IF NOT EXISTS `entry_last_modified_index` (`lastModified`);
+
+CREATE TABLE IF NOT EXISTS `_feed_category` (
+	`feed_id`     INT NOT NULL,
+	`category_id` INT NOT NULL,
+	PRIMARY KEY (`feed_id`, `category_id`),
+	FOREIGN KEY (`feed_id`) REFERENCES `_feed`(`id`) ON DELETE CASCADE,
+	FOREIGN KEY (`category_id`) REFERENCES `_category`(`id`) ON DELETE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
+ENGINE = INNODB;
+INSERT IGNORE INTO `_feed_category` (feed_id, category_id)
+	SELECT id, category FROM `_feed` WHERE category IS NOT NULL AND category != 0;
 SQL;
 
 $GLOBALS['SQL_DROP_TABLES'] = <<<'SQL'

--- a/app/SQL/install.sql.pgsql.php
+++ b/app/SQL/install.sql.pgsql.php
@@ -110,6 +110,17 @@ SQL;
 $GLOBALS['ALTER_TABLE_ENTRY_LAST_MODIFIED'] = <<<'SQL'
 ALTER TABLE `_entry` ADD COLUMN IF NOT EXISTS `lastModified` BIGINT;	-- 1.29.0
 CREATE INDEX IF NOT EXISTS `_entry_last_modified_index` ON `_entry` (`lastModified`);
+
+CREATE TABLE IF NOT EXISTS `_feed_category` (
+	"feed_id"     INT NOT NULL,
+	"category_id" INT NOT NULL,
+	PRIMARY KEY ("feed_id", "category_id"),
+	FOREIGN KEY ("feed_id") REFERENCES `_feed` ("id") ON DELETE CASCADE,
+	FOREIGN KEY ("category_id") REFERENCES `_category` ("id") ON DELETE CASCADE
+);
+INSERT INTO `_feed_category` (feed_id, category_id)
+	SELECT id, category FROM `_feed` WHERE category IS NOT NULL AND category != 0
+	ON CONFLICT DO NOTHING;
 SQL;
 
 $GLOBALS['SQL_DROP_TABLES'] = <<<'SQL'

--- a/app/SQL/install.sql.sqlite.php
+++ b/app/SQL/install.sql.sqlite.php
@@ -101,6 +101,16 @@ CREATE TABLE IF NOT EXISTS `entrytag` (
 	FOREIGN KEY (`id_entry`) REFERENCES `entry` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 CREATE INDEX IF NOT EXISTS entrytag_id_entry_index ON `entrytag` (`id_entry`);
+
+CREATE TABLE IF NOT EXISTS `feed_category` (
+	`feed_id`     INTEGER NOT NULL,
+	`category_id` INTEGER NOT NULL,
+	PRIMARY KEY (`feed_id`, `category_id`),
+	FOREIGN KEY (`feed_id`) REFERENCES `feed`(`id`) ON DELETE CASCADE,
+	FOREIGN KEY (`category_id`) REFERENCES `category`(`id`) ON DELETE CASCADE
+);
+INSERT OR IGNORE INTO `feed_category` (feed_id, category_id)
+	SELECT id, category FROM `feed` WHERE category IS NOT NULL AND category != 0;
 SQL;
 
 $GLOBALS['ALTER_TABLE_ENTRY_LAST_USER_MODIFIED'] = <<<'SQL'

--- a/app/SQL/install.sql.sqlite.php
+++ b/app/SQL/install.sql.sqlite.php
@@ -102,15 +102,15 @@ CREATE TABLE IF NOT EXISTS `entrytag` (
 );
 CREATE INDEX IF NOT EXISTS entrytag_id_entry_index ON `entrytag` (`id_entry`);
 
-CREATE TABLE IF NOT EXISTS `feed_category` (
+CREATE TABLE IF NOT EXISTS `_feed_category` (
 	`feed_id`     INTEGER NOT NULL,
 	`category_id` INTEGER NOT NULL,
 	PRIMARY KEY (`feed_id`, `category_id`),
-	FOREIGN KEY (`feed_id`) REFERENCES `feed`(`id`) ON DELETE CASCADE,
-	FOREIGN KEY (`category_id`) REFERENCES `category`(`id`) ON DELETE CASCADE
+	FOREIGN KEY (`feed_id`) REFERENCES `_feed`(`id`) ON DELETE CASCADE,
+	FOREIGN KEY (`category_id`) REFERENCES `_category`(`id`) ON DELETE CASCADE
 );
-INSERT OR IGNORE INTO `feed_category` (feed_id, category_id)
-	SELECT id, category FROM `feed` WHERE category IS NOT NULL AND category != 0;
+INSERT OR IGNORE INTO `_feed_category` (feed_id, category_id)
+	SELECT id, category FROM `_feed` WHERE category IS NOT NULL AND category != 0;
 SQL;
 
 $GLOBALS['ALTER_TABLE_ENTRY_LAST_USER_MODIFIED'] = <<<'SQL'

--- a/app/Services/ImportService.php
+++ b/app/Services/ImportService.php
@@ -75,6 +75,8 @@ class FreshRSS_Import_Service {
 		// feeds elements indexed by their categories names.
 		[$categories_elements, $categories_to_feeds] = $this->loadFromOutlines($opml_array['body'], '');
 
+		// First pass: resolve/create categories, build category name => object map
+		$resolved_categories = [];  // category_name => FreshRSS_Category|null
 		foreach ($categories_to_feeds as $category_name => $feeds_elements) {
 			$category_element = $categories_elements[$category_name] ?? null;
 
@@ -109,25 +111,62 @@ class FreshRSS_Import_Service {
 				$category = $default_category;
 			}
 
-			// Then, create the feeds one by one and attach them to the
-			// category we just got.
+			$resolved_categories[$category_name] = $category;
+		}
+
+		// Second pass: build feed_url => {element, category_ids:[]} to handle multi-category feeds
+		/** @var array<string, array{element: array<string,string>, category_ids: list<int>}> $feeds_by_url */
+		$feeds_by_url = [];
+		foreach ($categories_to_feeds as $category_name => $feeds_elements) {
+			$category = $resolved_categories[$category_name] ?? $default_category;
 			foreach ($feeds_elements as $feed_element) {
-				$limit_reached = $nb_feeds >= $limits['max_feeds'];
-				$can_create_feed = FreshRSS_Context::$isCli || !$limit_reached;
-				if (!$can_create_feed) {
-					Minz_Log::warning(
-						_t('feedback.sub.feed.over_max', $limits['max_feeds'])
-					);
-					$this->lastStatus = false;
+				$url = $feed_element['xmlUrl'] ?? '';
+				if ($url === '') {
+					continue;
+				}
+				if (!isset($feeds_by_url[$url])) {
+					$feeds_by_url[$url] = ['element' => $feed_element, 'category_ids' => []];
+				}
+				if ($category->id() > 0 && !in_array($category->id(), $feeds_by_url[$url]['category_ids'], true)) {
+					$feeds_by_url[$url]['category_ids'][] = $category->id();
+				}
+			}
+		}
+
+		// Third pass: create feeds with all their categories
+		foreach ($feeds_by_url as $url => $feed_data) {
+			$limit_reached = $nb_feeds >= $limits['max_feeds'];
+			$can_create_feed = FreshRSS_Context::$isCli || !$limit_reached;
+			if (!$can_create_feed) {
+				Minz_Log::warning(
+					_t('feedback.sub.feed.over_max', $limits['max_feeds'])
+				);
+				$this->lastStatus = false;
+				break;
+			}
+
+			// Use first category as primary for backwards compat
+			$primary_cat_id = $feed_data['category_ids'][0] ?? $default_category->id();
+			$primary_category = null;
+			foreach ($resolved_categories as $cat) {
+				if ($cat !== null && $cat->id() === $primary_cat_id) {
+					$primary_category = $cat;
 					break;
 				}
+			}
+			if ($primary_category === null) {
+				$primary_category = $default_category;
+			}
 
-				if ($this->createFeed($feed_element, $category, $dry_run) !== null) {
-					// TODO what if the feed already exists in the database?
-					$nb_feeds++;
-				} else {
-					$this->lastStatus = false;
+			$feed = $this->createFeed($feed_data['element'], $primary_category, $dry_run);
+			if ($feed !== null) {
+				// Set all categories in the join table
+				if (!$dry_run && !empty($feed_data['category_ids'])) {
+					$this->feedDAO->setFeedCategories($feed->id(), $feed_data['category_ids']);
 				}
+				$nb_feeds++;
+			} else {
+				$this->lastStatus = false;
 			}
 		}
 	}

--- a/p/api/fever.php
+++ b/p/api/fever.php
@@ -420,13 +420,13 @@ final class FeverAPI
 			if ($feed->priority() <= FreshRSS_Feed::PRIORITY_HIDDEN) {
 				continue;
 			}
-			$ids[$feed->categoryId()][] = $feed->id();
+			$catIds = $feed->categoryIds(); if (empty($catIds)) { $catIds = [$feed->categoryId()]; } foreach ($catIds as $catId) { $ids[$catId][] = $feed->id(); }
 		}
 
 		foreach ($ids as $category => $feedIds) {
 			$groups[] = [
 				'group_id' => $category,
-				'feed_ids' => implode(',', $feedIds)
+				'feed_ids' => implode(',', array_unique($feedIds))
 			];
 		}
 

--- a/tests/app/Models/FeedMultiCategoryTest.php
+++ b/tests/app/Models/FeedMultiCategoryTest.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for multi-category support added to FreshRSS_Feed model.
+ * Covers: categoryIds(), _categoryIds(), categoryId() fallback behaviour.
+ */
+final class FeedMultiCategoryTest extends TestCase {
+
+	// -----------------------------------------------------------------------
+	// categoryIds() — getter
+	// -----------------------------------------------------------------------
+
+	public function test_categoryIds_returns_primary_when_no_join_table_ids(): void {
+		$feed = new FreshRSS_Feed('https://example.com/feed', false);
+		$feed->_categoryId(42);
+		self::assertSame([42], $feed->categoryIds());
+	}
+
+	public function test_categoryIds_returns_empty_when_no_category_set(): void {
+		$feed = new FreshRSS_Feed('https://example.com/feed', false);
+		self::assertSame([], $feed->categoryIds());
+	}
+
+	public function test_categoryIds_returns_join_table_ids_when_set(): void {
+		$feed = new FreshRSS_Feed('https://example.com/feed', false);
+		$feed->_categoryId(1);
+		$feed->_categoryIds([10, 20, 30]);
+		self::assertSame([10, 20, 30], $feed->categoryIds());
+	}
+
+	public function test_categoryIds_deduplicates_ids(): void {
+		$feed = new FreshRSS_Feed('https://example.com/feed', false);
+		$feed->_categoryIds([5, 5, 10, 10, 15]);
+		self::assertSame([5, 10, 15], $feed->categoryIds());
+	}
+
+	public function test_categoryIds_casts_to_int(): void {
+		$feed = new FreshRSS_Feed('https://example.com/feed', false);
+		$feed->_categoryIds([7, 8]);  // already ints
+		self::assertSame([7, 8], $feed->categoryIds());
+	}
+
+	// -----------------------------------------------------------------------
+	// _categoryIds() — setter side-effects
+	// -----------------------------------------------------------------------
+
+	public function test_setting_categoryIds_updates_primary_categoryId(): void {
+		$feed = new FreshRSS_Feed('https://example.com/feed', false);
+		$feed->_categoryId(99);
+		$feed->_categoryIds([10, 20]);
+		// Primary categoryId should now be first element of categoryIds
+		self::assertSame(10, $feed->categoryId());
+	}
+
+	public function test_setting_empty_categoryIds_does_not_change_primary(): void {
+		$feed = new FreshRSS_Feed('https://example.com/feed', false);
+		$feed->_categoryId(99);
+		$feed->_categoryIds([]);
+		// Empty list should not override primary
+		self::assertSame(99, $feed->categoryId());
+	}
+
+	public function test_setting_single_categoryId_works(): void {
+		$feed = new FreshRSS_Feed('https://example.com/feed', false);
+		$feed->_categoryIds([42]);
+		self::assertSame([42], $feed->categoryIds());
+		self::assertSame(42, $feed->categoryId());
+	}
+
+	// -----------------------------------------------------------------------
+	// categoryId() — primary category fallback
+	// -----------------------------------------------------------------------
+
+	public function test_categoryId_returns_zero_when_nothing_set(): void {
+		$feed = new FreshRSS_Feed('https://example.com/feed', false);
+		self::assertSame(0, $feed->categoryId());
+	}
+
+	public function test_categoryId_returns_set_value(): void {
+		$feed = new FreshRSS_Feed('https://example.com/feed', false);
+		$feed->_categoryId(7);
+		self::assertSame(7, $feed->categoryId());
+	}
+
+	public function test_categoryId_returns_first_of_categoryIds_when_set(): void {
+		$feed = new FreshRSS_Feed('https://example.com/feed', false);
+		$feed->_categoryIds([3, 5, 9]);
+		self::assertSame(3, $feed->categoryId());
+	}
+}


### PR DESCRIPTION
Closes #1989

Changes proposed in this pull request:

- Add `feed_category` join table to all DB schemas (SQLite, MySQL, PostgreSQL) to store many-to-many feed-category relationships
- Add `categoryIds` field to `Feed` model with `categoryIds()` getter and `_categoryIds()` setter
- Add `setFeedCategories()` and `getFeedCategoryIds()` to `FeedDAO`; update `listByCategory()` to use the join table
- Update `CategoryDAO::listCategories()` to join via `feed_category` (falls back to legacy `feed.category` for feeds not yet in the join table)
- Fix OPML import (`ImportService`) to assign feeds to multiple categories when the same feed URL appears under multiple category outlines
- Fix Fever API (`getFeedsGroup`) to return all category memberships for feeds in multiple categories

How to test the feature manually:

- Import an OPML file where the same feed URL appears under multiple `<outline>` categories — verify the feed appears under all categories
- Export OPML and verify the feed is listed under each of its categories
- In Fever API client (e.g. Reeder), verify feeds appear in all their assigned categories

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested (OPML import/export round-trip, Fever API)
- [x] unit tests written (optional if too hard)
- [ ] documentation updated