### PR TITLE
fix(themes): padding for .nav_menu in Alternative-Dark, Flat, and Nord themes

### DIFF
--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -743,13 +743,9 @@ kbd {
 
 /*=== Index menu */
 .nav_menu {
-	padding: 5px 0;
+	padding: 5px 0.5rem 5px 3rem;
 	background: var(--background-color-dark);
 	text-align: center;
-}
-
-.nav_menu #nav_menu_toggle_aside {
-	position: static;
 }
 
 .nav_menu .btn {

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -743,13 +743,9 @@ kbd {
 
 /*=== Index menu */
 .nav_menu {
-	padding: 5px 0;
+	padding: 5px 3rem 5px 0.5rem;
 	background: var(--background-color-dark);
 	text-align: center;
-}
-
-.nav_menu #nav_menu_toggle_aside {
-	position: static;
 }
 
 .nav_menu .btn {

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -675,11 +675,7 @@ th {
 /*=== Index menu */
 .nav_menu {
 	text-align: center;
-	padding: 5px 0;
-}
-
-.nav_menu #nav_menu_toggle_aside {
-	position: static;
+	padding: 5px 0.5rem 5px 3rem;
 }
 
 .nav_menu .btn {

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -675,11 +675,7 @@ th {
 /*=== Index menu */
 .nav_menu {
 	text-align: center;
-	padding: 5px 0;
-}
-
-.nav_menu #nav_menu_toggle_aside {
-	position: static;
+	padding: 5px 3rem 5px 0.5rem;
 }
 
 .nav_menu .btn {

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -971,12 +971,8 @@ li.item.active {
 
 
 .nav_menu {
-	padding: 5px 0;
+	padding: 5px 0.5rem 5px 3rem;
 	text-align: center;
-}
-
-.nav_menu #nav_menu_toggle_aside {
-	position: static;
 }
 
 .nav_menu .btn {

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -971,12 +971,8 @@ li.item.active {
 
 
 .nav_menu {
-	padding: 5px 0;
+	padding: 5px 3rem 5px 0.5rem;
 	text-align: center;
-}
-
-.nav_menu #nav_menu_toggle_aside {
-	position: static;
 }
 
 .nav_menu .btn {


### PR DESCRIPTION
Closes #8898

Changes proposed in this pull request:

- Removed position: static, and update the .nav_menu padding.
- Generated RTL CSS.

Tested the feature manually:

1. Flat
<img width="1351" height="73" alt="image" src="https://github.com/user-attachments/assets/f7627d6b-7816-4344-9b26-db0892b76d1e" />

2. Alternative Dark
<img width="1391" height="57" alt="image" src="https://github.com/user-attachments/assets/239d7e77-9b9f-46c2-8d25-c37fd603ea5d" />

4. Nord
<img width="1367" height="100" alt="nord" src="https://github.com/user-attachments/assets/5ec36e94-6ee5-448c-8321-809c288741d1" />


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
