### PR TITLE
fix(theme): inherit font-family on form controls

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -64,6 +64,10 @@ html, body {
 	font-size: 100%;
 }
 
+button, input, select, textarea {
+	font-family: inherit;
+}
+
 main#stream {
 	container-type: inline-size;
 	container-name: main;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -64,6 +64,10 @@ html, body {
 	font-size: 100%;
 }
 
+button, input, select, textarea {
+	font-family: inherit;
+}
+
 main#stream {
 	container-type: inline-size;
 	container-name: main;


### PR DESCRIPTION
Browsers don't inherit `font-family` on form controls, so the rule on `html, body` in `frss.css` doesn't reach the "Mark as read" button or the search input. They fall back to the UA default instead of the theme font (most visible in Nord).

Adding `font-family: inherit` on `button, input, select, textarea` fixes it for every theme extending base-theme. `frss.rtl.css` regenerated with `make rtl`. `make test-all` passes locally.

Reported and tested by @JerryCrazy.

Fixes #8803