### PR TITLE
fix(themes): replace #load_more loading-state GIF with a CSS spinner

### DIFF
--- a/p/themes/Ansum/_components.css
+++ b/p/themes/Ansum/_components.css
@@ -201,11 +201,6 @@
 	}
 }
 
-#load_more.loading,
-#load_more.loading:hover {
-	background: url("loader.gif") center center no-repeat #34495e;
-}
-
 /*=== Boxes */
 .box {
 	background: var(--white);

--- a/p/themes/Ansum/_components.rtl.css
+++ b/p/themes/Ansum/_components.rtl.css
@@ -201,11 +201,6 @@
 	}
 }
 
-#load_more.loading,
-#load_more.loading:hover {
-	background: url("loader.gif") center center no-repeat #34495e;
-}
-
 /*=== Boxes */
 .box {
 	background: var(--white);

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -417,11 +417,6 @@ th {
 	color: #000;
 }
 
-#load_more.loading,
-#load_more.loading:hover {
-	background: url("loader.gif") center center no-repeat #34495e;
-}
-
 /*=== Boxes */
 .box {
 	border: 1px solid #ddd;

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -417,11 +417,6 @@ th {
 	color: #000;
 }
 
-#load_more.loading,
-#load_more.loading:hover {
-	background: url("loader.gif") center center no-repeat #34495e;
-}
-
 /*=== Boxes */
 .box {
 	border: 1px solid #ddd;

--- a/p/themes/Mapco/_components.css
+++ b/p/themes/Mapco/_components.css
@@ -189,11 +189,6 @@
 
 }
 
-#load_more.loading,
-#load_more.loading:hover {
-	background: url("loader.gif") center center no-repeat #34495e;
-}
-
 /*=== Boxes */
 .box {
 	background: var(--white);

--- a/p/themes/Mapco/_components.rtl.css
+++ b/p/themes/Mapco/_components.rtl.css
@@ -189,11 +189,6 @@
 
 }
 
-#load_more.loading,
-#load_more.loading:hover {
-	background: url("loader.gif") center center no-repeat #34495e;
-}
-
 /*=== Boxes */
 .box {
 	background: var(--white);

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -877,14 +877,6 @@ li.item.active {
 	margin: 0;
 }
 
-#load_more.loading {
-	background-color: var(--accent);
-}
-
-#load_more.loading:hover {
-	background-color: var(--highlight);
-}
-
 /*=== Notification and actualize notification */
 .notification {
 	background: var(--dropdown-bg);

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -877,14 +877,6 @@ li.item.active {
 	margin: 0;
 }
 
-#load_more.loading {
-	background-color: var(--accent);
-}
-
-#load_more.loading:hover {
-	background-color: var(--highlight);
-}
-
 /*=== Notification and actualize notification */
 .notification {
 	background: var(--dropdown-bg);

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -564,12 +564,6 @@ li.item.separator {
 	}
 }
 
-#load_more.loading,
-#load_more.loading:hover {
-	background: url(loader.gif) center center no-repeat var(--color-background-aside);
-}
-
-
 .content {
 	padding: 20px 10px;
 

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -564,12 +564,6 @@ li.item.separator {
 	}
 }
 
