### PR TITLE
fix(theme): hide Swage logo in reader view to prevent overlap

### DIFF
--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -1709,6 +1709,7 @@ button.as-link {
 	}
 }
 
-body:has(.aside:not(.visible)) .header .item.title {
+body:has(.aside:not(.visible)) .header .item.title,
+body.reader .header .item.title {
 	display: none;
 }

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -1709,6 +1709,7 @@ button.as-link {
 	}
 }
 
-body:has(.aside:not(.visible)) .header .item.title {
+body:has(.aside:not(.visible)) .header .item.title,
+body.reader .header .item.title {
 	display: none;
 }


### PR DESCRIPTION
Closes #8802.

In Swage's reader view, .aside.visible has padding-top: 0 (the compact aside is the original reader design), so the absolute-positioned logo from .header lands on the Subscription management button when the sidebar is open. Reproducible at 1082x830 in reader view.

Extends the existing hide rule added in #8739 to also cover body.reader. Verified on a local instance: logo gone in reader view, normal view unaffected.