### PR TITLE
docs: mention THIRDPARTY_EXTENSIONS_PATH override in extension instal…

### DIFF
--- a/docs/en/admins/15_extensions.md
+++ b/docs/en/admins/15_extensions.md
@@ -16,6 +16,8 @@ Result: Content of `./extensions/CustomCSS/` has f.e. `extension.php`, `metadata
 
 Important: Do not delete or overwrite the existing files `./extensions/.gitignore` and `./extensions/README.md`.
 
+> **Note:** If `THIRDPARTY_EXTENSIONS_PATH` is set in `data/constants.local.php`, extensions must be placed in that directory instead of `./extensions`. If extensions are not appearing in the UI, check whether this constant is configured.
+
 ## How to enable/disable and manage
 
 See in the front end: configuration menu `Configuration/Extensions`


### PR DESCRIPTION
Closes #8927

Adds a note to the extension installation instructions clarifying that if `THIRDPARTY_EXTENSIONS_PATH` is set in `data/constants.local.php`, that path takes precedence over `./extensions` for extension discovery. The failure mode is silent (no error in the UI), which makes it hard to debug without knowing this constant exists.

Context: FreshRSS/Extensions#480