### PR TITLE
fix: move disable button before remove button in user management

### DIFF
--- a/app/views/user/details.phtml
+++ b/app/views/user/details.phtml
@@ -86,8 +86,6 @@
 					<button type="submit" class="btn btn-attention" name="action" value="enable"><?= _t('gen.action.enable') ?></button>
 				<?php endif; ?>
 				<button type="submit" class="btn btn-attention confirm" name="action" value="delete"<?= $disabledIfAjax ?>><?= _t('gen.action.remove') ?></button>
-
-
 			<div>
 		</div>
 	</form>

--- a/app/views/user/details.phtml
+++ b/app/views/user/details.phtml
@@ -75,7 +75,6 @@
 			<div class="group-controls">
 				<button type="submit" class="btn btn-important" name="action" value="update"><?= _t('gen.action.update') ?></button>
 				<button type="submit" class="btn btn-attention confirm" name="action" value="purge"<?= $disabledIfAjax ?>><?= _t('gen.action.purge') ?></button>
-				<button type="submit" class="btn btn-attention confirm" name="action" value="delete"<?= $disabledIfAjax ?>><?= _t('gen.action.remove') ?></button>
 				<?php if ($isAdmin && !$isDefault): ?>
 					<button type="submit" class="btn btn-attention confirm" name="action" value="demote"<?= $disabledIfAjax ?>><?= _t('gen.action.demote') ?></button>
 				<?php elseif (!$isAdmin): ?>
@@ -86,6 +85,9 @@
 				<?php elseif (!$enabled): ?>
 					<button type="submit" class="btn btn-attention" name="action" value="enable"><?= _t('gen.action.enable') ?></button>
 				<?php endif; ?>
+				<button type="submit" class="btn btn-attention confirm" name="action" value="delete"<?= $disabledIfAjax ?>><?= _t('gen.action.remove') ?></button>
+
+
 			<div>
 		</div>
 	</form>


### PR DESCRIPTION
The order of action buttons when modifying a user was inconsistent. The "disable" button appeared after the "remove" button, which is counterintuitive since disabling a user is a less destructive action than removing one.

This commit reorders the buttons in `details.phtml` to reflect the severity of each action, from least to most destructive: update → purge → promote/demote → disable/enable → delete

Closes #8877


Changes proposed in this pull request:
- Reorder action buttons in `details.phtml` from least to most destructive
- Move promote/demote button before disable/enable and delete buttons
- Move disable/enable button before the delete button

How to test the feature manually:
1. Go to Administration > User management
2. Click the gear icon next to any user to open the details panel
3. Verify the button order is: Update, Purge, Promote/Demote, Disable/Enable, Delete

Pull request checklist:
- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).