### PR TITLE
Fix change sorting during paging

### DIFF
--- a/app/layout/nav_menu.phtml
+++ b/app/layout/nav_menu.phtml
@@ -234,6 +234,7 @@
 			$title = _t('index.menu.sort.desc');
 		}
 		$url_order = Minz_Request::currentRequest();
+		unset($url_order['params']['cid']);
 	?>
 	<div id="nav_menu_sort" class="group">
 		<div class="dropdown">


### PR DESCRIPTION
Continuation ID should be reset when changing sorting order, especially between DESC and ASC but also the other variants.
