### PR TITLE
fix(themes): show feed name at narrow widths when configured

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1564,7 +1564,6 @@ a.website:hover .favicon {
 	object-fit: cover;
 }
 
-
 .flux .flux_header .item.titleAuthorSummaryDate {
 	position: relative;
 	overflow: hidden;
@@ -2475,7 +2474,6 @@ html.slider-active {
 		--frss-padding-flux-items: 0.5rem;
 	}
 
-	.flux_header .item.website span,
 	.item .date,
 	.dropdown-menu > .no-mobile,
 	.no-mobile,
@@ -2499,7 +2497,6 @@ html.slider-active {
 	.header > .item.title .logo {
 		height: 24px;
 	}
-
 
 	header .item.search form {
 		display: none;
@@ -2564,10 +2561,6 @@ html.slider-active {
 			"thumbnail content content content content content content";
 		align-items: start;
 		list-style: none;
-	}
-
-	.flux .flux_header.has-thumbnail.has-summary li.website .websiteName {
-		display: inline;
 	}
 
 	/** place all the elements in their respective template areas */
@@ -2800,7 +2793,8 @@ html.slider-active {
 		padding: 0;
 	}
 
-	.flux_header .item.website {
+	/** Compensate for shrunk --frss-padding-flux-items so favicon cell stays 40px at narrow */
+	.flux_header.websiteicon .item.website {
 		width: 40px;
 	}
 

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1564,7 +1564,6 @@ a.website:hover .favicon {
 	object-fit: cover;
 }
 
-
 .flux .flux_header .item.titleAuthorSummaryDate {
 	position: relative;
 	overflow: hidden;
@@ -2475,7 +2474,6 @@ html.slider-active {
 		--frss-padding-flux-items: 0.5rem;
 	}
 
-	.flux_header .item.website span,
 	.item .date,
 	.dropdown-menu > .no-mobile,
 	.no-mobile,
@@ -2499,7 +2497,6 @@ html.slider-active {
 	.header > .item.title .logo {
 		height: 24px;
 	}
-
 
 	header .item.search form {
 		display: none;
@@ -2564,10 +2561,6 @@ html.slider-active {
 			"thumbnail content content content content content content";
 		align-items: start;
 		list-style: none;
-	}
-
-	.flux .flux_header.has-thumbnail.has-summary li.website .websiteName {
-		display: inline;
 	}
 
 	/** place all the elements in their respective template areas */
@@ -2800,7 +2793,8 @@ html.slider-active {
 		padding: 0;
 	}
 
-	.flux_header .item.website {
+	/** Compensate for shrunk --frss-padding-flux-items so favicon cell stays 40px at narrow */
+	.flux_header.websiteicon .item.website {
 		width: 40px;
 	}
 


### PR DESCRIPTION
## Problem

`Settings > Display` has a `Website` dropdown with `Icon only`, `Name only`, `Icon and name`, and `None`. At viewports ≤840px, the feed name is hidden in `Name only` and `Icon and name`, leaving only the favicon (or nothing). The setting is effectively ignored in narrow view.

Cause: two CSS rules in `base-theme/frss.css` predate the configurable modes from #4969 and assume icon-only behavior at narrow widths. #8631 added a partial workaround that re-shows the name only when both `Thumbnail` and `Summary` are enabled (the grid layout), so the bug only surfaces with the default `Thumbnail = none, Summary = off` config.

## Reproduction

1. `Settings > Display`, set `Website` to `Name only` or `Icon and name`
2. Resize the browser to ≤840px

Expected: feed name visible per the `Website` setting. Actual: only the favicon (or nothing) renders.

## Fix

In `base-theme/frss.css` (and the regenerated `frss.rtl.css`), inside the narrow `@media` block:

- Delete `.flux_header .item.website span { display: none }`. Hid the name span unconditionally; `Icon only` mode does not render the span at all, so the rule was dead there and harmful elsewhere.
- Delete `.flux .flux_header.has-thumbnail.has-summary li.website .websiteName { display: inline }`. The grid-layout workaround above; redundant once the underlying rule is gone.
- Scope `.flux_header .item.website { width: 40px }` to `.flux_header.websiteicon`. The 40px override only makes sense for `Icon only`. `Name only` and `Icon and name` now inherit their wide-view widths (150px and 200px). A short comment notes why the override is still needed at narrow: `--frss-padding-flux-items` shrinks from 0.75rem to 0.5rem in the narrow block, so without the override the icon cell would drop from 40px to 32px.