### PR TITLE
fix(themes): join Pafat's queries dropdown to its sibling at narrow widths

### DIFF
--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -218,8 +218,8 @@ th {
 }
 
 .stick .btn + .dropdown > .btn,
-.group .btn + .dropdown > .btn,
-.group .dropdown + .dropdown > .btn {
+.group .btn + .dropdown:last-child > .btn,
+.group .dropdown + .dropdown:last-child > .btn {
 	border-left: none;
 	border-radius: 0 3px 3px 0;
 }

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -218,8 +218,8 @@ th {
 }
 
 .stick .btn + .dropdown > .btn,
-.group .btn + .dropdown > .btn,
-.group .dropdown + .dropdown > .btn {
+.group .btn + .dropdown:last-child > .btn,
+.group .dropdown + .dropdown:last-child > .btn {
 	border-right: none;
 	border-radius: 3px 0 0 3px;
 }


### PR DESCRIPTION
In Pafat at narrow widths, the User queries dropdown inside `#nav_menu_actions.group` is visually disconnected from its sibling buttons: its right edge looks rounded but with a gap to its left neighbor (the search dropdown), so it doesn't visually cap the group cleanly. The cause is Pafat's existing rule

```css
.stick .btn + .dropdown > .btn,
.group .btn + .dropdown > .btn,
.group .dropdown + .dropdown > .btn {
    border-left: none;
    border-radius: 0 3px 3px 0;
}
```

which right-rounds **every** group dropdown that follows a button or another dropdown, not only the trailing one. When two group dropdowns sit side by side (the search dropdown followed by the queries dropdown), both end up right-rounded and look disconnected.

The fix adds `:last-child` to the two `.group` selectors so the right-radius only applies when the dropdown is the trailing element. Non-trailing group dropdowns then fall through to the base `.group .btn { border-radius: 0 }` rule and render with square corners, joining cleanly. A lone group dropdown (where `.dropdown` is `:only-child` of `.group`) is untouched, because it has no preceding sibling for the `+` combinator to match.

### Screenshots

#### Before, narrow Pafat: queries' right edge disconnected from search
<img width="316" height="179" alt="pafat before" src="https://github.com/user-attachments/assets/f5a5558f-e036-4cb6-8a6c-b33534de0ee1" />

#### After, narrow Pafat: queries joined to search and right-rounded as group cap
<img width="304" height="176" alt="pafat after" src="https://github.com/user-attachments/assets/65c371a0-f578-4a45-b797-5c669c8b293a" />

### Notes

- `.rtl.css` regenerated via `make rtl`.
- `npm run stylelint` passes.
- Verified at narrow width on FreshRSS 1.28.2-dev.

