### PR TITLE
chore(themes): rename "Nord theme" to "Nord"

### DIFF
--- a/docs/en/users/05_Configuration.md
+++ b/docs/en/users/05_Configuration.md
@@ -58,7 +58,7 @@ There’s no accounting for tastes, which is why FreshRSS offers 13 official the
 | Dark pink | Miicat_47 | |
 | Flat design | Marien Fressinaud | |
 | Mapco | Thomas Guesnon  | |
-| Nord theme | joelchrono12 | |
+| Nord | joelchrono12 | |
 | Origine | Marien Fressinaud | (default theme) |
 | Origine-compact | Kevin Papst | |
 | Pafat | Plopoyop | |

--- a/docs/fr/users/05_Configuration.md
+++ b/docs/fr/users/05_Configuration.md
@@ -64,7 +64,7 @@ propose 13 thèmes officiels :
 | Dark pink | Miicat_47 | |
 | Flat design | Marien Fressinaud | N’est plus pris en charge. Sera supprimé avec FreshRSS V1.22.0 |
 | Mapco | Thomas Guesnon  | |
-| Nord theme | joelchrono12 | |
+| Nord | joelchrono12 | |
 | Origine | Marien Fressinaud | (default theme) |
 | Origine-compact | Kevin Papst | |
 | Pafat | Plopoyop | |

--- a/p/themes/Nord/metadata.json
+++ b/p/themes/Nord/metadata.json
@@ -1,5 +1,5 @@
 {
-	"name": "Nord theme",
+	"name": "Nord",
 	"author": "joelchrono12",
 	"description": "A simple theme based on Nord’s color scheme",
 	"version": 0.1,


### PR DESCRIPTION
Rename the Nord theme display name from "Nord theme" to "Nord". The upstream Nord palette project at https://www.nordtheme.com refers to itself consistently as "Nord" throughout its branding; the "theme" suffix is redundant. The rename also matches the other entries in the theme picker (Ansum, Dark, Mapco, Pafat, Swage), which all use a single short name.

The theme directory, file paths, and CSS class names are unchanged. Only the user-facing display name in the theme picker (and the corresponding rows in the user docs) is affected.