### PR TITLE
fix(layout): reserve logo image box via intrinsic dimensions

### DIFF
--- a/app/layout/header.phtml
+++ b/app/layout/header.phtml
@@ -6,7 +6,7 @@
 	<div class="item title">
 		<a href="<?= Minz_Url::display(['c' => 'index', 'a' => 'index'], 'html', 'root') ?>">
 			<?php if (FreshRSS_Context::systemConf()->logo_html == '') { ?>
-				<img class="logo" src="<?= _i('FreshRSS-logo', FreshRSS_Themes::ICON_URL) ?>" alt="FreshRSS" loading="lazy" />
+				<img class="logo" src="<?= _i('FreshRSS-logo', FreshRSS_Themes::ICON_URL) ?>" alt="FreshRSS" width="1280" height="256" loading="lazy" />
 			<?php
 				} else {
 					echo FreshRSS_Context::systemConf()->logo_html;

--- a/app/layout/header.phtml
+++ b/app/layout/header.phtml
@@ -6,7 +6,7 @@
 	<div class="item title">
 		<a href="<?= Minz_Url::display(['c' => 'index', 'a' => 'index'], 'html', 'root') ?>">
 			<?php if (FreshRSS_Context::systemConf()->logo_html == '') { ?>
-				<img class="logo" src="<?= _i('FreshRSS-logo', FreshRSS_Themes::ICON_URL) ?>" alt="FreshRSS" width="1280" height="256" loading="lazy" />
+				<img class="logo" src="<?= _i('FreshRSS-logo', FreshRSS_Themes::ICON_URL) ?>" alt="FreshRSS" width="160" height="32" loading="lazy" />
 			<?php
 				} else {
 					echo FreshRSS_Context::systemConf()->logo_html;

--- a/app/layout/simple.phtml
+++ b/app/layout/simple.phtml
@@ -49,7 +49,7 @@
 		<div class="item title">
 			<a href="<?= Minz_Url::display(['c' => 'index', 'a' => 'index'], 'html', 'root') ?>">
 				<?php if (FreshRSS_Context::systemConf()->logo_html == '') { ?>
-					<img class="logo" src="<?= _i('FreshRSS-logo', FreshRSS_Themes::ICON_URL) ?>" alt="FreshRSS" width="1280" height="256" loading="lazy" />
+					<img class="logo" src="<?= _i('FreshRSS-logo', FreshRSS_Themes::ICON_URL) ?>" alt="FreshRSS" width="160" height="32" loading="lazy" />
 				<?php
 					} else {
 						echo FreshRSS_Context::systemConf()->logo_html;

--- a/app/layout/simple.phtml
+++ b/app/layout/simple.phtml
@@ -49,7 +49,7 @@
 		<div class="item title">
 			<a href="<?= Minz_Url::display(['c' => 'index', 'a' => 'index'], 'html', 'root') ?>">
 				<?php if (FreshRSS_Context::systemConf()->logo_html == '') { ?>
-					<img class="logo" src="<?= _i('FreshRSS-logo', FreshRSS_Themes::ICON_URL) ?>" alt="FreshRSS" loading="lazy" />
+					<img class="logo" src="<?= _i('FreshRSS-logo', FreshRSS_Themes::ICON_URL) ?>" alt="FreshRSS" width="1280" height="256" loading="lazy" />
 				<?php
 					} else {
 						echo FreshRSS_Context::systemConf()->logo_html;


### PR DESCRIPTION
## Summary

Found while investigating #8771: spam-clicking the FreshRSS logo would briefly flash a giant logo on screen between navigations. Couldn't reproduce it deterministically afterwards, but the underlying cause is real and well-known: the default `<img class="logo">` has no intrinsic `width`/`height`, so the browser has nothing to allocate a correctly-proportioned box from until either the CSS applies or the image is decoded. On a fast back-to-back navigation a cached image can paint at native size for a frame.

## Fix

Add the SVG's intrinsic dimensions (`1280 × 256`) as `width` and `height` attributes on the default logo `<img>` in `header.phtml` and `simple.phtml`. CSS still controls rendered height (2rem wide, 24px narrow); width auto-derives from the intrinsic ratio. Custom `logo_html` is untouched.

This is documented best practice for `<img>` to prevent [Cumulative Layout Shift](https://web.dev/articles/optimize-cls#images_without_dimensions) regardless of whether the flash is currently observable.