### PR TITLE
docs: mention db-backup.php and simplify git update steps

### DIFF
--- a/docs/en/admins/04_Updating.md
+++ b/docs/en/admins/04_Updating.md
@@ -25,10 +25,12 @@ Log in as admin, open the Settings menu (top right), choose Administration, then
 
 Use git to update, change branches, or switch to a specific version. From your FreshRSS install directory:
 
+> ⚠️ Make sure your backup is outside the FreshRSS directory before starting.
+
 ```sh
 git fetch --all
 git reset --hard          # discards local changes to tracked files
-git clean -f -d           # removes untracked files; back these up first if you want to keep any
+git clean -f -d           # removes untracked files (custom themes, extensions, local edits)
 git checkout edge         # or `latest` for stable, or a tag like `1.27.1` for a specific version
 git pull --ff-only        # skip for a tag checkout
 ```

--- a/docs/en/admins/04_Updating.md
+++ b/docs/en/admins/04_Updating.md
@@ -23,16 +23,19 @@ Log in as admin, open the Settings menu (top right), choose Administration, then
 
 ## Using git
 
-Use git to update, change branches, or switch to a specific version from the command line.
+Use git to update, change branches, or switch to a specific version. From your FreshRSS install directory:
 
-> ⚠️ Make sure your backup is outside the FreshRSS directory before starting.
+```sh
+git fetch --all
+git reset --hard          # discards local changes to tracked files
+git clean -f -d           # removes untracked files; back these up first if you want to keep any
+git checkout edge         # or `latest` for stable, or a tag like `1.27.1` for a specific version
+git pull --ff-only        # skip for a tag checkout
+```
 
-1. Change to your FreshRSS install directory and fetch updates.
-2. Checkout the branch or tag you wish to use (tags like `1.27.1` pin specific versions).
-3. Perform a hard reset to discard local changes.
-4. Delete files not tracked by git.
-5. Pull the new version.
-6. Re-apply file ownership and permissions.
+Then re-apply file ownership and permissions.
+
+See [Updating on Linux](07_LinuxUpdate.md#using-git) for the same flow with `sudo` and the FreshRSS permissions helper.
 
 ## Using a zip archive
 

--- a/docs/en/admins/05_Backup.md
+++ b/docs/en/admins/05_Backup.md
@@ -5,7 +5,7 @@
 - `./data/` - **required**. You can skip `cache/` and `favicons/`; FreshRSS rebuilds them.
 - `./extensions/` - **recommended** if you use third-party extensions.
 - `./i/themes/` - **optional**, only if you have added custom themes.
-- **External database** (MySQL, MariaDB, or PostgreSQL) - back up separately with `mysqldump`/`pg_dump`. SQLite is covered by `./data/` above. See [Exporting your data](#exporting-your-data) for per-user SQLite export.
+- **External database** (MySQL, MariaDB, PostgreSQL) - back up separately with [`./cli/db-backup.php`](#creating-a-database-backup) (portable SQLite per user) or `mysqldump`/`pg_dump`. SQLite is covered by `./data/` above.
 
 All other folders belong to the source code and are restored by a fresh install or upgrade.
 


### PR DESCRIPTION
Two follow-ups from @Alkarex's review of #8741.

## Backup ([thread](https://github.com/FreshRSS/FreshRSS/pull/8741#discussion_r3172289328))

Add `./cli/db-backup.php` to the "What to back up" list as a database-agnostic alternative to `mysqldump`/`pg_dump`. It was already documented further down the page; the top bullet just didn't point to it.

## Updating ([thread](https://github.com/FreshRSS/FreshRSS/pull/8741#discussion_r3172295060))

Simplify the "Using git" section:

- Replace the 6-step prose list with a command block matching the sequence in [`07_LinuxUpdate.md`](docs/en/admins/07_LinuxUpdate.md#using-git).
- Drop the top-level "move your backup outside the directory" warning. `git reset --hard` doesn't need it; the real hazard is `git clean -f -d` removing untracked files, so the warning sits inline on that line now.
- Link to the Linux page for the `sudo` and permissions-helper variant.