### PR TITLE
Add Newsairy iOS/macOS app to API clients list

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -292,6 +292,7 @@ et [l’API Fever](https://freshrss.github.io/FreshRSS/fr/users/06_Fever_API.htm
 | [Unread](https://www.goldenhillsoftware.com/unread/)                            | iOS         | –                                                            | ✓✓                   | Fever            | ✓            | ?        | ?                             | ?                  | ✓         | –     | –       | –           |
 | [Fiery Feeds](https://voidstern.net/fiery-feeds)         | iOS         | –                                                            | ✓✓                   | Fever            | ?            | ?        | ?                             | ?                  | ?         | –     | –       | –           |
 | [Netnewswire](https://ranchero.com/netnewswire/)                                      | iOS, macOS  | [✓](https://github.com/Ranchero-Software/NetNewsWire)        | En développement        | GReader          | ✓            | ?        | ?                             | ?                  | ✓         | –     | ?       | ✓           |
+| [Newsairy](https://apps.apple.com/us/app/newsairy/id6760046985) | iOS, macOS | – | ✓✓ | GReader | ✓ | ⭐ | ? | ✓ | ✓ | – | – | ✓ |
 
 # Bibliothèques incluses
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ and [Fever API](https://freshrss.github.io/FreshRSS/en/developers/06_Fever_API.h
 | [Unread](https://www.goldenhillsoftware.com/unread/)                            | iOS         | –                                                            | ✓✓                   | Fever            | ✓            | ?        | ?                             | ?                  | ✓         | –     | –       | –           |
 | [Fiery Feeds](https://voidstern.net/fiery-feeds)         | iOS         | –                                                            | ✓✓                   | Fever            | ?            | ?        | ?                             | ?                  | ?         | –     | –       | –           |
 | [Netnewswire](https://ranchero.com/netnewswire/)                                      | iOS, macOS  | [✓](https://github.com/Ranchero-Software/NetNewsWire)        | Work in progress       | GReader          | ✓            | ?        | ?                             | ?                  | ✓         | –     | ?       | ✓           |
+| [Newsairy](https://apps.apple.com/us/app/newsairy/id6760046985) | iOS, macOS | – | ✓✓ | GReader | ✓ | ⭐ | ? | ✓ | ✓ | – | – | ✓ |
 
 # Included libraries
 


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

Newsairy is an iCloud-native RSS/Atom/JSON feed reader for iOS and macOS, supporting the Google Reader API.
[App Store](https://apps.apple.com/us/app/newsairy/id6760046985)
[Site](https://qebapps.statichost.page/newsairy/newsairy/)

How to test the feature manually:

Try the app :-)

Pull request checklist:

- [X] clear commit messages
- [X] code manually tested
- [-] unit tests written (optional if too hard)
- [X] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
