### PR TITLE
Document PHP-FPM write restrictions for FreshRSS data path

### DIFF
--- a/docs/en/admins/03_Installation.md
+++ b/docs/en/admins/03_Installation.md
@@ -6,7 +6,7 @@ Before you begin, make sure that you’ve read the [prerequisites](02_Prerequisi
 
 1. If the computer you’re running on is not currently running a web server, you’ll first need to install and configure a web server, a version of PHP, and an appropriate database, as listed in the prerequisites. Specially, if you are using NGINX, please keep in mind that FreshRSS needs some specified variables to run properly. So make sure you’ve checked our configuration file. [Example Apache and Nginx configuration files can be found here](10_ServerConfig.md).
 
-2. Download your chosen version of FreshRSS, or fetch it via git. It’s advisable that you put FreshRSS in `/usr/share/`, and symlink the `./p/` folder to the root of your web server.[^1]
+2. Download your chosen version of FreshRSS, or fetch it via git. Put FreshRSS somewhere your PHP process can write to the `./data/` folder, such as `/var/www/FreshRSS`, and symlink the `./p/` folder to the root of your web server.[^1] Avoid placing the writable `./data/` folder under system read-only paths such as `/usr/share/` unless your PHP-FPM service is explicitly configured to allow writes there.
 
 3. Give ownership of the FreshRSS folder to your web server user (often `www-data`). Give group read permissions to all files in `.`[^2], and group write permissions to `./data/`.
 

--- a/docs/en/admins/06_LinuxInstall.md
+++ b/docs/en/admins/06_LinuxInstall.md
@@ -70,10 +70,11 @@ Begin by installing git, if you don’t already have it installed.
 apt install git
 ```
 
-Next, change to the install directory and download FreshRSS using git
+Next, change to the install directory and download FreshRSS using git. The following path keeps FreshRSS out of system read-only directories, which avoids write failures from hardened PHP-FPM service settings.
 
 ```sh
-cd /usr/share/
+mkdir -p /var/www/
+cd /var/www/
 git clone https://github.com/FreshRSS/FreshRSS.git
 ```
 
@@ -96,7 +97,7 @@ chown apache:www-data -R .
 Finally, symlink the public folder to your FreshRSS directory
 
 ```sh
-[ ! -e "/var/www/html/FreshRSS" ] && ln -s /usr/share/FreshRSS/p /var/www/html/FreshRSS || echo "/var/www/html/FreshRSS already exists"
+[ ! -e "/var/www/html/FreshRSS" ] && ln -s /var/www/FreshRSS/p /var/www/html/FreshRSS || echo "/var/www/html/FreshRSS already exists"
 ```
 
 ## Part 3: Creating a Database for FreshRSS

--- a/docs/en/users/07_Frequently_Asked_Questions.md
+++ b/docs/en/users/07_Frequently_Asked_Questions.md
@@ -53,6 +53,14 @@ semanage fcontext -a -t httpd_sys_rw_content_t '/usr/share/FreshRSS/data(/.*)?'
 restorecon -Rv /usr/share/FreshRSS/data
 ```
 
+## Permission denied under `/usr/share/` with PHP-FPM
+
+Some Linux distributions harden their PHP-FPM systemd service so that `/usr/` is read-only for PHP, even when file ownership and Unix permissions look correct. This can cause HTTP 500 errors such as `Permission denied` or `Read-only file system` when FreshRSS writes to `./data/users/*/log.txt`, marks entries as read, or updates user data.
+
+For new installations, install FreshRSS in a writable application path such as `/var/www/FreshRSS` instead of `/usr/share/FreshRSS`.
+
+For existing installations, move `./data/` to a writable location and link it back, or configure the PHP-FPM systemd unit with an appropriate `ReadWritePaths=` override for the FreshRSS `data` directory. Restart PHP-FPM after changing the systemd unit.
+
 ## Why do I have a blank page while trying to configure the sharing options?
 
 The `sharing` word in the URL is a trigger word for some ad-blocker rules. Starting with version 1.16, `sharing` has been replaced by `integration` in the faulty URL while keeping the exact same wording throughout the application.


### PR DESCRIPTION
Closes #8882

## Summary
- avoid recommending `/usr/share/` for writable FreshRSS data in the general install docs
- update the Debian/Ubuntu git install path and symlink example to `/var/www/FreshRSS`
- add an FAQ entry for PHP-FPM hardening that can make `/usr/` read-only despite correct Unix permissions

## Testing
- `git diff --check`
- `npx --yes markdownlint-cli@0.49.0 docs/en/admins/03_Installation.md docs/en/admins/06_LinuxInstall.md docs/en/users/07_Frequently_Asked_Questions.md`