### PR TITLE
refactor(themes): drop redundant multiline class on title

### DIFF
--- a/app/views/helpers/index/normal/entry_header.phtml
+++ b/app/views/helpers/index/normal/entry_header.phtml
@@ -64,7 +64,7 @@
 	?></li><?php
 	endif; ?>
 	<li class="item titleAuthorSummaryDate">
-		<a target="_blank" rel="noreferrer" href="<?= $this->entry->link() ?>" class="item-element title<?= (($topline_thumbnail !== 'none') || $topline_summary) ? ' multiline' : '' ?>" dir="auto"><?= $this->entry->title() ?><?php
+		<a target="_blank" rel="noreferrer" href="<?= $this->entry->link() ?>" class="item-element title" dir="auto"><?= $this->entry->title() ?><?php
 		if ($topline_display_authors):
 			?> <span class="author"><?= implode(' · ', $this->entry->authors()) ?></span><?php
 		endif;

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1513,7 +1513,8 @@ a.website:hover .favicon {
 	background-color: inherit;
 }
 
-.flux .item:has(.multiline) {
+.flux .flux_header.has-thumbnail .item.titleAuthorSummaryDate,
+.flux .flux_header.has-summary .item.titleAuthorSummaryDate {
 	vertical-align: top;
 }
 

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1513,7 +1513,8 @@ a.website:hover .favicon {
 	background-color: inherit;
 }
 
-.flux .item:has(.multiline) {
+.flux .flux_header.has-thumbnail .item.titleAuthorSummaryDate,
+.flux .flux_header.has-summary .item.titleAuthorSummaryDate {
 	vertical-align: top;
 }
 


### PR DESCRIPTION
The `multiline` class on the title `<a>` existed only so the parent `<li>` could detect it via `:has(.multiline)`. The underlying condition (thumbnail or summary enabled) is already exposed on the parent `<ul>` by the `has-thumbnail` and `has-summary` classes, so keying the rule on those directly removes the indirection. Same elements matched in modern browsers. Also applies where `:has()` isn't supported, which is relevant to #6776.

Part of preparing for the layout refactor discussed in the same issue: removing this `:has()` use is one less thing to reason about in the larger change.

## Test plan
- `make test-all` passes
- Article list renders identically in Origine with thumbnails and/or summaries enabled (verified by toggling each combination and comparing against the unpatched state)