### PR TITLE
feat(display): expose show_favicons toggle in Display settings

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -235,7 +235,7 @@ Voir le [dépôt dédié à ces extensions](https://github.com/FreshRSS/Extensio
 | Español (es) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
 | فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 91% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Suomi (fi) | ￭￭￭￭￭￭￭￭￭･ 93% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffi+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Français (fr) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Français (fr) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | עברית (he) | ￭￭￭￭･･････ 42% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhe+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Magyar (hu) | ￭￭￭￭￭￭￭￭￭･ 97% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhu+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭￭･ 90% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |

--- a/README.fr.md
+++ b/README.fr.md
@@ -235,7 +235,7 @@ Voir le [dépôt dédié à ces extensions](https://github.com/FreshRSS/Extensio
 | Español (es) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
 | فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 91% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Suomi (fi) | ￭￭￭￭￭￭￭￭￭･ 93% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffi+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Français (fr) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Français (fr) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | עברית (he) | ￭￭￭￭･･････ 42% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhe+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Magyar (hu) | ￭￭￭￭￭￭￭￭￭･ 97% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhu+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭￭･ 90% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |
@@ -245,14 +245,14 @@ Voir le [dépôt dédié à ces extensions](https://github.com/FreshRSS/Extensio
 | Latviešu (lv) | ￭￭￭￭￭￭￭￭･･ 83% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Flv+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Nederlands (nl) | ￭￭￭￭￭￭￭￭￭･ 97% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fnl+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Occitan (oc) | ￭￭￭￭￭￭￭･･･ 75% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Foc+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Polski (pl) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpl+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Polski (pl) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpl+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Português (Brasil) (pt-BR) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-BR+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Português (Portugal) (pt-PT) | ￭￭￭￭￭￭￭￭･･ 82% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-PT+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Português (Portugal) (pt-PT) | ￭￭￭￭￭￭￭￭･･ 81% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-PT+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Русский (ru) | ￭￭￭￭￭￭￭￭￭･ 97% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fru+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Slovenčina (sk) | ￭￭￭￭￭￭￭￭･･ 82% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fsk+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Türkçe (tr) | ￭￭￭￭￭￭￭￭￭･ 90% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ftr+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Türkçe (tr) | ￭￭￭￭￭￭￭￭･･ 89% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ftr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Українська (uk) | ￭￭￭￭￭￭￭￭￭･ 92% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fuk+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 简体中文 (zh-CN) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-CN+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 简体中文 (zh-CN) | ￭￭￭￭￭￭￭￭￭･ 97% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-CN+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 正體中文 (zh-TW) | ￭￭￭￭￭￭￭￭￭･ 95% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-TW+%2F%28TODO%7CDIRTY%29%24%2F) |
 
 </translations>

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ See the [repository dedicated to those extensions](https://github.com/FreshRSS/E
 | Español (es) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
 | فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 91% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Suomi (fi) | ￭￭￭￭￭￭￭￭￭･ 93% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffi+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Français (fr) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Français (fr) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | עברית (he) | ￭￭￭￭･･････ 42% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhe+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Magyar (hu) | ￭￭￭￭￭￭￭￭￭･ 97% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhu+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭￭･ 90% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ See the [repository dedicated to those extensions](https://github.com/FreshRSS/E
 | Español (es) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
 | فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 91% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Suomi (fi) | ￭￭￭￭￭￭￭￭￭･ 93% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffi+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Français (fr) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Français (fr) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | עברית (he) | ￭￭￭￭･･････ 42% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhe+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Magyar (hu) | ￭￭￭￭￭￭￭￭￭･ 97% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhu+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭￭･ 90% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |
@@ -141,14 +141,14 @@ See the [repository dedicated to those extensions](https://github.com/FreshRSS/E
 | Latviešu (lv) | ￭￭￭￭￭￭￭￭･･ 83% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Flv+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Nederlands (nl) | ￭￭￭￭￭￭￭￭￭･ 97% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fnl+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Occitan (oc) | ￭￭￭￭￭￭￭･･･ 75% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Foc+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Polski (pl) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpl+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Polski (pl) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpl+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Português (Brasil) (pt-BR) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-BR+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Português (Portugal) (pt-PT) | ￭￭￭￭￭￭￭￭･･ 82% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-PT+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Português (Portugal) (pt-PT) | ￭￭￭￭￭￭￭￭･･ 81% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-PT+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Русский (ru) | ￭￭￭￭￭￭￭￭￭･ 97% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fru+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Slovenčina (sk) | ￭￭￭￭￭￭￭￭･･ 82% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fsk+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Türkçe (tr) | ￭￭￭￭￭￭￭￭￭･ 90% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ftr+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Türkçe (tr) | ￭￭￭￭￭￭￭￭･･ 89% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ftr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Українська (uk) | ￭￭￭￭￭￭￭￭￭･ 92% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fuk+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 简体中文 (zh-CN) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-CN+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 简体中文 (zh-CN) | ￭￭￭￭￭￭￭￭￭･ 97% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-CN+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 正體中文 (zh-TW) | ￭￭￭￭￭￭￭￭￭･ 95% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-TW+%2F%28TODO%7CDIRTY%29%24%2F) |
 
 </translations>

--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -63,6 +63,7 @@ class FreshRSS_configure_Controller extends FreshRSS_ActionController {
 			FreshRSS_Context::userConf()->topline_date = Minz_Request::paramBoolean('topline_date');
 			FreshRSS_Context::userConf()->topline_link = Minz_Request::paramBoolean('topline_link');
 			FreshRSS_Context::userConf()->topline_website = Minz_Request::paramString('topline_website');
+			FreshRSS_Context::userConf()->show_favicons = Minz_Request::paramBoolean('show_favicons');
 			FreshRSS_Context::userConf()->topline_thumbnail = Minz_Request::paramString('topline_thumbnail');
 			FreshRSS_Context::userConf()->topline_summary = Minz_Request::paramBoolean('topline_summary');
 			FreshRSS_Context::userConf()->topline_display_authors = Minz_Request::paramBoolean('topline_display_authors');

--- a/app/i18n/cs/conf.php
+++ b/app/i18n/cs/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'sekund (0 znamená žádný časový limit)',
 			'timeout' => 'Časový limit HTML5 oznámení',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'Zobrazit navigační tlačítka',
 		'show_title_unread' => 'Zobrazit počet nepřečtených článků v názvu',
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'Sekunden (0 bedeutet keine Zeitüberschreitung)',
 			'timeout' => 'Zeitüberschreitung für HTML5-Benachrichtigung',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'Navigationsschaltflächen anzeigen',
 		'show_title_unread' => 'Anzahl ungelesener Artikel im Titel anzeigen',
 		'sidebar_hidden_by_default' => 'Seitenleiste standardmäßig ausblenden',

--- a/app/i18n/el/conf.php
+++ b/app/i18n/el/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'seconds (0 means no timeout)',	// TODO
 			'timeout' => 'HTML5 notification timeout',	// TODO
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'Show the navigation buttons',	// TODO
 		'show_title_unread' => 'Εμφάνιση αριθμού μη αναγνωσμένων άρθρων στον τίτλο',
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO

--- a/app/i18n/en-US/conf.php
+++ b/app/i18n/en-US/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'seconds (0 means no timeout)',	// IGNORE
 			'timeout' => 'HTML5 notification timeout',	// IGNORE
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// IGNORE
 		'show_nav_buttons' => 'Show the navigation buttons',	// IGNORE
 		'show_title_unread' => 'Show number of unread articles in the title',	// IGNORE
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// IGNORE

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'seconds (0 means no timeout)',
 			'timeout' => 'HTML5 notification timeout',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',
 		'show_nav_buttons' => 'Show the navigation buttons',
 		'show_title_unread' => 'Show number of unread articles in the title',
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',

--- a/app/i18n/es/conf.php
+++ b/app/i18n/es/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'segundos (0 significa sin límite de espera)',
 			'timeout' => 'Notificación de fin de espera HTML5',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'Mostrar los botones de navegación',
 		'show_title_unread' => 'Mostrar el número de artículos no leídos en el título',
 		'sidebar_hidden_by_default' => 'Ocultar barra lateral por defecto',

--- a/app/i18n/fa/conf.php
+++ b/app/i18n/fa/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => ' ثانیه (0 به معنای عدم وجود مهلت زمانی است)',
 			'timeout' => ' وقفه اعلان HTML5',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => ' دکمه های ناوبری را نشان دهید',
 		'show_title_unread' => 'نمایش تعداد مقالات خوانده نشده در عنوان',
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO

--- a/app/i18n/fi/conf.php
+++ b/app/i18n/fi/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'sekuntia (0 - ei taukoa)',
 			'timeout' => 'Tauko HTML5-ilmoitusten välissä',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'Näytä siirtymispainikkeet',
 		'show_title_unread' => 'Show number of unread articles in the title',	// TODO
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO

--- a/app/i18n/fr/conf.php
+++ b/app/i18n/fr/conf.php
@@ -53,7 +53,7 @@ return array(
 			'seconds' => 'secondes (0 signifie aucun timeout)',
 			'timeout' => 'Temps d’affichage de la notification HTML5',
 		),
-		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
+		'show_feed_icons_in_lists' => 'Afficher les favicônes des flux dans les listes',
 		'show_nav_buttons' => 'Afficher les boutons de navigation',
 		'show_title_unread' => 'Afficher le nombre d’articles non lus dans le titre',
 		'sidebar_hidden_by_default' => 'Masquer la barre latérale par défaut',

--- a/app/i18n/fr/conf.php
+++ b/app/i18n/fr/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'secondes (0 signifie aucun timeout)',
 			'timeout' => 'Temps d’affichage de la notification HTML5',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'Afficher les boutons de navigation',
 		'show_title_unread' => 'Afficher le nombre d’articles non lus dans le titre',
 		'sidebar_hidden_by_default' => 'Masquer la barre latérale par défaut',

--- a/app/i18n/he/conf.php
+++ b/app/i18n/he/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'שניות (0 משמעותה ללא פג תוקף)',
 			'timeout' => 'HTML5 התראה פג תוקף',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'Show the navigation buttons',	// TODO
 		'show_title_unread' => 'הצגת מספר המאמרים שלא נקראו בכותרת',
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO

--- a/app/i18n/hu/conf.php
+++ b/app/i18n/hu/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'másodpercek (A 0 azt jelenti, hogy nincs időkorlát)',
 			'timeout' => 'HTML5 értesítés hossza',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'Navigációs gombok megjelenítése',
 		'show_title_unread' => 'A meg nem nyitott cikkek számának megjelenítése a címben',
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO

--- a/app/i18n/id/conf.php
+++ b/app/i18n/id/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'detik (0 berarti tanpa batas waktu)',
 			'timeout' => 'Batas waktu pemberitahuan HTML5',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'Tampilkan tombol navigasi',
 		'show_title_unread' => 'Tampilkan jumlah artikel yang belum dibaca di judul',
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO

--- a/app/i18n/it/conf.php
+++ b/app/i18n/it/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'secondi (0 significa nessun timeout)',
 			'timeout' => 'Notifica timeout HTML5',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'Mostra i pulsanti di navigazione',
 		'show_title_unread' => 'Mostra il numero di articoli non letti nel titolo',
 		'sidebar_hidden_by_default' => 'Nascondi la barra laterale di default',

--- a/app/i18n/ja/conf.php
+++ b/app/i18n/ja/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => '秒 (0秒だとタイムアウトしません)',
 			'timeout' => 'HTML5 の通知タイムアウト時間',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'ナビゲーションボタンを表示する',
 		'show_title_unread' => 'タイトルに未読の記事数を表示',
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO

--- a/app/i18n/ko/conf.php
+++ b/app/i18n/ko/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => '초 (0: 타임아웃 없음)',
 			'timeout' => 'HTML5 알림 타임아웃',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => '내비게이션 버튼 보이기',
 		'show_title_unread' => '제목에 읽지 않은 기사 수 표시',
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO

--- a/app/i18n/lv/conf.php
+++ b/app/i18n/lv/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'sekundes (0 nozīmē, ka nav laika ierobežojuma)',
 			'timeout' => 'HTML5 paziņojuma laika ierobežojums',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'Rādīt navigācijas pogas',
 		'show_title_unread' => 'Rādīt nelasīto rakstu skaitu virsrakstā',
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO

--- a/app/i18n/nl/conf.php
+++ b/app/i18n/nl/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'seconden (0 betekent geen stop)',
 			'timeout' => 'HTML5 notificatie stop',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'Toon navigatieknoppen',
 		'show_title_unread' => 'Aantal ongelezen artikelen in de titel weergeven',
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO

--- a/app/i18n/oc/conf.php
+++ b/app/i18n/oc/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'segondas (0 significa cap de timeout)',
 			'timeout' => 'Temps d’afichatge de las notificacions HTML5',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'Mostrar los botons de navigacion',
 		'show_title_unread' => 'Mostra lo nombre d’articles non legits dins lo títol',
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO

--- a/app/i18n/pl/conf.php
+++ b/app/i18n/pl/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'sekund (0 oznacza wartość domyślną przeglądarki)',
 			'timeout' => 'Czas wyświetlania powiadomienia HTML5',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'Pokaż przyciski nawigacyjne',
 		'show_title_unread' => 'Pokaż liczbę nieprzeczytanych artykułów w tytule',
 		'sidebar_hidden_by_default' => 'Ukryj pasek boczny domyślnie',

--- a/app/i18n/pt-BR/conf.php
+++ b/app/i18n/pt-BR/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'segundos (0 significa sem timeout)',
 			'timeout' => 'Notificação em HTML5 de timeout',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'Mostrar botões de navegação',
 		'show_title_unread' => 'Mostrar o número de artigos não lidos no título',
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO

--- a/app/i18n/pt-PT/conf.php
+++ b/app/i18n/pt-PT/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'segundos (0 significa sem timeout)',
 			'timeout' => 'Notificação em HTML5 de timeout',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'Mostrar botões de navegação',
 		'show_title_unread' => 'Show number of unread articles in the title',	// TODO
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO

--- a/app/i18n/ru/conf.php
+++ b/app/i18n/ru/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'секунд (0 - нет таймаута)',
 			'timeout' => 'Таймаут уведомлений HTML5',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'Показать кнопки навигации',
 		'show_title_unread' => 'Показать количество непрочитанных статей в заголовке',
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO

--- a/app/i18n/sk/conf.php
+++ b/app/i18n/sk/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'sekundy (0 znamená bez limitu)',
 			'timeout' => 'Limit HTML5 oznámenia',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'Zobraziť tlačidlá oznámenia',
 		'show_title_unread' => 'Zobraziť počet neprečítaných článkov v názve',
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO

--- a/app/i18n/tr/conf.php
+++ b/app/i18n/tr/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'saniye (0, zaman aşımı yok anlamına gelir)',
 			'timeout' => 'HTML5 bildirim zaman aşımı',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'Gezinme düğmelerini göster',
 		'show_title_unread' => 'Başlıkta okunmamış makale sayısını göster',
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO

--- a/app/i18n/uk/conf.php
+++ b/app/i18n/uk/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => 'секунд (0 означає без тайм-ауту)',
 			'timeout' => 'Тайм-аут сповіщення HTML5',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => 'Показати кнопки навігації',
 		'show_title_unread' => 'Show number of unread articles in the title',	// TODO
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO

--- a/app/i18n/zh-CN/conf.php
+++ b/app/i18n/zh-CN/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => '秒（0 表示不超时）',
 			'timeout' => 'HTML5 通知超时时间',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => '显示导航按钮',
 		'show_title_unread' => '在标题中显示未读文章的数量',
 		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO

--- a/app/i18n/zh-TW/conf.php
+++ b/app/i18n/zh-TW/conf.php
@@ -53,6 +53,7 @@ return array(
 			'seconds' => '秒 (0 代表無逾時)',
 			'timeout' => 'HTML5 通知逾時',
 		),
+		'show_feed_icons_in_lists' => 'Show feed icons in lists',	// TODO
 		'show_nav_buttons' => '顯示導覽按鈕',
 		'show_title_unread' => '在標題中顯示未讀文章的數量',
 		'sidebar_hidden_by_default' => '預設隱藏側邊欄',

--- a/app/views/configure/display.phtml
+++ b/app/views/configure/display.phtml
@@ -171,6 +171,16 @@
 		</div>
 
 		<div class="form-group">
+			<div class="group-controls">
+				<label class="checkbox" for="show_favicons">
+					<input type="checkbox" name="show_favicons" id="show_favicons" value="1"<?=
+						FreshRSS_Context::userConf()->show_favicons ? ' checked="checked"' : '' ?> />
+					<?= _t('conf.display.show_feed_icons_in_lists') ?>
+				</label>
+			</div>
+		</div>
+
+		<div class="form-group">
 			<label class="group-name"><?= _t('conf.display.icon.entry') ?></label>
 			<div class="group-controls">
 				<table class="config-articleicons">

--- a/app/views/helpers/index/normal/entry_header.phtml
+++ b/app/views/helpers/index/normal/entry_header.phtml
@@ -49,7 +49,7 @@
 	if ($topline_website !== 'none'):
 	?><li class="item website <?= $topline_website ?>">
 		<a href="<?= _url('index', 'index', 'get', 'f_' . $this->feed->id()) ?>" class="item-element" title="<?= _t('gen.action.filter') ?>: <?= $this->feed->name() ?>">
-			<?php if (FreshRSS_Context::userConf()->show_favicons && 'name' !== $topline_website): ?><img class="favicon" src="<?= $this->feed->favicon() ?>" alt="✇" loading="lazy" /><?php endif; ?><?php if ('icon' !== $topline_website): ?><span class="websiteName"><?= $this->feed->name() ?></span><?php endif; ?>
+			<?php if ('name' !== $topline_website): ?><img class="favicon" src="<?= $this->feed->favicon() ?>" alt="✇" loading="lazy" /><?php endif; ?><?php if ('icon' !== $topline_website): ?><span class="websiteName"><?= $this->feed->name() ?></span><?php endif; ?>
 		</a>
 		</li><?php
 	endif; ?>

--- a/app/views/helpers/index/normal/entry_header.phtml
+++ b/app/views/helpers/index/normal/entry_header.phtml
@@ -47,7 +47,7 @@
 	}
 
 	if ($topline_website !== 'none'):
-	?><li class="item website <?= $topline_website ?>">
+	?><li class="item website website-<?= $topline_website ?>">
 		<a href="<?= _url('index', 'index', 'get', 'f_' . $this->feed->id()) ?>" class="item-element" title="<?= _t('gen.action.filter') ?>: <?= $this->feed->name() ?>">
 			<?php if ('name' !== $topline_website): ?><img class="favicon" src="<?= $this->feed->favicon() ?>" alt="✇" loading="lazy" /><?php endif; ?><?php if ('icon' !== $topline_website): ?><span class="websiteName"><?= $this->feed->name() ?></span><?php endif; ?>
 		</a>


### PR DESCRIPTION
The `show_favicons` user config flag has been a hidden setting in `data/users/<user>/config.php` with no UI exposure. This PR surfaces it as a checkbox on the Display settings page (below the Thumbnail dropdown), and resolves an overlap with the existing `topline_website` (Website) dropdown.

## What changes

1. New checkbox "Show feed icons in lists" on Display settings, bound to `show_favicons`. Default remains `true`, so existing users see no behaviour change.
2. `entry_header.phtml`: removes the `show_favicons` gate from the normal-view article topline. The `topline_website` dropdown becomes the sole authority for icons in that surface.

<img width="284" height="129" alt="image" src="https://github.com/user-attachments/assets/f71a6757-9501-4d79-ab49-b664db2fdf09" />

## Why the entry_header change

Before this PR, both flags gated the topline icon:

```php
if (show_favicons && 'name' !== topline_website) { /* icon */ }
if ('icon' !== topline_website) { /* name */ }
```

With the checkbox newly visible to users, the combination Website='Icon only' + Show feed icons=off would produce an empty website slot in the topline (no icon, no name). Dropping the `show_favicons` gate makes scope cleaner: Website dropdown controls the topline; the checkbox controls every other surface (sidebar, global view, reader view, opened-article header, subscription page, stats page).

The behaviour change only affects users who manually set `show_favicons=false` in config AND have `topline_website` set to `icon` or `full`. Since the flag was never UI-exposed, that population is likely small.

## Out of scope

- Active-feed sidebar icon exception in `aside_feed.phtml` (`||$f_active`) is unchanged.
- `simplify_over_n_feeds` sidebar gating is unchanged.

## Test plan

- Display settings page renders the new checkbox below the Thumbnail dropdown.
- Toggling it persists to `data/users/<user>/config.php`.
- Off: icons hidden in sidebar, normal view collapsed rows (when `topline_website` already excludes them), global view, reader view, opened article inner header.
- On: icons return in all the above.
- Conflict scenario: Website='Icon only' + checkbox off shows the icon in the topline (proving topline is now solely controlled by the dropdown).
- Active-feed sidebar exception still shows that one feed's icon (unchanged behaviour).

`make test-all` clean: 624 PHPUnit / 1160 assertions, PHPStan 0 errors, phpcs/eslint/stylelint/markdownlint clean.