### PR TITLE
fix(themes): apply intended nav row spacing in Pafat at narrow widths

### DIFF
--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -1093,19 +1093,20 @@ a.signin {
 
 	.nav_menu {
 		padding-left: 0;
+		padding-bottom: 5px;
 
-		.nav_menu .btn {
+		.btn {
 			margin: 5px 10px;
 		}
 
-		.nav_menu .stick,
-		.nav_menu .group {
+		.stick,
+		.group {
 			margin: 0 10px;
 			min-width: 0;
 		}
 
-		.nav_menu .stick .btn,
-		.nav_menu .group .btn {
+		.stick .btn,
+		.group .btn {
 			margin: 5px 0;
 		}
 	}

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -1093,19 +1093,20 @@ a.signin {
 
 	.nav_menu {
 		padding-right: 0;
+		padding-bottom: 5px;
 
-		.nav_menu .btn {
+		.btn {
 			margin: 5px 10px;
 		}
 
-		.nav_menu .stick,
-		.nav_menu .group {
+		.stick,
+		.group {
 			margin: 0 10px;
 			min-width: 0;
 		}
 
-		.nav_menu .stick .btn,
-		.nav_menu .group .btn {
+		.stick .btn,
+		.group .btn {
 			margin: 5px 0;
 		}
 	}


### PR DESCRIPTION
The narrow-viewport `@media (max-width: 840px)` block in Pafat repeats the parent `.nav_menu` class on its inner selectors (`.nav_menu .btn`, `.nav_menu .stick`, etc. inside a `.nav_menu { ... }` nesting block). Native CSS nesting expands those to `.nav_menu .nav_menu .btn` and so on, which never matches. Buttons and `.stick`/`.group` wrappers in the top nav row below 840px have been falling back to default layout instead of the intended margins.

Activating the dormant rules also exposes an asymmetry in the base `.nav_menu` padding (`5px 0 0 2.5rem`, with 0 padding-bottom). Combined with the now-active 5px button margin, buttons end up a few pixels below the visual centre. Adding `padding-bottom: 5px` inside the @media block rebalances them.

### Before
<img width="388" height="36" alt="Pafat before" src="https://github.com/user-attachments/assets/8e2333e6-c391-4a50-8641-ab10098fb433" />

### After
<img width="491" height="41" alt="Pafat after" src="https://github.com/user-attachments/assets/b9d11374-88be-43f5-bdfc-cec1d246a547" />