### PR TITLE
docs: standardise English heading style and surface hidden pages

### DIFF
--- a/docs/_includes/docs_nav.html
+++ b/docs/_includes/docs_nav.html
@@ -2,7 +2,7 @@
 	<ul>
 		<li><a href="{{ '/en/' | relative_url }}">Home</a></li>
 		<li>
-			<a href="{{ '/en/users/02_First_steps.html' | relative_url }}">User documentation</a>
+			<a href="{{ '/en/users/02_First_steps.html' | relative_url }}">User manual</a>
 			<ul>
 				{% for page in site.pages %}
 					{% if page.url contains '/en/users/' and page.title != nil and page.url != "/en/users/02_First_steps.html" %}
@@ -12,7 +12,7 @@
 			</ul>
 		</li>
 		<li>
-			<a href="{{ '/en/admins/01_Index.html' | relative_url }}">Administrator documentation</a>
+			<a href="{{ '/en/admins/01_Index.html' | relative_url }}">Administrator manual</a>
 			<ul>
 				{% for page in site.pages %}
 					{% if page.url contains '/en/admins/' and page.url != "/en/admins/01_Index.html" and page.title != nil %}
@@ -22,7 +22,7 @@
 			</ul>
 		</li>
 		<li>
-			<a href="{{ '/en/developers/01_Index.html' | relative_url }}">Developer documentation</a>
+			<a href="{{ '/en/developers/01_Index.html' | relative_url }}">Developer manual</a>
 			<ul>
 				{% for page in site.pages %}
 					{% if page.url contains '/en/developers/' and page.url != "/en/developers/01_Index.html" and page.title != nil %}

--- a/docs/en/admins/01_Index.md
+++ b/docs/en/admins/01_Index.md
@@ -1,4 +1,4 @@
-# FreshRSS Administration
+# Administrator manual
 
 Learn how to install, update, and backup FreshRSS, as well as how to use the command line tools.
 
@@ -16,18 +16,18 @@ Learn how to install, update, and backup FreshRSS, as well as how to use the com
 * [Backing up FreshRSS](05_Backup.md)
 * [Installing and managing extensions](15_extensions.md)
 * [Installing themes](11_Themes.md)
