### PR TITLE
feat(admin): visually dim disabled users in user management table

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -311,6 +311,7 @@ People are sorted by name so please keep this order.
 * [Twilek-de](https://github.com/Twilek-de): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Twilek-de)
 * [Uncovery](https://github.com/uncovery): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:uncovery)
 * [upskaling](https://github.com/upskaling): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:upskaling)
+* [Umaid Shahid](https://github.com/umaidshahid): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:umaidshahid), [Web](https://umaid.dev)
 * [UserRoot-Luca](https://github.com/UserRoot-Luca): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:UserRoot-Luca)
 * [Virgil Chen](https://github.com/VirgilChen97): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:VirgilChen97)
 * [VYSE V.E.O](https://github.com/V-E-O): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:V-E-O)

--- a/app/views/user/manage.phtml
+++ b/app/views/user/manage.phtml
@@ -105,7 +105,7 @@
 			</thead>
 			<tbody>
 				<?php foreach ($this->users as $username => $values): ?>
-					<tr <?= $values['is_default'] ? 'class="default-user"' : '' ?>
+					<tr <?= $values['is_default'] ? 'class="default-user"' : (!$values['enabled'] ? 'class="disabled-user"' : '') ?>
 						<?= is_numeric($values['feed_count']) ? '' : 'data-need-ajax="1"' ?>>
 						<td><a href="<?= _url('user', 'details', 'username', $username) ?>" class="configure open-slider" ><?= _i('configure') ?></a></td>
 						<td class="username"><?= $username ?></td>

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2408,6 +2408,10 @@ html.slider-active {
 	font-style: italic;
 }
 
+.disabled-user {
+	opacity: 0.5;
+}
+
 /*=== READER */
 /*===========*/
 .reader .aside {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2408,6 +2408,10 @@ html.slider-active {
 	font-style: italic;
 }
 
+.disabled-user {
+	opacity: 0.5;
+}
+
 /*=== READER */
 /*===========*/
 .reader .aside {


### PR DESCRIPTION
Closes #8765 

Changes proposed in this pull request:

- Add disabled-user CSS class to user rows in the management table when the account is disabled
- Add .disabled-user { opacity: 0.5; } style to base theme to visually dim disabled accounts
- Add entry to CREDITS.md

How to test the feature manually:

1. Go to Administration → User Management
2. Have at least one disabled user account in the list
3. Verify that disabled user rows appear dimmed (50% opacity) compared to active users, without any change in functionality

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
