### PR TITLE
fix(themes): align narrow drawer top with wide header

### DIFF
--- a/p/themes/Origine-compact/origine-compact.css
+++ b/p/themes/Origine-compact/origine-compact.css
@@ -4,6 +4,7 @@
 /*============*/
 :root {
 	--frss-padding-top-bottom: 0.125rem;
+	--height-header: 37.6px;
 }
 
 /*=== COMPONENTS */

--- a/p/themes/Origine-compact/origine-compact.rtl.css
+++ b/p/themes/Origine-compact/origine-compact.rtl.css
@@ -4,6 +4,7 @@
 /*============*/
 :root {
 	--frss-padding-top-bottom: 0.125rem;
+	--height-header: 37.6px;
 }
 
 /*=== COMPONENTS */

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -4,6 +4,7 @@
 /*============*/
 :root {
 	--frss-padding-top-bottom: 0.5rem;
+	--aside-padding-y: 0.5rem;
 
 	--background-color-light-gradient1: #fff;
 	--background-color-light-gradient2: #eee;

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -4,6 +4,7 @@
 /*============*/
 :root {
 	--frss-padding-top-bottom: 0.5rem;
+	--aside-padding-y: 0.5rem;
 
 	--background-color-light-gradient1: #fff;
 	--background-color-light-gradient2: #eee;

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2519,14 +2519,14 @@ html.slider-active {
 	#overlay .close,
 	.dropdown-menu .toggle_aside,
 	#slider .toggle_aside {
-		box-sizing: border-box;
-		height: var(--height-header);
 		padding: 0 1rem;
 		display: flex;
+		width: 100%;
+		height: var(--height-header);
+		border-bottom: 1px solid var(--frss-border-color);
+		box-sizing: border-box;
 		align-items: center;
 		justify-content: center;
-		width: 100%;
-		border-bottom: 1px solid var(--frss-border-color);
 	}
 
 	.aside:not(.aside_feed) {

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -45,6 +45,8 @@
 	--frss-padding-top-bottom: 0.5rem;
 
 	--width-aside: 300px;
+	--height-header: 56px;
+	--aside-padding-y: 10px;
 
 	line-height: 1.5;
 }
@@ -2489,6 +2491,7 @@ html.slider-active {
 
 	.header > .item {
 		padding: 5px;
+		min-height: var(--height-header);
 	}
 
 	.header > .item.title {
@@ -2516,11 +2519,14 @@ html.slider-active {
 	#overlay .close,
 	.dropdown-menu .toggle_aside,
 	#slider .toggle_aside {
-		padding: 1rem 0;
-		display: block;
+		box-sizing: border-box;
+		height: var(--height-header);
+		padding: 0 1rem;
+		display: flex;
+		align-items: center;
+		justify-content: center;
 		width: 100%;
 		border-bottom: 1px solid var(--frss-border-color);
-		text-align: center;
 	}
 
 	.aside:not(.aside_feed) {
@@ -2787,12 +2793,12 @@ html.slider-active {
 		transition: width 200ms linear;
 	}
 
-	.aside.aside_feed {
+	:root .aside.aside_feed {
 		padding: 0;
 	}
 
 	.aside_feed .configure-feeds {
-		margin-top: 10px;
+		margin-top: var(--aside-padding-y);
 	}
 
 	.aside_feed .tree-folder-items .feed .favicon {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2519,14 +2519,14 @@ html.slider-active {
 	#overlay .close,
 	.dropdown-menu .toggle_aside,
 	#slider .toggle_aside {
-		box-sizing: border-box;
-		height: var(--height-header);
 		padding: 0 1rem;
 		display: flex;
+		width: 100%;
+		height: var(--height-header);
+		border-bottom: 1px solid var(--frss-border-color);
+		box-sizing: border-box;
 		align-items: center;
 		justify-content: center;
-		width: 100%;
-		border-bottom: 1px solid var(--frss-border-color);
 	}
 
 	.aside:not(.aside_feed) {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -45,6 +45,8 @@
 	--frss-padding-top-bottom: 0.5rem;
 
 	--width-aside: 300px;
+	--height-header: 56px;
+	--aside-padding-y: 10px;
 
 	line-height: 1.5;
 }
@@ -2489,6 +2491,7 @@ html.slider-active {
 
 	.header > .item {
 		padding: 5px;
+		min-height: var(--height-header);
 	}
 
 	.header > .item.title {
@@ -2516,11 +2519,14 @@ html.slider-active {
 	#overlay .close,
 	.dropdown-menu .toggle_aside,
 	#slider .toggle_aside {
-		padding: 1rem 0;
-		display: block;
+		box-sizing: border-box;
+		height: var(--height-header);
+		padding: 0 1rem;
+		display: flex;
+		align-items: center;
+		justify-content: center;
 		width: 100%;
 		border-bottom: 1px solid var(--frss-border-color);
-		text-align: center;
 	}
 
 	.aside:not(.aside_feed) {
@@ -2787,12 +2793,12 @@ html.slider-active {
 		transition: width 200ms linear;
 	}
 
-	.aside.aside_feed {
+	:root .aside.aside_feed {
 		padding: 0;
 	}
 
 	.aside_feed .configure-feeds {
-		margin-top: 10px;
+		margin-top: var(--aside-padding-y);
 	}
 
 	.aside_feed .tree-folder-items .feed .favicon {


### PR DESCRIPTION
When the sidebar is open and the viewport crosses 840px into narrow view, the "Subscription management" button shifts down by about 12px:

- The X close button at the top of the drawer is taller than the wide header (about 58px vs 56px).
- The vertical space above the X is counted twice: once by `.aside.aside_feed { padding: 10px 0 }`, once by `.configure-feeds { margin-top: 10px }`.

Two tokens at base-theme `:root`:

- `--height-header: 56px` is used by the narrow `.header > .item` `min-height` and the narrow `.aside .toggle_aside` `height`. The X button row matches the header row.
- `--aside-padding-y: 10px` is used by the narrow `.configure-feeds` `margin-top`. Themes with non-default aside padding override the token at `:root`.

Two supporting changes in the narrow `@media`:

- `.aside .toggle_aside` rewritten from `padding: 1rem 0; display: block` to flex centering with `box-sizing: border-box; height: var(--height-header)`. The X icon is vertically centered without relying on padding math.
- `.aside.aside_feed { padding: 0 }` bumped to `:root .aside.aside_feed`. Same specificity declarations in per-theme files (loaded after base-theme) were shadowing the original.

## Per-theme overrides

- `Origine/origine.css`: `--aside-padding-y: 0.5rem`. Cascades to `Dark` and `Origine-compact`, which load Origine via `metadata.json`.
- `Origine-compact/origine-compact.css`: `--height-header: 37.6px`. Smaller logo, measured wide header is 37.6px.

## Test plan

Verified on `edge`:

- `#btn-subscription` `top` matches across wide and narrow drawer-open per theme: Nord/Alt-Dark/Dark/Pafat/Flat/Dark-pink at 66px, Origine and Dark at 64px, Origine-compact at 45.6px.
- X button vertically centered, height matches each theme's wide header.
- `npm run stylelint` passes.
- `npm run rtlcss` produces no further diff.