### PR TITLE
Set limits for regex during search

### DIFF
--- a/app/Models/EntryDAOSQLite.php
+++ b/app/Models/EntryDAOSQLite.php
@@ -54,7 +54,16 @@ class FreshRSS_EntryDAOSQLite extends FreshRSS_EntryDAO {
 		// https://www.sqlite.org/lang_expr.html#the_like_glob_regexp_match_and_extract_operators
 		$this->pdo->sqliteCreateFunction('regexp',
 			function (string $pattern, string $text): bool {
-				return preg_match($pattern, $text) === 1;
+				$oldBacktrackLimit = ini_set('pcre.backtrack_limit', '10000');
+				$oldRecursionLimit = ini_set('pcre.recursion_limit', '100');
+				$matches = preg_match($pattern, $text) === 1;
+				if ($oldBacktrackLimit !== false) {
+					ini_set('pcre.backtrack_limit', $oldBacktrackLimit);
+				}
+				if ($oldRecursionLimit !== false) {
+					ini_set('pcre.recursion_limit', $oldRecursionLimit);
+				}
+				return $matches;
 			},
 			2
 		);

--- a/app/Models/EntryDAOSQLite.php
+++ b/app/Models/EntryDAOSQLite.php
@@ -54,16 +54,7 @@ class FreshRSS_EntryDAOSQLite extends FreshRSS_EntryDAO {
 		// https://www.sqlite.org/lang_expr.html#the_like_glob_regexp_match_and_extract_operators
 		$this->pdo->sqliteCreateFunction('regexp',
 			function (string $pattern, string $text): bool {
-				$oldBacktrackLimit = ini_set('pcre.backtrack_limit', '10000');
-				$oldRecursionLimit = ini_set('pcre.recursion_limit', '100');
-				$matches = preg_match($pattern, $text) === 1;
-				if ($oldBacktrackLimit !== false) {
-					ini_set('pcre.backtrack_limit', $oldBacktrackLimit);
-				}
-				if ($oldRecursionLimit !== false) {
-					ini_set('pcre.recursion_limit', $oldRecursionLimit);
-				}
-				return $matches;
+				return preg_match($pattern, $text) === 1;
 			},
 			2
 		);

--- a/app/Models/SystemConfiguration.php
+++ b/app/Models/SystemConfiguration.php
@@ -38,7 +38,10 @@ final class FreshRSS_SystemConfiguration extends Minz_Configuration {
 	public static function init(string $config_filename, ?string $default_filename = null): FreshRSS_SystemConfiguration {
 		parent::register('system', $config_filename, $default_filename);
 		try {
-			return parent::get('system');
+			$conf = parent::get('system');
+			ini_set('pcre.backtrack_limit', $conf->limits['regex_backtrack_limit']);
+			ini_set('pcre.recursion_limit', $conf->limits['regex_recursion_limit']);
+			return $conf;
 		} catch (Minz_ConfigurationNamespaceException $ex) {
 			FreshRSS::killApp($ex->getMessage());
 		}

--- a/config.default.php
+++ b/config.default.php
@@ -142,6 +142,10 @@ return [
 
 		# Max amount of bytes that are allowed for upload of custom favicon
 		'max_favicon_upload_size' => 1048576,	# 1 MiB
+
+		# Limits for regex, useful to limit regex during user searches
+		'regex_backtrack_limit' => 10000,
+		'regex_recursion_limit' => 100,
 	],
 
 	# Options used by cURL when making HTTP requests, e.g. when the SimplePie library retrieves feeds.


### PR DESCRIPTION
Prevents regex searches from running for too long
(currently only for SQLite)