### PR TITLE
refactor: drive sidebar visibility from :root class

### DIFF
--- a/app/layout/layout.phtml
+++ b/app/layout/layout.phtml
@@ -34,6 +34,7 @@
 		<script id="jsonVars" type="application/json">
 <?php $this->renderHelper('javascript_vars'); ?>
 		</script>
+		<script src="<?= Minz_Url::display('/scripts/aside_init.js?' . @filemtime(PUBLIC_PATH . '/scripts/aside_init.js')) ?>"></script>
 		<?= FreshRSS_View::headScript() ?>
 		<link rel="manifest" href="<?= Minz_Url::display('/themes/manifest.json') ?>" />
 		<link rel="icon" id="favicon" type="image/svg+xml" href="<?= Minz_Url::display('/themes/icons/favicon.svg') ?>" />

--- a/app/layout/nav_menu.phtml
+++ b/app/layout/nav_menu.phtml
@@ -5,7 +5,7 @@
 <nav class="nav_menu">
 	<?php if ($actual_view === 'normal' || $actual_view === 'reader') { ?>
 		<div id="nav_menu_toggle_aside" class="group">
-			<button class="btn<?= $actual_view === 'normal' ? ' active' : '' ?>" title="<?= _t('conf.shortcut.toggle_aside') ?>">
+			<button class="btn" title="<?= _t('conf.shortcut.toggle_aside') ?>">
 				<?= _i('category') ?>
 			</button>
 		</div>

--- a/p/scripts/aside_init.js
+++ b/p/scripts/aside_init.js
@@ -11,11 +11,14 @@
 	const stored = isToggleable
 		? sessionStorage.getItem('FreshRSS_aside-toggled_' + view)
 		: null;
+	// Narrow and reader force-hide regardless of stored choice: at narrow widths
+	// the sidebar is an overlay that blocks content, so a wide-view "open" must
+	// not leak into narrow.
 	let hidden;
-	if (stored === '1') hidden = false;
-	else if (stored === '0') hidden = true;
-	else if (view === 'reader') hidden = true;
+	if (view === 'reader') hidden = true;
 	else if (window.matchMedia('(max-width: 840px)').matches) hidden = true;
+	else if (stored === '1') hidden = false;
+	else if (stored === '0') hidden = true;
 	else if (isToggleable) hidden = !!ctx.sidebar_hidden_by_default;
 	else hidden = false;
 	if (hidden) document.documentElement.classList.add('aside_hidden');

--- a/p/scripts/aside_init.js
+++ b/p/scripts/aside_init.js
@@ -1,0 +1,22 @@
+'use strict';
+
+// Resolve sidebar visibility before <body> paints so the drawer doesn't flash open/closed.
+// Source of truth is `:root.aside_hidden`; main.js keeps it in sync at runtime.
+(function () {
+	const jsonEl = document.getElementById('jsonVars');
+	if (!jsonEl) return;
+	const ctx = JSON.parse(jsonEl.textContent).context;
+	const view = ctx.current_view;
+	const isToggleable = view === 'normal' || view === 'reader';
+	const stored = isToggleable
+		? sessionStorage.getItem('FreshRSS_aside-toggled_' + view)
+		: null;
+	let hidden;
+	if (stored === '1') hidden = false;
+	else if (stored === '0') hidden = true;
+	else if (view === 'reader') hidden = true;
+	else if (window.matchMedia('(max-width: 840px)').matches) hidden = true;
+	else if (isToggleable) hidden = !!ctx.sidebar_hidden_by_default;
+	else hidden = false;
+	if (hidden) document.documentElement.classList.add('aside_hidden');
+})();

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -924,67 +924,42 @@ function init_posts() {
 	}
 }
 
