### PR TITLE
Reintroduce today / yesterday / before yesterday

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -227,33 +227,33 @@ Voir le [dépôt dédié à ces extensions](https://github.com/FreshRSS/Extensio
 
 | Langage | Progression | |
 | - | - | - |
-| Čeština (cs) | ￭￭￭￭￭￭￭￭･･ 82% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fcs+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Čeština (cs) | ￭￭￭￭￭￭￭￭･･ 81% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fcs+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Deutsch (de) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fde+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Ελληνικά (el) | ￭￭￭･･･････ 38% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fel+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Ελληνικά (el) | ￭￭￭･･･････ 37% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fel+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (en) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Español (es) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
-| فارسی (fa) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Español (es) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
+| فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Suomi (fi) | ￭￭￭￭￭￭￭￭￭･ 92% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffi+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Français (fr) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
-| עברית (he) | ￭￭￭￭･･････ 42% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhe+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Magyar (hu) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhu+%2F%28TODO%7CDIRTY%29%24%2F) |
+| עברית (he) | ￭￭￭￭･･････ 41% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhe+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Magyar (hu) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhu+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭･･ 89% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Italiano (it) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fit+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 日本語 (ja) | ￭￭￭￭￭￭￭￭･･ 88% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fja+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Italiano (it) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fit+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 日本語 (ja) | ￭￭￭￭￭￭￭￭･･ 87% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fja+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 한국어 (ko) | ￭￭￭￭￭￭￭￭･･ 81% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fko+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Latviešu (lv) | ￭￭￭￭￭￭￭￭･･ 82% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Flv+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Nederlands (nl) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fnl+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Occitan (oc) | ￭￭￭￭￭￭￭･･･ 74% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Foc+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Polski (pl) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpl+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Português (Brasil) (pt-BR) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-BR+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Português (Portugal) (pt-PT) | ￭￭￭￭￭￭￭￭･･ 81% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-PT+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Русский (ru) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fru+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Português (Brasil) (pt-BR) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-BR+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Português (Portugal) (pt-PT) | ￭￭￭￭￭￭￭￭･･ 80% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-PT+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Русский (ru) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fru+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Slovenčina (sk) | ￭￭￭￭￭￭￭￭･･ 81% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fsk+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Türkçe (tr) | ￭￭￭￭￭￭￭￭･･ 89% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ftr+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Українська (uk) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fuk+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 简体中文 (zh-CN) | ￭￭￭￭￭￭￭￭￭･ 97% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-CN+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 正體中文 (zh-TW) | ￭￭￭￭￭￭￭￭￭･ 96% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-TW+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Türkçe (tr) | ￭￭￭￭￭￭￭￭･･ 88% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ftr+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Українська (uk) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fuk+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 简体中文 (zh-CN) | ￭￭￭￭￭￭￭￭￭･ 96% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-CN+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 正體中文 (zh-TW) | ￭￭￭￭￭￭￭￭￭･ 95% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-TW+%2F%28TODO%7CDIRTY%29%24%2F) |
 
 </translations>
 

--- a/README.md
+++ b/README.md
@@ -123,33 +123,33 @@ See the [repository dedicated to those extensions](https://github.com/FreshRSS/E
 
 | Language | Progress | |
 | - | - | - |
-| Čeština (cs) | ￭￭￭￭￭￭￭￭･･ 82% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fcs+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Čeština (cs) | ￭￭￭￭￭￭￭￭･･ 81% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fcs+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Deutsch (de) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fde+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Ελληνικά (el) | ￭￭￭･･･････ 38% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fel+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Ελληνικά (el) | ￭￭￭･･･････ 37% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fel+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (en) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Español (es) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
-| فارسی (fa) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Español (es) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
+| فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Suomi (fi) | ￭￭￭￭￭￭￭￭￭･ 92% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffi+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Français (fr) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
-| עברית (he) | ￭￭￭￭･･････ 42% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhe+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Magyar (hu) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhu+%2F%28TODO%7CDIRTY%29%24%2F) |
+| עברית (he) | ￭￭￭￭･･････ 41% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhe+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Magyar (hu) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhu+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭･･ 89% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Italiano (it) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fit+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 日本語 (ja) | ￭￭￭￭￭￭￭￭･･ 88% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fja+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Italiano (it) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fit+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 日本語 (ja) | ￭￭￭￭￭￭￭￭･･ 87% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fja+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 한국어 (ko) | ￭￭￭￭￭￭￭￭･･ 81% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fko+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Latviešu (lv) | ￭￭￭￭￭￭￭￭･･ 82% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Flv+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Nederlands (nl) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fnl+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Occitan (oc) | ￭￭￭￭￭￭￭･･･ 74% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Foc+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Polski (pl) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpl+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Português (Brasil) (pt-BR) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-BR+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Português (Portugal) (pt-PT) | ￭￭￭￭￭￭￭￭･･ 81% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-PT+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Русский (ru) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fru+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Português (Brasil) (pt-BR) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-BR+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Português (Portugal) (pt-PT) | ￭￭￭￭￭￭￭￭･･ 80% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-PT+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Русский (ru) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fru+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Slovenčina (sk) | ￭￭￭￭￭￭￭￭･･ 81% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fsk+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Türkçe (tr) | ￭￭￭￭￭￭￭￭･･ 89% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ftr+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Українська (uk) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fuk+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 简体中文 (zh-CN) | ￭￭￭￭￭￭￭￭￭･ 97% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-CN+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 正體中文 (zh-TW) | ￭￭￭￭￭￭￭￭￭･ 96% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-TW+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Türkçe (tr) | ￭￭￭￭￭￭￭￭･･ 88% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ftr+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Українська (uk) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fuk+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 简体中文 (zh-CN) | ￭￭￭￭￭￭￭￭￭･ 96% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-CN+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 正體中文 (zh-TW) | ￭￭￭￭￭￭￭￭￭･ 95% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-TW+%2F%28TODO%7CDIRTY%29%24%2F) |
 
 </translations>
 

