### PR TITLE
Respect simplepie_syslog_enabled for the "uses cache" debug logs

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -682,7 +682,9 @@ class FreshRSS_Feed extends Minz_Model {
 					$this->_attribute('SimplePieHash', $simplePie->get_hash());
 					return $simplePie;
 				}
-				syslog(LOG_DEBUG, 'FreshRSS SimplePie uses cache for ' . $clean_url);
+				if (FreshRSS_Context::systemConf()->simplepie_syslog_enabled) {
+					syslog(LOG_DEBUG, 'FreshRSS SimplePie uses cache for ' . $clean_url);
+				}
 			}
 		}
 		return null;

--- a/app/Utils/httpUtil.php
+++ b/app/Utils/httpUtil.php
@@ -431,7 +431,9 @@ final class FreshRSS_http_Util {
 			if ($cacheMtime !== false && $cacheMtime > time() - intval($limits['cache_duration'])) {
 				$body = @file_get_contents($cachePath);
 				if ($body != false) {
-					syslog(LOG_DEBUG, 'FreshRSS uses cache for ' . \SimplePie\Misc::url_remove_credentials($url));
+					if (FreshRSS_Context::systemConf()->simplepie_syslog_enabled) {
+						syslog(LOG_DEBUG, 'FreshRSS uses cache for ' . \SimplePie\Misc::url_remove_credentials($url));
+					}
 					return ['body' => $body, 'effective_url' => $url, 'redirect_count' => 0, 'fail' => false, 'status' => -200, 'error' => ''];
 				}
 			}


### PR DESCRIPTION
## Problem

With `simplepie_syslog_enabled => false`, syslog still fills up on every refresh (e.g. every 30 min via cron) with lines like:

```
FreshRSS[…]: FreshRSS SimplePie uses cache for https://…
```

Closes #8540.

## Cause

Two cache-hit `syslog(LOG_DEBUG, …)` calls are not guarded by `simplepie_syslog_enabled`, unlike the neighbouring SimplePie `GET` logs (`app/Utils/httpUtil.php:465`, `app/Models/SimplePieFetch.php:55`):

- `app/Models/Feed.php` — `FreshRSS SimplePie uses cache for …`
- `app/Utils/httpUtil.php` — `FreshRSS uses cache for …`

## Change

Wrap both in the existing `simplepie_syslog_enabled` guard. Nothing else changes:

- the `return` after the httpUtil log still runs on a cache hit;
- real error / fatal logs (`DatabaseDAO`, `p/i/index.php`) are deliberately left alone;
- `simplepie_syslog_enabled` defaults to `true`, so default installs are unaffected — only users who explicitly disabled it stop seeing the noise.

## Checklist

- [x] Code follows the project style (`php -l`, `phpcs`, `phpstan` pass)
- [ ] Tests added — n/a: guarding two log statements with an existing setting; no logic to unit-test
