### PR TITLE
feat(import): accept .txt URL lists alongside OPML/JSON/ZIP

### DIFF
--- a/app/Controllers/importExportController.php
+++ b/app/Controllers/importExportController.php
@@ -249,7 +249,8 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 	 * so it can be imported through the existing OPML pipeline.
 	 */
 	private static function txtToOpml(string $contents): string {
-		$contents = preg_replace('/^\xEF\xBB\xBF/', '', $contents) ?? $contents;
+		$utf8BOM = "\xEF\xBB\xBF";
+		$contents = preg_replace('/^' . $utf8BOM . '/', '', $contents) ?? $contents;
 		$outlines = '';
 		foreach (preg_split('/\R/', $contents) ?: [] as $line) {
 			$url = trim($line);

--- a/app/Controllers/importExportController.php
+++ b/app/Controllers/importExportController.php
@@ -266,7 +266,7 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 				}
 				continue;
 			}
-			$escaped = htmlspecialchars($url, ENT_QUOTES | ENT_XML1, 'UTF-8');
+			$escaped = htmlspecialchars($url, ENT_COMPAT | ENT_XML1, 'UTF-8');
 			$outlines .= '<outline type="rss" text="' . $escaped . '" xmlUrl="' . $escaped . '" />' . "\n";
 		}
 		return '<?xml version="1.0" encoding="UTF-8"?>' . "\n"

--- a/app/Controllers/importExportController.php
+++ b/app/Controllers/importExportController.php
@@ -98,6 +98,11 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 		} elseif ('zip' === $type_file) {
 			// ZIP extension is not loaded
 			throw new FreshRSS_ZipMissing_Exception();
+		} elseif ('txt' === $type_file) {
+			$contents = file_get_contents($path);
+			if (is_string($contents)) {
+				$list_files['opml'][] = self::txtToOpml($contents);
+			}
 		} elseif ('unknown' !== $type_file) {
 			$list_files[$type_file][] = file_get_contents($path);
 		}
@@ -219,6 +224,8 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 	private static function guessFileType(string $filename): string {
 		if (str_ends_with($filename, '.zip')) {
 			return 'zip';
+		} elseif (str_ends_with($filename, '.txt')) {
+			return 'txt';
 		} elseif (stripos($filename, 'opml') !== false) {
 			return 'opml';
 		} elseif (str_ends_with($filename, '.json')) {
@@ -235,6 +242,36 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 			}
 		}
 		return 'unknown';
+	}
+
+	/**
+	 * Wraps a newline-separated list of feed URLs into a minimal OPML document
+	 * so it can be imported through the existing OPML pipeline.
+	 */
+	private static function txtToOpml(string $contents): string {
+		$contents = preg_replace('/^\xEF\xBB\xBF/', '', $contents) ?? $contents;
+		$outlines = '';
+		foreach (preg_split('/\R/', $contents) ?: [] as $line) {
+			$url = trim($line);
+			if ($url === '' || str_starts_with($url, '#')) {
+				continue;
+			}
+			if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+				$message = 'TXT import: skipping invalid URL “' . $url . '”';
+				if (FreshRSS_Context::$isCli) {
+					fwrite(STDERR, $message . "\n");
+				} else {
+					Minz_Log::warning($message);
+				}
+				continue;
+			}
+			$escaped = htmlspecialchars($url, ENT_QUOTES | ENT_XML1, 'UTF-8');
+			$outlines .= '<outline type="rss" text="' . $escaped . '" xmlUrl="' . $escaped . '" />' . "\n";
+		}
+		return '<?xml version="1.0" encoding="UTF-8"?>' . "\n"
+			. '<opml version="2.0"><body>' . "\n"
+			. $outlines
+			. '</body></opml>' . "\n";
 	}
 
 	private function ttrssXmlToJson(string $xml): string|false {

--- a/cli/import-for-user.php
+++ b/cli/import-for-user.php
@@ -27,7 +27,7 @@ if (!is_readable($filename)) {
 	fail('FreshRSS error: file is not readable “' . $filename . '”');
 }
 
-echo 'FreshRSS importing ZIP/OPML/JSON for user “', $username, "”…\n";
+echo 'FreshRSS importing ZIP/OPML/JSON/TXT for user “', $username, "”…\n";
 
 $importController = new FreshRSS_importExport_Controller();
 


### PR DESCRIPTION
Adds plain-text URL lists as a recognised import format. Files with a `.txt` extension are wrapped into an OPML document and handed to the existing OPML import path, so dedup, category assignment and feed limits work the same as they do for OPML. Available through both `cli/import-for-user.php` and the web import form.

Reworks #5268 along the lines suggested in that thread: no new CLI file, integrated into `import-for-user.php` and the web form, detected by extension.

## Format

One URL per line. Blank lines and `#` comments are skipped. A leading UTF-8 BOM is stripped. CRLF and LF both work. Lines that don't parse as a URL are logged and skipped; the rest are imported.

## Test plan

Tested on a live instance (SQLite, PHP 8.5):

- [x] CLI with a mixed file (valid URLs, blanks, comments, malformed URL, URL with a space): valid feeds inserted into the default category, invalid lines on stderr, exit 0
- [x] CLI rerun on the same file: no duplicate rows
- [x] CLI on an empty file: exit 0, no error
- [x] Web path (`$isCli = false`): warnings go to the user log file instead of stderr
- [x] Generated OPML round-trips through `LibOpml::parseString` with `&`, `"`, `<`, `>` in URLs intact
- [x] `composer run-script phpcs`, `phpstan` and `phpunit` (624 tests) pass