### PR TITLE
Clarify in docs `favicons/` should not be skipped during backup

### DIFF
--- a/docs/en/admins/05_Backup.md
+++ b/docs/en/admins/05_Backup.md
@@ -2,7 +2,7 @@
 
 ## What to back up
 
-- `./data/` - **required**. You can skip `cache/` and `favicons/`; FreshRSS rebuilds them.
+- `./data/` - **required**. You can skip `cache/`; FreshRSS rebuilds it.
 - `./extensions/` - **recommended** if you use third-party extensions.
 - `./i/themes/` - **optional**, only if you have added custom themes.
 - **External database** (MySQL, MariaDB, PostgreSQL) - back up separately with [`./cli/db-backup.php`](#creating-a-database-backup) (portable SQLite per user) or `mysqldump`/`pg_dump`. SQLite is covered by `./data/` above.


### PR DESCRIPTION
Alternative for https://github.com/FreshRSS/FreshRSS/pull/8972, at least until the migration system is improved to support rollbacks.