### PR TITLE
fix: use spec-compliant `no-referrer` meta value

### DIFF
--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -45,7 +45,7 @@
 		<meta name="msapplication-TileColor" content="#FFF" />
 		<meta name="theme-color" content="#FFF" />
 <?php if (!FreshRSS_Context::systemConf()->allow_referrer) { ?>
-		<meta name="referrer" content="never" />
+		<meta name="referrer" content="no-referrer" />
 <?php } ?>
 		<?= FreshRSS_View::headTitle() ?>
 <?php

--- a/app/layout/simple.phtml
+++ b/app/layout/simple.phtml
@@ -33,7 +33,7 @@
 		<meta name="msapplication-TileColor" content="#FFF" />
 		<meta name="theme-color" content="#FFF" />
 <?php if (!FreshRSS_Context::systemConf()->allow_referrer) { ?>
-		<meta name="referrer" content="never" />
+		<meta name="referrer" content="no-referrer" />
 <?php } ?>
 		<?= FreshRSS_View::headTitle() ?>
 		<?php if ($this->rss_url != ''): ?>


### PR DESCRIPTION
`never` was removed from the Referrer Policy spec in 2016 and is only honoured by current browsers as a legacy alias. Replace with the spec-compliant `no-referrer` token.

## How tested

Each browser was pointed at a minimal local page that mirrors how FreshRSS uses the meta tag, then a link to a request inspector was clicked. Pass = no `Referer` header in the resulting request.

**Test page** (served via `python3 -m http.server 8000`):

~~~html
<!DOCTYPE html>
<html>
<head>
  <meta name="referrer" content="no-referrer">
</head>
<body>
  <a href="https://httpbin.org/headers">inspect headers</a>
</body>
</html>
~~~

**Procedure:** open `http://localhost:8000/test.html`, click the link, inspect the JSON `headers` object returned by httpbin.org.

**Results:**

| Browser | Engine | Version | `Referer` sent? |
|---|---|---|---|
| Safari | WebKit | 26 | No (pass) |
| LibreWolf | Gecko | 150 | No (pass) |
| Chromium | Blink | 149 | No (pass) |
| SeaMonkey | Gecko (legacy) | 2.53.23 | Yes (pre-existing, also leaks with `never`) |

The SeaMonkey result is unchanged behaviour: it ignores `<meta name="referrer">` for both `never` and `no-referrer`, so this PR neither fixes nor regresses it. Filed for awareness only.

Closes #8718