### PR TITLE
fix(themes): cover .group elements in Flat nav row spacing rules at narrow widths

### DIFF
--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -969,11 +969,13 @@ th {
 		min-height: 0;
 	}
 
-	.nav_menu .stick {
+	.nav_menu .stick,
+	.nav_menu .group {
 		margin: 0 10px;
 	}
 
-	.nav_menu .stick .btn {
+	.nav_menu .stick .btn,
+	.nav_menu .group .btn {
 		margin: 5px 0;
 	}
 

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -969,11 +969,13 @@ th {
 		min-height: 0;
 	}
 
-	.nav_menu .stick {
+	.nav_menu .stick,
+	.nav_menu .group {
 		margin: 0 10px;
 	}
 
-	.nav_menu .stick .btn {
+	.nav_menu .stick .btn,
+	.nav_menu .group .btn {
 		margin: 5px 0;
 	}
 


### PR DESCRIPTION
At narrow widths (`max-width: 840px`), every button in Flat's nav row has horizontal spacing around it, breaking the visual grouping that exists at wider widths. Multi-button groups that should appear joined as one block (e.g. the Views buttons: envelopes, stars, bookmark) end up rendered as separated standalone buttons. The cause is that `.nav_menu .btn { margin: 5px 10px }` adds horizontal margin to every button at narrow width, and the existing override `.nav_menu .stick .btn { margin: 5px 0 }` only covers `.stick` groups, not `.group`.

The fix adds `.nav_menu .group` alongside `.nav_menu .stick` in both the outer-wrapper margin rule and the child-btn margin override, mirroring the pattern already used by Alt-Dark, Origine, and Pafat at narrow widths.

### Screenshots

#### Wide screen (correct, unchanged)
<img width="578" height="44" alt="flat wide" src="https://github.com/user-attachments/assets/152fa4a3-861d-4ee6-a9a6-c427382a5e96" />

#### Narrow screen, before
<img width="622" height="43" alt="flat before" src="https://github.com/user-attachments/assets/846d9bdd-1991-42d2-abcd-dfb2078434be" />

#### Narrow screen, after
<img width="476" height="41" alt="flat after" src="https://github.com/user-attachments/assets/77e24903-ed28-4516-b09d-c8abf5e67c09" />

### Notes

- Verified at narrow width: Mark-as-read dropdown, Views (joined), Sort, Update feeds, Toggle sidebar render correctly. No desktop change.
- `.rtl.css` regenerated via `make rtl`.
- `npm run stylelint` passes.


