### PR TITLE
Revert "fix(themes): keep article nav bar pinned to bottom in iOS standalone PWAs (#8933)"

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -31,7 +31,6 @@ People are sorted by name so please keep this order.
 * [Andy Valencia](https://github.com/vandys): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:vandys), [Web](https://www.vsta.org/andy/)
 * [Annika Backstrom](https://github.com/abackstrom): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:abackstrom), [Web](https://sixohthree.com/)
 * [Anton Smirnov](https://github.com/arokettu): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:arokettu), [Web](https://sandfox.me/)
-* [Antonio Santos](https://github.com/Otolock): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Otolock), [Web](https://antoniosantos.io/)
 * [ArthurHoaro](https://github.com/ArthurHoaro): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:ArthurHoaro)
 * [Artur Weigandt](https://github.com/Art4): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Art4), [Web](https://ruhr.social/@Art4)
 * [ASMfreaK](https://github.com/ASMfreaK): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:ASMfreaK)

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1927,10 +1927,6 @@ a.website:hover .favicon {
 	width: var(--width-aside);
 	padding-bottom: env(safe-area-inset-bottom);
 	z-index: 50;
-	/* Promote to its own compositor layer so iOS standalone PWAs keep the bar
-	   pinned to the viewport after a programmatic scroll (e.g. prev/next entry),
-	   working around a WebKit bug that otherwise lets it drift to mid-screen. */
-	transform: translateZ(0);
 }
 
 .aside:not(.visible) ~ #nav_entries {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1927,10 +1927,6 @@ a.website:hover .favicon {
 	width: var(--width-aside);
 	padding-bottom: env(safe-area-inset-bottom);
 	z-index: 50;
-	/* Promote to its own compositor layer so iOS standalone PWAs keep the bar
-	   pinned to the viewport after a programmatic scroll (e.g. prev/next entry),
-	   working around a WebKit bug that otherwise lets it drift to mid-screen. */
-	transform: translateZ(0);
 }
 
 .aside:not(.visible) ~ #nav_entries {


### PR DESCRIPTION
Reverts #8933.

## Why

PR #8933 added `transform: translateZ(0)` to `#nav_entries` to keep the article navigation bar pinned to the bottom in iOS standalone PWAs (#8829). While that promotes the element to its own compositor layer, a non-`none` `transform` also:

- makes the element a **containing block** for `position: fixed` descendants, and
- establishes a **new stacking context**.

Those side effects introduced a regression, so this reverts the change to restore the previous behaviour while a less invasive fix for #8829 is worked out.

## Scope

Reverts the whole PR for a clean rollback:

- `p/themes/base-theme/frss.css` — remove `transform: translateZ(0)` on `#nav_entries`
- `p/themes/base-theme/frss.rtl.css` — same (generated)
- `CREDITS.md` — revert accompanying entry

Re-opens #8829.