### PR TITLE
fix(themes): apply intended hr styling in Ansum and Mapco article bodies

### DIFF
--- a/p/themes/Ansum/_layout.css
+++ b/p/themes/Ansum/_layout.css
@@ -260,7 +260,7 @@ main.prompt {
 		line-height: 1.8rem;
 	}
 
-	.content hr {
+	hr {
 		margin: 30px 10px;
 		background: var(--grey-medium-light);
 		height: 1px;

--- a/p/themes/Ansum/_layout.rtl.css
+++ b/p/themes/Ansum/_layout.rtl.css
@@ -260,7 +260,7 @@ main.prompt {
 		line-height: 1.8rem;
 	}
 
-	.content hr {
+	hr {
 		margin: 30px 10px;
 		background: var(--grey-medium-light);
 		height: 1px;

--- a/p/themes/Mapco/_layout.css
+++ b/p/themes/Mapco/_layout.css
@@ -272,7 +272,7 @@ main.prompt {
 		line-height: 1.8rem;
 	}
 
-	.content hr {
+	hr {
 		margin: 30px 10px;
 		background: var(--grey-medium-light);
 		height: 1px;

--- a/p/themes/Mapco/_layout.rtl.css
+++ b/p/themes/Mapco/_layout.rtl.css
@@ -272,7 +272,7 @@ main.prompt {
 		line-height: 1.8rem;
 	}
 
-	.content hr {
+	hr {
 		margin: 30px 10px;
 		background: var(--grey-medium-light);
 		height: 1px;


### PR DESCRIPTION
The nested rule `.content, .content_thin { ... .content hr { ... } }` in Ansum/_layout.css and Mapco/_layout.css expands the inner selector to `.content .content hr` / `.content_thin .content hr`, which never matches any markup. `<hr>` separators in article bodies have fallen back to browser defaults instead of the styled rule (light grey 1px line with soft shadow). Dating back to the SCSS sources from 2019 and preserved verbatim through the native-CSS conversion in #8241.

Drop the `.content` prefix on the inner selector so the rule applies as `.content hr, .content_thin hr`.

### Before
<img width="789" height="129" alt="Mapco before" src="https://github.com/user-attachments/assets/26f06596-1fca-4de0-aef1-816cf1c95de8" />

### After
<img width="789" height="189" alt="Mapco after" src="https://github.com/user-attachments/assets/39438699-34b9-4f1c-b4b9-16b1166f96fd" />

### Worth keeping?

The styled rule adds 60px of vertical whitespace around the line (30px above, 30px below), on top of an article area that already has generous spacing. If maintainers don't think that's an improvement, I'm happy to replace this PR with one that deletes the dead rule outright.