### PR TITLE
Dynamic OPML: optionally reproduce the remote OPML's categories

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -233,21 +233,21 @@ Voir le [dépôt dédié à ces extensions](https://github.com/FreshRSS/Extensio
 | Deutsch (de) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fde+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Ελληνικά (el) | ￭￭￭￭￭￭￭･･･ 75% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fel+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (en) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen+%2F%28TODO%7CDIRTY%29%24%2F) |
-| English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |
+| English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Español (es) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
 | فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Suomi (fi) | ￭￭￭￭￭￭￭￭￭･ 91% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffi+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Français (fr) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Français (fr) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | עברית (he) | ￭￭￭￭･･････ 41% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhe+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Magyar (hu) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhu+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭･･ 89% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭･･ 88% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Italiano (it) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fit+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 日本語 (ja) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fja+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 한국어 (ko) | ￭￭￭￭￭￭￭￭･･ 81% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fko+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Latviešu (lv) | ￭￭￭￭￭￭￭￭･･ 81% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Flv+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Nederlands (nl) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fnl+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Occitan (oc) | ￭￭￭￭￭￭￭･･･ 74% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Foc+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Polski (pl) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpl+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Polski (pl) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpl+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Português (Brasil) (pt-BR) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-BR+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Português (Portugal) (pt-PT) | ￭￭￭￭￭￭￭￭･･ 80% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-PT+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Русский (ru) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fru+%2F%28TODO%7CDIRTY%29%24%2F) |
@@ -255,7 +255,7 @@ Voir le [dépôt dédié à ces extensions](https://github.com/FreshRSS/Extensio
 | Türkçe (tr) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ftr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Українська (uk) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fuk+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 简体中文 (zh-CN) | ￭￭￭￭￭￭￭￭￭･ 96% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-CN+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 正體中文 (zh-TW) | ￭￭￭￭￭￭￭￭￭･ 97% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-TW+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 正體中文 (zh-TW) | ￭￭￭￭￭￭￭￭￭･ 96% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-TW+%2F%28TODO%7CDIRTY%29%24%2F) |
 
 </translations>
 

--- a/README.md
+++ b/README.md
@@ -129,21 +129,21 @@ See the [repository dedicated to those extensions](https://github.com/FreshRSS/E
 | Deutsch (de) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fde+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Ελληνικά (el) | ￭￭￭￭￭￭￭･･･ 75% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fel+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (en) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen+%2F%28TODO%7CDIRTY%29%24%2F) |
-| English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |
+| English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Español (es) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
 | فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Suomi (fi) | ￭￭￭￭￭￭￭￭￭･ 91% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffi+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Français (fr) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Français (fr) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | עברית (he) | ￭￭￭￭･･････ 41% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhe+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Magyar (hu) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhu+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭･･ 89% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭･･ 88% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Italiano (it) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fit+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 日本語 (ja) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fja+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 한국어 (ko) | ￭￭￭￭￭￭￭￭･･ 81% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fko+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Latviešu (lv) | ￭￭￭￭￭￭￭￭･･ 81% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Flv+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Nederlands (nl) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fnl+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Occitan (oc) | ￭￭￭￭￭￭￭･･･ 74% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Foc+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Polski (pl) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpl+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Polski (pl) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpl+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Português (Brasil) (pt-BR) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-BR+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Português (Portugal) (pt-PT) | ￭￭￭￭￭￭￭￭･･ 80% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-PT+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Русский (ru) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fru+%2F%28TODO%7CDIRTY%29%24%2F) |
@@ -151,7 +151,7 @@ See the [repository dedicated to those extensions](https://github.com/FreshRSS/E
 | Türkçe (tr) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ftr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Українська (uk) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fuk+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 简体中文 (zh-CN) | ￭￭￭￭￭￭￭￭￭･ 96% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-CN+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 正體中文 (zh-TW) | ￭￭￭￭￭￭￭￭￭･ 97% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-TW+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 正體中文 (zh-TW) | ￭￭￭￭￭￭￭￭￭･ 96% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-TW+%2F%28TODO%7CDIRTY%29%24%2F) |
 
 </translations>
 

