### PR TITLE
Keep mobile article navigation at the bottom

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2869,6 +2869,7 @@ html.slider-active {
 
 	#nav_entries {
 		display: flex !important;
+		top: auto;
 		width: 100%;
 	}
 

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2869,6 +2869,7 @@ html.slider-active {
 
 	#nav_entries {
 		display: flex !important;
+		top: auto;
 		width: 100%;
 	}
 


### PR DESCRIPTION
This keeps the mobile article navigation fixed to the bottom of the viewport by clearing any inherited top offset in the small-screen rule. It updates both LTR and RTL base theme CSS so the previous/next bar remains anchored while browsing on mobile Safari.

Verification: targeted CSS assertion for both base theme files; `git diff --check`.

Closes #8829
