### PR TITLE
revert(themes): hide feed name at narrow viewports

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2833,12 +2833,6 @@ html.slider-active {
 		width: 40px;
 	}
 
-	/** Cap website column when feed name is shown, to leave room for the title */
-	.flux_header.websitename .item.website,
-	.flux_header.websitefull .item.website {
-		width: clamp(120px, 18vw, 150px);
-	}
-
 	.flux:not(.current):hover .item.title {
 		position: relative;
 		width: auto;

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2509,6 +2509,7 @@ html.slider-active {
 		--frss-padding-flux-items: 0.5rem;
 	}
 
+	.flux_header .item.website span,
 	.item .date,
 	.dropdown-menu > .no-mobile,
 	.no-mobile,
@@ -2596,6 +2597,10 @@ html.slider-active {
 			"thumbnail content content content content content content";
 		align-items: start;
 		list-style: none;
+	}
+
+	.flux .flux_header.has-thumbnail.has-summary li.website .websiteName {
+		display: inline;
 	}
 
 	/** place all the elements in their respective template areas */
@@ -2828,8 +2833,7 @@ html.slider-active {
 		padding: 0;
 	}
 
-	/** Compensate for shrunk --frss-padding-flux-items so favicon cell stays 40px at narrow */
-	.flux_header.websiteicon .item.website {
+	.flux_header .item.website {
 		width: 40px;
 	}
 

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2833,12 +2833,6 @@ html.slider-active {
 		width: 40px;
 	}
 
-	/** Cap website column when feed name is shown, to leave room for the title */
-	.flux_header.websitename .item.website,
-	.flux_header.websitefull .item.website {
-		width: clamp(120px, 18vw, 150px);
-	}
-
 	.flux:not(.current):hover .item.title {
 		position: relative;
 		width: auto;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2509,6 +2509,7 @@ html.slider-active {
 		--frss-padding-flux-items: 0.5rem;
 	}
 
+	.flux_header .item.website span,
 	.item .date,
 	.dropdown-menu > .no-mobile,
 	.no-mobile,
@@ -2596,6 +2597,10 @@ html.slider-active {
 			"thumbnail content content content content content content";
 		align-items: start;
 		list-style: none;
+	}
+
+	.flux .flux_header.has-thumbnail.has-summary li.website .websiteName {
+		display: inline;
 	}
 
 	/** place all the elements in their respective template areas */
@@ -2828,8 +2833,7 @@ html.slider-active {
 		padding: 0;
 	}
 
-	/** Compensate for shrunk --frss-padding-flux-items so favicon cell stays 40px at narrow */
-	.flux_header.websiteicon .item.website {
+	.flux_header .item.website {
 		width: 40px;
 	}
 


### PR DESCRIPTION
Reverts #8801 (keeping its incidental blank-line cleanups) and #8815, restoring icon-only feed column on mobile (#8814).

I filed the original PR thinking the icon-only behavior was an inconsistency bug versus the configurable `topline_website` setting, not realizing it was a deliberate mobile choice. The `clamp()` cap helped, but the column still takes space the title could use, and on phones icon-only is the better tradeoff.

A distinct narrow-viewport setting for `topline_website` was raised as a future improvement.

## Test plan

- [x] Narrow viewport, all three `topline_website` modes: name hidden, favicon shown, title fills the row
- [x] Wide viewport: setting respected, unchanged from edge
- [x] `has-thumbnail.has-summary` grid at narrow: name reappears in its dedicated grid area
- [x] `npm run stylelint` + `npm run rtlcss` clean