### PR TITLE
Feeds tree: sort feed names with locale-aware collation

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -299,7 +299,18 @@ class FreshRSS_Category extends Minz_Model {
 		if ($this->feeds === null) {
 			return;
 		}
-		uasort($this->feeds, static fn(FreshRSS_Feed $a, FreshRSS_Feed $b) => strnatcasecmp($a->name(), $b->name()));
+		// Sort locale-aware so accented and non-ASCII feed names sort near their base letter
+		// instead of byte-wise: strnatcasecmp() compares raw UTF-8 bytes, which pushes names
+		// starting with a non-ASCII character (e.g. an accented capital) to the very end.
+		// Without a user language (e.g. CLI), keep the previous byte-wise sort and avoid
+		// Collator::create(''), whose ordering depends on the environment default locale.
+		$language = FreshRSS_Context::hasUserConf() ? FreshRSS_Context::userConf()->language : '';
+		$collator = $language === '' ? null : \Collator::create($language);
+		if ($collator === null) {
+			uasort($this->feeds, static fn(FreshRSS_Feed $a, FreshRSS_Feed $b): int => strnatcasecmp($a->name(), $b->name()));
+			return;
+		}
+		uasort($this->feeds, static fn(FreshRSS_Feed $a, FreshRSS_Feed $b): int => (int)$collator->compare($a->name(), $b->name()));
 	}
 
 	/**

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -299,17 +299,16 @@ class FreshRSS_Category extends Minz_Model {
 		if ($this->feeds === null) {
 			return;
 		}
-		// Sort locale-aware with Collator so accented/non-ASCII names sort near their base
-		// letter instead of byte-wise (strnatcasecmp pushes them to the end). Fall back to
-		// strnatcasecmp without a user language (e.g. CLI) or when the intl extension is
-		// missing — class_exists() avoids a fatal "class not found" (intl is not required).
+
+		// Sort locale-aware with Collator if available
 		$language = FreshRSS_Context::hasUserConf() ? FreshRSS_Context::userConf()->language : '';
 		$collator = ($language === '' || !class_exists('Collator')) ? null : \Collator::create($language);
-		if ($collator === null) {
-			uasort($this->feeds, static fn(FreshRSS_Feed $a, FreshRSS_Feed $b): int => strnatcasecmp($a->name(), $b->name()));
+		if ($collator !== null) {
+			uasort($this->feeds, static fn(FreshRSS_Feed $a, FreshRSS_Feed $b): int => (int)$collator->compare($a->name(), $b->name()));
 			return;
 		}
-		uasort($this->feeds, static fn(FreshRSS_Feed $a, FreshRSS_Feed $b): int => (int)$collator->compare($a->name(), $b->name()));
+
+		uasort($this->feeds, static fn(FreshRSS_Feed $a, FreshRSS_Feed $b): int => strnatcasecmp($a->name(), $b->name()));
 	}
 
 	/**

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -299,16 +299,7 @@ class FreshRSS_Category extends Minz_Model {
 		if ($this->feeds === null) {
 			return;
 		}
-
-		// Sort locale-aware with Collator if available
-		$language = FreshRSS_Context::hasUserConf() ? FreshRSS_Context::userConf()->language : '';
-		$collator = ($language === '' || !class_exists('Collator')) ? null : \Collator::create($language);
-		if ($collator !== null) {
-			uasort($this->feeds, static fn(FreshRSS_Feed $a, FreshRSS_Feed $b): int => (int)$collator->compare($a->name(), $b->name()));
-			return;
-		}
-
-		uasort($this->feeds, static fn(FreshRSS_Feed $a, FreshRSS_Feed $b): int => strnatcasecmp($a->name(), $b->name()));
+		uasort($this->feeds, static fn(FreshRSS_Feed $a, FreshRSS_Feed $b): int => FreshRSS_Context::localeCompare($a->name(), $b->name()));
 	}
 
 	/**

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -299,14 +299,10 @@ class FreshRSS_Category extends Minz_Model {
 		if ($this->feeds === null) {
 			return;
 		}
-		// Sort locale-aware so accented and non-ASCII feed names sort near their base letter
-		// instead of byte-wise: strnatcasecmp() compares raw UTF-8 bytes, which pushes names
-		// starting with a non-ASCII character (e.g. an accented capital) to the very end.
-		// Without a user language (e.g. CLI), keep the previous byte-wise sort and avoid
-		// Collator::create(''), whose ordering depends on the environment default locale.
-		// The intl extension (\Collator) is only recommended, not required, so guard for it
-		// with class_exists(): without it, keep the previous byte-wise sort instead of a
-		// fatal "class not found", so the locale-aware ordering stays a progressive enhancement.
+		// Sort locale-aware with Collator so accented/non-ASCII names sort near their base
+		// letter instead of byte-wise (strnatcasecmp pushes them to the end). Fall back to
+		// strnatcasecmp without a user language (e.g. CLI) or when the intl extension is
+		// missing — class_exists() avoids a fatal "class not found" (intl is not required).
 		$language = FreshRSS_Context::hasUserConf() ? FreshRSS_Context::userConf()->language : '';
 		$collator = ($language === '' || !class_exists('Collator')) ? null : \Collator::create($language);
 		if ($collator === null) {

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -304,8 +304,11 @@ class FreshRSS_Category extends Minz_Model {
 		// starting with a non-ASCII character (e.g. an accented capital) to the very end.
 		// Without a user language (e.g. CLI), keep the previous byte-wise sort and avoid
 		// Collator::create(''), whose ordering depends on the environment default locale.
+		// The intl extension (\Collator) is only recommended, not required, so guard for it
+		// with class_exists(): without it, keep the previous byte-wise sort instead of a
+		// fatal "class not found", so the locale-aware ordering stays a progressive enhancement.
 		$language = FreshRSS_Context::hasUserConf() ? FreshRSS_Context::userConf()->language : '';
-		$collator = $language === '' ? null : \Collator::create($language);
+		$collator = ($language === '' || !class_exists('Collator')) ? null : \Collator::create($language);
 		if ($collator === null) {
 			uasort($this->feeds, static fn(FreshRSS_Feed $a, FreshRSS_Feed $b): int => strnatcasecmp($a->name(), $b->name()));
 			return;

--- a/app/Models/CategoryDAO.php
+++ b/app/Models/CategoryDAO.php
@@ -310,7 +310,7 @@ class FreshRSS_CategoryDAO extends Minz_ModelPdo {
 			$aPosition = $a->attributeInt('position');
 			$bPosition = $b->attributeInt('position');
 			if ($aPosition === $bPosition) {
-				return strnatcasecmp($a->name(), $b->name());
+				return FreshRSS_Context::localeCompare($a->name(), $b->name());
 			} elseif (null === $aPosition) {
 				return 1;
 			} elseif (null === $bPosition) {

--- a/app/Models/Context.php
+++ b/app/Models/Context.php
@@ -667,4 +667,20 @@ final class FreshRSS_Context {
 		$timezone = ini_get('date.timezone');
 		return $timezone != false ? $timezone : 'UTC';
 	}
+
+	/**
+	 * Sort locale-aware with Collator if available
+	 */
+	public static function localeCompare(string $a, string $b): int {
+		static $collator = null;
+		if ($collator !== false && !($collator instanceof \Collator)) {
+			$language = FreshRSS_Context::hasUserConf() ? FreshRSS_Context::userConf()->language : '';
+			$collator = ($language === '' || !class_exists('Collator')) ? false : (\Collator::create($language) ?? false);
+		}
+
+		if ($collator === false) {
+			return strnatcasecmp($a, $b);
+		}
+		return (int)$collator->compare($a, $b);
+	}
 }

