### PR TITLE
fix(themes): use has-date class for date-aware list layout

### DIFF
--- a/app/views/helpers/index/normal/entry_header.phtml
+++ b/app/views/helpers/index/normal/entry_header.phtml
@@ -19,6 +19,9 @@
 	if ($topline_summary) {
 		$headerClasses[] = 'has-summary';
 	}
+	if ($topline_date) {
+		$headerClasses[] = 'has-date';
+	}
 	if ($this->feed === null || $this->entry === null) {
 		return;
 	}

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1504,7 +1504,7 @@ a.website:hover .favicon {
 	font-weight: bold;
 }
 
-.flux:not(.current):hover .flux_header .item .title:has(~ .date) {
+.flux:not(.current):hover .flux_header.has-date .item .title {
 	padding-right: 0.5rem;
 	z-index: 2;
 }
@@ -1583,7 +1583,7 @@ a.website:hover .favicon {
 	text-decoration: none;
 }
 
-.flux .flux_header .item .title:has(~.date) {
+.flux .flux_header.has-date .item .title {
 	padding-right: 155px;
 }
 
@@ -1601,7 +1601,7 @@ a.website:hover .favicon {
 	margin-bottom: 0.5rem;
 }
 
-.flux .flux_header .item .summary:has(~.date) {
+.flux .flux_header.has-date .item .summary {
 	max-width: 90%;
 }
 
@@ -2574,7 +2574,7 @@ html.slider-active {
 		padding-right: 1rem;
 	}
 
-	.flux .flux_header .item .title:has(~.date) {
+	.flux .flux_header.has-date .item .title {
 		padding-right: 1rem;
 	}
 

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1504,7 +1504,7 @@ a.website:hover .favicon {
 	font-weight: bold;
 }
 
-.flux:not(.current):hover .flux_header .item .title:has(~ .date) {
+.flux:not(.current):hover .flux_header.has-date .item .title {
 	padding-left: 0.5rem;
 	z-index: 2;
 }
@@ -1583,7 +1583,7 @@ a.website:hover .favicon {
 	text-decoration: none;
 }
 
-.flux .flux_header .item .title:has(~.date) {
+.flux .flux_header.has-date .item .title {
 	padding-left: 155px;
 }
 
@@ -1601,7 +1601,7 @@ a.website:hover .favicon {
 	margin-bottom: 0.5rem;
 }
 
-.flux .flux_header .item .summary:has(~.date) {
+.flux .flux_header.has-date .item .summary {
 	max-width: 90%;
 }
 
@@ -2574,7 +2574,7 @@ html.slider-active {
 		padding-left: 1rem;
 	}
 
-	.flux .flux_header .item .title:has(~.date) {
+	.flux .flux_header.has-date .item .title {
 		padding-left: 1rem;
 	}
 


### PR DESCRIPTION
Replaces the four `:has(~.date)` selectors with a `has-date` modifier class on `.flux_header`, mirroring the existing `has-thumbnail` and `has-summary`. The PHP template adds the class when `$topline_date` is true.

Functionally identical in browsers that support `:has()`. Fixes the date overlap in browsers that don't (#6776).

## Test plan
- `make test-all` passes
- Verified in Origine and Nord themes, with date display on and off, in both modern (LibreWolf) and `:has()`-less (SeaMonkey) browsers