### PR TITLE
TXT import compatibility HTML comments

### DIFF
--- a/app/Controllers/importExportController.php
+++ b/app/Controllers/importExportController.php
@@ -254,7 +254,7 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 		$outlines = '';
 		foreach (preg_split('/\R/', $contents) ?: [] as $line) {
 			$url = trim($line);
-			if ($url === '' || str_starts_with($url, '#')) {
+			if ($url === '' || str_starts_with($url, '#') || str_starts_with($url, '<')) {
 				continue;
 			}
 			if (filter_var($url, FILTER_VALIDATE_URL) === false) {


### PR DESCRIPTION
Discard lines starting with `<` for e.g. HTML/XML comments, tags 

Compatibility with TXT format of https://atlasflux.saynete.net

Follow-up of https://github.com/FreshRSS/FreshRSS/pull/8818