### PR TITLE
fix(themes): keep article nav bar pinned to bottom in iOS standalone PWAs

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -31,6 +31,7 @@ People are sorted by name so please keep this order.
 * [Andy Valencia](https://github.com/vandys): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:vandys), [Web](https://www.vsta.org/andy/)
 * [Annika Backstrom](https://github.com/abackstrom): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:abackstrom), [Web](https://sixohthree.com/)
 * [Anton Smirnov](https://github.com/arokettu): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:arokettu), [Web](https://sandfox.me/)
+* [Antonio Santos](https://github.com/Otolock): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Otolock), [Web](https://antoniosantos.io/)
 * [ArthurHoaro](https://github.com/ArthurHoaro): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:ArthurHoaro)
 * [Artur Weigandt](https://github.com/Art4): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Art4), [Web](https://ruhr.social/@Art4)
 * [ASMfreaK](https://github.com/ASMfreaK): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:ASMfreaK)

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1927,6 +1927,11 @@ a.website:hover .favicon {
 	width: var(--width-aside);
 	padding-bottom: env(safe-area-inset-bottom);
 	z-index: 50;
+	/* Promote to its own compositor layer so iOS standalone PWAs keep the bar
+	   pinned to the viewport after a programmatic scroll (e.g. prev/next entry),
+	   working around a WebKit bug that otherwise lets it drift to mid-screen. */
+	transform: translateZ(0);
+	will-change: transform;
 }
 
 .aside:not(.visible) ~ #nav_entries {

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1931,7 +1931,6 @@ a.website:hover .favicon {
 	   pinned to the viewport after a programmatic scroll (e.g. prev/next entry),
 	   working around a WebKit bug that otherwise lets it drift to mid-screen. */
 	transform: translateZ(0);
-	will-change: transform;
 }
 
 .aside:not(.visible) ~ #nav_entries {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1927,6 +1927,11 @@ a.website:hover .favicon {
 	width: var(--width-aside);
 	padding-bottom: env(safe-area-inset-bottom);
 	z-index: 50;
+	/* Promote to its own compositor layer so iOS standalone PWAs keep the bar
+	   pinned to the viewport after a programmatic scroll (e.g. prev/next entry),
+	   working around a WebKit bug that otherwise lets it drift to mid-screen. */
+	transform: translateZ(0);
+	will-change: transform;
 }
 
 .aside:not(.visible) ~ #nav_entries {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1931,7 +1931,6 @@ a.website:hover .favicon {
 	   pinned to the viewport after a programmatic scroll (e.g. prev/next entry),
 	   working around a WebKit bug that otherwise lets it drift to mid-screen. */
 	transform: translateZ(0);
-	will-change: transform;
 }
 
 .aside:not(.visible) ~ #nav_entries {


### PR DESCRIPTION
## Problem

When FreshRSS is used as a **standalone PWA on iOS** (added to the home screen), the article navigation bar (`#nav_entries`, the prev / up / next buttons) detaches from the bottom and drifts to the middle of the screen after tapping the prev/next buttons.

Fixes #8829.

## Cause

`#nav_entries` is `position: fixed; bottom: 0`. On iOS standalone PWAs, WebKit fails to repaint `position: fixed` elements after a **programmatic** scroll. Tapping prev/next runs `next_entry`/`prev_entry` → `toggleContent`, which scrolls the article container in JS (`box_to_move.scrollTop = …`). That scripted scroll is the trigger, which is why the bar wanders only after using those buttons — and why it does not happen in regular Safari, where the browser chrome provides repaint hooks the standalone shell lacks.

This also explains why #8833 did not fix it: its `top: auto` was a no-op, because nothing in the stylesheet ever sets a `top` value on `#nav_entries`.

## Fix

Promote `#nav_entries` to its own compositor layer (`transform: translateZ(0)` + `will-change: transform`). WebKit then keeps it pinned to the viewport across programmatic scrolls. Minimal, vanilla CSS, no new dependencies.

`frss.rtl.css` was regenerated with `make rtl` (not hand-edited).

## Testing

Verified on an iPhone home-screen PWA (Mobile Safari 26.x): with the change, the bar stays anchored at the bottom while tapping prev/next through articles. Behaviour in desktop/regular Safari is unchanged.