### PR TITLE
Reduce sidebar animation duration from 200ms to 100ms

### DIFF
--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -687,7 +687,7 @@ th {
 
 @media (max-width: 840px) {
 	.aside {
-		transition: width 200ms linear;
+		transition: width 100ms ease-in;
 	}
 
 	.aside .toggle_aside,

--- a/p/themes/base-theme/base.rtl.css
+++ b/p/themes/base-theme/base.rtl.css
@@ -687,7 +687,7 @@ th {
 
 @media (max-width: 840px) {
 	.aside {
-		transition: width 200ms linear;
+		transition: width 100ms ease-in;
 	}
 
 	.aside .toggle_aside,

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2124,7 +2124,7 @@ html.slider-active {
 }
 
 #slider.sliding {
-	transition: width 200ms linear;
+	transition: width 100ms ease-in;
 }
 
 #close-slider {
@@ -2812,7 +2812,7 @@ html.slider-active {
 		width: 0;
 		overflow: hidden;
 		z-index: 100;
-		transition: width 200ms linear;
+		transition: width 100ms ease-in;
 	}
 
 	.aside.aside_feed {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2124,7 +2124,7 @@ html.slider-active {
 }
 
 #slider.sliding {
-	transition: width 200ms linear;
+	transition: width 100ms ease-in;
 }
 
 #close-slider {
@@ -2812,7 +2812,7 @@ html.slider-active {
 		width: 0;
 		overflow: hidden;
 		z-index: 100;
-		transition: width 200ms linear;
+		transition: width 100ms ease-in;
 	}
 
 	.aside.aside_feed {


### PR DESCRIPTION
#8747 (re?)introduced an animation I find unbearably slow. If it was always there I suppose I just got used to it.

How to test the feature manually:

1. Open and close the sidebar on a sufficiently small width.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
