### PR TITLE
fix: persist sort order chosen via nav dropdown

### DIFF
--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -129,6 +129,37 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 			Minz_Error::error(404);
 		}
 
+		if (Minz_Request::paramString('saveSort', plaintext: true) !== ''
+				&& Minz_Request::isPost()
+				&& FreshRSS_Auth::hasAccess()
+				&& FreshRSS_Auth::isCsrfOk()) {
+			$userConf = FreshRSS_Context::userConf();
+			if ($userConf->sort !== FreshRSS_Context::$sort || $userConf->sort_order !== FreshRSS_Context::$order) {
+				$userConf->sort = FreshRSS_Context::$sort;
+				$userConf->sort_order = FreshRSS_Context::$order;
+				$userConf->save();
+			}
+			$redirect = Minz_Request::currentRequest();
+			unset($redirect['params']['saveSort'], $redirect['params']['_csrf']);
+			$hasOverride = false;
+			if (!empty(FreshRSS_Context::$current_get['feed'])) {
+				$id = FreshRSS_Context::$current_get['feed'];
+				$feed = FreshRSS_Category::findFeed(FreshRSS_Context::categories(), $id)
+					?? FreshRSS_Factory::createFeedDao()->searchById($id);
+				$hasOverride = $feed?->defaultSort() !== null || $feed?->defaultOrder() !== null;
+			} elseif (!empty(FreshRSS_Context::$current_get['category'])) {
+				$id = FreshRSS_Context::$current_get['category'];
+				$category = FreshRSS_Context::categories()[$id]
+					?? FreshRSS_Factory::createCategoryDao()->searchById($id);
+				$hasOverride = $category?->defaultSort() !== null || $category?->defaultOrder() !== null;
+			}
+			if (!$hasOverride) {
+				unset($redirect['params']['sort'], $redirect['params']['order']);
+			}
+			Minz_Request::forward($redirect, redirect: true);
+			return;
+		}
+
 		$this->_csp([
 			'default-src' => "'self'",
 			'frame-src' => '*',

--- a/app/Models/UserConfiguration.php
+++ b/app/Models/UserConfiguration.php
@@ -58,7 +58,7 @@ declare(strict_types=1);
  * @property bool $sidebar_hidden_by_default
  * @property 'big'|'small'|'none' $mark_read_button
  * @property 'ASC'|'DESC' $sort_order
- * @property 'id'|'c.name'|'date'|'f.name'|'length'|'link'|'rand'|'title' $sort
+ * @property 'id'|'c.name'|'date'|'f.name'|'lastUserModified'|'length'|'link'|'rand'|'title' $sort
  * @property 'ASC'|'DESC' $secondary_sort_order
  * @property 'id'|'date'|'link'|'title' $secondary_sort
  * @property array<int,array<string,string>> $sharing

--- a/app/layout/header.phtml
+++ b/app/layout/header.phtml
@@ -48,11 +48,11 @@
 		<?php } ?>
 	</div>
 
+	<form id="post-csrf" method="post">
+		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
+	</form>
 	<?php if (FreshRSS_Auth::hasAccess()) { ?>
 	<nav class="item configure">
-		<form id="post-csrf" method="post">
-			<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
-		</form>
 		<div class="dropdown">
 			<div id="dropdown-configure" class="dropdown-target"></div>
 			<a class="btn dropdown-toggle" href="#dropdown-configure"><?= _i('configure') ?></a>

--- a/app/layout/nav_menu.phtml
+++ b/app/layout/nav_menu.phtml
@@ -234,7 +234,7 @@
 			$title = _t('index.menu.sort.desc');
 		}
 		$url_order = Minz_Request::currentRequest();
-		unset($url_order['params']['cid']);
+		unset($url_order['params']['cid'], $url_order['params']['saveSort']);
 	?>
 	<div id="nav_menu_sort" class="group">
 		<div class="dropdown">
@@ -242,39 +242,39 @@
 			<a id="toggle-order" class="dropdown-toggle btn" href="#dropdown-sort" title="<?= _t('index.menu.sort.primary') ?>"><?= _i($icon) ?></a>
 			<ul class="dropdown-menu" role="radiogroup">
 				<li class="item" role="radio" aria-checked="<?= FreshRSS_Context::$order === 'DESC' && FreshRSS_Context::$sort === 'id' ? 'true' : 'false' ?>">
-					<a href="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'id', 'order' => 'DESC']]) ?>"><?= _t('index.menu.sort.id_desc') ?></a></li>
+					<button class="as-link" form="post-csrf" type="submit" formaction="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'id', 'order' => 'DESC', 'saveSort' => '1']]) ?>"><?= _t('index.menu.sort.id_desc') ?></button></li>
 				<li class="item" role="radio" aria-checked="<?= FreshRSS_Context::$order === 'DESC' && FreshRSS_Context::$sort === 'date' ? 'true' : 'false' ?>">
-					<a href="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'date', 'order' => 'DESC']]) ?>"><?= _t('index.menu.sort.date_desc') ?></a></li>
+					<button class="as-link" form="post-csrf" type="submit" formaction="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'date', 'order' => 'DESC', 'saveSort' => '1']]) ?>"><?= _t('index.menu.sort.date_desc') ?></button></li>
 				<li class="item" role="radio" aria-checked="<?= FreshRSS_Context::$order === 'DESC' && FreshRSS_Context::$sort === 'lastUserModified' ? 'true' : 'false' ?>">
-					<a href="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'lastUserModified', 'order' => 'DESC']]) ?>"><?= _t('index.menu.sort.user_modified_desc') ?></a></li>
+					<button class="as-link" form="post-csrf" type="submit" formaction="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'lastUserModified', 'order' => 'DESC', 'saveSort' => '1']]) ?>"><?= _t('index.menu.sort.user_modified_desc') ?></button></li>
 				<li class="item" role="radio" aria-checked="<?= FreshRSS_Context::$order === 'DESC' && FreshRSS_Context::$sort === 'length' ? 'true' : 'false' ?>">
-					<a href="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'length', 'order' => 'DESC']]) ?>"><?= _t('index.menu.sort.length_desc') ?></a></li>
+					<button class="as-link" form="post-csrf" type="submit" formaction="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'length', 'order' => 'DESC', 'saveSort' => '1']]) ?>"><?= _t('index.menu.sort.length_desc') ?></button></li>
 				<li class="item" role="radio" aria-checked="<?= FreshRSS_Context::$order === 'DESC' && FreshRSS_Context::$sort === 'link' ? 'true' : 'false' ?>">
-					<a href="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'link', 'order' => 'DESC']]) ?>"><?= _t('index.menu.sort.link_desc') ?></a></li>
+					<button class="as-link" form="post-csrf" type="submit" formaction="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'link', 'order' => 'DESC', 'saveSort' => '1']]) ?>"><?= _t('index.menu.sort.link_desc') ?></button></li>
 				<li class="item" role="radio" aria-checked="<?= FreshRSS_Context::$order === 'DESC' && FreshRSS_Context::$sort === 'title' ? 'true' : 'false' ?>">
-					<a href="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'title', 'order' => 'DESC']]) ?>"><?= _t('index.menu.sort.title_desc') ?></a></li>
+					<button class="as-link" form="post-csrf" type="submit" formaction="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'title', 'order' => 'DESC', 'saveSort' => '1']]) ?>"><?= _t('index.menu.sort.title_desc') ?></button></li>
 				<li class="item" role="radio" aria-checked="<?= FreshRSS_Context::$order === 'DESC' && FreshRSS_Context::$sort === 'f.name' ? 'true' : 'false' ?>">
-					<a href="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'f.name', 'order' => 'DESC']]) ?>"><?= _t('index.menu.sort.f.name_desc') ?></a></li>
+					<button class="as-link" form="post-csrf" type="submit" formaction="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'f.name', 'order' => 'DESC', 'saveSort' => '1']]) ?>"><?= _t('index.menu.sort.f.name_desc') ?></button></li>
 				<li class="item" role="radio" aria-checked="<?= FreshRSS_Context::$order === 'DESC' && FreshRSS_Context::$sort === 'c.name' ? 'true' : 'false' ?>">
-					<a href="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'c.name', 'order' => 'DESC']]) ?>"><?= _t('index.menu.sort.c.name_desc') ?></a></li>
+					<button class="as-link" form="post-csrf" type="submit" formaction="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'c.name', 'order' => 'DESC', 'saveSort' => '1']]) ?>"><?= _t('index.menu.sort.c.name_desc') ?></button></li>
 				<li class="item separator" role="radio" aria-checked="<?= FreshRSS_Context::$sort === 'rand' ? 'true' : 'false' ?>">
-					<a href="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'rand', 'order' => null]]) ?>"><?= _t('index.menu.sort.rand') ?></a></li>
+					<button class="as-link" form="post-csrf" type="submit" formaction="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'rand', 'order' => null, 'saveSort' => '1']]) ?>"><?= _t('index.menu.sort.rand') ?></button></li>
 				<li class="item separator" role="radio" aria-checked="<?= FreshRSS_Context::$order === 'ASC' && FreshRSS_Context::$sort === 'id' ? 'true' : 'false' ?>">
-					<a href="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'id', 'order' => 'ASC']]) ?>"><?= _t('index.menu.sort.id_asc') ?></a></li>
+					<button class="as-link" form="post-csrf" type="submit" formaction="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'id', 'order' => 'ASC', 'saveSort' => '1']]) ?>"><?= _t('index.menu.sort.id_asc') ?></button></li>
 				<li class="item" role="radio" aria-checked="<?= FreshRSS_Context::$order === 'ASC' && FreshRSS_Context::$sort === 'date' ? 'true' : 'false' ?>">
-					<a href="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'date', 'order' => 'ASC']]) ?>"><?= _t('index.menu.sort.date_asc') ?></a></li>
+					<button class="as-link" form="post-csrf" type="submit" formaction="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'date', 'order' => 'ASC', 'saveSort' => '1']]) ?>"><?= _t('index.menu.sort.date_asc') ?></button></li>
 				<li class="item" role="radio" aria-checked="<?= FreshRSS_Context::$order === 'ASC' && FreshRSS_Context::$sort === 'lastUserModified' ? 'true' : 'false' ?>">
-					<a href="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'lastUserModified', 'order' => 'ASC']]) ?>"><?= _t('index.menu.sort.user_modified_asc') ?></a></li>
+					<button class="as-link" form="post-csrf" type="submit" formaction="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'lastUserModified', 'order' => 'ASC', 'saveSort' => '1']]) ?>"><?= _t('index.menu.sort.user_modified_asc') ?></button></li>
 				<li class="item" role="radio" aria-checked="<?= FreshRSS_Context::$order === 'ASC' && FreshRSS_Context::$sort === 'length' ? 'true' : 'false' ?>">
-					<a href="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'length', 'order' => 'ASC']]) ?>"><?= _t('index.menu.sort.length_asc') ?></a></li>
+					<button class="as-link" form="post-csrf" type="submit" formaction="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'length', 'order' => 'ASC', 'saveSort' => '1']]) ?>"><?= _t('index.menu.sort.length_asc') ?></button></li>
 				<li class="item" role="radio" aria-checked="<?= FreshRSS_Context::$order === 'ASC' && FreshRSS_Context::$sort === 'link' ? 'true' : 'false' ?>">
-					<a href="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'link', 'order' => 'ASC']]) ?>"><?= _t('index.menu.sort.link_asc') ?></a></li>
+					<button class="as-link" form="post-csrf" type="submit" formaction="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'link', 'order' => 'ASC', 'saveSort' => '1']]) ?>"><?= _t('index.menu.sort.link_asc') ?></button></li>
 				<li class="item" role="radio" aria-checked="<?= FreshRSS_Context::$order === 'ASC' && FreshRSS_Context::$sort === 'title' ? 'true' : 'false' ?>">
-					<a href="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'title', 'order' => 'ASC']]) ?>"><?= _t('index.menu.sort.title_asc') ?></a></li>
+					<button class="as-link" form="post-csrf" type="submit" formaction="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'title', 'order' => 'ASC', 'saveSort' => '1']]) ?>"><?= _t('index.menu.sort.title_asc') ?></button></li>
 				<li class="item" role="radio" aria-checked="<?= FreshRSS_Context::$order === 'ASC' && FreshRSS_Context::$sort === 'f.name' ? 'true' : 'false' ?>">
-					<a href="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'f.name', 'order' => 'ASC']]) ?>"><?= _t('index.menu.sort.f.name_asc') ?></a></li>
+					<button class="as-link" form="post-csrf" type="submit" formaction="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'f.name', 'order' => 'ASC', 'saveSort' => '1']]) ?>"><?= _t('index.menu.sort.f.name_asc') ?></button></li>
 				<li class="item" role="radio" aria-checked="<?= FreshRSS_Context::$order === 'ASC' && FreshRSS_Context::$sort === 'c.name' ? 'true' : 'false' ?>">
-					<a href="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'c.name', 'order' => 'ASC']]) ?>"><?= _t('index.menu.sort.c.name_asc') ?></a></li>
+					<button class="as-link" form="post-csrf" type="submit" formaction="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'c.name', 'order' => 'ASC', 'saveSort' => '1']]) ?>"><?= _t('index.menu.sort.c.name_asc') ?></button></li>
 			</ul>
 			<a class="dropdown-close" href="#close">❌</a>
 		</div>


### PR DESCRIPTION
## Summary

Fixes #8227. Sort/order chosen via the nav dropdown is now saved to the user's `sort` and `sort_order` config, so it survives a browser close. Previously the choice only lived in URL params.

## Approach

Dropdown items submit via the existing `post-csrf` form, pointing at a URL with a `saveSort=1` flag. The index controller persists `sort`/`order` (already restricted to the allowlist by `Context::updateUsingRequest`) to user config when they differ from the current values, then redirects.

The redirect URL drops `saveSort` and the `_csrf` token. It also drops `sort` and `order`, except when the current view is a feed or category with a per-feed/per-category override (#8234). With an override present, the params stay so the user's just-clicked choice wins on the next page.

The save path is gated on `Minz_Request::isPost()`, `FreshRSS_Auth::hasAccess()`, and `FreshRSS_Auth::isCsrfOk()`.

To make the dropdown POSTs work for anonymous read-only users when allowed by config, the `<form id="post-csrf">` in `header.phtml` was lifted out of the auth gate. The actual save still requires authentication.

Sort/order URL params on other paths (shared links, navigation, paging) act as session-level overrides and do not mutate user config, keeping the design from #7585 and #7974. Per-feed and per-category sort defaults (#8234) still take precedence over the global default.

## Testing

Tested manually on a self-hosted edge install with SQLite.

- Picked a non-default sort in the nav dropdown. The page POSTed and redirected to `/i/?a=normal&rid=...` (`rid` is added by `Minz_Request::forward` on every redirect; `a` reflects the current action). The article list rendered in the chosen order.
- Settings -> Reading reflected the new default after the click.
- Cleared cookies in a private window, logged back in, and visited the home view. Articles rendered in the persisted order on first paint.
- The override branch (per-feed override keeping `sort`/`order` in the redirect URL) was verified by reading the controller; no override was configured to test live.
- PHPCS clean on changed files. Initial PHPStan failure on `UserConfiguration::$sort` accepting `lastUserModified` was fixed by extending the property's PHPDoc union to match the values the dropdown already produces.