### PR TITLE
feat(import): support category field in JSON feed import

### DIFF
--- a/app/Controllers/importExportController.php
+++ b/app/Controllers/importExportController.php
@@ -581,10 +581,7 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 		$cat_name = trim($origin['category'] ?? '');
 		if ($cat_name !== '') {
 			$new_cat = $this->categoryDAO->searchByName($cat_name);
-			$new_cat_id = $new_cat === null ? $this->categoryDAO->addCategory(['name' => $cat_name]) : $new_cat->id();
-			if ($new_cat_id !== false) {
-				$cat_id = $new_cat_id;
-			}
+			$cat_id = $new_cat?->id() ?: $this->categoryDAO->addCategory(['name' => $cat_name]) ?: FreshRSS_CategoryDAO::DEFAULTCATEGORYID;
 		}
 
 		try {

--- a/app/Controllers/importExportController.php
+++ b/app/Controllers/importExportController.php
@@ -10,8 +10,7 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 
 	private FreshRSS_FeedDAO $feedDAO;
 
-	/** @var FreshRSS_CategoryDAO */
-	private $categoryDAO;
+	private FreshRSS_CategoryDAO $categoryDAO;
 
 	/**
 	 * This action is called before every other action in that class. It is
@@ -66,7 +65,7 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 
 		$this->entryDAO = FreshRSS_Factory::createEntryDao($username);
 		$this->feedDAO = FreshRSS_Factory::createFeedDao($username);
-		$this->categoryDAO = FreshRSS_Factory::createCategoryDao();
+		$this->categoryDAO = FreshRSS_Factory::createCategoryDao($username);
 
 		$type_file = self::guessFileType($name);
 
@@ -579,10 +578,11 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 		$name = empty($origin['title']) ? $website : $origin['title'];
 
 		$cat_id = FreshRSS_CategoryDAO::DEFAULTCATEGORYID;
-		if (!empty($origin['category'])) {
-			$new_cat = $this->categoryDAO->searchByName($origin['category']);
-			$new_cat_id = $new_cat === null ? $this->categoryDAO->addCategory(['name' => $origin['category']]) : $new_cat->id();
-			if ($new_cat_id != false) {
+		$cat_name = trim($origin['category'] ?? '');
+		if ($cat_name !== '') {
+			$new_cat = $this->categoryDAO->searchByName($cat_name);
+			$new_cat_id = $new_cat === null ? $this->categoryDAO->addCategory(['name' => $cat_name]) : $new_cat->id();
+			if ($new_cat_id !== false) {
 				$cat_id = $new_cat_id;
 			}
 		}

--- a/app/Controllers/importExportController.php
+++ b/app/Controllers/importExportController.php
@@ -579,16 +579,10 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 		$name = empty($origin['title']) ? $website : $origin['title'];
 
 		$cat_id = FreshRSS_CategoryDAO::DEFAULTCATEGORYID;
-		if(!empty($origin['category'])) {
-			$new_cat_id = null;
-
-			$new_cat = $this->categoryDAO->searchByName($origin['category']); // returns FreshRSS_Category
-			if($new_cat != null) {
-				$new_cat_id=$new_cat->id();
-			} else {
-				$new_cat_id = $this->categoryDAO->addCategory(['name' => $origin['category']]); // returns id
-			}
-			if($new_cat_id != null) {
+		if (!empty($origin['category'])) {
+			$new_cat = $this->categoryDAO->searchByName($origin['category']);
+			$new_cat_id = $new_cat === null ? $this->categoryDAO->addCategory(['name' => $origin['category']]) : $new_cat->id();
+			if ($new_cat_id != false) {
 				$cat_id = $new_cat_id;
 			}
 		}

--- a/app/Controllers/importExportController.php
+++ b/app/Controllers/importExportController.php
@@ -10,6 +10,9 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 
 	private FreshRSS_FeedDAO $feedDAO;
 
+	/** @var FreshRSS_CategoryDAO */
+	private $categoryDAO;
+
 	/**
 	 * This action is called before every other action in that class. It is
 	 * the common boilerplate for every action. It is triggered by the
@@ -23,6 +26,7 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 
 		$this->entryDAO = FreshRSS_Factory::createEntryDao();
 		$this->feedDAO = FreshRSS_Factory::createFeedDao();
+		$this->categoryDAO = FreshRSS_Factory::createCategoryDao();
 	}
 
 	/**
@@ -62,6 +66,7 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 
 		$this->entryDAO = FreshRSS_Factory::createEntryDao($username);
 		$this->feedDAO = FreshRSS_Factory::createFeedDao($username);
+		$this->categoryDAO = FreshRSS_Factory::createCategoryDao();
 
 		$type_file = self::guessFileType($name);
 
@@ -573,10 +578,25 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 		}
 		$name = empty($origin['title']) ? $website : $origin['title'];
 
+		$cat_id = FreshRSS_CategoryDAO::DEFAULTCATEGORYID;
+		if(!empty($origin['category'])) {
+			$new_cat_id = null;
+
+			$new_cat = $this->categoryDAO->searchByName($origin['category']); // returns FreshRSS_Category
+			if($new_cat != null) {
+				$new_cat_id=$new_cat->id();
+			} else {
+				$new_cat_id = $this->categoryDAO->addCategory(['name' => $origin['category']]); // returns id
+			}
+			if($new_cat_id != null) {
+				$cat_id = $new_cat_id;
+			}
+		}
+
 		try {
 			// Create a Feed object and add it in database.
 			$feed = new FreshRSS_Feed($url);
-			$feed->_categoryId(FreshRSS_CategoryDAO::DEFAULTCATEGORYID);
+			$feed->_categoryId($cat_id);
 			$feed->_name($name);
 			$feed->_website($website);
 			if (!empty($origin['disable'])) {


### PR DESCRIPTION
Supersedes #5638 (open since Sept 2023).

Picks up @robertdahlem's original work, cherry-picked verbatim so authorship is preserved (along with @Alkarex's syntax fix). Rebased onto current `edge` with one polish commit on top.

## What it does

JSON feed import now reads `origin.category` and places the feed in that category, creating it on-the-fly if missing. Without the field, behaviour is unchanged.

```json
{
  "items": [
    {
      "guid": "…",
      "origin": {
        "title": "…",
        "feedUrl": "…",
        "category": "Tech News"
      }
    }
  ]
}
```

Mainly useful for tools producing JSON imports (the TT-RSS exporter that motivated the original PR, hand-edited JSON, scripted provisioning). FreshRSS's own JSON export does not emit `origin.category` today; that would be a separate change.

## What the polish commit changes

- `!== false` after `addCategory()` (per @ColonelMoutarde's earlier review).
- Typed property syntax for `$categoryDAO`, matching `$entryDAO`/`$feedDAO`.
- Pass `$username` to `createCategoryDao()` in `importFile()` so `cli/import-for-user.php --user X` creates categories on the right account.
- Trim the category name; skip if empty after trim. Stops a whitespace-only `"category"` value from creating an empty-named row, and lets `"  Tech News  "` reuse an existing `"Tech News"`.

The `$username` fix could be split out if a tighter PR is preferred.

## Verification

CLI smoke tests via `cli/import-for-user.php`:

- New category created on first occurrence
- Existing category reused (no duplicates)
- `"  Tech News  "` reuses `"Tech News"` after trim
- `"   "` falls back to the default category
- Missing field falls back to the default category
- `--user` propagation works
- 191-char truncation in `addCategory` behaves as expected

`composer test` clean: 624 PHPUnit / 1160 assertions, PHPStan 0 errors, phpcs and lint clean.

A PHPUnit test could be added, but there are no existing tests for `importExportController` to mirror, so placement isn't obvious.