### PR TITLE
feat(cli): add purge.php to apply purge policy from CLI

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -134,6 +134,11 @@ cd /usr/share/FreshRSS
 
 ./cli/db-optimize.php --user username
 # Optimize database (reduces the size) for a given user (perform `OPTIMIZE TABLE` in MySQL, `VACUUM` in SQLite)
+
+./cli/purge.php --user username
+# Apply the purge policy (max number of articles, max age, exceptions) to all feeds of the given user.
+# Equivalent to clicking ‘Purge now’ in the GUI, but suitable for cron.
+# Purge queries are expensive and blocking; running daily or weekly is usually enough.
 ```
 
 ### Translation

--- a/cli/purge.php
+++ b/cli/purge.php
@@ -1,0 +1,43 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+require __DIR__ . '/_cli.php';
+
+performRequirementCheck(FreshRSS_Context::systemConf()->db['type'] ?? '');
+
+$cliOptions = new class extends CliOptionsParser {
+	public string $user;
+
+	public function __construct() {
+		$this->addRequiredOption('user', (new CliOption('user')));
+		parent::__construct();
+	}
+};
+
+if (!empty($cliOptions->errors)) {
+	fail('FreshRSS error: ' . array_shift($cliOptions->errors) . "\n" . $cliOptions->usage);
+}
+
+$username = cliInitUser($cliOptions->user);
+
+echo 'FreshRSS purging old entries for user “', $username, "”…\n";
+
+$databaseDAO = FreshRSS_Factory::createDatabaseDAO();
+$databaseDAO->minorDbMaintenance();
+
+$feedDAO = FreshRSS_Factory::createFeedDao();
+$feeds = $feedDAO->listFeeds();
+
+$nb_total = 0;
+$feedDAO->beginTransaction();
+foreach ($feeds as $feed) {
+	$nb_total += ($feed->cleanOldEntries() ?: 0);
+}
+$feedDAO->updateCachedValues();
+$feedDAO->commit();
+
+invalidateHttpCache($username);
+
+echo "FreshRSS purged {$nb_total} old entries for {$username}\n";
+
+done(true);


### PR DESCRIPTION
## Summary

- Adds `cli/purge.php` so the purge policy can be applied from cron, mirroring `cli/db-optimize.php`.
- Documents it in `cli/README.md`.

Aims to be a small, contained answer to #3636: reuses the same `Feed::cleanOldEntries()` logic the GUI's "Purge now" button calls, packaged as a standard `cli/` script.

From the discussion there, @Alkarex wrote:

> We should add a few more CLI commands just like we have `cli/db-optimize.php`

@jerheij and @johnwarne also asked for a cron-friendly path.

## Questions for reviewers

I noticed the issue is labeled Documentation, so I am not sure whether the intent on the team's side was a docs-only resolution. If so, feel free to close this. I personally find an automated purge interesting.

A few smaller open points I left out of this PR. Happy to fold any of them in here, or follow up in a separate PR, depending on what you prefer.

1. **The 1/30 random trigger in `feedController.php`.** Should it stay, be removed, or made configurable (the latter suggested by @selticq)? It is independent of this script.
2. **Deduplicate with `entryController::purgeAction`.** The per-feed loop is the same five lines in both. Would you prefer a shared method, e.g. `FreshRSS_feed_Controller::purgeOldEntriesForCurrentUser`?
3. **No-policy warning.** If a user has no archiving policy set, the script silently reports "purged 0" and exits 0. Should it warn?

## Test plan

- [x] `make test-all` (PHPUnit, PHPCS, PHPStan, ESLint, Stylelint, Markdownlint)
- [x] Self-hosted run (1.28.2-dev, SQLite, ~12k entries): purged 19 read articles per policy; favourites and unread untouched; second run was a no-op.