--- a/app/Controllers/categoryController.php
+++ b/app/Controllers/categoryController.php
@@ -63,9 +63,11 @@ class FreshRSS_category_Controller extends FreshRSS_ActionController {
 			if ($opml_url != '') {
 				$cat->_kind(FreshRSS_Category::KIND_DYNAMIC_OPML);
 				$cat->_attribute('opml_url', $opml_url);
+				$cat->_attribute('opml_create_categories', Minz_Request::paramBoolean('opml_create_categories') ?: null);
 			} else {
 				$cat->_kind(FreshRSS_Category::KIND_NORMAL);
 				$cat->_attribute('opml_url', null);
+				$cat->_attribute('opml_create_categories', null);
 			}
 
 			if ($catDAO->addCategoryObject($cat)) {
@@ -150,9 +152,11 @@ class FreshRSS_category_Controller extends FreshRSS_ActionController {
 			if ($opml_url != '') {
 				$category->_kind(FreshRSS_Category::KIND_DYNAMIC_OPML);
 				$category->_attribute('opml_url', $opml_url);
+				$category->_attribute('opml_create_categories', Minz_Request::paramBoolean('opml_create_categories') ?: null);
 			} else {
 				$category->_kind(FreshRSS_Category::KIND_NORMAL);
 				$category->_attribute('opml_url', null);
+				$category->_attribute('opml_create_categories', null);
 			}
 
 			$defaultSortOrder = Minz_Request::paramString('defaultSortOrder', plaintext: true);

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -222,67 +222,11 @@ class FreshRSS_Category extends Minz_Model {
 				\SimplePie\Misc::url_remove_credentials($url));
 			$ok = false;
 		} else {
-			$dryRunCategory = new FreshRSS_Category();
 			$importService = new FreshRSS_Import_Service();
-			$importService->importOpml($opml, $dryRunCategory, true);
-			if ($importService->lastStatus()) {
-				$feedDAO = FreshRSS_Factory::createFeedDao();
-				$limits = FreshRSS_Context::systemConf()->limits;
-				$maxFeeds = (int)($limits['max_feeds'] ?? 0);
-				$nbFeeds = $maxFeeds > 0 ? $feedDAO->count() : 0;
-
-				/** @var array<string,FreshRSS_Feed> */
-				$dryRunFeeds = [];
-				foreach ($dryRunCategory->feeds() as $dryRunFeed) {
-					$dryRunFeeds[$dryRunFeed->url()] = $dryRunFeed;
-				}
-
-				/** @var array<string,FreshRSS_Feed> */
-				$existingFeeds = [];
-				foreach ($this->feeds() as $existingFeed) {
-					$existingFeeds[$existingFeed->url()] = $existingFeed;
-					if (empty($dryRunFeeds[$existingFeed->url()])) {
-						// The feed does not exist in the new dynamic OPML, so mute (disable) that feed
-						$existingFeed->_mute(true);
-						$ok &= ($feedDAO->updateFeed($existingFeed->id(), [
-							'ttl' => $existingFeed->ttl(true),
-						]) !== false);
-					}
-				}
-
-				foreach ($dryRunCategory->feeds() as $dryRunFeed) {
-					if (empty($existingFeeds[$dryRunFeed->url()])) {
-						// The feed does not exist in the current category, so add that feed
-						if ($maxFeeds > 0 && $nbFeeds >= $maxFeeds) {
-							// Respect the per-user maximum number of feeds
-							Minz_Log::warning(_t('feedback.sub.feed.over_max', $maxFeeds) .
-								' (dynamic OPML category ' . $this->id() . ')');
-							$ok = false;
-							break;
-						}
-						$dryRunFeed->_category($this);
-						if ($feedDAO->addFeedObject($dryRunFeed) === false) {
-							$ok = false;
-						} else {
-							$nbFeeds++;
-						}
-						$existingFeeds[$dryRunFeed->url()] = $dryRunFeed;
-					} else {
-						$existingFeed = $existingFeeds[$dryRunFeed->url()];
-						if ($existingFeed->mute()) {
-							// The feed already exists in the current category but was muted (disabled), so unmute (enable) again
-							$existingFeed->_mute(false);
-							$ok &= ($feedDAO->updateFeed($existingFeed->id(), [
-								'ttl' => $existingFeed->ttl(true),
-							]) !== false);
-						}
-					}
-				}
-			} else {
-				$ok = false;
-				Minz_Log::warning('Error loading dynamic OPML for category ' . $this->id() . '! ' .
-					\SimplePie\Misc::url_remove_credentials($url));
-			}
+			// When `opml_create_categories` is enabled, honor the remote OPML's own category
+			// structure; otherwise keep the legacy behavior of putting every feed into this category.
+			$createCategories = $this->attributeBoolean('opml_create_categories') ?? false;
+			$ok = $this->syncDynamicOpmlFeeds($importService, $opml, $url, $createCategories);
 		}
 
 		$catDAO = FreshRSS_Factory::createCategoryDao();
@@ -292,7 +236,148 @@ class FreshRSS_Category extends Minz_Model {
 			$catDAO->updateLastError($this->id());
 		}
 
-		return (bool)$ok;
+		return $ok;
+	}
+
+	/**
+	 * Sync the feeds of this Dynamic OPML category against the remote OPML.
+	 *
+	 * @param bool $createCategories When true, the remote OPML's category structure is honored:
+	 *   feeds go into categories named as in the remote OPML (existing categories reused, missing
+	 *   ones created), feeds at the OPML root go into this (anchor) category, and only feeds owned
+	 *   by this Dynamic OPML (tagged with the `dynamic_opml` attribute) are managed — so manually
+	 *   added feeds sharing a category are never touched. When false (legacy), every feed is placed
+	 *   into this single category and the managed set is simply this category's feeds.
+	 */
+	private function syncDynamicOpmlFeeds(FreshRSS_Import_Service $importService, string $opml, string $url, bool $createCategories): bool {
+		$dryRunCategory = new FreshRSS_Category();
+		$importService->importOpml($opml, $createCategories ? null : $dryRunCategory, true);
+		if (!$importService->lastStatus()) {
+			Minz_Log::warning('Error loading dynamic OPML for category ' . $this->id() . '! ' .
+				\SimplePie\Misc::url_remove_credentials($url));
+			return false;
+		}
+
+		$ok = true;
+		$feedDAO = FreshRSS_Factory::createFeedDao();
+		$catDAO = FreshRSS_Factory::createCategoryDao();
+		$limits = FreshRSS_Context::systemConf()->limits;
+		$maxFeeds = (int)($limits['max_feeds'] ?? 0);
+		$maxCategories = (int)($limits['max_categories'] ?? 0);
+		$nbFeeds = $maxFeeds > 0 ? $feedDAO->count() : 0;
+		$nbCategories = $maxCategories > 0 ? $catDAO->count() : 0;
+
+		// Desired feeds from the remote OPML: url => [feed, OPML category name ('' = root)].
+		/** @var array<string,array{feed:FreshRSS_Feed,categoryName:string}> */
+		$desiredFeeds = [];
+		if ($createCategories) {
+			foreach ($importService->importedCategories() as $categoryName => $importedCategory) {
+				foreach ($importedCategory->feeds() as $importedFeed) {
+					$desiredFeeds[$importedFeed->url()] = ['feed' => $importedFeed, 'categoryName' => (string)$categoryName];
+				}
+			}
+		} else {
+			foreach ($dryRunCategory->feeds() as $importedFeed) {
+				$desiredFeeds[$importedFeed->url()] = ['feed' => $importedFeed, 'categoryName' => ''];
+			}
+		}
+
+		// Feeds currently managed by this Dynamic OPML.
+		/** @var array<string,FreshRSS_Feed> */
+		$managedFeeds = [];
+		if ($createCategories) {
+			foreach ($feedDAO->listFeeds() as $feed) {
+				if ($feed->attributeInt('dynamic_opml') === $this->id()) {
+					$managedFeeds[$feed->url()] = $feed;
+				}
+			}
+		} else {
+			foreach ($this->feeds() as $feed) {
+				$managedFeeds[$feed->url()] = $feed;
+			}
+		}
+
+		// Mute feeds that disappeared from the remote OPML.
+		foreach ($managedFeeds as $feedUrl => $feed) {
+			if (!isset($desiredFeeds[$feedUrl]) && !$feed->mute()) {
+				$feed->_mute(true);
+				$ok = ($feedDAO->updateFeed($feed->id(), ['ttl' => $feed->ttl(true)]) !== false) && $ok;
+			}
+		}
+
+		// Add feeds new to this Dynamic OPML, and unmute those that came back.
+		/** @var array<string,FreshRSS_Category|null> */
+		$targetCategories = [];
+		foreach ($desiredFeeds as $feedUrl => $item) {
+			if (isset($managedFeeds[$feedUrl])) {
+				$existingFeed = $managedFeeds[$feedUrl];
+				if ($existingFeed->mute()) {
+					$existingFeed->_mute(false);
+					$ok = ($feedDAO->updateFeed($existingFeed->id(), ['ttl' => $existingFeed->ttl(true)]) !== false) && $ok;
+				}
+				continue;
+			}
+
+			// Respect the per-user maximum number of feeds.
+			if ($maxFeeds > 0 && $nbFeeds >= $maxFeeds) {
+				Minz_Log::warning(_t('feedback.sub.feed.over_max', $maxFeeds) .
+					' (dynamic OPML category ' . $this->id() . ')');
+				$ok = false;
+				break;
+			}
+
+			$categoryName = $item['categoryName'];
+			if (!array_key_exists($categoryName, $targetCategories)) {
+				$targetCategories[$categoryName] = $createCategories
+					? $this->resolveDynamicOpmlCategory($categoryName, $catDAO, $maxCategories, $nbCategories)
+					: $this;
+			}
+			$category = $targetCategories[$categoryName];
+			if ($category === null) {
+				$ok = false;
+				continue;
+			}
+
+			$feed = $item['feed'];
+			$feed->_category($category);
+			if ($createCategories) {
+				$feed->_attribute('dynamic_opml', $this->id());
+			}
+			if ($feedDAO->addFeedObject($feed) === false) {
+				$ok = false;
+			} else {
+				$nbFeeds++;
+			}
+		}
+
+		return $ok;
+	}
+
+	/**
+	 * Find or create the FreshRSS category for a remote OPML category name (create-categories mode).
+	 * An empty name (feeds at the OPML root, or a name equal to this category) maps to this anchor category.
+	 */
+	private function resolveDynamicOpmlCategory(string $categoryName, FreshRSS_CategoryDAO $catDAO, int $maxCategories, int &$nbCategories): ?FreshRSS_Category {
+		if ($categoryName === '' || $categoryName === $this->name()) {
+			return $this;
+		}
+		$existing = $catDAO->searchByName($categoryName);
+		if ($existing !== null) {
+			return $existing;
+		}
+		if ($maxCategories > 0 && $nbCategories >= $maxCategories && !FreshRSS_Context::$isCli) {
+			Minz_Log::warning(_t('feedback.sub.category.over_max', $maxCategories) .
+				' (dynamic OPML category ' . $this->id() . ')');
+			return null;
+		}
+		$category = new FreshRSS_Category($categoryName);
+		$id = $catDAO->addCategoryObject($category);
+		if ($id === false) {
+			return null;
+		}
+		$category->_id($id);
+		$nbCategories++;
+		return $category;
 	}
 
 	private function sortFeeds(): void {

--- a/app/Services/ImportService.php
+++ b/app/Services/ImportService.php
@@ -14,6 +14,13 @@ class FreshRSS_Import_Service {
 	private bool $lastStatus;
 
 	/**
+	 * Categories resolved during the last importOpml() call, keyed by their OPML category name
+	 * (empty string for feeds at the OPML root). Each category has its imported feeds attached.
+	 * @var array<string,FreshRSS_Category>
+	 */
+	private array $importedCategories = [];
+
+	/**
 	 * Initialize the service for the given user.
 	 */
 	public function __construct(?string $username = null) {
@@ -24,6 +31,15 @@ class FreshRSS_Import_Service {
 	/** @return bool true if success, false otherwise */
 	public function lastStatus(): bool {
 		return $this->lastStatus;
+	}
+
+	/**
+	 * Categories resolved during the last importOpml() call, keyed by their OPML category name
+	 * (empty string for feeds at the OPML root), each with its imported feeds attached.
+	 * @return array<string,FreshRSS_Category>
+	 */
+	public function importedCategories(): array {
+		return $this->importedCategories;
 	}
 
 	/**
@@ -38,6 +54,7 @@ class FreshRSS_Import_Service {
 			@set_time_limit(300);
 		}
 		$this->lastStatus = true;
+		$this->importedCategories = [];
 		$opml_array = [];
 		try {
 			$libopml = new \marienfressinaud\LibOpml\LibOpml(strict: false);
@@ -108,6 +125,10 @@ class FreshRSS_Import_Service {
 				// outline, or if we weren't able to create the category.
 				$category = $default_category;
 			}
+
+			// Remember the resolved category (with its imported feeds attached below)
+			// so callers such as Dynamic OPML can honor the OPML category structure.
+			$this->importedCategories[$category_name] = $category;
 
 			// Then, create the feeds one by one and attach them to the
 			// category we just got.

--- a/app/i18n/cs/sub.php
+++ b/app/i18n/cs/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Expand category',	// TODO
 		'information' => 'Informace',
 		'open' => 'Open category',	// TODO
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'ADRESA URL OPML',
 		'position' => 'Zobrazit pozici',
 		'position_help' => 'Pro ovládání pořadí řazení kategorií',

--- a/app/i18n/de/sub.php
+++ b/app/i18n/de/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Kategorie aufklappen',
 		'information' => 'Information',	// IGNORE
 		'open' => 'Kategorie öffnen',
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'URL der OPML-Datei',
 		'position' => 'Reihenfolge',
 		'position_help' => 'Sortierreihenfolge der Kategorien steuern',

--- a/app/i18n/el/sub.php
+++ b/app/i18n/el/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Expand category',	// TODO
 		'information' => 'Information',	// TODO
 		'open' => 'Open category',	// TODO
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'OPML URL',	// TODO
 		'position' => 'Display position',	// TODO
 		'position_help' => 'To control category sort order',	// TODO

--- a/app/i18n/en-US/sub.php
+++ b/app/i18n/en-US/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Expand category',	// IGNORE
 		'information' => 'Information',	// IGNORE
 		'open' => 'Open category',	// IGNORE
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'OPML URL',	// IGNORE
 		'position' => 'Display position',	// IGNORE
 		'position_help' => 'To control category sort order',	// IGNORE

--- a/app/i18n/en/sub.php
+++ b/app/i18n/en/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Expand category',
 		'information' => 'Information',
 		'open' => 'Open category',
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',
 		'opml_url' => 'OPML URL',
 		'position' => 'Display position',
 		'position_help' => 'To control category sort order',

--- a/app/i18n/es/sub.php
+++ b/app/i18n/es/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Expandir categoría',
 		'information' => 'Información',
 		'open' => 'Abrir categoría',
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'URL del OPML',
 		'position' => 'Posición de visualización',
 		'position_help' => 'Para controlar el orden de clasificación de categorías',

--- a/app/i18n/fa/sub.php
+++ b/app/i18n/fa/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'دسته‌بندی را گسترش دهید',
 		'information' => ' اطلاعات',
 		'open' => 'دسته‌بندی باز',
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => ' URL OPML',
 		'position' => ' موقعیت نمایش',
 		'position_help' => 'برای کنترل ترتیب مرتب‌سازی دسته‌بندی',

--- a/app/i18n/fi/sub.php
+++ b/app/i18n/fi/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Laajenna luokka',
 		'information' => 'Tiedot',
 		'open' => 'Avaa luokka',
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'OPML-tiedoston URL-osoite',
 		'position' => 'Näyttöjärjestys',
 		'position_help' => 'Määritä luokkien lajittelujärjestys',

--- a/app/i18n/fr/sub.php
+++ b/app/i18n/fr/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Développer la catégorie',
 		'information' => 'Informations',
 		'open' => 'Ouvrir la catégorie',
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'URL de l’OPML',
 		'position' => 'Position d’affichage',
 		'position_help' => 'Pour contrôler l’ordre de tri des catégories',

--- a/app/i18n/he/sub.php
+++ b/app/i18n/he/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Expand category',	// TODO
 		'information' => 'מידע',
 		'open' => 'Open category',	// TODO
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'OPML URL',	// TODO
 		'position' => 'Display position',	// TODO
 		'position_help' => 'To control category sort order',	// TODO

--- a/app/i18n/hu/sub.php
+++ b/app/i18n/hu/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Kategória kinyitása',
 		'information' => 'Információ',
 		'open' => 'Kategória megnyitása',
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'OPML URL',	// IGNORE
 		'position' => 'Megjelenítési pozíció',
 		'position_help' => 'Kategória rendezési sorrend',

--- a/app/i18n/id/sub.php
+++ b/app/i18n/id/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Kembangkan kategori',
 		'information' => 'Informasi',
 		'open' => 'Buka kategori',
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'URL OPML',
 		'position' => 'Posisi tampilan',
 		'position_help' => 'Untuk mengatur urutan pengurutan kategori',

--- a/app/i18n/it/sub.php
+++ b/app/i18n/it/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Espandi categoria',
 		'information' => 'Informazioni',
 		'open' => 'Aprire la categoria!',
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'URL OPML',
 		'position' => 'Mostra posizione',
 		'position_help' => 'Per controllare l’ordinamento della categoria',

--- a/app/i18n/ja/sub.php
+++ b/app/i18n/ja/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'カテゴリを展開する',
 		'information' => '情報',
 		'open' => 'カテゴリを開く',
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'OPMLのURL',
 		'position' => '表示位置',
 		'position_help' => 'カテゴリの表示順を指定します',

--- a/app/i18n/ko/sub.php
+++ b/app/i18n/ko/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Expand category',	// TODO
 		'information' => '정보',
 		'open' => 'Open category',	// TODO
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'OPML URL',	// IGNORE
 		'position' => '표시 위치',
 		'position_help' => '정렬 순서 제어',

--- a/app/i18n/lv/sub.php
+++ b/app/i18n/lv/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Expand category',	// TODO
 		'information' => 'Informācija',
 		'open' => 'Open category',	// TODO
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'OPML URL',	// IGNORE
 		'position' => 'Displeja pozīcija',
 		'position_help' => 'Lai pārvaldītu kategoriju šķirošanas secību',

--- a/app/i18n/nl/sub.php
+++ b/app/i18n/nl/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Categorie uitklappen',
 		'information' => 'Informatie',
 		'open' => 'Categorie openen',
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'OPML URL',	// IGNORE
 		'position' => 'Weergavepositie',
 		'position_help' => 'Om de categorieweergave-sorteervolgorde te controleren',

--- a/app/i18n/oc/sub.php
+++ b/app/i18n/oc/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Expand category',	// TODO
 		'information' => 'Informacions',
 		'open' => 'Open category',	// TODO
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'URL OPML',
 		'position' => 'Mostrar la posicion',
 		'position_help' => 'Per contrarotlar l’òrdre de tria de la categoria',

--- a/app/i18n/pl/sub.php
+++ b/app/i18n/pl/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Rozszerz kategorię',
 		'information' => 'Informacje',
 		'open' => 'Otwórz kategorię',
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'Adres OPML',
 		'position' => 'Miejsce wyświetlania',
 		'position_help' => 'Kontrola porządku sortowania kategorii',

--- a/app/i18n/pt-BR/sub.php
+++ b/app/i18n/pt-BR/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Expandir categoria',
 		'information' => 'Informações',
 		'open' => 'Abrir categoria',
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'URL de OPML',
 		'position' => 'Posição de exibição',
 		'position_help' => 'Para controlar a ordem de exibição',

--- a/app/i18n/pt-PT/sub.php
+++ b/app/i18n/pt-PT/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Expand category',	// TODO
 		'information' => 'Informações',
 		'open' => 'Open category',	// TODO
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'URL de OPML',
 		'position' => 'Posição de visualização',
 		'position_help' => 'Para controlar a ordem de visualização',

--- a/app/i18n/ru/sub.php
+++ b/app/i18n/ru/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Развернуть категорию',
 		'information' => 'Информация',
 		'open' => 'Открыть категорию',
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'OPML ссылка',
 		'position' => 'Положение отображения',
 		'position_help' => 'Влияет на порядок отображения категорий',

--- a/app/i18n/sk/sub.php
+++ b/app/i18n/sk/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Expand category',	// TODO
 		'information' => 'Informácia',
 		'open' => 'Open category',	// TODO
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'OPML URL',	// IGNORE
 		'position' => 'Zobrazť pozíciu',
 		'position_help' => 'Na kontrolu zoradenia kategórií',

--- a/app/i18n/tr/sub.php
+++ b/app/i18n/tr/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Kategoriyi genişlet',
 		'information' => 'Bilgi',
 		'open' => 'Kategoriyi aç',
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'OPML URL’si',
 		'position' => 'Görüntüleme konumu',
 		'position_help' => 'Kategori sıralama düzenini kontrol etmek için',

--- a/app/i18n/uk/sub.php
+++ b/app/i18n/uk/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => 'Розгорнути категорію',
 		'information' => 'Інформація',
 		'open' => 'Відкрити категорію',
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'URL-адреса OPML',
 		'position' => 'Пріоритет показу',
 		'position_help' => 'Визначає порядок категорій',

--- a/app/i18n/zh-CN/sub.php
+++ b/app/i18n/zh-CN/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => '展开分类',
 		'information' => '信息',
 		'open' => '打开分类',
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'OPML URL',	// IGNORE
 		'position' => '显示位置',
 		'position_help' => '控制分类排列顺序',

--- a/app/i18n/zh-TW/sub.php
+++ b/app/i18n/zh-TW/sub.php
@@ -33,6 +33,8 @@ return array(
 		'expand' => '展開類別',
 		'information' => '資訊',
 		'open' => '開啟類別',
+		'opml_create_categories' => 'Reproduce the categories from the remote OPML',	// TODO
+		'opml_create_categories_help' => 'Reproduce the category structure of the remote OPML instead of putting every feed into this single category. Categories are created as needed (existing categories with the same name are reused), and feeds outside any category are placed into this category.',	// TODO
 		'opml_url' => 'OPML URL',	// IGNORE
 		'position' => '顯示位置',
 		'position_help' => '用於控制類別排序',

--- a/app/views/helpers/category/update.phtml
+++ b/app/views/helpers/category/update.phtml
@@ -116,6 +116,16 @@
 						<p class="help"><?= _i('help') ?> <?= _t('sub.category.dynamic_opml.help') ?></p>
 					</div>
 				</div>
+				<div class="form-group">
+					<label class="group-name" for="opml_create_categories"><?= _t('sub.category.opml_create_categories') ?></label>
+					<div class="group-controls">
+						<label class="checkbox" for="opml_create_categories">
+							<input type="checkbox" name="opml_create_categories" id="opml_create_categories" value="1"<?=
+								$this->category->attributeBoolean('opml_create_categories') ? ' checked="checked"' : '' ?> />
+							<?= _t('sub.category.opml_create_categories_help') ?>
+						</label>
+					</div>
+				</div>
 				<div class="form-group form-actions">
 					<div class="group-controls">
 						<button type="submit" class="btn btn-important"><?= _t('gen.action.submit') ?></button>

--- a/app/views/subscription/add.phtml
+++ b/app/views/subscription/add.phtml
@@ -406,6 +406,14 @@
 			</div>
 		</div>
 
+		<div class="form-group">
+			<label class="group-name" for="opml_create_categories"><?= _t('sub.category.opml_create_categories') ?></label>
+			<div class="group-controls">
+				<input type="checkbox" name="opml_create_categories" id="opml_create_categories" value="1" />
+				<p class="help"><?= _i('help') ?> <?= _t('sub.category.opml_create_categories_help') ?></p>
+			</div>
+		</div>
+
 		<div class="form-group form-actions">
 			<div class="group-controls">
 				<button type="submit" class="btn btn-important"><?= _t('gen.action.add') ?></button>

--- a/docs/en/developers/OPML.md
+++ b/docs/en/developers/OPML.md
@@ -104,6 +104,8 @@ A number of [cURL options](https://curl.se/libcurl/c/curl_easy_setopt.html) are 
 
 * `frss:opmlUrl`: If non-empty, indicates that this outline (category) should be dynamically populated from a remote OPML at the specified URL.
 
+By default, every feed found in the remote OPML is placed into that single (dynamic OPML) category. A dynamic OPML category also has an optional *“Reproduce the categories from the remote OPML”* setting: when enabled, the remote OPML’s own category structure is reproduced — feeds are placed into categories named as in the remote OPML (existing categories with the same name are reused, missing ones are created), and feeds that are not in any category go into the dynamic OPML category itself. Only the feeds managed by this dynamic OPML are added, muted (when they disappear from the remote OPML) or unmuted, so feeds you added manually to those categories are never affected.
+
 ### Example
 
 ```xml


### PR DESCRIPTION
Closes #6049

## Changes proposed in this pull request

A **Dynamic OPML** category previously placed every feed from the remote OPML into a single category, ignoring the remote OPML's own category structure. This adds an opt-in per-category option, **“Reproduce the categories from the remote OPML”**, so a remote OPML can be used as a source of truth including its categories.

When enabled:
- Categories are created from the remote OPML, named as in the OPML (existing categories with the same name are reused); feeds that are not in any category go into the Dynamic OPML (anchor) category.
- Feeds added by this Dynamic OPML are tagged with a `dynamic_opml` attribute, so the add / mute-on-removal / unmute-on-return sync only ever touches the feeds this Dynamic OPML manages — feeds you added manually to the same categories are never affected.

When disabled (the default), the behavior is unchanged (every feed goes into the single category).

Category creation reuses the existing OPML importer (`FreshRSS_Import_Service::importOpml()`), which already builds categories from the OPML structure; a new `importedCategories()` getter exposes that structure to the Dynamic OPML sync.

## How to test the feature manually

1. Add a Dynamic OPML category, tick “Reproduce the categories from the remote OPML”, and point it at a remote OPML that groups feeds into categories.
2. Refresh — the OPML's categories are reproduced and populated; feeds outside any category land in the Dynamic OPML category.
3. Remove a feed from the remote OPML and refresh — it is muted; feeds you added by hand to those categories are left alone.

Verified locally with `freshrss/freshrss:alpine`: an OPML with a `Tech` category plus a root feed creates the `Tech` category and places feeds correctly (tagged), removing a feed mutes it, and a manually-added feed in `Tech` is never muted. `php -l`, `phpcs` and `phpstan` all pass. The new i18n key was propagated to all languages via `cli/manipulate.translation.php --action format`.

## Pull request checklist

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard) — verified via an end-to-end Docker test of the create/sync/mute paths
- [x] documentation updated
