### PR TITLE
fix(themes): cap narrow-viewport sidebar and restore aside selectors

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -1139,7 +1139,7 @@ kbd {
 		filter: brightness(2);
 	}
 
-	.aside:target + .close-aside, .configure .dropdown-target:target ~ .dropdown-close {
+	.aside.visible + .close-aside, .configure .dropdown-target:target ~ .dropdown-close {
 		background-color: var(--background-color-slider-shadow);
 	}
 

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -1139,7 +1139,7 @@ kbd {
 		filter: brightness(2);
 	}
 
-	.aside:target + .close-aside, .configure .dropdown-target:target ~ .dropdown-close {
+	.aside.visible + .close-aside, .configure .dropdown-target:target ~ .dropdown-close {
 		background-color: var(--background-color-slider-shadow);
 	}
 

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -1233,7 +1233,7 @@ optgroup::before {
 /*===========*/
 
 @media (max-width: 840px) {
-	.aside:target + .close-aside,
+	.aside.visible + .close-aside,
 	.configure .dropdown-target:target ~ .dropdown-close {
 		backdrop-filter: grayscale(60%) blur(1px);
 	}
@@ -1243,7 +1243,6 @@ optgroup::before {
 	}
 
 	.nav.aside {
-		max-width: 300px;
 		border-radius: 0;
 	}
 

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -1233,7 +1233,7 @@ optgroup::before {
 /*===========*/
 
 @media (max-width: 840px) {
-	.aside:target + .close-aside,
+	.aside.visible + .close-aside,
 	.configure .dropdown-target:target ~ .dropdown-close {
 		backdrop-filter: grayscale(60%) blur(1px);
 	}
@@ -1243,7 +1243,6 @@ optgroup::before {
 	}
 
 	.nav.aside {
-		max-width: 300px;
 		border-radius: 0;
 	}
 

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -1163,7 +1163,7 @@ button:hover .icon,
 		padding-bottom: 0;
 	}
 
-	.aside:target {
+	.aside.visible {
 		box-shadow: 3px 0 3px var(--text-shadow-color);
 	}
 

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -1163,7 +1163,7 @@ button:hover .icon,
 		padding-bottom: 0;
 	}
 
-	.aside:target {
+	.aside.visible {
 		box-shadow: -3px 0 3px var(--text-shadow-color);
 	}
 

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -880,7 +880,7 @@ main.post .drop-section li.item.feed a:hover .icon {
 	margin-bottom: 1rem;
 }
 
-.aside:target .toggle_aside {
+.aside.visible .toggle_aside {
 	border-bottom: 1px solid var(--frss-border-color);
 }
 
@@ -1243,8 +1243,7 @@ body.reader {
 		text-align: center;
 	}
 
-	.aside:target {
-		width: var(--width-aside);
+	.aside.visible {
 		padding-top: 0;
 	}
 }

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -880,7 +880,7 @@ main.post .drop-section li.item.feed a:hover .icon {
 	margin-bottom: 1rem;
 }
 
-.aside:target .toggle_aside {
+.aside.visible .toggle_aside {
 	border-bottom: 1px solid var(--frss-border-color);
 }
 
@@ -1243,8 +1243,7 @@ body.reader {
 		text-align: center;
 	}
 
-	.aside:target {
-		width: var(--width-aside);
+	.aside.visible {
 		padding-top: 0;
 	}
 }

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2495,7 +2495,10 @@ html.slider-active {
 		display: none;
 	}
 
+	/* Material navigation drawer: theme override or 320px cap, with 56px touch-peek */
 	.aside.visible {
+		width: min(var(--width-aside, 320px), calc(100vw - 56px));
+		height: 100vh;
 		box-shadow: 3px 3px 5px var(--frss-box-shadow-color-transparent);
 	}
 
@@ -2772,12 +2775,6 @@ html.slider-active {
 		overflow: hidden;
 		z-index: 100;
 		transition: width 200ms linear;
-	}
-
-	/* Material navigation drawer: theme override or 320px cap, with 56px touch-peek */
-	.aside.visible {
-		width: min(var(--width-aside, 320px), calc(100vw - 56px));
-		height: 100vh;
 	}
 
 	.aside.aside_feed {

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2774,9 +2774,9 @@ html.slider-active {
 		transition: width 200ms linear;
 	}
 
-	.aside.visible,
-	.reader .aside.visible {
-		width: 90%;
+	/* Material navigation drawer: theme override or 320px cap, with 56px touch-peek */
+	.aside.visible {
+		width: min(var(--width-aside, 320px), calc(100vw - 56px));
 		height: 100vh;
 	}
 

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2495,7 +2495,10 @@ html.slider-active {
 		display: none;
 	}
 
+	/* Material navigation drawer: theme override or 320px cap, with 56px touch-peek */
 	.aside.visible {
+		width: min(var(--width-aside, 320px), calc(100vw - 56px));
+		height: 100vh;
 		box-shadow: -3px 3px 5px var(--frss-box-shadow-color-transparent);
 	}
 
@@ -2772,12 +2775,6 @@ html.slider-active {
 		overflow: hidden;
 		z-index: 100;
 		transition: width 200ms linear;
-	}
-
-	/* Material navigation drawer: theme override or 320px cap, with 56px touch-peek */
-	.aside.visible {
-		width: min(var(--width-aside, 320px), calc(100vw - 56px));
-		height: 100vh;
 	}
 
 	.aside.aside_feed {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2774,9 +2774,9 @@ html.slider-active {
 		transition: width 200ms linear;
 	}
 
-	.aside.visible,
-	.reader .aside.visible {
-		width: 90%;
+	/* Material navigation drawer: theme override or 320px cap, with 56px touch-peek */
+	.aside.visible {
+		width: min(var(--width-aside, 320px), calc(100vw - 56px));
 		height: 100vh;
 	}
 


### PR DESCRIPTION
## Summary

The narrow-viewport sidebar (`.aside.visible` at `<840px`) has used `width: 90%` since the original 2014 base-theme commit. On a typical phone (~390px) this leaves only ~40px of the underlying article view visible behind the open drawer, more than the feed tree usually needs.

This PR caps the narrow-viewport sidebar at the Material navigation drawer width (320px), with a 56px touch peek of the underlying view on narrower screens. Themes that define their own `--width-aside` (only Swage today) keep their existing width via the custom property fallback.

While in this code, two recent refactors had dropped related rules across leaf themes. This PR also restores those:

- The rename in #8201 was missed in four leaf themes (Swage, Nord, Origine, Alternative-Dark), leaving stale `.aside:target` selectors that no longer match.
- Swage's narrow-viewport sidebar width override was dropped in #8200; the new base cap covers that case for Swage and the other themes equally.

Nord's now-redundant `max-width: 300px` aside override is dropped at the same time. `.rtl.css` mirrors regenerated with `npm run rtlcss`.

## Screenshots

| Before | After |
| --- | --- |
| <img width="498" height="158" alt="alt-dark before" src="https://github.com/user-attachments/assets/1796d12f-ccfb-42cd-ba74-a8a0ccfb704b" /> | <img width="498" height="158" alt="alt-dark after" src="https://github.com/user-attachments/assets/07496e44-0490-4437-92a9-6433fc025d0a" /> |

## Test plan

Verified locally:

- [x] Narrow viewport in normal view, Alt-Dark: sidebar caps at 320px
- [x] Narrow viewport in normal view, Swage: sidebar at 231px (via `--width-aside`)
- [x] Narrow viewport in reader view, Swage: sidebar at 231px
- [x] Touch peek visible to the right of the drawer
- [x] Origine: box-shadow on sidebar's right edge when open
- [x] Nord: backdrop blur and grayscale visible when sidebar open
- [x] Alt-Dark: backdrop tint visible when sidebar open
- [x] Other base-inheriting themes (Pafat, Mapco, Ansum, Flat, Dark, Origine-compact): cap applies, no breakage
- [x] Desktop (`>840px`): no visual change
- [x] RTL locale: sidebar opens from the right, same widths apply