### PR TITLE
fix(themes): drop topline_website value from <li> class to avoid filter collision

### DIFF
--- a/app/views/helpers/index/normal/entry_header.phtml
+++ b/app/views/helpers/index/normal/entry_header.phtml
@@ -47,7 +47,7 @@
 	}
 
 	if ($topline_website !== 'none'):
-	?><li class="item website <?= $topline_website ?>">
+	?><li class="item website">
 		<a href="<?= _url('index', 'index', 'get', 'f_' . $this->feed->id()) ?>" class="item-element" title="<?= _t('gen.action.filter') ?>: <?= $this->feed->name() ?>">
 			<?php if (FreshRSS_Context::userConf()->show_favicons && 'name' !== $topline_website): ?><img class="favicon" src="<?= $this->feed->favicon() ?>" alt="✇" loading="lazy" /><?php endif; ?><?php if ('icon' !== $topline_website): ?><span class="websiteName"><?= $this->feed->name() ?></span><?php endif; ?>
 		</a>


### PR DESCRIPTION
On Nord and Dark with topline-website set to "Icon only", article-list favicons render filtered (tinted on Nord, darkened on Dark). The article body shows them correctly.

The `<li>` in entry_header.phtml is rendered with the topline value as a literal class: `<li class="item website <?= $topline_website ?>">`. With value `icon`, the result collides with the bare `.icon` filter rules in Nord and Dark, which cascade onto the favicon inside.

The class is unused. No theme CSS targets `.website.icon`, `.website.name`, or `.website.full`. Layout uses the parent `<ul>`'s concatenated form (`.websiteicon`, `.websitename`). Dropping it fixes the bug with no loss of information.

Latent since #4969 (2023-03-04).

## Reproduce

1. Set theme to Nord or Dark.
2. Display settings: set "Topline website" to "Icon only".
3. Open the article list. Favicons render with a color filter on every entry.

## Screenshots

| Nord (broken) | Dark (broken) | After fix |
|---|---|---|
| <img width="32" height="34" alt="Screenshot 2026-05-10 at 09 55 18" src="https://github.com/user-attachments/assets/7215ed0e-132a-4a36-9f55-5d34699fa700" /> | <img width="26" height="27" alt="Screenshot 2026-05-10 at 09 56 49" src="https://github.com/user-attachments/assets/c53747d2-0c15-449e-a69b-e2168e3973c8" /> | <img width="30" height="32" alt="Screenshot 2026-05-10 at 01 26 55" src="https://github.com/user-attachments/assets/a7753677-54b6-4edb-a316-0e8c2038e34a" /> |