### PR TITLE
Decode HTML in article titles

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -167,7 +167,7 @@ class FreshRSS_Entry extends Minz_Model {
 				}
 			}
 		}
-		return $title;
+		return html_entity_decode($title, ENT_QUOTES | ENT_HTML5, 'UTF-8');
 	}
 
 	#[Deprecated('Use authors() instead')]


### PR DESCRIPTION
I subscribe to the [Malwarebytes RSS feed](https://www.malwarebytes.com/blog/feed/index.xml) which uses encoded punctuation in its article titles. This makes it really hard to read when the title shows up as `Why we＆#8217;re still not doing April Fools＆#8217; Day`.

Changes proposed in this pull request:

- Modify the `title()` function to return `$title` with decoded HTML

How to test the feature manually:

1. Subscribe to https://www.malwarebytes.com/blog
2. Titles like the one mentioned above now display as `Why we're still not doing April Fools' Day`

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