--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -56,6 +56,10 @@ class FreshRSS_configure_Controller extends FreshRSS_ActionController {
 			}
 			FreshRSS_Context::userConf()->darkMode = Minz_Request::paramString('darkMode') ?: 'auto';
 			FreshRSS_Context::userConf()->content_width = Minz_Request::paramString('content_width') ?: 'thin';
+			$dateTransitions = Minz_Request::paramString('date_transitions');
+			if (in_array($dateTransitions, ['full', 'simple', 'none'], true)) {
+				FreshRSS_Context::userConf()->date_transitions = $dateTransitions;
+			}
 			FreshRSS_Context::userConf()->topline_read = Minz_Request::paramBoolean('topline_read');
 			FreshRSS_Context::userConf()->topline_favorite = Minz_Request::paramBoolean('topline_favorite');
 			FreshRSS_Context::userConf()->topline_myLabels = Minz_Request::paramBoolean('topline_myLabels');

--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -31,7 +31,7 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 	}
 
 	/**
-	 * @return '.future'|'.today'|'.yesterday'|''
+	 * @return '.future'|'.today'|'.yesterday'|'.before_yesterday'|''
 	 */
 	private static function dayRelative(int $timestamp, bool $mayBeFuture): string {
 		static $today = null;
@@ -46,8 +46,26 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 			return '.today';
 		} elseif ($timestamp >= $today - 86400) {
 			return '.yesterday';
+		} elseif (FreshRSS_Context::userConf()->date_transitions === 'simple') {
+			return '.before_yesterday';
 		}
 		return '';
