### PR TITLE
fix(themes): scope Mapco and Ansum aside transition to width

### DIFF
--- a/p/themes/Ansum/_mobile.css
+++ b/p/themes/Ansum/_mobile.css
@@ -4,7 +4,7 @@
 @media (max-width: 840px) {
 	.aside {
 
-		transition: all 0.2s ease-in-out;
+		transition: width 0.2s ease-in-out;
 
 		&.aside_feed {
 			padding: 0;

--- a/p/themes/Ansum/_mobile.rtl.css
+++ b/p/themes/Ansum/_mobile.rtl.css
@@ -4,7 +4,7 @@
 @media (max-width: 840px) {
 	.aside {
 
-		transition: all 0.2s ease-in-out;
+		transition: width 0.2s ease-in-out;
 
 		&.aside_feed {
 			padding: 0;

--- a/p/themes/Mapco/_mobile.css
+++ b/p/themes/Mapco/_mobile.css
@@ -4,7 +4,7 @@
 @media (max-width: 840px) {
 	.aside {
 
-		transition: all 0.2s ease-in-out;
+		transition: width 0.2s ease-in-out;
 
 		&.aside_feed {
 			padding: 0;

--- a/p/themes/Mapco/_mobile.rtl.css
+++ b/p/themes/Mapco/_mobile.rtl.css
@@ -4,7 +4,7 @@
 @media (max-width: 840px) {
 	.aside {
 
-		transition: all 0.2s ease-in-out;
+		transition: width 0.2s ease-in-out;
 
 		&.aside_feed {
 			padding: 0;


### PR DESCRIPTION
Mapco and Ansum apply `transition: all 0.2s ease-in-out` to `.aside` in their narrow `@media`. When the viewport crosses 840px with the sidebar open, the resulting `.aside` position change (`static` to `fixed`) gets animated alongside width, producing a visible artefact where the X button slides down then scrolls back up before settling.

Limit the transition to the property that should actually animate (`width`), matching base-theme's existing `transition: width 200ms linear`.

```css
@media (max-width: 840px) {
  .aside {
    /* before */ transition: all 0.2s ease-in-out;
    /* after  */ transition: width 0.2s ease-in-out;
  }
}
```

Other `transition: all` declarations in these themes (on `.item` / `.btn` / form inputs, scoped to hover styling) are intentional and untouched.

The artefact only manifests when the drawer stays open across the 840px boundary, which is the behaviour introduced by #8775. On current `edge`, `init_nav_menu`'s `media.onchange` toggles the aside off when crossing the breakpoint, hiding the bug.

## Test plan

In Mapco or Ansum:

- Open the sidebar in wide view (>840px).
- Drag the browser window narrower than 840px with the sidebar still open.
- Expected: clean snap to the new layout, no slide/scroll on the X button.

`npm run stylelint` and `npm run rtlcss` both clean (no further diff).
