### PR TITLE
Fix GH issue links with label filter in docs

### DIFF
--- a/docs/en/contributing.md
+++ b/docs/en/contributing.md
@@ -40,7 +40,7 @@ If you have to write code, please follow [our coding style recommendations](deve
 
 > ℹ Check [`AGENTS.md`](https://github.com/FreshRSS/FreshRSS/blob/edge/AGENTS.md) for detailed coding conventions (both for humans and AI agents).
 
-**Tip:** if you’re searching for easy-to-fix bugs, please have a look at the “[good first issue](https://github.com/FreshRSS/FreshRSS/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)” and “[help wanted](https://github.com/FreshRSS/FreshRSS/issues?q=label%3A%22help+wanted+%3Aoctocat%3A%22)” ticket labels.
+**Tip:** if you’re searching for easy-to-fix bugs, please have a look at the “[good first issue](https://github.com/FreshRSS/FreshRSS/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22Good%20first%20issue%201%EF%B8%8F%E2%83%A3%22)” and “[help wanted](https://github.com/FreshRSS/FreshRSS/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22)” ticket labels.
 
 ## Submit an idea
 

--- a/docs/fr/contributing.md
+++ b/docs/fr/contributing.md
@@ -48,7 +48,7 @@ de codage](developers/01_First_steps.md).
 
 > ℹ Voir [`AGENTS.md`](https://github.com/FreshRSS/FreshRSS/blob/edge/AGENTS.md) pour les conventions de code (à la fois pour les humains et agents IA).
 
-**Conseil :** si vous cherchez des bugs faciles à corriger, jetez un coup d’oeil à la vignette « [good first issue](https://github.com/FreshRSS/FreshRSS/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) ».
+**Conseil :** si vous cherchez des bugs faciles à corriger, jetez un coup d’oeil à la vignette « [good first issue](https://github.com/FreshRSS/FreshRSS/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22Good%20first%20issue%201%EF%B8%8F%E2%83%A3%22) ».
 
 ## Soumettre une idée
 


### PR DESCRIPTION
The "good first issue" and "help wanted" links under https://freshrss.github.io/FreshRSS/en/contributing.html#fix-a-bug aren't working.