### PR TITLE
fix(themes): remove dropdown-close backdrop in Nord wide view

### DIFF
--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -415,10 +415,6 @@ svg:hover {
 	text-decoration: none;
 }
 
-.dropdown-close {
-	backdrop-filter: grayscale(25%) brightness(0.9);
-}
-
 .dropdown-close a:hover {
 	background: none;
 }

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -415,10 +415,6 @@ svg:hover {
 	text-decoration: none;
 }
 
-.dropdown-close {
-	backdrop-filter: grayscale(25%) brightness(0.9);
-}
-
 .dropdown-close a:hover {
 	background: none;
 }


### PR DESCRIPTION
## Summary

Nord is the only shipped theme that applies a `backdrop-filter` to `.dropdown-close` outside the narrow-viewport `@media` block. Opening any dropdown in wide view (Settings, mark-read menu, etc.) therefore dims the page behind it, which reads as inconsistent against:

- every other theme, which leaves the wide-view click-catcher transparent;
- Nord's own narrow-view treatment, which uses `grayscale(60%) blur(1px)` as a clear modal scrim for the slide-out aside.

This PR removes the wide-view rule. `.dropdown-close` remains a full-screen invisible click target, so click-outside-to-close behaviour is unchanged. The narrow-view scrim further down the file is untouched.

```css
/* removed from nord.css and nord.rtl.css */
.dropdown-close {
    backdrop-filter: grayscale(25%) brightness(0.9);
}
```

## Test plan

Verified locally:

- Wide view: Settings dropdown no longer darkens the page; click-outside still closes
- Wide view: same behaviour for mark-read menu and other `.dropdown-toggle` instances
- `npm run stylelint` passes
- `npm run rtlcss` produces no further diff (`nord.rtl.css` matches the regenerator output)