--- a/app/Models/Context.php
+++ b/app/Models/Context.php
@@ -672,11 +672,10 @@ final class FreshRSS_Context {
 	 * Sort locale-aware with Collator if available
 	 */
 	public static function localeCompare(string $a, string $b): int {
-		static $collatorLanguage = null;
 		static $collator = null;
-		$language = FreshRSS_Context::hasUserConf() ? FreshRSS_Context::userConf()->language : '';
-		if ($collatorLanguage !== $language) {
-			$collatorLanguage = $language;
+
+		if ($collator === null) {
+			$language = FreshRSS_Context::hasUserConf() ? FreshRSS_Context::userConf()->language : '';
 			if ($language === '' || !class_exists(\Collator::class)) {
 				$collator = false;
 			} else {

--- a/app/Models/Context.php
+++ b/app/Models/Context.php
@@ -672,12 +672,25 @@ final class FreshRSS_Context {
 	 * Sort locale-aware with Collator if available
 	 */
 	public static function localeCompare(string $a, string $b): int {
+		static $collatorLanguage = null;
 		static $collator = null;
-		if ($collator !== false && !($collator instanceof \Collator)) {
-			$language = FreshRSS_Context::hasUserConf() ? FreshRSS_Context::userConf()->language : '';
-			$collator = ($language === '' || !class_exists('Collator')) ? false : (\Collator::create($language) ?? false);
+		$language = FreshRSS_Context::hasUserConf() ? FreshRSS_Context::userConf()->language : '';
+		if ($collatorLanguage !== $language) {
+			$collatorLanguage = $language;
+			if ($language === '' || !class_exists(\Collator::class)) {
+				$collator = false;
+			} else {
+				$collator = \Collator::create($language) ?? false;
+			}
+			if ($collator instanceof \Collator) {
+				$collator->setAttribute(\Collator::NUMERIC_COLLATION, \Collator::ON);
+			}
 		}
 
-		return $collator === false ? strnatcasecmp($a, $b) : (int)$collator->compare($a, $b);
+		if (!($collator instanceof \Collator)) {
+			return strnatcasecmp($a, $b);
+		}
+		$result = $collator->compare($a, $b);
+		return $result === false ? strnatcasecmp($a, $b) : $result;
 	}
 }

--- a/app/Models/Context.php
+++ b/app/Models/Context.php
@@ -678,9 +678,6 @@ final class FreshRSS_Context {
 			$collator = ($language === '' || !class_exists('Collator')) ? false : (\Collator::create($language) ?? false);
 		}
 
-		if ($collator === false) {
-			return strnatcasecmp($a, $b);
-		}
-		return (int)$collator->compare($a, $b);
+		return $collator === false ? strnatcasecmp($a, $b) : (int)$collator->compare($a, $b);
 	}
 }

--- a/app/Models/FeedDAO.php
+++ b/app/Models/FeedDAO.php
@@ -537,7 +537,7 @@ class FreshRSS_FeedDAO extends Minz_ModelPdo {
 		/** @var list<array{id:int,url:string,kind:int,category:int,name:string,website:string,description:string,lastUpdate:int,priority:int,
 		 * 	pathEntries:string,httpAuth:string,error:int,ttl:int,attributes?:string,cache_nbUnreads:int,cache_nbEntries:int}> $res */
 		$feeds = self::daoToFeeds($res);
-		uasort($feeds, static fn(FreshRSS_Feed $a, FreshRSS_Feed $b) => strnatcasecmp($a->name(), $b->name()));
+		uasort($feeds, static fn(FreshRSS_Feed $a, FreshRSS_Feed $b) => FreshRSS_Context::localeCompare($a->name(), $b->name()));
 		return $feeds;
 	}
 

--- a/app/Models/Share.php
+++ b/app/Models/Share.php
@@ -55,7 +55,7 @@ class FreshRSS_Share {
 			self::register($share_options);
 		}
 
-		uasort(self::$list_sharing, static fn(FreshRSS_Share $a, FreshRSS_Share $b) => strcasecmp($a->name() ?? '', $b->name() ?? ''));
+		uasort(self::$list_sharing, static fn(FreshRSS_Share $a, FreshRSS_Share $b) => FreshRSS_Context::localeCompare($a->name() ?? '', $b->name() ?? ''));
 	}
 
 	/**


### PR DESCRIPTION
## Problem

The feed **tree** (left sidebar) and the **feed-title view** (main body) order feeds differently for names with accents or symbols. As reported in #8300, a Spanish feed starting with `Ú` appears **last** in the tree, after every ASCII-named feed.

The tree is sorted in PHP by `FreshRSS_Category::sortFeeds()` with `strnatcasecmp()`, which compares raw UTF-8 **bytes** — so any name starting with a non-ASCII character (`0xC3…` for `Á`, `Ñ`, `Ú`, …) sorts after `A–Z`. The main view is sorted by the database according to its collation, which orders accented letters near their base letter — hence the mismatch (as @Alkarex noted in the issue).

Closes #8300.

## Change

`sortFeeds()` now compares with a `Collator` (`ext-intl`, already a hard requirement) for the user's language, falling back to the previous `strnatcasecmp()` if a collator cannot be created:

```php
$collator = \Collator::create(FreshRSS_Context::hasUserConf() ? FreshRSS_Context::userConf()->language : '');
```

Sorting a Spanish set, before / after:

```
old: banana, Manzana, nube, Zorro, Ábaco, Ñandú, Úlcera, árbol
new: Ábaco, árbol, banana, Manzana, nube, Ñandú, Úlcera, Zorro
```

This makes the tree order locale-aware and much closer to the main view. Exact parity with the main view still depends on the database collation (which is admin/DB-specific and cannot be reproduced generically in PHP), but the "accented names sort last" problem is gone.

## Checklist

- [x] Code follows the project style (`php -l`, `phpcs`, `phpstan` pass)
- [ ] Tests added — n/a: a one-line comparator change with no server-side branch worth a fixture (verified manually — see the before/after above)