-#load_more.loading,
-#load_more.loading:hover {
-	background: url(loader.gif) center center no-repeat var(--color-background-aside);
-}
-
-
 .content {
 	padding: 20px 10px;
 

--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -300,11 +300,6 @@ th {
 .pagination:last-child .item {
 }
 
-#load_more.loading,
-#load_more.loading:hover {
-	font-size: 0;
-}
-
 /*=== Boxes */
 .box {
 }

--- a/p/themes/base-theme/base.rtl.css
+++ b/p/themes/base-theme/base.rtl.css
@@ -300,11 +300,6 @@ th {
 .pagination:last-child .item {
 }
 
-#load_more.loading,
-#load_more.loading:hover {
-	font-size: 0;
-}
-
 /*=== Boxes */
 .box {
 }

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1977,21 +1977,21 @@ a.website:hover .favicon {
 }
 
 #load_more.loading::after {
-	background: radial-gradient(farthest-side, currentColor 94%, transparent) top/5px 5px no-repeat,
-		conic-gradient(transparent 30%, currentColor);
-	width: 24px;
-	border-radius: 50%;
 	content: "";
 	position: absolute;
 	top: calc(50% - 12px);
 	left: calc(50% - 12px);
-	aspect-ratio: 1;
-	mask: radial-gradient(farthest-side, transparent calc(100% - 5px), #000 0);
+	width: 24px;
+	height: 24px;
+	border: 3px solid currentColor;
+	border-right-color: transparent;
+	border-radius: 50%;
+	opacity: 0.7;
 	animation: frss-spin 1s linear infinite;
 }
 
 @keyframes frss-spin {
-	to { transform: rotate(1turn); }
+	to { transform: rotate(360deg); }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1969,9 +1969,33 @@ a.website:hover .favicon {
 
 #load_more.loading,
 #load_more.loading:hover {
-	padding: 10px 20px;
-	background: var(--frss-loading-image) center center no-repeat var(--frss-background-color);
+	position: relative;
+	min-width: 40px;
+	background: none;
+	border-color: transparent;
 	font-size: 0;
+}
+
+#load_more.loading::after {
+	background: radial-gradient(farthest-side, currentColor 94%, transparent) top/5px 5px no-repeat,
+		conic-gradient(transparent 30%, currentColor);
+	width: 24px;
+	border-radius: 50%;
+	content: "";
+	position: absolute;
+	top: calc(50% - 12px);
+	left: calc(50% - 12px);
+	aspect-ratio: 1;
+	mask: radial-gradient(farthest-side, transparent calc(100% - 5px), #000 0);
+	animation: frss-spin 1s linear infinite;
+}
+
+@keyframes frss-spin {
+	to { transform: rotate(1turn); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+	#load_more.loading::after { animation: none; }
 }
 
 .loading {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1984,7 +1984,7 @@ a.website:hover .favicon {
 	width: 24px;
 	height: 24px;
 	border: 3px solid currentColor;
-	border-right-color: transparent;
+	border-left-color: transparent;
 	border-radius: 50%;
 	opacity: 0.7;
 	animation: frss-spin 1s linear infinite;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1969,9 +1969,33 @@ a.website:hover .favicon {
 
 #load_more.loading,
 #load_more.loading:hover {
-	padding: 10px 20px;
-	background: var(--frss-loading-image) center center no-repeat var(--frss-background-color);
+	position: relative;
+	min-width: 40px;
+	background: none;
+	border-color: transparent;
 	font-size: 0;
+}
+
+#load_more.loading::after {
+	background: radial-gradient(farthest-side, currentColor 94%, transparent) top/5px 5px no-repeat,
+		conic-gradient(transparent 30%, currentColor);
+	width: 24px;
+	border-radius: 50%;
+	content: "";
+	position: absolute;
+	top: calc(50% - 12px);
+	right: calc(50% - 12px);
+	aspect-ratio: 1;
+	mask: radial-gradient(farthest-side, transparent calc(100% - 5px), #000 0);
+	animation: frss-spin 1s linear infinite;
+}
+
+@keyframes frss-spin {
+	to { transform: rotate(-1turn); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+	#load_more.loading::after { animation: none; }
 }
 
 .loading {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1977,21 +1977,21 @@ a.website:hover .favicon {
 }
 
 #load_more.loading::after {
-	background: radial-gradient(farthest-side, currentColor 94%, transparent) top/5px 5px no-repeat,
-		conic-gradient(transparent 30%, currentColor);
-	width: 24px;
-	border-radius: 50%;
 	content: "";
 	position: absolute;
 	top: calc(50% - 12px);
 	right: calc(50% - 12px);
-	aspect-ratio: 1;
-	mask: radial-gradient(farthest-side, transparent calc(100% - 5px), #000 0);
+	width: 24px;
+	height: 24px;
+	border: 3px solid currentColor;
+	border-right-color: transparent;
+	border-radius: 50%;
+	opacity: 0.7;
 	animation: frss-spin 1s linear infinite;
 }
 
 @keyframes frss-spin {
-	to { transform: rotate(-1turn); }
+	to { transform: rotate(-360deg); }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
In its `.loading` state, the "Load more" button keeps its `.btn` frame on every theme, and on most themes the spinner inside is hard to see or invisible. Nord, Flat, Mapco, Ansum and Swage had per-theme overrides that papered over the spinner symptom with coloured fills instead of fixing the cause.

Replace the GIF with a CSS spinner in base-theme that:

- inherits `currentColor` from the button, so it reads correctly on every theme,
- drops the button frame and background fill in the loading state,
- respects `prefers-reduced-motion`,
- renders crisply at any DPI.

The per-theme `#load_more.loading` overrides become redundant and are removed. `loader.gif` is still used by a few other rules in base-theme, so the asset stays.

## Screenshots

| Before (Nord) | Before (Alt-Dark) | After (v2) |
|---|---|---|
| <img width="50" height="52" alt="Untitled" src="https://github.com/user-attachments/assets/3a07858f-fdf3-4874-85c7-3d68a84bf342" /> | <img width="50" height="48" alt="Screenshot 2026-05-10 at 22 04 32" src="https://github.com/user-attachments/assets/434bbbe1-1b6a-4beb-aebe-3dca6dc1dbee" /> | <img width="35" height="36" alt="Screenshot 2026-05-11 at 11 05 43" src="https://github.com/user-attachments/assets/0d590702-43d8-4607-a631-f522d984473a" /> |

## Reproduction

1. Configuration > Reading: turn off "Load more articles at the bottom of the page".
2. DevTools > Network: set throttling to the slowest preset (e.g. GPRS, ~50 kbps) so the loading state is observable.
3. Click "Load more" and watch the loading state. The button frame stays visible on every theme; on most themes the spinner inside is also hard to see or invisible.

## Notes

- RTL stylesheets regenerated via `npm run rtlcss`.
- Per-theme `loader.gif` copies (`Nord/loader.gif`, `Dark/loader.gif`, etc.) have never been referenced: CSS relative URLs in `--frss-loading-image` resolve against `base-theme/frss.css` regardless of active theme. They were already orphaned before this change; cleanup of those copies is a separate change.
- The same spinner pattern would work for the remaining `loader.gif` consumers; after that the asset is fully removable.


