### PR TITLE
Fix headers given to SimplePie, e.g. for HTTP/2

### DIFF
--- a/app/Utils/httpUtil.php
+++ b/app/Utils/httpUtil.php
@@ -355,9 +355,7 @@ final class FreshRSS_http_Util {
 
 		$responseHeaders = '';
 		curl_setopt($ch, CURLOPT_HEADERFUNCTION, function (\CurlHandle $ch, string $header) use (&$responseHeaders) {
-			if (trim($header) !== '') {	// Skip e.g. separation with trailer headers
-				$responseHeaders .= $header;
-			}
+			$responseHeaders .= $header;
 			return strlen($header);
 		});
 


### PR DESCRIPTION
Fix https://github.com/FreshRSS/FreshRSS/issues/8729
Follow-up of https://github.com/FreshRSS/FreshRSS/pull/7983
Related https://github.com/simplepie/simplepie/issues/942

Would need a bit more test with examples of HTTP trailer headers to test for regression
