### PR TITLE
fix(js): stop sidebar auto-reopening on page navigation

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -970,7 +970,7 @@ function init_nav_menu() {
 		const active = toggle_aside.classList.contains('active');
 		if (state != active) toggle_aside_click(false);
 	}
-	if (getComputedStyle(aside).display !== 'none') {
+	if (toggle_aside.classList.contains('active')) {
 		if (context.current_view === 'normal') aside.classList.add('visible');
 		sync(media);
 	}


### PR DESCRIPTION
## Summary

Fixes #8771. My earlier #8747 broke this: at narrow viewports the sidebar re-opens by itself when navigating (e.g. clicking the logo) on sessions where it was previously closed.

That PR removed an inline `aside.style.display = 'none'` from the sidebar close path. A check further down in `init_nav_menu()` was implicitly relying on it to detect "sidebar is currently hidden":

```js
if (getComputedStyle(aside).display !== 'none') { ... aside.classList.add('visible') ... }
```

At narrow viewports `aside`'s computed display stays `table-cell` after a close (the narrow `@media` hides via `width: 0`, not `display`), so the check now always passes and re-adds `.visible`.

## Fix

Gate on `toggle_aside.classList.contains('active')` instead, the actual source of truth for whether the sidebar should be open.