### PR TITLE
Preventive measure against search ingestion

### DIFF
--- a/app/Models/BooleanSearch.php
+++ b/app/Models/BooleanSearch.php
@@ -24,6 +24,8 @@ class FreshRSS_BooleanSearch implements \Stringable {
 		bool $expandUserQueries = true
 	) {
 		$input = trim($input);
+		$input = ltrim($input, ' )');
+		$input = rtrim($input, ' (\\');
 		if ($input === '') {
 			return;
 		}


### PR DESCRIPTION
We were not vulnerable to it, but here is an additional layer of security against search ingestions, in particular in public user queries, where someone could try to ingest a search like `) OR (interesting`
