### PR TITLE
Add unread count as reading category sort order option

### DIFF
--- a/app/Controllers/configureController.php
+++ b/app/Controllers/configureController.php
@@ -146,6 +146,8 @@ class FreshRSS_configure_Controller extends FreshRSS_ActionController {
 			FreshRSS_Context::userConf()->show_feed_name = Minz_Request::paramStringNull('show_feed_name') ?? 't';
 			FreshRSS_Context::userConf()->show_article_icons = Minz_Request::paramStringNull('show_article_icons') ?? 't';
 			FreshRSS_Context::userConf()->hide_read_feeds = Minz_Request::paramBoolean('hide_read_feeds');
+			$sidebarSortFeedsBy = Minz_Request::paramStringNull('sidebar_sort_feeds_by', plaintext: true);
+			FreshRSS_Context::userConf()->sidebar_sort_feeds_by = $sidebarSortFeedsBy === 'unread' ? 'unread' : 'alpha';
 			FreshRSS_Context::userConf()->onread_jump_next = Minz_Request::paramBoolean('onread_jump_next');
 			FreshRSS_Context::userConf()->lazyload = Minz_Request::paramBoolean('lazyload');
 			FreshRSS_Context::userConf()->sides_close_article = Minz_Request::paramBoolean('sides_close_article');

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -299,7 +299,13 @@ class FreshRSS_Category extends Minz_Model {
 		if ($this->feeds === null) {
 			return;
 		}
-		uasort($this->feeds, static fn(FreshRSS_Feed $a, FreshRSS_Feed $b) => strnatcasecmp($a->name(), $b->name()));
+		$sortBy = FreshRSS_Context::userConf()->sidebar_sort_feeds_by ?? 'alpha';
+		if ($sortBy === 'unread') {
+			uasort($this->feeds, static fn(FreshRSS_Feed $a, FreshRSS_Feed $b) =>
+				($b->nbNotRead() <=> $a->nbNotRead()) ?: strnatcasecmp($a->name(), $b->name()));
+		} else {
+			uasort($this->feeds, static fn(FreshRSS_Feed $a, FreshRSS_Feed $b) => strnatcasecmp($a->name(), $b->name()));
+		}
 	}
 
 	/**

--- a/app/Models/UserConfiguration.php
+++ b/app/Models/UserConfiguration.php
@@ -56,6 +56,7 @@ declare(strict_types=1);
  * @property bool $show_nav_buttons
  * @property bool $show_title_unread
  * @property 'all'|'important'|'none' $show_unread_count
+ * @property 'alpha'|'unread' $sidebar_sort_feeds_by
  * @property bool $sidebar_hidden_by_default
  * @property 'big'|'small'|'none' $mark_read_button
  * @property 'ASC'|'DESC' $sort_order

--- a/app/i18n/en-US/conf.php
+++ b/app/i18n/en-US/conf.php
@@ -306,6 +306,11 @@ return array(
 			'unread_or_favorite' => 'Show unreads and favorites',	// IGNORE
 		),
 		'show_fav_unread_help' => 'Applies also on labels',	// IGNORE
+		'sidebar_sort_feeds_by' => array(
+			'_' => 'Sort feeds by',	// IGNORE
+			'alpha' => 'Alphabetically',	// IGNORE
+			'unread' => 'Unread count',	// IGNORE
+		),
 		'sides_close_article' => 'Clicking outside of article text area closes the article',	// IGNORE
 		'star' => array(
 			'when' => 'Mark an article as favorite…',

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -306,6 +306,11 @@ return array(
 			'unread_or_favorite' => 'Show unreads and favourites',
 		),
 		'show_fav_unread_help' => 'Applies also on labels',
+		'sidebar_sort_feeds_by' => array(
+			'_' => 'Sort feeds by',
+			'alpha' => 'Alphabetically',
+			'unread' => 'Unread count',
+		),
 		'sides_close_article' => 'Clicking outside of article text area closes the article',
 		'star' => array(
 			'when' => 'Mark an article as favourite…',

--- a/app/views/configure/reading.phtml
+++ b/app/views/configure/reading.phtml
@@ -167,6 +167,22 @@
 					</label>
 				</div>
 			</div>
+
+			<div class="form-group">
+				<label class="group-name" for="sidebar_sort_feeds_by"><?=
+					_t('conf.reading.sidebar_sort_feeds_by._')
+				?></label>
+				<div class="group-controls">
+					<select name="sidebar_sort_feeds_by" id="sidebar_sort_feeds_by">
+						<option value="alpha"<?= FreshRSS_Context::userConf()->sidebar_sort_feeds_by === 'alpha' ? ' selected="selected"' : '' ?>><?=
+							_t('conf.reading.sidebar_sort_feeds_by.alpha')
+						?></option>
+						<option value="unread"<?= FreshRSS_Context::userConf()->sidebar_sort_feeds_by === 'unread' ? ' selected="selected"' : '' ?>><?=
+							_t('conf.reading.sidebar_sort_feeds_by.unread')
+						?></option>
+					</select>
+				</div>
+			</div>
 		</fieldset>
 
 		<fieldset>

--- a/config-user.default.php
+++ b/config-user.default.php
@@ -45,6 +45,7 @@ return array (
 	'show_feed_name' => 'a',	// {0 => none, a => with authors, t => above title}
 	'show_article_icons' => 't', // {a => with_authors, t => above title}
 	'hide_read_feeds' => true,
+	'sidebar_sort_feeds_by' => 'alpha',	// {alpha => alphabetical, unread => unread count}
 	'onread_jump_next' => true,
 	'lazyload' => true,
 	'sides_close_article' => false,

--- a/tests/app/Models/CategoryTest.php
+++ b/tests/app/Models/CategoryTest.php
@@ -4,6 +4,20 @@ declare(strict_types=1);
 use PHPUnit\Framework\Attributes\DataProvider;
 
 final class CategoryTest extends \PHPUnit\Framework\TestCase {
+	private ?FreshRSS_UserConfiguration $previousUserConf = null;
+
+	#[\Override]
+	protected function setUp(): void {
+		$this->previousUserConf = FreshRSS_Context::hasUserConf() ? FreshRSS_Context::userConf() : null;
+		$userConf = $this->previousUserConf instanceof FreshRSS_UserConfiguration ?
+			clone $this->previousUserConf : clone FreshRSS_UserConfiguration::default();
+		FreshRSS_Context::setUserConf($userConf);
+	}
+
+	#[\Override]
+	protected function tearDown(): void {
+		FreshRSS_Context::setUserConf($this->previousUserConf);
+	}
 
 	public static function test__construct_whenNoParameters_createsObjectWithDefaultValues(): void {
 		$category = new FreshRSS_Category();
@@ -30,29 +44,11 @@ final class CategoryTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function test_feedOrdering(): void {
-		$feed_1 = $this->getMockBuilder(FreshRSS_Feed::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$feed_1->method('id')->withAnyParameters()->willReturn(1);
-		$feed_1->expects(self::any())
-			->method('name')
-			->willReturn('AAA');
+		FreshRSS_Context::userConf()->sidebar_sort_feeds_by = 'alpha';
 
-		$feed_2 = $this->getMockBuilder(FreshRSS_Feed::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$feed_2->method('id')->withAnyParameters()->willReturn(2);
-		$feed_2->expects(self::any())
-			->method('name')
-			->willReturn('ZZZ');
-
-		$feed_3 = $this->getMockBuilder(FreshRSS_Feed::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$feed_3->method('id')->withAnyParameters()->willReturn(3);
-		$feed_3->expects(self::any())
-			->method('name')
-			->willReturn('lll');
+		$feed_1 = $this->mockFeed(1, 'AAA');
+		$feed_2 = $this->mockFeed(2, 'ZZZ');
+		$feed_3 = $this->mockFeed(3, 'lll');
 
 		$category = new FreshRSS_Category('test', 0, [
 			$feed_1,
@@ -69,15 +65,7 @@ final class CategoryTest extends \PHPUnit\Framework\TestCase {
 		$feed = next($feeds) ?: FreshRSS_Feed::default();
 		self::assertSame('ZZZ', $feed->name());
 
-		/** @var FreshRSS_Feed&PHPUnit\Framework\MockObject\MockObject */
-		$feed_4 = $this->getMockBuilder(FreshRSS_Feed::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$feed_4->method('id')->withAnyParameters()->willReturn(4);
-		$feed_4->expects(self::any())
-			->method('name')
-			->willReturn('BBB');
-		$feed_4->method('id')->withAnyParameters()->willReturn(5);
+		$feed_4 = $this->mockFeed(4, 'BBB');
 
 		$category->addFeed($feed_4);
 		$feeds = $category->feeds();
@@ -91,5 +79,39 @@ final class CategoryTest extends \PHPUnit\Framework\TestCase {
 		self::assertSame('lll', $feed->name());
 		$feed = next($feeds) ?: FreshRSS_Feed::default();
 		self::assertSame('ZZZ', $feed->name());
+	}
+
+	public function test_feedOrderingByUnreadCount(): void {
+		FreshRSS_Context::userConf()->sidebar_sort_feeds_by = 'unread';
+
+		$category = new FreshRSS_Category('test', 0, [
+			$this->mockFeed(1, 'CCC', 3),
+			$this->mockFeed(2, 'AAA', 8),
+			$this->mockFeed(3, 'BBB', 8),
+			$this->mockFeed(4, 'DDD', 0),
+		]);
+		$feeds = $category->feeds();
+
+		self::assertCount(4, $feeds);
+		self::assertSame('AAA', (reset($feeds) ?: FreshRSS_Feed::default())->name());
+		self::assertSame('BBB', (next($feeds) ?: FreshRSS_Feed::default())->name());
+		self::assertSame('CCC', (next($feeds) ?: FreshRSS_Feed::default())->name());
+		self::assertSame('DDD', (next($feeds) ?: FreshRSS_Feed::default())->name());
+	}
+
+	/** @return FreshRSS_Feed&PHPUnit\Framework\MockObject\MockObject */
+	private function mockFeed(int $id, string $name, int $nbNotRead = 0): FreshRSS_Feed {
+		$feed = $this->getMockBuilder(FreshRSS_Feed::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$feed->method('id')->withAnyParameters()->willReturn($id);
+		$feed->expects(self::any())
+			->method('name')
+			->willReturn($name);
+		$feed->expects(self::any())
+			->method('nbNotRead')
+			->willReturn($nbNotRead);
+
+		return $feed;
 	}
 }


### PR DESCRIPTION
Adds a reading preference to sort feeds in the sidebar by unread count.
Falls back to alphabetical order when feeds have the same unread count.
This uses the existing cached unread count exposed by FreshRSS_Feed::nbNotRead().

Changes proposed in this pull request:

- Add a "Sort feeds by" setting to the reading configuration page
- Keep alphabetical sorting as the default
- Add optional unread-count sorting for feeds within categories
- Add tests for unread-count sorting and alphabetical tie-breaking

How to test the feature manually:

1. Go to Configuration > Reading and set "Sort feeds by" to "Unread count"
2. Check a category that has feeds with different unread counts
3. Confirm feeds with more unread articles appear first, and feeds with the same unread count stay alphabetical


Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written
- [ ] documentation updated