### PR TITLE
refactor(themes): drop redundant :has() in dropdown label selector

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -409,7 +409,7 @@ input[type="checkbox"] {
 	display: none;
 }
 
-.dropdown-menu .item label:not(.noHover):has(input[type="checkbox"]) {
+.dropdown-menu .item label:not(.noHover) {
 	padding-left: 2.5rem;
 	text-indent: -2.5rem;
 }

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -409,7 +409,7 @@ input[type="checkbox"] {
 	display: none;
 }
 
-.dropdown-menu .item label:not(.noHover):has(input[type="checkbox"]) {
+.dropdown-menu .item label:not(.noHover) {
 	padding-right: 2.5rem;
 	text-indent: -2.5rem;
 }


### PR DESCRIPTION
The `:has(input[type="checkbox"])` check is redundant. Every `<label>` inside `.dropdown-menu .item` already has a checkbox child (constructed in `main.js`), so the selector matches the same set as `:not(.noHover)` alone. Removing it makes the rule work in browsers without `:has()` support (#6776).

## Test plan
- `make test-all` passes
- Verified the labels dropdown renders correctly in LibreWolf with sample tags