### PR TITLE
Fix slider not reinitializing after form submit

### DIFF
--- a/lib/Minz/Dispatcher.php
+++ b/lib/Minz/Dispatcher.php
@@ -53,6 +53,10 @@ final class Minz_Dispatcher {
 				$this->controller->lastAction();
 
 				if (!self::$needsReset) {
+					$model = $this->controller->view();
+					if ($model instanceof FreshRSS_View && $model->displaySlider) {
+						FreshRSS_View::prependScript(Minz_Url::display('/scripts/extra.js?' . @filemtime(PUBLIC_PATH . '/scripts/extra.js')));
+					}
 					$this->controller->declareCspHeader();
 					$this->controller->view()->build();
 				}

--- a/p/scripts/extra.js
+++ b/p/scripts/extra.js
@@ -632,32 +632,30 @@ function init_extra_afterDOM() {
 	if (loginButton) {
 		loginButton.addEventListener('click', forgetOpenCategories);
 	}
-	if (!['normal', 'global', 'reader'].includes(context.current_view)) {
-		init_crypto_forms();
-		init_password_observers(document.body);
-		init_select_observers();
-		init_configuration_alert();
-		init_2stateButton();
-		init_update_feed();
-		init_details_attributes();
-		init_user_stats();
-		init_enable_notify_button();
+	init_crypto_forms();
+	init_password_observers(document.body);
+	init_select_observers();
+	init_configuration_alert();
+	init_2stateButton();
+	init_update_feed();
+	init_details_attributes();
+	init_user_stats();
+	init_enable_notify_button();
 
-		data_auto_leave_validation(document.body);
+	data_auto_leave_validation(document.body);
 
-		const slider = document.getElementById('slider');
-		if (slider) {
-			slider.addEventListener('freshrss:slider-load', function (e) {
-				init_password_observers(slider);
-			});
-			init_slider(slider);
-			init_archiving(slider);
-			init_url_observers(slider);
-		} else {
-			init_display(document.body);
-			init_archiving(document.body);
-			init_url_observers(document.body);
-		}
+	const slider = document.getElementById('slider');
+	if (slider) {
+		slider.addEventListener('freshrss:slider-load', function (e) {
+			init_password_observers(slider);
+		});
+		init_slider(slider);
+		init_archiving(slider);
+		init_url_observers(slider);
+	} else {
+		init_display(document.body);
+		init_archiving(document.body);
+		init_url_observers(document.body);
 	}
 
 	if (window.console) {


### PR DESCRIPTION
"Follow-up" of https://github.com/FreshRSS/FreshRSS/pull/8612 (not fixing a regression, just a bug)

Some features like URL observers and custom favicon JS (e.g. *Reset to default* button) wouldn't work, due to `extra.js` not being loaded properly on pages where the slider content was already included in the HTML.