### PR TITLE
Fix search in shared user queries

### DIFF
--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -258,6 +258,7 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 
 		try {
 			$this->view->entries = FreshRSS_index_Controller::listEntriesByContext();
+			$this->view->entries->current();	// Init the generator to catch potential exceptions
 		} catch (FreshRSS_EntriesGetter_Exception $e) {
 			Minz_Log::notice($e->getMessage());
 			Minz_Error::error(404);
@@ -335,10 +336,10 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 	/**
 	 * This method returns a list of entries based on the Context object.
 	 * @param int $postsPerPage override `FreshRSS_Context::$number`
-	 * @return Traversable<FreshRSS_Entry>
+	 * @return Generator<FreshRSS_Entry>
 	 * @throws FreshRSS_EntriesGetter_Exception
 	 */
-	public static function listEntriesByContext(?int $postsPerPage = null): Traversable {
+	public static function listEntriesByContext(?int $postsPerPage = null): Generator {
 		$entryDAO = FreshRSS_Factory::createEntryDao();
 
 		$get = FreshRSS_Context::currentGet(true);

--- a/p/api/query.php
+++ b/p/api/query.php
@@ -117,8 +117,10 @@ $view = new FreshRSS_View();
 
 try {
 	FreshRSS_Context::updateUsingRequest(false);
-	Minz_Request::_param('search', $userSearch->toString());	// Restore user search
 	$view->entries = FreshRSS_index_Controller::listEntriesByContext();
+	$view->entries->current();	// Init the generator to consume the aggregated search and catch potential exceptions
+	Minz_Request::_param('search', $userSearch->toString());	// Restore user search for display and exports
+	FreshRSS_Context::$search = $userSearch;	// Restore user search for display and exports
 } catch (Minz_Exception) {
 	Minz_Error::error(400, 'Bad user query!');
 	die();


### PR DESCRIPTION
The internal search was shown in the UI as the user search. This was due to the lazy nature of the Generator. Improve the try/catch behaviour at the same time.

How to test:
* Make a user query with a search parameter
* Share the user query as HTML
* Observe the search field (should be empty with this PR,  while it contained the internal search before)
