### PR TITLE
SimplePie: Fix wrong player_parent logic leading to invalid type

### DIFF
--- a/lib/simplepie/simplepie/src/Item.php
+++ b/lib/simplepie/simplepie/src/Item.php
@@ -1236,13 +1236,14 @@ class Item implements RegistryAware
             }
 
             // PLAYER
-            if ($player_parent = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'player')) {
-                if (isset($player_parent[0]['attribs']['']['url'])) {
-                    $player_parent = $this->sanitize($player_parent[0]['attribs']['']['url'], \SimplePie\SimplePie::CONSTRUCT_IRI, $this->get_own_base($player_parent[0]));
+            $player_parent = null;
+            if ($player_tags = $this->get_item_tags(\SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'player')) {
+                if (isset($player_tags[0]['attribs']['']['url'])) {
+                    $player_parent = $this->sanitize($player_tags[0]['attribs']['']['url'], \SimplePie\SimplePie::CONSTRUCT_IRI, $this->get_own_base($player_tags[0]));
                 }
-            } elseif ($player_parent = $parent->get_channel_tags(\SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'player')) {
-                if (isset($player_parent[0]['attribs']['']['url'])) {
-                    $player_parent = $this->sanitize($player_parent[0]['attribs']['']['url'], \SimplePie\SimplePie::CONSTRUCT_IRI, $this->get_own_base($player_parent[0]));
+            } elseif ($player_tags = $parent->get_channel_tags(\SimplePie\SimplePie::NAMESPACE_MEDIARSS, 'player')) {
+                if (isset($player_tags[0]['attribs']['']['url'])) {
+                    $player_parent = $this->sanitize($player_tags[0]['attribs']['']['url'], \SimplePie\SimplePie::CONSTRUCT_IRI, $this->get_own_base($player_tags[0]));
                 }
             }
 


### PR DESCRIPTION
```
PHP Fatal error: Uncaught TypeError:
SimplePie\Enclosure::__construct(): Argument #20 ($player) must be of type ?string, array given
in /opt/freshrss/lib/simplepie/simplepie/src/Enclosure.php:199
```

This happens when there is no`url` parameter.

Example of feed:
* https://feeds.feedburner.com/crunchyroll/rss/anime?lang=deDE

fix https://github.com/FreshRSS/FreshRSS/issues/8892

Upstream PR:
* https://github.com/simplepie/simplepie/pull/978
