### PR TITLE
Fever API: log the client IP address on authentication failure

### DIFF
--- a/p/api/fever.php
+++ b/p/api/fever.php
@@ -188,7 +188,8 @@ final class FeverAPI
 				Minz_Log::error('Fever API: Please reset your API password!');
 				Minz_User::change();
 			}
-			Minz_Log::warning('Fever API: wrong credentials! ' . $feverKey, API_LOG);
+			Minz_Log::warning('Fever API: wrong credentials! ' . $feverKey .
+				' ; Remote IP address=' . Minz_Request::connectionRemoteAddress(), API_LOG);
 		}
 		return false;
 	}


### PR DESCRIPTION
Closes #6814

## Changes proposed in this pull request

A failed Fever API authentication returns `{"api_version":4,"auth":0}` with HTTP **200**, so from the web-server log a failure is indistinguishable from a success and fail2ban cannot detect/ban repeated attempts (#6814).

The failure was already logged to the API log (`data/users/_/log_api.txt`) in `p/api/fever.php`, but **without the client IP**. This appends the remote IP to that warning, using the existing `Minz_Request::connectionRemoteAddress()` helper (same format as `app/Controllers/authController.php`), so a fail2ban filter watching the FreshRSS API log can extract and ban the address.

Example log line now:

```
[warning] --- Fever API: wrong credentials! deadbeef… ; Remote IP address=203.0.113.5
```

## How to test the feature manually

1. Install FreshRSS with the API enabled and create a user with an API password.
2. Send a wrong Fever key: `curl -X POST 'https://your-instance/api/fever.php?api' -d 'api_key=deadbeefdeadbeefdeadbeefdeadbeef'` → response `{"auth":0}`.
3. Check `data/users/_/log_api.txt` — the "wrong credentials" warning now includes `Remote IP address=<your IP>`.

Verified locally with the `freshrss/freshrss:alpine` image (Apache): the log line correctly includes the client IP (`::1`). `php -l`, `phpcs` and `phpstan` all pass.

## Pull request checklist

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated (N/A — no docs change; log message only)