-function toggle_aside_click(manual = true) {
-	const aside = document.querySelector('.aside');
-	const toggle_aside = document.querySelector('#nav_menu_toggle_aside button');
-	if (!toggle_aside) {
-		return;
-	}
-
-	const active = toggle_aside.classList.contains('active');
-	const isNarrow = window.matchMedia('(max-width: 840px)').matches;
-	if (active) {
-		toggle_aside.classList.remove('active');
-		aside.classList.remove('visible');
-		aside.classList.toggle('is-hidden', !isNarrow);
-	} else {
-		toggle_aside.classList.add('active');
-		aside.classList.add('visible');
-		aside.classList.remove('is-hidden');
-	}
-
+function setAsideHidden(hidden, manual = true) {
+	document.documentElement.classList.toggle('aside_hidden', hidden);
 	if (manual && ['normal', 'reader'].includes(context.current_view)) {
-		sessionStorage.setItem(`FreshRSS_aside-toggled_${context.current_view}`, !active ? 1 : 0);
+		sessionStorage.setItem(`FreshRSS_aside-toggled_${context.current_view}`, hidden ? 0 : 1);
 	}
 }
 
+function toggle_aside_click(manual = true) {
+	setAsideHidden(!document.documentElement.classList.contains('aside_hidden'), manual);
+}
+
 function init_nav_menu() {
-	const aside = document.querySelector('.aside');
 	const toggle_aside = document.querySelector('#nav_menu_toggle_aside button');
 	if (!toggle_aside) {
 		return;
 	}
 
-	function sync(e) {
-		const active = toggle_aside.classList.contains('active');
-		if ((e.matches && active) || (!e.matches && !active)) {
-			toggle_aside_click(false);
-		}
-	}
-
+	// Re-evaluate the viewport-dependent fallback when the user has not made a session choice
 	const media = window.matchMedia('(max-width: 840px)');
-	media.onchange = sync;
+	media.onchange = () => {
+		const state = sessionStorage.getItem(`FreshRSS_aside-toggled_${context.current_view}`);
+		if (state !== null) return;
+		let shouldHide;
+		if (context.current_view === 'reader') shouldHide = true;
+		else if (media.matches) shouldHide = true;
+		else shouldHide = !!context.sidebar_hidden_by_default;
+		setAsideHidden(shouldHide, false);
+	};
 
-	const state = sessionStorage.getItem(`FreshRSS_aside-toggled_${context.current_view}`);
-	if (state !== null) {
-		const active = toggle_aside.classList.contains('active');
-		if (state != active) toggle_aside_click(false);
-	}
-	if (toggle_aside.classList.contains('active')) {
-		if (context.current_view === 'normal') aside.classList.add('visible');
-		sync(media);
-	}
-	if (state === null && context.sidebar_hidden_by_default && ['normal', 'reader'].includes(context.current_view)) {
-		const active = toggle_aside.classList.contains('active');
-		if (active) toggle_aside_click(false);
-	}
 	const close_aside = [
 		document.querySelector('.aside a.toggle_aside'),
 		document.querySelector('a.close-aside'), // background of aside (#close)
 	];
 
 	toggle_aside.addEventListener('click', toggle_aside_click);
-	close_aside.forEach(close => close.addEventListener('click', toggle_aside_click));
+	close_aside.forEach(close => close && close.addEventListener('click', toggle_aside_click));
 }
 
 function rememberOpenCategory(category_id, isOpen) {

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -941,14 +941,19 @@ function init_nav_menu() {
 		return;
 	}
 
-	// Re-evaluate the viewport-dependent fallback when the user has not made a session choice
 	const media = window.matchMedia('(max-width: 840px)');
-	media.onchange = () => {
+	media.onchange = (e) => {
+		if (e.matches) {
+			// Narrow: sidebar overlays content. Hide it without persisting,
+			// so the wide-view preference is preserved for the round trip.
+			setAsideHidden(true, false);
+			return;
+		}
 		const state = sessionStorage.getItem(`FreshRSS_aside-toggled_${context.current_view}`);
-		if (state !== null) return;
 		let shouldHide;
-		if (context.current_view === 'reader') shouldHide = true;
-		else if (media.matches) shouldHide = true;
+		if (state === '1') shouldHide = false;
+		else if (state === '0') shouldHide = true;
+		else if (context.current_view === 'reader') shouldHide = true;
 		else shouldHide = !!context.sidebar_hidden_by_default;
 		setAsideHidden(shouldHide, false);
 	};

--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -231,7 +231,8 @@ th {
 
 .btn.active,
 .btn:active,
-.dropdown-target:target ~ .btn.dropdown-toggle {
+.dropdown-target:target ~ .btn.dropdown-toggle,
+:root:not(.aside_hidden) #nav_menu_toggle_aside .btn {
 	background: var(--background-color-light);
 }
 
@@ -1139,7 +1140,7 @@ kbd {
 		filter: brightness(2);
 	}
 
-	.aside.visible + .close-aside, .configure .dropdown-target:target ~ .dropdown-close {
+	:root:not(.aside_hidden) .aside + .close-aside, .configure .dropdown-target:target ~ .dropdown-close {
 		background-color: var(--background-color-slider-shadow);
 	}
 

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -231,7 +231,8 @@ th {
 
 .btn.active,
 .btn:active,
-.dropdown-target:target ~ .btn.dropdown-toggle {
+.dropdown-target:target ~ .btn.dropdown-toggle,
+:root:not(.aside_hidden) #nav_menu_toggle_aside .btn {
 	background: var(--background-color-light);
 }
 
@@ -1139,7 +1140,7 @@ kbd {
 		filter: brightness(2);
 	}
 
-	.aside.visible + .close-aside, .configure .dropdown-target:target ~ .dropdown-close {
+	:root:not(.aside_hidden) .aside + .close-aside, .configure .dropdown-target:target ~ .dropdown-close {
 		background-color: var(--background-color-slider-shadow);
 	}
 

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -217,13 +217,15 @@ button.as-link[disabled] {
 
 .btn.active,
 .btn:active,
-.dropdown-target:target ~ .btn.dropdown-toggle {
+.dropdown-target:target ~ .btn.dropdown-toggle,
+:root:not(.aside_hidden) #nav_menu_toggle_aside .btn {
 	background-color: var(--dark-background-color3);
 	box-shadow: none;
 }
 
 .btn.active .icon,
-.dropdown-target:target ~ .btn.dropdown-toggle .icon {
+.dropdown-target:target ~ .btn.dropdown-toggle .icon,
+:root:not(.aside_hidden) #nav_menu_toggle_aside .btn .icon {
 	filter: brightness(1);
 }
 

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -217,13 +217,15 @@ button.as-link[disabled] {
 
 .btn.active,
 .btn:active,
-.dropdown-target:target ~ .btn.dropdown-toggle {
+.dropdown-target:target ~ .btn.dropdown-toggle,
+:root:not(.aside_hidden) #nav_menu_toggle_aside .btn {
 	background-color: var(--dark-background-color3);
 	box-shadow: none;
 }
 
 .btn.active .icon,
-.dropdown-target:target ~ .btn.dropdown-toggle .icon {
+.dropdown-target:target ~ .btn.dropdown-toggle .icon,
+:root:not(.aside_hidden) #nav_menu_toggle_aside .btn .icon {
 	filter: brightness(1);
 }
 

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -194,7 +194,8 @@ th {
 .btn.active,
 .btn:active,
 .btn:hover,
-.dropdown-target:target ~ .btn.dropdown-toggle {
+.dropdown-target:target ~ .btn.dropdown-toggle,
+:root:not(.aside_hidden) #nav_menu_toggle_aside .btn {
 	background: #2980b9;
 }
 

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -194,7 +194,8 @@ th {
 .btn.active,
 .btn:active,
 .btn:hover,
-.dropdown-target:target ~ .btn.dropdown-toggle {
+.dropdown-target:target ~ .btn.dropdown-toggle,
+:root:not(.aside_hidden) #nav_menu_toggle_aside .btn {
 	background: #2980b9;
 }
 

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -214,7 +214,8 @@ table th, table td {
 	line-height: 25px;
 }
 
-.btn.active {
+.btn.active,
+:root:not(.aside_hidden) #nav_menu_toggle_aside .btn {
 	background-color: var(--main-background);
 	border: 1px solid var(--accent);
 }
@@ -1229,7 +1230,7 @@ optgroup::before {
 /*===========*/
 
 @media (max-width: 840px) {
-	.aside.visible + .close-aside,
+	:root:not(.aside_hidden) .aside + .close-aside,
 	.configure .dropdown-target:target ~ .dropdown-close {
 		backdrop-filter: grayscale(60%) blur(1px);
 	}

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -214,7 +214,8 @@ table th, table td {
 	line-height: 25px;
 }
 
-.btn.active {
+.btn.active,
+:root:not(.aside_hidden) #nav_menu_toggle_aside .btn {
 	background-color: var(--main-background);
 	border: 1px solid var(--accent);
 }
@@ -1229,7 +1230,7 @@ optgroup::before {
 /*===========*/
 
 @media (max-width: 840px) {
-	.aside.visible + .close-aside,
+	:root:not(.aside_hidden) .aside + .close-aside,
 	.configure .dropdown-target:target ~ .dropdown-close {
 		backdrop-filter: grayscale(60%) blur(1px);
 	}

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -310,7 +310,8 @@ button:hover .icon,
 
 .btn.active,
 .btn:active,
-.dropdown-target:target ~ .btn.dropdown-toggle {
+.dropdown-target:target ~ .btn.dropdown-toggle,
+:root:not(.aside_hidden) #nav_menu_toggle_aside .btn {
 	background-color: var(--background-color-grey);
 	box-shadow: 0px 2px 4px var(--box-shadow-color-inset) inset, 0px 1px 2px var(--background-color-grey);
 }
@@ -319,12 +320,14 @@ button:hover .icon,
 	filter: brightness(1.1);
 }
 
-.btn.active, .btn:active {
+.btn.active, .btn:active,
+:root:not(.aside_hidden) #nav_menu_toggle_aside .btn {
 	filter: brightness(0.95);
 }
 
 .btn.active .icon,
-.btn:active .icon {
+.btn:active .icon,
+:root:not(.aside_hidden) #nav_menu_toggle_aside .btn .icon {
 	filter: brightness(1.1);
 }
 
@@ -1163,7 +1166,7 @@ button:hover .icon,
 		padding-bottom: 0;
 	}
 
-	.aside.visible {
+	.aside {
 		box-shadow: 3px 0 3px var(--text-shadow-color);
 	}
 
@@ -1334,7 +1337,8 @@ button:hover .icon,
 
 	:root.darkMode_auto .nav_menu .btn.active,
 	:root.darkMode_auto .nav_menu .btn:active,
-	:root.darkMode_auto .nav_menu .dropdown-target:target ~ .btn.dropdown-toggle {
+	:root.darkMode_auto .nav_menu .dropdown-target:target ~ .btn.dropdown-toggle,
+	:root.darkMode_auto:not(.aside_hidden) #nav_menu_toggle_aside .btn {
 		background: #292929;
 	}
 
@@ -1351,7 +1355,8 @@ button:hover .icon,
 	}
 
 	:root.darkMode_auto .btn.active .icon,
-	:root.darkMode_auto .btn:active .icon {
+	:root.darkMode_auto .btn:active .icon,
+	:root.darkMode_auto:not(.aside_hidden) #nav_menu_toggle_aside .btn .icon {
 		filter: brightness(1.4);
 	}
 

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -310,7 +310,8 @@ button:hover .icon,
 
 .btn.active,
 .btn:active,
-.dropdown-target:target ~ .btn.dropdown-toggle {
+.dropdown-target:target ~ .btn.dropdown-toggle,
+:root:not(.aside_hidden) #nav_menu_toggle_aside .btn {
 	background-color: var(--background-color-grey);
 	box-shadow: 0px 2px 4px var(--box-shadow-color-inset) inset, 0px 1px 2px var(--background-color-grey);
 }
@@ -319,12 +320,14 @@ button:hover .icon,
 	filter: brightness(1.1);
 }
 
-.btn.active, .btn:active {
+.btn.active, .btn:active,
+:root:not(.aside_hidden) #nav_menu_toggle_aside .btn {
 	filter: brightness(0.95);
 }
 
 .btn.active .icon,
-.btn:active .icon {
+.btn:active .icon,
+:root:not(.aside_hidden) #nav_menu_toggle_aside .btn .icon {
 	filter: brightness(1.1);
 }
 
@@ -1163,7 +1166,7 @@ button:hover .icon,
 		padding-bottom: 0;
 	}
 
-	.aside.visible {
+	.aside {
 		box-shadow: -3px 0 3px var(--text-shadow-color);
 	}
 
@@ -1334,7 +1337,8 @@ button:hover .icon,
 
 	:root.darkMode_auto .nav_menu .btn.active,
 	:root.darkMode_auto .nav_menu .btn:active,
-	:root.darkMode_auto .nav_menu .dropdown-target:target ~ .btn.dropdown-toggle {
+	:root.darkMode_auto .nav_menu .dropdown-target:target ~ .btn.dropdown-toggle,
+	:root.darkMode_auto:not(.aside_hidden) #nav_menu_toggle_aside .btn {
 		background: #292929;
 	}
 
@@ -1351,7 +1355,8 @@ button:hover .icon,
 	}
 
 	:root.darkMode_auto .btn.active .icon,
-	:root.darkMode_auto .btn:active .icon {
+	:root.darkMode_auto .btn:active .icon,
+	:root.darkMode_auto:not(.aside_hidden) #nav_menu_toggle_aside .btn .icon {
 		filter: brightness(1.4);
 	}
 

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -254,7 +254,8 @@ th {
 
 .btn.active,
 .btn:active,
-.dropdown-target:target ~ .btn.dropdown-toggle {
+.dropdown-target:target ~ .btn.dropdown-toggle,
+:root:not(.aside_hidden) #nav_menu_toggle_aside .btn {
 	background-color: var(--background-color-grey-button-active);
 }
 

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -254,7 +254,8 @@ th {
 
 .btn.active,
 .btn:active,
-.dropdown-target:target ~ .btn.dropdown-toggle {
+.dropdown-target:target ~ .btn.dropdown-toggle,
+:root:not(.aside_hidden) #nav_menu_toggle_aside .btn {
 	background-color: var(--background-color-grey-button-active);
 }
 

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -878,7 +878,7 @@ main.post .drop-section li.item.feed a:hover .icon {
 	margin-bottom: 1rem;
 }
 
-.aside.visible .toggle_aside {
+:root:not(.aside_hidden) .aside .toggle_aside {
 	border-bottom: 1px solid var(--frss-border-color);
 }
 
@@ -1240,7 +1240,7 @@ body.reader {
 		text-align: center;
 	}
 
-	.aside.visible {
+	:root:not(.aside_hidden) .aside {
 		padding-top: 0;
 	}
 }
@@ -1426,9 +1426,8 @@ main.global {
 			margin-right: auto;
 		}
 
-		&:target {
-			width: 78% !important;
-			z-index: 1000;
+		:root:not(.aside_hidden) & {
+			width: min(var(--width-aside), calc(100vw - 56px));
 		}
 	}
 
@@ -1717,6 +1716,6 @@ button.as-link {
 	}
 }
 
-body:has(.aside:not(.visible)) .header .item.title {
+:root.aside_hidden .header .item.title {
 	display: none;
 }

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -878,7 +878,7 @@ main.post .drop-section li.item.feed a:hover .icon {
 	margin-bottom: 1rem;
 }
 
-.aside.visible .toggle_aside {
+:root:not(.aside_hidden) .aside .toggle_aside {
 	border-bottom: 1px solid var(--frss-border-color);
 }
 
@@ -1240,7 +1240,7 @@ body.reader {
 		text-align: center;
 	}
 
-	.aside.visible {
+	:root:not(.aside_hidden) .aside {
 		padding-top: 0;
 	}
 }
@@ -1426,9 +1426,8 @@ main.global {
 			margin-left: auto;
 		}
 
-		&:target {
-			width: 78% !important;
-			z-index: 1000;
+		:root:not(.aside_hidden) & {
+			width: min(var(--width-aside), calc(100vw - 56px));
 		}
 	}
 
@@ -1717,6 +1716,6 @@ button.as-link {
 	}
 }
 
-body:has(.aside:not(.visible)) .header .item.title {
+:root.aside_hidden .header .item.title {
 	display: none;
 }

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1334,7 +1334,7 @@ input[type="search"] {
 	vertical-align: top;
 }
 
-.aside.is-hidden {
+:root.aside_hidden .aside {
 	display: none;
 }
 
@@ -1942,7 +1942,7 @@ a.website:hover .favicon {
 	z-index: 50;
 }
 
-.aside:not(.visible) ~ #nav_entries {
+:root.aside_hidden .aside ~ #nav_entries {
 	display: none;
 }
 
@@ -2418,7 +2418,7 @@ html.slider-active {
 	display: none;
 }
 
-.reader .aside.visible {
+:root:not(.aside_hidden) .reader .aside {
 	display: table-cell;
 	width: var(--width-aside);
 }
@@ -2505,11 +2505,11 @@ html.slider-active {
 		display: none;
 	}
 
-	/* Material navigation drawer: theme width, capped at viewport minus 56px touch-peek */
-	.aside.visible {
-		width: min(var(--width-aside), calc(100vw - 56px));
-		height: 100vh;
-		box-shadow: 3px 3px 5px var(--frss-box-shadow-color-transparent);
+	/* Narrow drawer collapse: keep display so the width transition runs */
+	:root.aside_hidden .aside {
+		display: block;
+		width: 0;
+		box-shadow: none;
 	}
 
 	.aside .toggle_aside,
@@ -2755,7 +2755,7 @@ html.slider-active {
 		}
 	}
 
-	.aside.visible + .close-aside,
+	:root:not(.aside_hidden) .aside + .close-aside,
 	.configure .dropdown-target:target ~ .dropdown-close {
 		background-color: var(--frss-modal-background-color-transparent);
 		display: block;
@@ -2777,11 +2777,14 @@ html.slider-active {
 		display: initial;
 	}
 
+	/* Material navigation drawer: theme width, capped at viewport minus 56px touch-peek */
 	.aside {
 		position: fixed;
 		top: 0; bottom: 0;
 		left: -1px;
-		width: 0;
+		width: min(var(--width-aside), calc(100vw - 56px));
+		height: 100vh;
+		box-shadow: 3px 3px 5px var(--frss-box-shadow-color-transparent);
 		overflow: hidden;
 		z-index: 100;
 		transition: width 200ms linear;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1334,7 +1334,7 @@ input[type="search"] {
 	vertical-align: top;
 }
 
-.aside.is-hidden {
+:root.aside_hidden .aside {
 	display: none;
 }
 
@@ -1942,7 +1942,7 @@ a.website:hover .favicon {
 	z-index: 50;
 }
 
-.aside:not(.visible) ~ #nav_entries {
+:root.aside_hidden .aside ~ #nav_entries {
 	display: none;
 }
 
@@ -2418,7 +2418,7 @@ html.slider-active {
 	display: none;
 }
 
-.reader .aside.visible {
+:root:not(.aside_hidden) .reader .aside {
 	display: table-cell;
 	width: var(--width-aside);
 }
@@ -2505,11 +2505,11 @@ html.slider-active {
 		display: none;
 	}
 
-	/* Material navigation drawer: theme width, capped at viewport minus 56px touch-peek */
-	.aside.visible {
-		width: min(var(--width-aside), calc(100vw - 56px));
-		height: 100vh;
-		box-shadow: -3px 3px 5px var(--frss-box-shadow-color-transparent);
+	/* Narrow drawer collapse: keep display so the width transition runs */
+	:root.aside_hidden .aside {
+		display: block;
+		width: 0;
+		box-shadow: none;
 	}
 
 	.aside .toggle_aside,
@@ -2755,7 +2755,7 @@ html.slider-active {
 		}
 	}
 
-	.aside.visible + .close-aside,
+	:root:not(.aside_hidden) .aside + .close-aside,
 	.configure .dropdown-target:target ~ .dropdown-close {
 		background-color: var(--frss-modal-background-color-transparent);
 		display: block;
@@ -2777,11 +2777,14 @@ html.slider-active {
 		display: initial;
 	}
 
+	/* Material navigation drawer: theme width, capped at viewport minus 56px touch-peek */
 	.aside {
 		position: fixed;
 		top: 0; bottom: 0;
 		right: -1px;
-		width: 0;
+		width: min(var(--width-aside), calc(100vw - 56px));
+		height: 100vh;
+		box-shadow: -3px 3px 5px var(--frss-box-shadow-color-transparent);
 		overflow: hidden;
 		z-index: 100;
 		transition: width 200ms linear;


### PR DESCRIPTION
The sidebar and its toggle button flash briefly on every page navigation. This PR decides their visibility state in `<head>`, before the browser paints anything, so there's nothing to flash. Also consolidates the state model onto one CSS class instead of three, removing the bug class that caused #8771. Mirrors the existing `:root.darkMode_*` convention. Supersedes the gate fix in #8773.

## What's wrong today

**The flash.** The server can't know your per-tab sidebar state, that's in `sessionStorage`, browser-only. So PHP renders a default, JS corrects it after first paint, and you see the gap, both for the sidebar drawer and for the toggle button's active styling.

**State sprawl.** Sidebar visibility was tracked across three runtime classes (`.aside.is-hidden`, `.aside.visible`, `.btn.active`) that JS had to keep in sync. #8771 happened because removing one piece broke another that implicitly relied on it.

## Approach

Single source of truth: a `:root.aside_hidden` class on `<html>`. Present means hidden, absent means visible. CSS reads it for both the sidebar drawer and the toggle button. JS toggles it.

`p/scripts/aside_init.js` runs synchronously in `<head>`, before the browser paints `<body>`. Resolution order:

1. sessionStorage state from this tab
2. otherwise hidden in reader view
3. otherwise hidden at narrow viewport (mobile drawer pattern)
4. otherwise the user's `sidebar_hidden_by_default` setting

The narrow-viewport default applies on all views; sessionStorage and user-preference steps are gated to views with the toggle button (normal, reader).

## Why a new script file

The init can't live in `main.js`: that script is `defer async`, runs after first paint, too late. Loading `main.js` synchronously would block parsing for ~50KB. Inlining would be smallest but CSP `'self'` blocks inline scripts. A small external file (~500 bytes, cacheable) is the cheapest option that satisfies all three.

## What changes

- `.aside` visibility rules across base-theme + 4 themes (Origine, Swage, Alternative-Dark, Nord) rewritten to scope from `:root.aside_hidden` / `:root:not(.aside_hidden)` instead of `.aside.is-hidden` / `.aside.visible`. Narrow drawer collapse uses `width: 0` to preserve the slide animation.
- Toggle button active styling is derived from `:root:not(.aside_hidden) #nav_menu_toggle_aside .btn` in every theme that styles `.btn.active` (Flat, Origine, Alternative-Dark, Dark, Pafat, Nord). The `.classList.toggle('active')` JS calls and the PHP-rendered `.active` class are gone.
- `toggle_aside_click()` is a thin wrapper around `setAsideHidden(hidden, manual)`. `init_nav_menu()` only wires event handlers and a media-query handler now; state restoration is done by the inline init.

## Tested

- Narrow viewport: navigate with sidebar open and closed, both states preserved, no flash
- Wide viewport: same
- Reader view: hidden by default, toggleable
- Resize across the 840px breakpoint
- Non-toggleable views (Settings, manage-feeds): aside hidden by default in narrow viewport
- Swage narrow drawer toggles open and closed
