### PR TITLE
fix(themes): restore sidebar slide animation at narrow viewports

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -932,14 +932,15 @@ function toggle_aside_click(manual = true) {
 	}
 
 	const active = toggle_aside.classList.contains('active');
+	const isNarrow = window.matchMedia('(max-width: 840px)').matches;
 	if (active) {
 		toggle_aside.classList.remove('active');
 		aside.classList.remove('visible');
-		aside.style.display = 'none';
+		aside.classList.toggle('is-hidden', !isNarrow);
 	} else {
 		toggle_aside.classList.add('active');
 		aside.classList.add('visible');
-		aside.style.display = '';
+		aside.classList.remove('is-hidden');
 	}
 
 	if (manual && ['normal', 'reader'].includes(context.current_view)) {

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1330,6 +1330,10 @@ input[type="search"] {
 	vertical-align: top;
 }
 
+.aside.is-hidden {
+	display: none;
+}
+
 .aside + .close-aside {
 	display: none;
 }

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1330,6 +1330,10 @@ input[type="search"] {
 	vertical-align: top;
 }
 
+.aside.is-hidden {
+	display: none;
+}
+
 .aside + .close-aside {
 	display: none;
 }


### PR DESCRIPTION
## Summary

The narrow-viewport sidebar slide animation has been dormant since #8201. The `transition: width 200ms linear` rule reaches `.aside` correctly (verified via DevTools computed values), but the inline `display: none` toggle in `toggle_aside_click()` blocks it: width can't interpolate to/from `display: none` without `transition-behavior: allow-discrete`.

## Fix

Replace the inline `display` manipulation with a CSS class `is-hidden`, applied only when `!isNarrow`. At narrow viewports `.aside` is already `position: fixed; width: 0; overflow: hidden`, so width-collapse alone hides it. At wide viewports the class is kept so the sidebar is fully removed from layout flow when toggled off.

Wide viewports remain animation-free by design: `.aside` is `display: table-cell` there, so animating width would reflow the article list every frame.

## Test plan

- [x] Narrow viewport (≤840px): sidebar slides on open and close
- [x] Wide viewport: toggle hides and shows instantly
- [x] Resize across breakpoint while open: no stuck state

## Follow-up

`prefers-reduced-motion: reduce` opt-out would be a nice add but is cleaner once the `.aside { transition }` rule is consolidated; currently lives in many theme files on `edge`.