+	}
+
+	/**
+	 * Build a date-based transition line.
+	 * @param 'index.feed.published'|'index.feed.received'|'index.feed.userModified' $i18nPrefix
+	 */
+	private static function dateTransition(string $i18nPrefix, int $timestamp, bool $mayBeFuture): string {
+		if (FreshRSS_Context::userConf()->date_transitions === 'none') {
+			return '';
+		}
+		$suffix = self::dayRelative($timestamp, $mayBeFuture);
+		$label = _t($i18nPrefix . $suffix);
+		if ($suffix === '.before_yesterday') {
+			return $label;
+		}
+		return $label . ' — ' . timestamptodate($timestamp, hour: false);
 	}
 
 	/**
@@ -55,12 +73,9 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 	 */
 	public static function transition(FreshRSS_Entry $entry): string {
 		return match (FreshRSS_Context::$sort) {
-			'id' => _t('index.feed.received' . self::dayRelative($entry->dateAdded(raw: true), mayBeFuture: false)) .
-				' — ' . timestamptodate($entry->dateAdded(raw: true), hour: false),
-			'date' => _t('index.feed.published' . self::dayRelative($entry->date(raw: true), mayBeFuture: true)) .
-				' — ' . timestamptodate($entry->date(raw: true), hour: false),
-			'lastUserModified' => _t('index.feed.userModified' . self::dayRelative($entry->lastUserModified() ?? 0, mayBeFuture: false)) .
-				' — ' . timestamptodate($entry->lastUserModified() ?? 0, hour: false),
+			'id' => self::dateTransition('index.feed.received', $entry->dateAdded(raw: true), mayBeFuture: false),
+			'date' => self::dateTransition('index.feed.published', $entry->date(raw: true), mayBeFuture: true),
+			'lastUserModified' => self::dateTransition('index.feed.userModified', $entry->lastUserModified() ?? 0, mayBeFuture: false),
 			'c.name' => $entry->feed()?->category()?->name() ?? '',
 			'f.name' => $entry->feed()?->name() ?? '',
 			default => '',

--- a/app/Models/UserConfiguration.php
+++ b/app/Models/UserConfiguration.php
@@ -69,6 +69,7 @@ declare(strict_types=1);
  * @property string $theme
  * @property string $darkMode
  * @property string $token
+ * @property 'full'|'simple'|'none' $date_transitions
  * @property bool $topline_date
  * @property bool $topline_display_authors
  * @property bool $topline_favorite

--- a/app/i18n/cs/conf.php
+++ b/app/i18n/cs/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'For compatible themes only',	// TODO
 			'no' => 'Ne',
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => 'Spodní řádek',
 			'display_authors' => 'Autoři',

--- a/app/i18n/cs/index.php
+++ b/app/i18n/cs/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'Nejsou žádné články k zobrazení.',
 		'published' => array(
 			'_' => 'Published',	// TODO
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'Published in the future',	// TODO
 			'today' => 'Published today',	// TODO
 			'yesterday' => 'Published yesterday',	// TODO
 		),
 		'received' => array(
 			'_' => 'Received',	// TODO
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Received today',	// TODO
 			'yesterday' => 'Received yesterday',	// TODO
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Zobrazení přehledu',
 		'userModified' => array(
 			'_' => 'Modified by user',	// TODO
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Modified by user today',	// TODO
 			'yesterday' => 'Modified by user yesterday',	// TODO
 		),

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'Nur für kompatible Themes',
 			'no' => 'Nein',
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => 'Fußzeile',
 			'display_authors' => 'Autoren',

--- a/app/i18n/de/index.php
+++ b/app/i18n/de/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'Keine Artikel vorhanden.',
 		'published' => array(
 			'_' => 'Veröffentlicht',
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'In Zukunft veröffentlicht',
 			'today' => 'Heute veröffentlicht',
 			'yesterday' => 'Gestern veröffentlicht',
 		),
 		'received' => array(
 			'_' => 'Empfangen',
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Heute empfangen',
 			'yesterday' => 'Gestern empfangen',
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Globale Ansicht',
 		'userModified' => array(
 			'_' => 'Vom Benutzer geändert',
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Heute vom Benutzer geändert',
 			'yesterday' => 'Gestern vom Benutzer geändert',
 		),

--- a/app/i18n/el/conf.php
+++ b/app/i18n/el/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'For compatible themes only',	// TODO
 			'no' => 'No',	// TODO
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => 'Bottom line',	// TODO
 			'display_authors' => 'Authors',	// TODO

--- a/app/i18n/el/index.php
+++ b/app/i18n/el/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'There are no articles to show.',	// TODO
 		'published' => array(
 			'_' => 'Published',	// TODO
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'Published in the future',	// TODO
 			'today' => 'Published today',	// TODO
 			'yesterday' => 'Published yesterday',	// TODO
 		),
 		'received' => array(
 			'_' => 'Received',	// TODO
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Received today',	// TODO
 			'yesterday' => 'Received yesterday',	// TODO
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Global view',	// TODO
 		'userModified' => array(
 			'_' => 'Modified by user',	// TODO
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Modified by user today',	// TODO
 			'yesterday' => 'Modified by user yesterday',	// TODO
 		),

--- a/app/i18n/en-US/conf.php
+++ b/app/i18n/en-US/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'For compatible themes only',	// IGNORE
 			'no' => 'No',	// IGNORE
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// IGNORE
+			'full' => 'Per day',	// IGNORE
+			'none' => 'None',	// IGNORE
+			'simple' => 'Today, yesterday, and older',	// IGNORE
+		),
 		'icon' => array(
 			'bottom_line' => 'Bottom line',	// IGNORE
 			'display_authors' => 'Authors',	// IGNORE

--- a/app/i18n/en-US/index.php
+++ b/app/i18n/en-US/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'There are no articles to show.',	// IGNORE
 		'published' => array(
 			'_' => 'Published',	// IGNORE
+			'before_yesterday' => 'Published before yesterday',	// IGNORE
 			'future' => 'Published in the future',	// IGNORE
 			'today' => 'Published today',	// IGNORE
 			'yesterday' => 'Published yesterday',	// IGNORE
 		),
 		'received' => array(
 			'_' => 'Received',	// IGNORE
+			'before_yesterday' => 'Received before yesterday',	// IGNORE
 			'today' => 'Received today',	// IGNORE
 			'yesterday' => 'Received yesterday',	// IGNORE
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Global view',	// IGNORE
 		'userModified' => array(
 			'_' => 'Modified by user',	// IGNORE
+			'before_yesterday' => 'Modified by user before yesterday',	// IGNORE
 			'today' => 'Modified by user today',	// IGNORE
 			'yesterday' => 'Modified by user yesterday',	// IGNORE
 		),

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'For compatible themes only',
 			'no' => 'No',
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',
+			'full' => 'Per day',
+			'none' => 'None',
+			'simple' => 'Today, yesterday, and older',
+		),
 		'icon' => array(
 			'bottom_line' => 'Bottom line',
 			'display_authors' => 'Authors',

--- a/app/i18n/en/index.php
+++ b/app/i18n/en/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'There are no articles to show.',
 		'published' => array(
 			'_' => 'Published',
+			'before_yesterday' => 'Published before yesterday',
 			'future' => 'Published in the future',
 			'today' => 'Published today',
 			'yesterday' => 'Published yesterday',
 		),
 		'received' => array(
 			'_' => 'Received',
+			'before_yesterday' => 'Received before yesterday',
 			'today' => 'Received today',
 			'yesterday' => 'Received yesterday',
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Global view',
 		'userModified' => array(
 			'_' => 'Modified by user',
+			'before_yesterday' => 'Modified by user before yesterday',
 			'today' => 'Modified by user today',
 			'yesterday' => 'Modified by user yesterday',
 		),

--- a/app/i18n/es/conf.php
+++ b/app/i18n/es/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'Solo para temas compatibles',
 			'no' => 'No',	// IGNORE
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => 'Línea inferior',
 			'display_authors' => 'Autores',

--- a/app/i18n/es/index.php
+++ b/app/i18n/es/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'No hay artículos a mostrar.',
 		'published' => array(
 			'_' => 'Publicado',
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'Publicado en el futuro',
 			'today' => 'Publicado hoy',
 			'yesterday' => 'Publicado ayer',
 		),
 		'received' => array(
 			'_' => 'Recibido',
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Recibido hoy',
 			'yesterday' => 'Recibido ayer',
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Vista global',
 		'userModified' => array(
 			'_' => 'Modificado por usuario',
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Modificado por usuario hoy',
 			'yesterday' => 'Modificado por usuario ayer',
 		),

--- a/app/i18n/fa/conf.php
+++ b/app/i18n/fa/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'کمک',
 			'no' => 'خیر',
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => ' خط پایین',
 			'display_authors' => ' نویسندگان',

--- a/app/i18n/fa/index.php
+++ b/app/i18n/fa/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => ' هیچ مقاله ای برای نمایش وجود ندارد.',
 		'published' => array(
 			'_' => 'منتشر شده',
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'منتشر شده در آینده',
 			'today' => 'امروز منتشر شده',
 			'yesterday' => 'دیروز منتشر شده',
 		),
 		'received' => array(
 			'_' => 'دریافت شده',
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'امروز دریافت شد',
 			'yesterday' => 'دیروز دریافت شد',
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => ' نمای جهانی',
 		'userModified' => array(
 			'_' => 'ویرایش شده توسط کاربر',
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'امروز توسط کاربر ویرایش شده',
 			'yesterday' => 'دیروز توسط کاربر ویرایش شده',
 		),

--- a/app/i18n/fi/conf.php
+++ b/app/i18n/fi/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'Toimii vain yhteensopivissa teemoissa',
 			'no' => 'Ei',
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => 'Alin rivi',
 			'display_authors' => 'Kirjoittajat',

--- a/app/i18n/fi/index.php
+++ b/app/i18n/fi/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'Näytettäviä artikkeleita ei ole.',
 		'published' => array(
 			'_' => 'Published',	// TODO
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'Published in the future',	// TODO
 			'today' => 'Published today',	// TODO
 			'yesterday' => 'Published yesterday',	// TODO
 		),
 		'received' => array(
 			'_' => 'Received',	// TODO
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Saapuneet tänään',
 			'yesterday' => 'Saapuneet eilen',
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Yleisnäkymä',
 		'userModified' => array(
 			'_' => 'Modified by user',	// TODO
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Modified by user today',	// TODO
 			'yesterday' => 'Modified by user yesterday',	// TODO
 		),

--- a/app/i18n/fr/conf.php
+++ b/app/i18n/fr/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'Seulement pour les thèmes compatibles',
 			'no' => 'Non',
 		),
+		'date_transitions' => array(
+			'_' => 'Séparateurs de dates',
+			'full' => 'Par jour',
+			'none' => 'Aucun',
+			'simple' => 'Aujourd’hui, hier, et plus anciens',
+		),
 		'icon' => array(
 			'bottom_line' => 'Ligne du bas',
 			'display_authors' => 'Auteurs',

--- a/app/i18n/fr/index.php
+++ b/app/i18n/fr/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'Il n’y a aucun article à afficher.',
 		'published' => array(
 			'_' => 'Publié',
+			'before_yesterday' => 'Publié avant-hier ou avant',
 			'future' => 'Publié dans le futur',
 			'today' => 'Publié aujourd’hui',
 			'yesterday' => 'Publié hier',
 		),
 		'received' => array(
 			'_' => 'Reçu',
+			'before_yesterday' => 'Reçu avant-hier ou avant',
 			'today' => 'Reçu aujourd’hui',
 			'yesterday' => 'Reçu hier',
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Vue globale',
 		'userModified' => array(
 			'_' => 'Modifié par l’utilisateur',
+			'before_yesterday' => 'Modifié avant-hier ou avant',
 			'today' => 'Modifié par l’utilisateur aujourd’hui',
 			'yesterday' => 'Modifié par l’utilisateur hier',
 		),

--- a/app/i18n/he/conf.php
+++ b/app/i18n/he/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'For compatible themes only',	// TODO
 			'no' => 'No',	// TODO
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => 'שורה תחתונה',
 			'display_authors' => 'Authors',	// TODO

--- a/app/i18n/he/index.php
+++ b/app/i18n/he/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'אין מאמר להצגה.',
 		'published' => array(
 			'_' => 'Published',	// TODO
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'Published in the future',	// TODO
 			'today' => 'Published today',	// TODO
 			'yesterday' => 'Published yesterday',	// TODO
 		),
 		'received' => array(
 			'_' => 'Received',	// TODO
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Received today',	// TODO
 			'yesterday' => 'Received yesterday',	// TODO
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'תצוגה גלובלית',
 		'userModified' => array(
 			'_' => 'Modified by user',	// TODO
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Modified by user today',	// TODO
 			'yesterday' => 'Modified by user yesterday',	// TODO
 		),

--- a/app/i18n/hu/conf.php
+++ b/app/i18n/hu/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'Csak kompatibilis témákhoz',
 			'no' => 'Nem',
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => 'Alsó sor',
 			'display_authors' => 'Szerzők',

--- a/app/i18n/hu/index.php
+++ b/app/i18n/hu/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'Nincs megjeleníthető cikk.',
 		'published' => array(
 			'_' => 'Közzétéve',
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'A jövőben közzétéve',
 			'today' => 'Ma közzétéve',
 			'yesterday' => 'Tegnap közzétéve',
 		),
 		'received' => array(
 			'_' => 'Beérkezett',
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Ma beérkezett',
 			'yesterday' => 'Tegnap beérkezett',
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Globális nézet',
 		'userModified' => array(
 			'_' => 'Felhasználó által módosítva',
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Felhasználó által módosítva ma',
 			'yesterday' => 'Felhasználó által módosítva tegnap',
 		),

--- a/app/i18n/id/conf.php
+++ b/app/i18n/id/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'Hanya untuk tema yang kompatibel',
 			'no' => 'Tidak',
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => 'Baris bawah',
 			'display_authors' => 'Penulis',

--- a/app/i18n/id/index.php
+++ b/app/i18n/id/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'Tidak ada artikel untuk diperlihatkan.',
 		'published' => array(
 			'_' => 'Published',	// TODO
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'Published in the future',	// TODO
 			'today' => 'Published today',	// TODO
 			'yesterday' => 'Published yesterday',	// TODO
 		),
 		'received' => array(
 			'_' => 'Received',	// TODO
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Diterima hari ini',
 			'yesterday' => 'Diterima kemarin',
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Tampilan Global',
 		'userModified' => array(
 			'_' => 'Modified by user',	// TODO
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Modified by user today',	// TODO
 			'yesterday' => 'Modified by user yesterday',	// TODO
 		),

--- a/app/i18n/it/conf.php
+++ b/app/i18n/it/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'Solo per i temi compatibili',
 			'no' => 'No',	// IGNORE
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => 'Barra in fondo',
 			'display_authors' => 'Autori',

--- a/app/i18n/it/index.php
+++ b/app/i18n/it/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'Non ci sono articoli da mostrare.',
 		'published' => array(
 			'_' => 'Pubblicato',
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'Pubblicato nel futuro',
 			'today' => 'Pubblicato oggi',
 			'yesterday' => 'Pubblicato ieri',
 		),
 		'received' => array(
 			'_' => 'Ricevuto',
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Ricevuto oggi',
 			'yesterday' => 'Ricevuto ieri',
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Vista globale per categorie',
 		'userModified' => array(
 			'_' => 'Modificato dall’utente',
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Modificato dall’utente oggi',
 			'yesterday' => 'Modificato dall’utente ieri',
 		),

--- a/app/i18n/ja/conf.php
+++ b/app/i18n/ja/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => '対応するテーマのみ',
 			'no' => '無効',
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => '行の下部',
 			'display_authors' => '著者',

--- a/app/i18n/ja/index.php
+++ b/app/i18n/ja/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => '表示できる記事がありません',
 		'published' => array(
 			'_' => 'Published',	// TODO
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'Published in the future',	// TODO
 			'today' => 'Published today',	// TODO
 			'yesterday' => 'Published yesterday',	// TODO
 		),
 		'received' => array(
 			'_' => 'Received',	// TODO
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => '今日',
 			'yesterday' => '昨日',
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'グローバルビュー',
 		'userModified' => array(
 			'_' => 'Modified by user',	// TODO
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Modified by user today',	// TODO
 			'yesterday' => 'Modified by user yesterday',	// TODO
 		),

--- a/app/i18n/ko/conf.php
+++ b/app/i18n/ko/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'For compatible themes only',	// TODO
 			'no' => '끄기',
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => '하단',
 			'display_authors' => '저자',

--- a/app/i18n/ko/index.php
+++ b/app/i18n/ko/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => '글이 없습니다.',
 		'published' => array(
 			'_' => 'Published',	// TODO
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'Published in the future',	// TODO
 			'today' => 'Published today',	// TODO
 			'yesterday' => 'Published yesterday',	// TODO
 		),
 		'received' => array(
 			'_' => 'Received',	// TODO
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Received today',	// TODO
 			'yesterday' => 'Received yesterday',	// TODO
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => '전체 모드',
 		'userModified' => array(
 			'_' => 'Modified by user',	// TODO
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Modified by user today',	// TODO
 			'yesterday' => 'Modified by user yesterday',	// TODO
 		),

--- a/app/i18n/lv/conf.php
+++ b/app/i18n/lv/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'Tikai saderīgām tēmām',
 			'no' => 'Nē',
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => 'Apakšējā līnija',
 			'display_authors' => 'Autori',

--- a/app/i18n/lv/index.php
+++ b/app/i18n/lv/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'Nav neviena raksta, ko parādīt.',
 		'published' => array(
 			'_' => 'Published',	// TODO
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'Published in the future',	// TODO
 			'today' => 'Published today',	// TODO
 			'yesterday' => 'Published yesterday',	// TODO
 		),
 		'received' => array(
 			'_' => 'Received',	// TODO
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Received today',	// TODO
 			'yesterday' => 'Received yesterday',	// TODO
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Globālais skats',
 		'userModified' => array(
 			'_' => 'Modified by user',	// TODO
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Modified by user today',	// TODO
 			'yesterday' => 'Modified by user yesterday',	// TODO
 		),

--- a/app/i18n/nl/conf.php
+++ b/app/i18n/nl/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'Alleen voor compatibele thema’s',
 			'no' => 'Nee',
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => 'Onderaan',
 			'display_authors' => 'Auteurs',

--- a/app/i18n/nl/index.php
+++ b/app/i18n/nl/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'Er is geen artikel om te laten zien.',
 		'published' => array(
 			'_' => 'Gepubliceerd',
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'In de toekomst gepubliceerd',
 			'today' => 'Vandaag gepubliceerd',
 			'yesterday' => 'Gisteren gepubliceerd',
 		),
 		'received' => array(
 			'_' => 'Ontvangen',
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Vandaag ontvangen',
 			'yesterday' => 'Gisteren ontvangen',
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Globale weergave',
 		'userModified' => array(
 			'_' => 'Aangepast door gebruiker',
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Vandaag aangepast door gebruiker',
 			'yesterday' => 'Gisteren aangepast door gebruiker',
 		),

--- a/app/i18n/oc/conf.php
+++ b/app/i18n/oc/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'For compatible themes only',	// TODO
 			'no' => 'No',	// TODO
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => 'Linha enbàs',
 			'display_authors' => 'Autors',

--- a/app/i18n/oc/index.php
+++ b/app/i18n/oc/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'I a pas cap de flux de mostrar.',
 		'published' => array(
 			'_' => 'Published',	// TODO
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'Published in the future',	// TODO
 			'today' => 'Published today',	// TODO
 			'yesterday' => 'Published yesterday',	// TODO
 		),
 		'received' => array(
 			'_' => 'Received',	// TODO
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Received today',	// TODO
 			'yesterday' => 'Received yesterday',	// TODO
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Vista generala',
 		'userModified' => array(
 			'_' => 'Modified by user',	// TODO
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Modified by user today',	// TODO
 			'yesterday' => 'Modified by user yesterday',	// TODO
 		),

--- a/app/i18n/pl/conf.php
+++ b/app/i18n/pl/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'Wyłącznie dla kompatybilnych wyglądów',
 			'no' => 'Wyłączony',
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => 'Dolny margines',
 			'display_authors' => 'Autorzy',

--- a/app/i18n/pl/index.php
+++ b/app/i18n/pl/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'Brak wiadomości do wyświetlenia.',
 		'published' => array(
 			'_' => 'Opublikowane',
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'Opublikowane w przyszłości',
 			'today' => 'Opublikowane dzisiaj',
 			'yesterday' => 'Opublikowane wczoraj',
 		),
 		'received' => array(
 			'_' => 'Otrzymane',
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Otrzymane dzisiaj',
 			'yesterday' => 'Otrzymane wczoraj',
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Widok globalny',
 		'userModified' => array(
 			'_' => 'Zmodyfikowane przez użytkownika',
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Zmodyfikowane przez użytkownika dzisiaj',
 			'yesterday' => 'Zmodyfikowane przez użytkownika wczoraj',
 		),

--- a/app/i18n/pt-BR/conf.php
+++ b/app/i18n/pt-BR/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'Somente para temas compatíveis',
 			'no' => 'Não',
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => 'Linha inferior',
 			'display_authors' => 'Autores',

--- a/app/i18n/pt-BR/index.php
+++ b/app/i18n/pt-BR/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'Não há nenhum artigo para mostrar.',
 		'published' => array(
 			'_' => 'Publicado',
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'Publicado no futuro',
 			'today' => 'Publicado hoje',
 			'yesterday' => 'Publicado ontem',
 		),
 		'received' => array(
 			'_' => 'Recebido',
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Recebido hoje',
 			'yesterday' => 'Recebido ontem',
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Visualização Global',
 		'userModified' => array(
 			'_' => 'Modificado pelo usuário',
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Modificado pelo usuário hoje',
 			'yesterday' => 'Modificado pelo usuário ontem',
 		),

--- a/app/i18n/pt-PT/conf.php
+++ b/app/i18n/pt-PT/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'For compatible themes only',	// TODO
 			'no' => 'Não',
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => 'Linha inferior',
 			'display_authors' => 'Autores',

--- a/app/i18n/pt-PT/index.php
+++ b/app/i18n/pt-PT/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'Não há nenhum artigo para mostrar.',
 		'published' => array(
 			'_' => 'Published',	// TODO
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'Published in the future',	// TODO
 			'today' => 'Published today',	// TODO
 			'yesterday' => 'Published yesterday',	// TODO
 		),
 		'received' => array(
 			'_' => 'Received',	// TODO
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Received today',	// TODO
 			'yesterday' => 'Received yesterday',	// TODO
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Visualização Global',
 		'userModified' => array(
 			'_' => 'Modified by user',	// TODO
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Modified by user today',	// TODO
 			'yesterday' => 'Modified by user yesterday',	// TODO
 		),

--- a/app/i18n/ru/conf.php
+++ b/app/i18n/ru/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'Только для совместимых тем',
 			'no' => 'Нет',
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => 'Нижняя линия',
 			'display_authors' => 'Авторы',

--- a/app/i18n/ru/index.php
+++ b/app/i18n/ru/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'Нет статей для отображения.',
 		'published' => array(
 			'_' => 'Опубликовано',
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'Опубликовано в будущем',
 			'today' => 'Опубликовано сегодня',
 			'yesterday' => 'Опубликовано вчера',
 		),
 		'received' => array(
 			'_' => 'Получено',
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Получено сегодня',
 			'yesterday' => 'Получено вчера',
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Глобальный вид',
 		'userModified' => array(
 			'_' => 'Изменено пользователем',
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Изменено пользователем сегодня',
 			'yesterday' => 'Изменено пользователем вчера',
 		),

--- a/app/i18n/sk/conf.php
+++ b/app/i18n/sk/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'For compatible themes only',	// TODO
 			'no' => 'Nie',
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => 'Spodný riadok',
 			'display_authors' => 'Autori',

--- a/app/i18n/sk/index.php
+++ b/app/i18n/sk/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'Žiadne články.',
 		'published' => array(
 			'_' => 'Published',	// TODO
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'Published in the future',	// TODO
 			'today' => 'Published today',	// TODO
 			'yesterday' => 'Published yesterday',	// TODO
 		),
 		'received' => array(
 			'_' => 'Received',	// TODO
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Received today',	// TODO
 			'yesterday' => 'Received yesterday',	// TODO
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Prehľad',
 		'userModified' => array(
 			'_' => 'Modified by user',	// TODO
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Modified by user today',	// TODO
 			'yesterday' => 'Modified by user yesterday',	// TODO
 		),

--- a/app/i18n/tr/conf.php
+++ b/app/i18n/tr/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'Yalnızca uyumlu temalar için',
 			'no' => 'Hayır',
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => 'Alt satır',
 			'display_authors' => 'Yazarlar',

--- a/app/i18n/tr/index.php
+++ b/app/i18n/tr/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'Gösterilecek makale yok.',
 		'published' => array(
 			'_' => 'Published',	// TODO
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'Published in the future',	// TODO
 			'today' => 'Published today',	// TODO
 			'yesterday' => 'Published yesterday',	// TODO
 		),
 		'received' => array(
 			'_' => 'Received',	// TODO
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Bugün alınanlar',
 			'yesterday' => 'Dün alınanlar',
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Genel görünüm',
 		'userModified' => array(
 			'_' => 'Modified by user',	// TODO
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Modified by user today',	// TODO
 			'yesterday' => 'Modified by user yesterday',	// TODO
 		),

--- a/app/i18n/uk/conf.php
+++ b/app/i18n/uk/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => 'Лише для підтримуваних тем',
 			'no' => 'Вимкнено',
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => 'Нижній рядок',
 			'display_authors' => 'Автори',

--- a/app/i18n/uk/index.php
+++ b/app/i18n/uk/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => 'Нема статей для показу.',
 		'published' => array(
 			'_' => 'Оприлюднено',
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'Оприлюднено в майбутньому',
 			'today' => 'Оприлюднено сьогодні',
 			'yesterday' => 'Оприлюднено вчора',
 		),
 		'received' => array(
 			'_' => 'Отримано',
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Отримано сьогодні',
 			'yesterday' => 'Отримано вчора',
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => 'Глобальний показ',
 		'userModified' => array(
 			'_' => 'Змінено користувачем',
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Змінено користувачем сьогодні',
 			'yesterday' => 'Змінено користувачем учора',
 		),

--- a/app/i18n/zh-CN/conf.php
+++ b/app/i18n/zh-CN/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => '仅适用于兼容性主题',
 			'no' => '关闭',
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => '底栏',
 			'display_authors' => '作者',

--- a/app/i18n/zh-CN/index.php
+++ b/app/i18n/zh-CN/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => '没有文章可以显示。',
 		'published' => array(
 			'_' => '已发布',
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => '未来发布',
 			'today' => '今日发布',
 			'yesterday' => '昨日发布',
 		),
 		'received' => array(
 			'_' => '已接收',
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => '今日接收',
 			'yesterday' => '昨日接收',
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => '全局视图',
 		'userModified' => array(
 			'_' => '用户已修改',
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => '用户今日修改',
 			'yesterday' => '用户昨日修改',
 		),

--- a/app/i18n/zh-TW/conf.php
+++ b/app/i18n/zh-TW/conf.php
@@ -38,6 +38,12 @@ return array(
 			'help' => '僅適用於相容主題',
 			'no' => '否',
 		),
+		'date_transitions' => array(
+			'_' => 'Date transitions',	// TODO
+			'full' => 'Per day',	// TODO
+			'none' => 'None',	// TODO
+			'simple' => 'Today, yesterday, and older',	// TODO
+		),
 		'icon' => array(
 			'bottom_line' => '底部',
 			'display_authors' => '作者',

--- a/app/i18n/zh-TW/index.php
+++ b/app/i18n/zh-TW/index.php
@@ -38,12 +38,14 @@ return array(
 		'empty' => '無文章可顯示。',
 		'published' => array(
 			'_' => 'Published',	// TODO
+			'before_yesterday' => 'Published before yesterday',	// TODO
 			'future' => 'Published in the future',	// TODO
 			'today' => 'Published today',	// TODO
 			'yesterday' => 'Published yesterday',	// TODO
 		),
 		'received' => array(
 			'_' => 'Received',	// TODO
+			'before_yesterday' => 'Received before yesterday',	// TODO
 			'today' => 'Received today',	// TODO
 			'yesterday' => 'Received yesterday',	// TODO
 		),
@@ -53,6 +55,7 @@ return array(
 		'title_global' => '全域檢視',
 		'userModified' => array(
 			'_' => 'Modified by user',	// TODO
+			'before_yesterday' => 'Modified by user before yesterday',	// TODO
 			'today' => 'Modified by user today',	// TODO
 			'yesterday' => 'Modified by user yesterday',	// TODO
 		),

--- a/app/views/configure/display.phtml
+++ b/app/views/configure/display.phtml
@@ -232,6 +232,23 @@
 		</div>
 
 		<div class="form-group">
+			<label class="group-name" for="date_transitions"><?= _t('conf.display.date_transitions._') ?></label>
+			<div class="group-controls">
+				<select name="date_transitions" id="date_transitions" required="">
+					<option value="full" <?= FreshRSS_Context::userConf()->date_transitions === 'full' ? 'selected="selected"' : '' ?>>
+						<?= _t('conf.display.date_transitions.full') ?>
+					</option>
+					<option value="simple" <?= FreshRSS_Context::userConf()->date_transitions === 'simple' ? 'selected="selected"' : '' ?>>
+						<?= _t('conf.display.date_transitions.simple') ?>
+					</option>
+					<option value="none" <?= FreshRSS_Context::userConf()->date_transitions === 'none' ? 'selected="selected"' : '' ?>>
+						<?= _t('conf.display.date_transitions.none') ?>
+					</option>
+				</select>
+			</div>
+		</div>
+
+		<div class="form-group">
 			<div class="group-controls">
 				<label class="checkbox" for="html5_enable_notif">
 					<input type="checkbox" name="html5_enable_notif" id="html5_enable_notif" value="1"<?=

--- a/config-user.default.php
+++ b/config-user.default.php
@@ -32,6 +32,8 @@ return array (
 	'view_mode' => 'normal',
 	'default_view' => 'adaptive',
 	'default_state' => FreshRSS_Entry::STATE_NOT_READ,
+	# Date transition dividers: 'full' (per-day), 'simple' (today/yesterday/older), 'none'
+	'date_transitions' => 'simple',
 	'show_fav_unread' => false,
 	'show_title_unread' => true,
 	# Unread-count visibility in sidebar: 'all' | 'important' | 'none'


### PR DESCRIPTION
References #8358.

Changes proposed in this pull request:

Reintroduces the old display method as well as one without any date dividers whatsoever.

Draft partially because it's a poc and partially because I don't really understand how those transitions things are supposed to behave yet.

How to test the feature manually:

Switch between the settings in Settings → Display → Date transitions

<img width="744" height="309" alt="image" src="https://github.com/user-attachments/assets/1e65dd3e-85bf-4406-9aaf-67cf168d850c" />


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
