### PR TITLE
OPML: include each feed's refresh interval (TTL) in export/import

### DIFF
--- a/app/Services/ImportService.php
+++ b/app/Services/ImportService.php
@@ -195,6 +195,11 @@ class FreshRSS_Import_Service {
 				$feed->_attribute('unicityCriteriaForced', true);
 			}
 
+			if (isset($feed_elt['frss:ttl'])) {
+				// Signed refresh interval (TTL); a negative value indicates a muted feed
+				$feed->_ttl((int)$feed_elt['frss:ttl']);
+			}
+
 			if (isset($feed_elt['frss:cssFullContent'])) {
 				$feed->_pathEntries(Minz_Helper::htmlspecialchars_utf8($feed_elt['frss:cssFullContent']));
 			}

--- a/app/views/helpers/export/opml.phtml
+++ b/app/views/helpers/export/opml.phtml
@@ -55,6 +55,11 @@ function feedsToOutlines(array $feeds, bool $excludeMutedFeeds = false): array {
 			$outline['frss:unicityCriteriaForced'] = 'true';
 		}
 
+		// Refresh interval (TTL), signed: a negative value indicates a muted feed
+		if ($feed->ttl(raw: true) !== FreshRSS_Feed::TTL_DEFAULT) {
+			$outline['frss:ttl'] = (string)$feed->ttl(raw: true);
+		}
+
 		if ($feed->kind() === FreshRSS_Feed::KIND_HTML_XPATH || $feed->kind() === FreshRSS_Feed::KIND_XML_XPATH) {
 			/** @var array<string,string> */
 			$xPathSettings = $feed->attributeArray('xpath') ?? [];

--- a/docs/en/developers/OPML.md
+++ b/docs/en/developers/OPML.md
@@ -92,6 +92,7 @@ A number of [cURL options](https://curl.se/libcurl/c/curl_easy_setopt.html) are 
 * `frss:priority`: Used for priority / visibility of the articles of that feed. Can be: `important`, `main` (default), `category`, `feed`, `hidden`.
 * `frss:unicityCriteria`: Criteria used for the unicity of articles. E.g. `id` (default), `link`, `sha1:link_published`, `sha1:link_published_title`, `sha1:title`, [etc](https://github.com/FreshRSS/FreshRSS/blob/1c92d55917029d291d00009b674d8552934a69ec/app/Models/Feed.php#L652-L666).
 * `frss:unicityCriteriaForced`: Boolean to force the usage of the selected unicity criterion even in the case of many duplicates (otherwise, the default behaviour is to fall back to a more precise unicity criteria).
+* `frss:ttl`: Refresh interval of the feed, in seconds. A negative value indicates a muted feed (automatic refresh disabled). When absent, the importing instance’s default refresh interval is used.
 * `frss:cssFullContent`: [CSS Selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) to enable the download and extraction of the matching HTML section of each articles’ Web address.
 	* Example: `div.main, .summary`
 * `frss:cssContentFilter`: [CSS Selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) to remove the matching HTML elements from the article content or from the full content retrieved by `frss:cssFullContent`.


### PR DESCRIPTION
Closes #5914

## Changes proposed in this pull request

Moving feeds between FreshRSS instances via OPML lost each feed's **refresh interval (TTL)**, forcing users to reconfigure it manually per feed. This adds a `frss:ttl` attribute to the OPML export (under the existing `https://freshrss.org/opml` namespace) and reads it back on import, so the interval survives a round-trip.

- **Export** (`app/views/helpers/export/opml.phtml`): write `frss:ttl` when the feed's TTL is not the default. The value is the *signed* TTL, so a negative value also carries the muted state.
- **Import** (`app/Services/ImportService.php`): read `frss:ttl` and apply it via `FreshRSS_Feed::_ttl()`, which decodes the sign (restoring both the interval and the muted state).
- **Docs** (`docs/en/developers/OPML.md`): document the new attribute.

A default (non-muted) feed omits the attribute, so it keeps the importing instance's own default.

## How to test the feature manually

1. Set a custom refresh interval on a feed (and optionally mute another), then export your subscriptions — the OPML now contains `frss:ttl="…"` for those feeds.
2. Import that OPML on another instance — the feeds keep their refresh interval (and muted state).

Verified locally with `freshrss/freshrss:alpine`: importing an OPML with `frss:ttl="3600"` and `frss:ttl="-1800"` stores `ttl = 3600` and `-1800` in the DB, and re-exporting produces `frss:ttl="3600"` / `frss:ttl="-1800"` (full round-trip). `php -l`, `phpcs` and `phpstan` all pass.

## Pull request checklist

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard) — verified via an import→DB→export round-trip
- [x] documentation updated
