### PR TITLE
Docker Alpine 3.24.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23
+FROM alpine:3.24
 
 ENV TZ=UTC
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]

--- a/Docker/Dockerfile-Alpine
+++ b/Docker/Dockerfile-Alpine
@@ -1,14 +1,14 @@
-FROM alpine:3.23
+FROM alpine:3.24
 
 ENV TZ=UTC
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 RUN apk add --no-cache \
 	tzdata \
-	apache2 php84-apache2 \
-	php84 php84-curl php84-gmp php84-intl php84-mbstring php84-xml php84-zip \
-	php84-ctype php84-dom php84-fileinfo php84-iconv php84-json php84-opcache php84-openssl php84-phar php84-session php84-simplexml php84-xmlreader php84-xmlwriter php84-xml php84-tokenizer php84-zlib \
-	php84-pdo_sqlite php84-pdo_mysql php84-pdo_pgsql
+	apache2 php-apache2 \
+	php php-curl php-gmp php-intl php-mbstring php-xml php-zip \
+	php-ctype php-dom php-fileinfo php-iconv php-json php-opcache php-openssl php-phar php-session php-simplexml php-xmlreader php-xmlwriter php-xml php-tokenizer php-zlib \
+	php-pdo_sqlite php-pdo_mysql php-pdo_pgsql
 
 RUN mkdir -p /var/www/FreshRSS /run/apache2/
 WORKDIR /var/www/FreshRSS
@@ -42,7 +42,7 @@ RUN \
 	sed -r -i "/^\s*#\s*LoadModule .*mod_(deflate|expires|filter|headers|mime|remoteip|setenvif).so$/s/^\s*#//" \
 		/etc/apache2/httpd.conf && \
 	# PHP configuration
-	if [ ! -f /usr/bin/php ]; then ln -s /usr/bin/php84 /usr/bin/php; else true; fi && \
+	if [ ! -f /usr/bin/php ]; then ln -s /usr/bin/php85 /usr/bin/php; else true; fi && \
 	# Disable built-in FreshRSS updates when using Docker, as the full image is supposed to be updated instead
 	sed -r -i "\\#disable_update#s#^.*#\t'disable_update' => true,#" ./config.default.php && \
 	# Configure cron job


### PR DESCRIPTION
https://alpinelinux.org/posts/Alpine-3.24.0-released.html

Update to PHP 8.5 from PHP 8.4:
revert to using Alpine's default PHP version, which is now PHP 8.5.7 instead of the previous default of PHP 8.3.x.

We will want to first merge the PHP 8.5 bug I have just found in SimplePie https://github.com/simplepie/simplepie/pull/979
