### PR TITLE
refactor(themes): consolidate shared narrow @media rules into frss.css

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -1116,7 +1116,6 @@ kbd {
 
 	.aside {
 		box-shadow: 3px 0 3px var(--background-color-active);
-		transition: width 200ms linear;
 	}
 
 	.aside .toggle_aside,
@@ -1142,10 +1141,6 @@ kbd {
 
 	.aside:target + .close-aside, .configure .dropdown-target:target ~ .dropdown-close {
 		background-color: var(--background-color-slider-shadow);
-	}
-
-	.aside.aside_feed {
-		padding: 0;
 	}
 
 	.configure .dropdown .dropdown-menu {

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -1116,7 +1116,6 @@ kbd {
 
 	.aside {
 		box-shadow: -3px 0 3px var(--background-color-active);
-		transition: width 200ms linear;
 	}
 
 	.aside .toggle_aside,
@@ -1142,10 +1141,6 @@ kbd {
 
 	.aside:target + .close-aside, .configure .dropdown-target:target ~ .dropdown-close {
 		background-color: var(--background-color-slider-shadow);
-	}
-
-	.aside.aside_feed {
-		padding: 0;
 	}
 
 	.configure .dropdown .dropdown-menu {

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -972,18 +972,10 @@ th {
 		padding-bottom: 0;
 	}
 
-	.aside {
-		transition: width 200ms linear;
-	}
-
 	.aside .toggle_aside,
 	#overlay .close,
 	.dropdown-menu .toggle_aside {
 		background: #2c3e50;
-	}
-
-	.aside.aside_feed {
-		padding: 0;
 	}
 
 	.nav_menu .btn {

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -972,18 +972,10 @@ th {
 		padding-bottom: 0;
 	}
 
-	.aside {
-		transition: width 200ms linear;
-	}
-
 	.aside .toggle_aside,
 	#overlay .close,
 	.dropdown-menu .toggle_aside {
 		background: #2c3e50;
-	}
-
-	.aside.aside_feed {
-		padding: 0;
 	}
 
 	.nav_menu .btn {

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -1240,11 +1240,6 @@ optgroup::before {
 
 	.aside {
 		left: 0;
-		transition: width 200ms linear;
-	}
-
-	.aside.aside_feed {
-		padding: 0;
 	}
 
 	.nav.aside {

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -1240,11 +1240,6 @@ optgroup::before {
 
 	.aside {
 		right: 0;
-		transition: width 200ms linear;
-	}
-
-	.aside.aside_feed {
-		padding: 0;
 	}
 
 	.nav.aside {

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -1163,10 +1163,6 @@ button:hover .icon,
 		padding-bottom: 0;
 	}
 
-	.aside {
-		transition: width 200ms linear;
-	}
-
 	.aside:target {
 		box-shadow: 3px 0 3px var(--text-shadow-color);
 	}
@@ -1177,10 +1173,6 @@ button:hover .icon,
 	#slider .toggle_aside {
 		background-color: var(--background-color-light-shadowed);
 		border-bottom: 1px solid var(--border-color);
-	}
-
-	.aside.aside_feed {
-		padding: 0;
 	}
 
 	.post {

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -1163,10 +1163,6 @@ button:hover .icon,
 		padding-bottom: 0;
 	}
 
-	.aside {
-		transition: width 200ms linear;
-	}
-
 	.aside:target {
 		box-shadow: -3px 0 3px var(--text-shadow-color);
 	}
@@ -1177,10 +1173,6 @@ button:hover .icon,
 	#slider .toggle_aside {
 		background-color: var(--background-color-light-shadowed);
 		border-bottom: 1px solid var(--border-color);
-	}
-
-	.aside.aside_feed {
-		padding: 0;
 	}
 
 	.post {

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -1090,19 +1090,11 @@ a.signin {
 		padding-bottom: 0;
 	}
 
-	.aside {
-		transition: width 200ms linear;
-	}
-
 	.aside .toggle_aside,
 	#overlay .close,
 	.dropdown-menu .toggle_aside {
 		background-color: var(--background-color-grey);
 		border-bottom: 1px solid var(--border-color-grey-light);
-	}
-
-	.aside.aside_feed {
-		padding: 0;
 	}
 
 	.nav_menu {

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -1090,19 +1090,11 @@ a.signin {
 		padding-bottom: 0;
 	}
 
-	.aside {
-		transition: width 200ms linear;
-	}
-
 	.aside .toggle_aside,
 	#overlay .close,
 	.dropdown-menu .toggle_aside {
 		background-color: var(--background-color-grey);
 		border-bottom: 1px solid var(--border-color-grey-light);
-	}
-
-	.aside.aside_feed {
-		padding: 0;
 	}
 
 	.nav_menu {

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -1410,7 +1410,6 @@ main.global {
 	.aside {
 		padding: 0;
 		width: 0;
-		transition: width 200ms linear;
 
 		.toggle_aside {
 			background-color: var(--color-background-aside);

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -1410,7 +1410,6 @@ main.global {
 	.aside {
 		padding: 0;
 		width: 0;
-		transition: width 200ms linear;
 
 		.toggle_aside {
 			background-color: var(--color-background-aside);

--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -2,6 +2,9 @@
 
 @charset "UTF-8";
 
+/* Scaffold for the base-theme fallback. Other themes do not load this file;
+   cross-theme defaults belong in frss.css. */
+
 /*=== GENERAL */
 /*============*/
 html, body {

--- a/p/themes/base-theme/base.rtl.css
+++ b/p/themes/base-theme/base.rtl.css
@@ -2,6 +2,9 @@
 
 @charset "UTF-8";
 
+/* Scaffold for the base-theme fallback. Other themes do not load this file;
+   cross-theme defaults belong in frss.css. */
+
 /*=== GENERAL */
 /*============*/
 html, body {

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1,5 +1,7 @@
 @charset "UTF-8";
 
+/* Shared base loaded by every theme via the "_frss.css" entry in metadata.json. */
+
 /*=== GENERAL */
 /*============*/
 :root {
@@ -2769,12 +2771,17 @@ html.slider-active {
 		width: 0;
 		overflow: hidden;
 		z-index: 100;
+		transition: width 200ms linear;
 	}
 
 	.aside.visible,
 	.reader .aside.visible {
 		width: 90%;
 		height: 100vh;
+	}
+
+	.aside.aside_feed {
+		padding: 0;
 	}
 
 	.aside_feed .configure-feeds {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1,5 +1,7 @@
 @charset "UTF-8";
 
+/* Shared base loaded by every theme via the "_frss.css" entry in metadata.json. */
+
 /*=== GENERAL */
 /*============*/
 :root {
@@ -2769,12 +2771,17 @@ html.slider-active {
 		width: 0;
 		overflow: hidden;
 		z-index: 100;
+		transition: width 200ms linear;
 	}
 
 	.aside.visible,
 	.reader .aside.visible {
 		width: 90%;
 		height: 100vh;
+	}
+
+	.aside.aside_feed {
+		padding: 0;
 	}
 
 	.aside_feed .configure-feeds {


### PR DESCRIPTION
Two narrow-viewport rules were duplicated across leaf themes: `.aside { transition: width 200ms linear }` and `.aside.aside_feed { padding: 0 }`. This PR lifts both into the existing `@media (max-width: 840px)` block in `base-theme/frss.css` and removes the duplicates from Alternative-Dark, Flat, Origine, Pafat, and Nord. Swage's redundant `transition` line is also dropped (its other `.aside` properties stay).

Verified visually across Alternative-Dark, Ansum, Flat, Mapco, Nord, Origine, and Pafat at narrow and wide viewports. No regressions. Ansum and Mapco keep their own `.aside { transition: all 0.2s ease-in-out }` via source-order. Themes that previously had no explicit `.aside` rule (Dark, Dark-pink, Origine-compact via inheritance) gain identical computed values to their parent themes.

Also adds top-of-file comments to `base-theme/base.css` and `base-theme/frss.css` clarifying that `base.css` is a scaffold loaded only for the unconfigured base-theme fallback, while `frss.css` is the real shared base loaded by every theme via the `_frss.css` prefix in `metadata.json`. Follow-up to #8743, which initially targeted the wrong file before being corrected.