-* [Setting Up Automatic Feed Updating](08_FeedUpdates.md)
+* [Setting up automatic feed updating](08_FeedUpdates.md)
 * [Database configuration](DatabaseConfig.md)
 * [Using the command line interface (CLI)](https://github.com/FreshRSS/FreshRSS/tree/edge/cli)
-* [Configuration without an user interface](17_configs_not_ui.md)
+* [Configuration without a user interface](17_configs_not_ui.md)
 * [Frequently asked questions](04_Frequently_Asked_Questions.md)
 
 ### User access
 
 * [User management](12_User_management.md)
-* [Access Control](09_AccessControl.md)
+* [Access control](09_AccessControl.md)
 * [OpenID Connect](16_OpenID-Connect.md)
-* [Configuring the email address validation](05_Configuring_email_validation.md)
+* [Configuring email address validation](05_Configuring_email_validation.md)
 
 ### Web server configuration
 
@@ -37,6 +37,6 @@ Learn how to install, update, and backup FreshRSS, as well as how to use the com
 ### Special server information
 
 * [Installation on Debian 9/Ubuntu 16.04](06_LinuxInstall.md)
-* [Installation on Cloud Providers](14_CloudProviders.md)
+* [Installation on cloud providers](14_CloudProviders.md)
 * [Updating on Debian 9/Ubuntu 16.04](07_LinuxUpdate.md)
 

--- a/docs/en/admins/02_Prerequisites.md
+++ b/docs/en/admins/02_Prerequisites.md
@@ -1,4 +1,4 @@
-# Server Requirements
+# Server requirements
 
 FreshRSS is a web application. This means you’ll need a web server to run it. FreshRSS requirements are really low, so it should run on most shared host servers, or any old computer you happen to have on hand.
 

--- a/docs/en/admins/03_Installation.md
+++ b/docs/en/admins/03_Installation.md
@@ -1,4 +1,4 @@
-# General Installation Instructions
+# General installation instructions
 
 These instructions are intended as general guidelines for installing FreshRSS. You may wish to consult the [Step-by-step Tutorial for installing FreshRSS on Debian 9/Ubuntu 16.04](06_LinuxInstall.md) if you don’t currently have a web server and don’t have experience setting one up.
 

--- a/docs/en/admins/04_Frequently_Asked_Questions.md
+++ b/docs/en/admins/04_Frequently_Asked_Questions.md
@@ -1,4 +1,4 @@
-# Frequently Asked Questions
+# Frequently asked questions
 
 We may not have answered all of your questions in the previous sections. The FAQ contains some questions that have not been answered elsewhere.
 

--- a/docs/en/admins/05_Configuring_email_validation.md
+++ b/docs/en/admins/05_Configuring_email_validation.md
@@ -1,4 +1,4 @@
-# Configuring the email address validation
+# Configuring email address validation
 
 FreshRSS can verify that users give a valid email address. It is not configured
 by default so you’ll have to follow these few steps to verify email addresses.

--- a/docs/en/admins/08_FeedUpdates.md
+++ b/docs/en/admins/08_FeedUpdates.md
@@ -1,4 +1,4 @@
-# Setting Up Automatic Feed Updating
+# Setting up automatic feed updating
 
 FreshRSS is updated by the `./app/actualize_script.php` script. Knowing this, we can periodically trigger it to ensure up-to-date feeds.
 

--- a/docs/en/admins/09_AccessControl.md
+++ b/docs/en/admins/09_AccessControl.md
@@ -1,4 +1,4 @@
-# Access Control
+# Access control
 
 FreshRSS offers three methods of Access control: Form Authentication using JavaScript, HTTP based Authentication, or an uncontrolled state with no authentication required.
 

--- a/docs/en/admins/10_ServerConfig.md
+++ b/docs/en/admins/10_ServerConfig.md
@@ -1,4 +1,4 @@
-# Apache/Nginx Configuration Files
+# Apache/Nginx configuration files
 
 > ℹ️ For improved security, remove sensitive information in the Web server logs by using our [`sensitive-log.sh` script](https://github.com/FreshRSS/FreshRSS/blob/edge/cli/sensitive-log.sh),
 on the model of our [reference Apache configuration](https://github.com/FreshRSS/FreshRSS/blob/edge/Docker/FreshRSS.Apache.conf) used for our official Docker images

--- a/docs/en/admins/12_User_management.md
+++ b/docs/en/admins/12_User_management.md
@@ -1,4 +1,4 @@
-# User Management
+# User management
 
 ## User list
 

--- a/docs/en/admins/13_Default_user.md
+++ b/docs/en/admins/13_Default_user.md
@@ -1,4 +1,4 @@
-# Default User
+# Default user
 
 Currently, we have one `main user`, also called `default user`, or `admin`. All the others are `regular users`.
 

--- a/docs/en/admins/14_CloudProviders.md
+++ b/docs/en/admins/14_CloudProviders.md
@@ -1,4 +1,4 @@
-# Installation on Cloud Providers
+# Installation on cloud providers
 
 Some hosting platforms provide documentation to install FreshRSS, or even better, an installation wizard to enjoy your very own instance.
 

--- a/docs/en/admins/16_OpenID-Connect-Authentik.md
+++ b/docs/en/admins/16_OpenID-Connect-Authentik.md
@@ -1,4 +1,4 @@
-# Setting up Authentik for FreshRSS
+# Setting up Authentik
 
 **[authentik](https://goauthentik.io/)** is an open-source Identity Provider compatible with OpenID Connect (OIDC) (see [FreshRSS’ OpenID Connect documentation](16_OpenID-Connect.md)).
 

--- a/docs/en/admins/17_configs_not_ui.md
+++ b/docs/en/admins/17_configs_not_ui.md
@@ -1,4 +1,4 @@
-# System Configurations without an User Interface
+# System configurations without a user interface
 
 Most of configurations are available in the user interface.
 

--- a/docs/en/admins/18_Pocket-ID.md
+++ b/docs/en/admins/18_Pocket-ID.md
@@ -1,4 +1,4 @@
-# Setting up Pocket ID for FreshRSS
+# Setting up Pocket ID
 
 **[Pocket ID](https://github.com/stonith404/pocket-id)** is a simple OIDC provider that allows users to authenticate with their passkeys to your services.
 (See [FreshRSS’ OpenID Connect documentation](16_OpenID-Connect.md)).

--- a/docs/en/admins/Caddy.md
+++ b/docs/en/admins/Caddy.md
@@ -1,4 +1,4 @@
-## Using Caddy as a Reverse Proxy
+# Using Caddy as a reverse proxy
 
 How to configure Caddy as a reverse proxy to serve FreshRSS through a subfolder or subdomain
 

--- a/docs/en/admins/logs_and_errors.md
+++ b/docs/en/admins/logs_and_errors.md
@@ -1,4 +1,4 @@
-# Logging and Error Messages
+# Logging and error messages
 
 ## Read the Log
 

--- a/docs/en/contributing.md
+++ b/docs/en/contributing.md
@@ -1,4 +1,4 @@
-# Contributor Guidelines
+# Contributor guidelines
 
 ## Chat with us
 

--- a/docs/en/developers/01_Index.md
+++ b/docs/en/developers/01_Index.md
@@ -1,4 +1,4 @@
-# FreshRSS Development
+# Developer manual
 
 ## First Steps
 
@@ -16,8 +16,8 @@ Start by creating your development environment. A guide to setting up FreshRSSâ€
 
 ## Backend Development
 
-* [Making extensions for FreshRSS](03_Backend/05_Extensions.md)
-* [Database Schema](03_Backend/01_Database_schema.md)
+* [Writing extensions](03_Backend/05_Extensions.md)
+* [Database schema](03_Backend/01_Database_schema.md)
 * [External libraries](03_Backend/03_External_libraries.md)
 
 ## Frontend Development
@@ -27,7 +27,7 @@ Start by creating your development environment. A guide to setting up FreshRSSâ€
 
 ## Namespaces
 
-* [OPML FreshRSS namespace](OPML.md)
+* [OPML namespace](OPML.md)
 
 ## Minz
 

--- a/docs/en/developers/03_Backend/01_Database_schema.md
+++ b/docs/en/developers/03_Backend/01_Database_schema.md
@@ -1,4 +1,4 @@
-# Database Schema
+# Database schema
 
 > **TODO**
 

--- a/docs/en/developers/03_Backend/03_External_libraries.md
+++ b/docs/en/developers/03_Backend/03_External_libraries.md
@@ -1,1 +1,1 @@
-# External Libraries
+# External libraries

--- a/docs/en/developers/03_Backend/05_Extensions.md
+++ b/docs/en/developers/03_Backend/05_Extensions.md
@@ -1,4 +1,4 @@
-# Writing extensions for FreshRSS
+# Writing extensions
 
 ## About FreshRSS
 

--- a/docs/en/developers/06_Fever_API.md
+++ b/docs/en/developers/06_Fever_API.md
@@ -1,4 +1,4 @@
-# FreshRSS - Fever API implementation
+# Fever API implementation
 
 See [Mobile access](../users/06_Mobile_access.md) for general aspects of API access.
 Additionally [page about our Google Reader compatible API](06_GoogleReader_API.md) for another possibility.

--- a/docs/en/developers/06_GoogleReader_API.md
+++ b/docs/en/developers/06_GoogleReader_API.md
@@ -1,4 +1,4 @@
-# FreshRSS - Google Reader compatible API implementation
+# Google Reader compatible API implementation
 
 See [Mobile access](../users/06_Mobile_access.md) for general aspects of API access.
 

--- a/docs/en/developers/Minz/index.md
+++ b/docs/en/developers/Minz/index.md
@@ -1,4 +1,4 @@
-# Minz Framework
+# Minz framework
 
 Minz is the homemade PHP framework used by FreshRSS.
 

--- a/docs/en/developers/OPML.md
+++ b/docs/en/developers/OPML.md
@@ -1,4 +1,4 @@
-# OPML in FreshRSS
+# OPML
 
 FreshRSS supports the [OPML](https://en.wikipedia.org/wiki/OPML) format to export and import lists of RSS/Atom feeds in a standard way, compatible with several other RSS aggregators.
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -30,9 +30,9 @@ FreshRSS has a lot of features including:
 
 This documentation is split into different sections:
 
-* [User documentation](./users/02_First_steps.md), where you can discover all the possibilities offered by FreshRSS
-* [Administrator documentation](./admins/01_Index.md) for detailed installation and maintenance related tasks
-* [Developer documentation](./developers/01_Index.md) to guide you in the source code of FreshRSS and to help you if you want to contribute
+* [User manual](./users/02_First_steps.md), where you can discover all the possibilities offered by FreshRSS
+* [Administrator manual](./admins/01_Index.md) for detailed installation and maintenance related tasks
+* [Developer manual](./developers/01_Index.md) to guide you in the source code of FreshRSS and to help you if you want to contribute
 * [Contributor guidelines](./contributing.md) for those who want to help improve FreshRSS
 
 ## Demo

--- a/docs/en/users/02_First_steps.md
+++ b/docs/en/users/02_First_steps.md
@@ -1,4 +1,4 @@
-# User Documentation
+# User manual
 
 Learning how to handle a new application is not always easy. We’ve tried to make FreshRSS as intuitive as possible, but you might still need a little help to master the program.
 

--- a/docs/en/users/06_Mobile_access.md
+++ b/docs/en/users/06_Mobile_access.md
@@ -1,6 +1,6 @@
 This page assumes you have completed the [server setup](../admins/03_Installation.md).
 
-# Mobile Access
+# Mobile access
 
 You can access FreshRSS on mobile devices via browser and via mobile apps.
 

--- a/docs/en/users/07_Frequently_Asked_Questions.md
+++ b/docs/en/users/07_Frequently_Asked_Questions.md
@@ -1,3 +1,5 @@
+# Frequently asked questions
+
 We may not have answered all of your questions in the previous sections. The FAQ contains some questions that have not been answered elsewhere.
 
 ## What is `/i` at the end of the application URL?

--- a/docs/en/users/08_sharing_services.md
+++ b/docs/en/users/08_sharing_services.md
@@ -1,4 +1,4 @@
-# Sharing Services
+# Sharing services
 
 FreshRSS has the option to share links with a bunch of services.
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Standardise H1 casing across `docs/en/` to sentence case
- Remove the redundant "FreshRSS" prefix/suffix from titles where the docs
  site context already implies it (e.g. `OPML in FreshRSS` -> `OPML`,
  `FreshRSS Administration` -> `Administrator manual`)
- Align the three section index H1s as `Administrator manual` /
  `Developer manual` / `User manual`, matching the existing root H1
  `FreshRSS manual (English)`
- Add missing H1s to `users/07_Frequently_Asked_Questions.md` and
  `admins/Caddy.md` so they appear in the sidebar (the nav template
  filters out pages where `page.title == nil`, which is the case when a
  file has no `#` heading)
- Update sidebar parent labels in `_includes/docs_nav.html` and the
  chapter list in `en/index.md` to use the new `* manual` naming
- Update link text in `admins/01_Index.md` and `developers/01_Index.md`
  that referenced the old H1s
- Bundle two grammar fixes: `an User Interface` -> `a user interface`,
  and drop the awkward `the` in `Configuring the email address validation`