### PR TITLE
Change examples in API docs to authenticate via POST instead of GET

### DIFF
--- a/docs/en/developers/06_GoogleReader_API.md
+++ b/docs/en/developers/06_GoogleReader_API.md
@@ -45,8 +45,8 @@ Then point your mobile application to the `greader.php` address (e.g. `https://f
 Examples of basic queries:
 
 ```sh
-# Initial login, using API password (Email and Passwd can be given either as GET, or POST - better)
-curl 'https://freshrss.example.net/api/greader.php/accounts/ClientLogin?Email=alice&Passwd=Abcdef123456'
+# Initial login, using API password via POST
+curl -X POST 'https://freshrss.example.net/api/greader.php/accounts/ClientLogin' -d 'Email=alice&Passwd=Abcdef123456'
 SID=alice/8e6845e089457af25303abc6f53356eb60bdb5f8
 Auth=alice/8e6845e089457af25303abc6f53356eb60bdb5f8
 

--- a/docs/fr/users/06_Mobile_access.md
+++ b/docs/fr/users/06_Mobile_access.md
@@ -76,8 +76,8 @@ possibilité.
 Exemples de requêtes simples :
 
 ```sh
-# Authentification utilisant le mot de passe API (Email et Passwd peuvent être passés en GET, ou POST - mieux)
-curl 'https://freshrss.example.net/api/greader.php/accounts/ClientLogin?Email=alice&Passwd=Abcdef123456'
+# Authentification utilisant le mot de passe API
+curl -X POST 'https://freshrss.example.net/api/greader.php/accounts/ClientLogin' -d 'Email=alice&Passwd=Abcdef123456'
 SID=alice/8e6845e089457af25303abc6f53356eb60bdb5f8
 Auth=alice/8e6845e089457af25303abc6f53356eb60bdb5f8
 


### PR DESCRIPTION
Related to https://github.com/FreshRSS/FreshRSS/issues/8834
We should avoid bad examples like this, someone could copy the example blindly and send the credentials in an unsafe way.