### PR TITLE
fix: do not report PRIORITY_HIDDEN feeds in nbUnreadsPerFeed

### DIFF
--- a/app/views/javascript/nbUnreadsPerFeed.phtml
+++ b/app/views/javascript/nbUnreadsPerFeed.phtml
@@ -8,7 +8,9 @@ $result = [
 ];
 foreach ($this->categories as $cat) {
 	foreach ($cat->feeds() as $feed) {
-		$result['feeds'][$feed->id()] = $feed->nbNotRead();
+		if ($feed->priority() > FreshRSS_Feed::PRIORITY_HIDDEN) {
+			$result['feeds'][$feed->id()] = $feed->nbNotRead();
+		}
 	}
 }
 foreach ($this->tags as $tag) {


### PR DESCRIPTION
Fixes #8694

## Problem
When a feed has PRIORITY_HIDDEN, its unread count is still reported by
nbUnreadsPerFeed, but the sidebar does not render a DOM element for it
(aside_feed.phtml:114). In refreshUnreads(), the per-feed tracked count
for the missing element stays at 0, while the server keeps reporting
unreads > 0. On "All articles" (isAll), this triggers the "new articles
available" banner every 2 minutes indefinitely.

## Fix
Filter PRIORITY_HIDDEN feeds out of the nbUnreadsPerFeed response. This
matches the existing convention in Category.php:42, which uses
`$feed->priority() > FreshRSS_Feed::PRIORITY_HIDDEN` for the same
"don't count hidden unreads" decision. It also aligns with the SQL for
"All articles" (entryController.php:112-114), which already excludes
hidden feeds from that view.

## Alternatives considered
- Frontend guard in refreshUnreads() to skip feeds with no DOM element:
  treats the symptom, not the cause; any future consumer of the endpoint
  would re-inherit the bug.
- Sending priority in JSON and filtering client-side: duplicates a policy
  that already lives in the model layer.

## Notes
- Only consumer of nbUnreadsPerFeed is p/scripts/main.js:2044. No API,
  CLI, or extension impact.
- Edge case: when viewing a hidden feed directly, aside_feed.phtml
  renders it in the sidebar (the !$f_active exception). With this fix
  the sidebar count for that feed will not auto-refresh on that view.
  isAll is false there, so the banner does not loop in that case.
- Independent confirmation by @WillPresley on the issue.
- Tested locally against 1.28.2-dev.