### PR TITLE
simplepie: fix potential `XML error: No memory` when parsing huge feed

### DIFF
--- a/lib/simplepie/simplepie/src/Parser.php
+++ b/lib/simplepie/simplepie/src/Parser.php
@@ -139,6 +139,9 @@ class Parser implements RegistryAware
             $xml = xml_parser_create_ns($this->encoding, $this->separator);
             xml_parser_set_option($xml, XML_OPTION_SKIP_WHITE, 1);
             xml_parser_set_option($xml, XML_OPTION_CASE_FOLDING, 0);
+            if (80400 <= \PHP_VERSION_ID) {
+                xml_parser_set_option($xml, XML_OPTION_PARSE_HUGE, 1);
+            }
             xml_set_character_data_handler($xml, [$this, 'cdata']);
             xml_set_element_handler($xml, [$this, 'tag_open'], [$this, 'tag_close']);
 


### PR DESCRIPTION
After upgrade debian-based image from `freshrss:1.27.0` to `freshrss:1.28.1`, feed projectzero `https://projectzero.google/feed.xml` start failing to update, the log says `https://projectzero.google/feed.xml is invalid XML, likely due to invalid characters. XML error: No memory at line 1250, column 2167 [https://projectzero.google/feed.xml]`.

According to the PHP doc[1]:
>  XML_OPTION_PARSE_HUGE (int)
>     Available as of PHP 8.4.0. When libxml2 < 2.7.0 is used (e.g. on PHP 7.x), this option is enabled by default and cannot be disabled.

There is a new option `XML_OPTION_PARSE_HUGE` after PHP 8.4.0. And indeed there is an upgrade to PHP 8.4 between 1.27.0 and 1.28.1 in debian-based docker image. And the new default value is `false`[2].

Set this option to `1` fixed the problem for me.

1. https://www.php.net/manual/en/xml.constants.php#constant.xml-option-parse-huge
2. https://github.com/php/php-src/blob/90744ec52a50e0eacab47d5a51d82c1b26607b76/ext/xml/xml.c#L1116

This should Closes #8516
why alpine-based docker image is not affected, my wild guess is it do not use `libxml2`.