### PR TITLE
fix(themes): cap website column at narrow widths (#8814)

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2823,6 +2823,12 @@ html.slider-active {
 		width: 40px;
 	}
 
+	/** Cap website column when feed name is shown, to leave room for the title */
+	.flux_header.websitename .item.website,
+	.flux_header.websitefull .item.website {
+		width: clamp(120px, 18vw, 150px);
+	}
+
 	.flux:not(.current):hover .item.title {
 		position: relative;
 		width: auto;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2823,6 +2823,12 @@ html.slider-active {
 		width: 40px;
 	}
 
+	/** Cap website column when feed name is shown, to leave room for the title */
+	.flux_header.websitename .item.website,
+	.flux_header.websitefull .item.website {
+		width: clamp(120px, 18vw, 150px);
+	}
+
 	.flux:not(.current):hover .item.title {
 		position: relative;
 		width: auto;


### PR DESCRIPTION
#8801 removed two narrow @media rules that had previously forced icon-only behavior at mobile widths, so users with `topline_website = name` or `full` would actually see the feed name on phones. With those rules gone, the `.item.website` column inherited the wide-width defaults (200px for `full`, 150px for `name`), squashing the article title into a few characters of ellipsis (#8814).

Re-introduce a narrow-width cap for the name-bearing modes:

```css
.flux_header.websitename .item.website,
.flux_header.websitefull .item.website {
	width: clamp(120px, 18vw, 150px);
}
```

`clamp(120px, 18vw, 150px)` keeps a 120px floor on phones (favicon plus a readable name), scales with viewport across the 667-833px range, and caps at 150px to match the wide-width `websitename` default. The column shrinks rather than grows as the viewport narrows across the 840px breakpoint, and the title regains the bulk of the row.

## Screenshots

| Zoom | Before | After |
|---|---|---|
| 175% | <img width="1080" height="2118" alt="scale175-original" src="https://github.com/user-attachments/assets/a3fa3e5b-2471-4dcf-a378-a3317873071e" /> | <img width="1080" height="2123" alt="scale175" src="https://github.com/user-attachments/assets/aa60966a-b96a-42e0-ab73-a672c169937b" /> |
| 150% | <img width="1080" height="2115" alt="scale150-original" src="https://github.com/user-attachments/assets/2e3e8908-9333-4336-86a3-c784e617f1fe" /> | <img width="1080" height="2121" alt="scale150" src="https://github.com/user-attachments/assets/fb52ba08-ccb2-4a1d-a912-a5d68cbb04ab" /> |
| 100% | <img width="1080" height="2124" alt="scale100-original" src="https://github.com/user-attachments/assets/17ee2cb5-214f-4e4a-bdd7-2413dfffd11f" /> | <img width="1080" height="2122" alt="scale100" src="https://github.com/user-attachments/assets/e8dd518a-5047-42fa-b86f-23bb21935cc0" /> |

## Test plan

- [x] Phone at 100%, 150%, 175% browser zoom: title gets most of the row, feed name visible and ellipsised when long
- [x] `topline_website = icon` still shows favicon-only at 40px
- [x] `topline_website = name` and `full` both render correctly
- [x] Wide viewports (>840px) unaffected