### PR TITLE
cli/health.php: output a diagnostic when the health check fails

### DIFF
--- a/cli/health.php
+++ b/cli/health.php
@@ -27,10 +27,16 @@ $content = curl_exec($ch);
 $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
 if ($httpCode !== 200 || !is_string($content)) {
+	$curlError = curl_error($ch);
+	fwrite(STDERR, 'Error: Health check failed for ' . $address . ': ' .
+		($curlError !== '' ? $curlError : ('unexpected HTTP status ' . $httpCode)) . PHP_EOL);
 	die(1);
 }
 
 $content = rtrim($content, "\n\r");
 if (!str_starts_with($content, '<!DOCTYPE html>') || !str_ends_with($content, '</html>') || !str_contains($content, '/scripts/api.js')) {
+	fwrite(STDERR, 'Error: Health check failed for ' . $address .
+		': the response does not look like a FreshRSS page' .
+		' (check that the URL points to a working FreshRSS instance with the API enabled).' . PHP_EOL);
 	die(2);
 }


### PR DESCRIPTION
Closes #8026

## Changes proposed in this pull request

The Docker healthcheck script `cli/health.php` previously exited with a bare `die(1)` / `die(2)` and **no message**, so a failing healthcheck showed only "unhealthy" (in `docker inspect` or when run manually) with no indication of the cause — as reported in #8026.

It now prints an informative diagnostic to STDERR before each failing exit, **without changing the exit codes** that Docker `HEALTHCHECK` relies on:

- `die(1)` — a connection/transport failure now reports the cURL error (e.g. "Connection refused" / timeout, the empty-output case from the report), and an unexpected HTTP status reports the code (e.g. 500, or the 302 an OIDC misconfiguration produces).
- `die(2)` — a response that is not a FreshRSS page now says so and hints at the likely cause.

## How to test the feature manually

```sh
# Connection failure:
php cli/health.php --url=http://127.0.0.1:9999/   # -> exit 1 + "…Failed to connect…"
# 200 but not a FreshRSS page:
php cli/health.php --url=https://example.com/      # -> exit 2 + "…does not look like a FreshRSS page…"
# Working instance:
php cli/health.php                                 # -> exit 0, no output
```

Verified locally with the `freshrss/freshrss:alpine` image (all three cases above, exit codes unchanged). `php -l`, `phpcs` and `phpstan` all pass.

## Pull request checklist

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard) — CLI-level output change
- [x] documentation updated (no user-facing docs change; exit codes unchanged)
