### PR TITLE
Fix access control in `rss` and `opml` actions

### DIFF
--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -251,6 +251,7 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 		// Check if user has access.
 		if (!FreshRSS_Auth::hasAccess() && !$allow_anonymous && !Minz_Request::tokenIsOk()) {
 			Minz_Error::error(403, redirect: false);
+			return;
 		}
 
 		try {
@@ -287,6 +288,7 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 		// Check if user has access.
 		if (!FreshRSS_Auth::hasAccess() && !$allow_anonymous && !Minz_Request::tokenIsOk()) {
 			Minz_Error::error(403, redirect: false);
+			return;
 		}
 
 		try {


### PR DESCRIPTION
Due to missing `return` statement while using `redirect: false`, no `exit()` is done during `Minz_Error::error()`

Regression from https://github.com/FreshRSS/FreshRSS/pull/8434