### PR TITLE
fix(i18n): validate language directory names against gen.lang.* keys

### DIFF
--- a/cli/check.translation.php
+++ b/cli/check.translation.php
@@ -43,6 +43,12 @@ if (isset($cliOptions->language)) {
 }
 
 $isValidated = true;
+$languageNameIssues = $i18nData->validateLanguageNames();
+foreach ($languageNameIssues as $issue) {
+	fwrite(STDERR, "Error: {$issue}\n");
+	$isValidated = false;
+}
+
 $result = [];
 $report = [];
 $percentage = [];
@@ -116,6 +122,13 @@ function writeToReadme(string $readmePath, string $markdownTable): void {
 }
 
 if ($cliOptions->generateReadme) {
+	if ($languageNameIssues !== []) {
+		// Refuse to regenerate the README when language directory names and
+		// `gen.lang.*` keys disagree, otherwise we would silently produce a
+		// corrupt translation table (e.g. literal `gen.lang.*` keys instead of
+		// localised language names). Routine incomplete translations are fine.
+		exit(1);
+	}
 	$markdownTable = <<<EOF
 	| __language__ | __translated__ | |
 	| - | - | - |

--- a/cli/i18n/I18nData.php
+++ b/cli/i18n/I18nData.php
@@ -247,6 +247,45 @@ class I18nData {
 	}
 
 	/**
+	 * Verify that the set of available language directories matches the set of
+	 * `gen.lang.<code>` keys in the reference language, case-sensitively.
+	 *
+	 * Catches two classes of mismatch:
+	 * - A language directory whose name has no matching `gen.lang.<code>` key
+	 *   (case-folding on case-insensitive filesystems such as macOS APFS, typo,
+	 *   or a new language added without its display name).
+	 * - A `gen.lang.<code>` key with no matching directory (orphan after a
+	 *   language was removed).
+	 *
+	 * @return list<string> Human-readable mismatches; empty when consistent.
+	 */
+	public function validateLanguageNames(): array {
+		$prefix = 'gen.lang.';
+		$declared = [];
+		foreach (array_keys($this->data[static::REFERENCE_LANGUAGE]['gen.php'] ?? []) as $key) {
+			if (str_starts_with((string)$key, $prefix)) {
+				$declared[] = substr((string)$key, strlen($prefix));
+			}
+		}
+		sort($declared);
+
+		$available = $this->getAvailableLanguages();
+		$issues = [];
+		foreach (array_diff($available, $declared) as $orphanDir) {
+			$issues[] = "Language directory `app/i18n/{$orphanDir}/` has no matching "
+				. "`gen.lang.{$orphanDir}` key in the reference language. Possible causes: "
+				. 'case mismatch (e.g. on macOS APFS), typo, or missing display-name key.';
+		}
+		foreach (array_diff($declared, $available) as $orphanKey) {
+			$issues[] = "Reference key `gen.lang.{$orphanKey}` has no matching "
+				. "`app/i18n/{$orphanKey}/` directory. Possible cause: orphan key after "
+				. 'a language was removed.';
+		}
+
+		return $issues;
+	}
+
+	/**
 	 * Return all available languages without the reference language
 	 * @return list<string>
 	 */

--- a/tests/cli/i18n/I18nDataTest.php
+++ b/tests/cli/i18n/I18nDataTest.php
@@ -869,4 +869,50 @@ final class I18nDataTest extends \PHPUnit\Framework\TestCase {
 		$data = new I18nData($rawData);
 		self::assertSame($this->referenceData['en'], $data->getReferenceLanguage());
 	}
+
+	/** @return array<string,array<string,array<string,I18nValue>>> */
+	private function dataWithLangKeys(string ...$langCodes): array {
+		$genFile = [];
+		foreach ($langCodes as $code) {
+			$genFile['gen.lang.' . $code] = $this->value;
+		}
+		return [
+			'en' => ['gen.php' => $genFile],
+		];
+	}
+
+	public function testValidateLanguageNamesPassesWhenDirsAndKeysMatch(): void {
+		$rawData = $this->dataWithLangKeys('en', 'fr', 'zh-TW');
+		$rawData['fr'] = [];
+		$rawData['zh-TW'] = [];
+		$data = new I18nData($rawData);
+		self::assertSame([], $data->validateLanguageNames());
+	}
+
+	public function testValidateLanguageNamesFlagsCaseMismatch(): void {
+		$rawData = $this->dataWithLangKeys('en', 'zh-TW');
+		$rawData['zh-tw'] = [];
+		$data = new I18nData($rawData);
+		$issues = $data->validateLanguageNames();
+		self::assertCount(2, $issues);
+		self::assertStringContainsString('app/i18n/zh-tw/', $issues[0]);
+		self::assertStringContainsString('gen.lang.zh-TW', $issues[1]);
+	}
+
+	public function testValidateLanguageNamesFlagsOrphanDirectory(): void {
+		$rawData = $this->dataWithLangKeys('en');
+		$rawData['fr'] = [];
+		$data = new I18nData($rawData);
+		$issues = $data->validateLanguageNames();
+		self::assertCount(1, $issues);
+		self::assertStringContainsString('app/i18n/fr/', $issues[0]);
+	}
+
+	public function testValidateLanguageNamesFlagsOrphanKey(): void {
+		$rawData = $this->dataWithLangKeys('en', 'fr');
+		$data = new I18nData($rawData);
+		$issues = $data->validateLanguageNames();
+		self::assertCount(1, $issues);
+		self::assertStringContainsString('gen.lang.fr', $issues[0]);
+	}
 }


### PR DESCRIPTION
Changes:

- Add `I18nData::validateLanguageNames()` that checks `app/i18n/<lang>/` directories against `gen.lang.<lang>` keys in the reference language, both ways, and returns the mismatches
- Wire the check into `cli/check.translation.php`: print issues to STDERR and refuse to regenerate the README when there are any. Routine incomplete-translation behaviour is unchanged
- Add four PHPUnit tests in `tests/cli/i18n/I18nDataTest.php` covering clean state, case mismatch, orphan directory, and orphan key

Catches a silent corruption most easily triggered on macOS APFS: git tracks `zh-TW`, the local FS reads back `zh-tw`, the `_t('gen.lang.zh-tw')` lookup misses, and the README ends up with `gen.lang.zh-tw (zh-tw)` instead of `正體中文 (zh-TW)`. The same check also flags missing display-name keys for new languages and orphan keys after a language is removed.