### PR TITLE
feat: respect prefers-reduced-motion for animations and smooth scroll

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -21,6 +21,11 @@ if (!Element.prototype.remove) Element.prototype.remove = function () { if (this
 // </Polyfills>
 
 // <Utils>
+const reducedMotionQuery = matchMedia('(prefers-reduced-motion: reduce)');
+function scrollBehavior() {
+	return reducedMotionQuery.matches ? 'auto' : 'smooth';
+}
+
 function xmlHttpRequestJson(req) {
 	let json = req.response;
 	if (req.responseType !== 'json') {	// IE11
@@ -808,9 +813,9 @@ async function mylabels(key) {
 	const scrollTop = needsScroll(mylabelsDropdown.closest('.horizontal-list'));
 	if (scrollTop !== 0) {
 		if (mylabelsDropdown.closest('.horizontal-list.flux_header')) {
-			mylabelsDropdown.nextElementSibling.nextElementSibling.scrollIntoView({ behavior: "smooth", block: "start" });
+			mylabelsDropdown.nextElementSibling.nextElementSibling.scrollIntoView({ behavior: scrollBehavior(), block: "start" });
 		} else {
-			mylabelsDropdown.nextElementSibling.nextElementSibling.scrollIntoView({ behavior: "smooth", block: "end" });
+			mylabelsDropdown.nextElementSibling.nextElementSibling.scrollIntoView({ behavior: scrollBehavior(), block: "end" });
 		}
 	}
 
@@ -842,9 +847,9 @@ function auto_share(key) {
 		const scrollTop = needsScroll(share.closest('.horizontal-list'));
 		if (scrollTop !== 0) {
 			if (share.closest('.horizontal-list.flux_header')) {
-				share.nextElementSibling.nextElementSibling.scrollIntoView({ behavior: "smooth", block: "start" });
+				share.nextElementSibling.nextElementSibling.scrollIntoView({ behavior: scrollBehavior(), block: "start" });
 			} else {
-				share.nextElementSibling.nextElementSibling.scrollIntoView({ behavior: "smooth", block: "end" });
+				share.nextElementSibling.nextElementSibling.scrollIntoView({ behavior: scrollBehavior(), block: "end" });
 			}
 		}
 		// Force the key value if there is only one action, so we can trigger it automatically

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2936,3 +2936,12 @@ html.slider-active {
 .drag-drop-marker {
 	margin: -1px;
 }
+
+/* Honor the OS reduced-motion preference (WCAG 2.3.3). */
+@media (prefers-reduced-motion: reduce) {
+	*, *::before, *::after {
+		transition-duration: 0.01ms !important;
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+	}
+}

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2937,7 +2937,6 @@ html.slider-active {
 	margin: -1px;
 }
 
-/* Honor the OS reduced-motion preference (WCAG 2.3.3). */
 @media (prefers-reduced-motion: reduce) {
 	*, *::before, *::after {
 		transition-duration: 0.01ms !important;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2936,3 +2936,12 @@ html.slider-active {
 .drag-drop-marker {
 	margin: -1px;
 }
+
+/* Honor the OS reduced-motion preference (WCAG 2.3.3). */
+@media (prefers-reduced-motion: reduce) {
+	*, *::before, *::after {
+		transition-duration: 0.01ms !important;
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+	}
+}

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2937,7 +2937,6 @@ html.slider-active {
 	margin: -1px;
 }
 
-/* Honor the OS reduced-motion preference (WCAG 2.3.3). */
 @media (prefers-reduced-motion: reduce) {
 	*, *::before, *::after {
 		transition-duration: 0.01ms !important;


### PR DESCRIPTION
## Summary

Adds handling for the OS-level `prefers-reduced-motion` setting, which FreshRSS currently ignores.

- Base theme (LTR + RTL): a universal `@media (prefers-reduced-motion: reduce)` rule shortens all `transition-duration` and `animation-duration` to 0.01ms. Near-zero rather than zero, so any `transitionend` listeners added later still fire; there are none in `p/scripts/` today.
- `main.js`: the four smooth `scrollIntoView` calls check the preference and pass `behavior: "auto"` when it's set. The CSS rule doesn't reach JS-driven scrolls, and Safari doesn't honor `prefers-reduced-motion` for `scrollIntoView` on its own.

No effect when the preference isn't set.

WCAG 2.3.3 (AAA).

## Test plan

- [x] No-preference: animations behave as before
- [x] Reduce-motion on (Librewolf with RFP off): Nord category dropdowns snap open/closed; animations return when the preference is cleared
- [x] No `transitionend` / `animationend` listeners in `p/scripts/`, so the 0.01ms duration is safe