### PR TITLE
Fix statistics repartition averages

### DIFF
--- a/app/Controllers/statsController.php
+++ b/app/Controllers/statsController.php
@@ -231,13 +231,19 @@ class FreshRSS_stats_Controller extends FreshRSS_ActionController {
 		$this->view->repartition 			= $statsDAO->calculateEntryRepartitionPerFeed($id);
 
 		$this->view->repartitionHour 		= $statsDAO->calculateEntryRepartitionPerFeedPerHour($id);
-		$this->view->averageHour 			= $statsDAO->calculateEntryAveragePerFeedPerHour($id);
+		$this->view->averageHour 			= FreshRSS_StatsDAO::calculateEntryAverageFromRepartition(
+			$this->view->repartitionHour
+		);
 
 		$this->view->repartitionDayOfWeek 	= $statsDAO->calculateEntryRepartitionPerFeedPerDayOfWeek($id);
-		$this->view->averageDayOfWeek 		= $statsDAO->calculateEntryAveragePerFeedPerDayOfWeek($id);
+		$this->view->averageDayOfWeek 		= FreshRSS_StatsDAO::calculateEntryAverageFromRepartition(
+			$this->view->repartitionDayOfWeek
+		);
 
 		$this->view->repartitionMonth 		= $statsDAO->calculateEntryRepartitionPerFeedPerMonth($id);
-		$this->view->averageMonth 			= $statsDAO->calculateEntryAveragePerFeedPerMonth($id);
+		$this->view->averageMonth 			= FreshRSS_StatsDAO::calculateEntryAverageFromRepartition(
+			$this->view->repartitionMonth
+		);
 
 		$hours24Labels = [];
 		for ($i = 0; $i < 24; $i++) {

--- a/app/Models/StatsDAO.php
+++ b/app/Models/StatsDAO.php
@@ -210,10 +210,7 @@ class FreshRSS_StatsDAO extends Minz_ModelPdo {
 	 * @param array<int,int> $repartition
 	 */
 	public static function calculateEntryAverageFromRepartition(array $repartition): float {
-		if (empty($repartition)) {
-			return 0.0;
-		}
-		return array_sum($repartition) / count($repartition);
+		return empty($repartition) ? 0.0 : array_sum($repartition) / count($repartition);
 	}
 
 	/**

--- a/app/Models/StatsDAO.php
+++ b/app/Models/StatsDAO.php
@@ -206,6 +206,17 @@ class FreshRSS_StatsDAO extends Minz_ModelPdo {
 	}
 
 	/**
+	 * Calculates the average number of articles from an entry repartition.
+	 * @param array<int,int> $repartition
+	 */
+	public static function calculateEntryAverageFromRepartition(array $repartition): float {
+		if (empty($repartition)) {
+			return 0.0;
+		}
+		return array_sum($repartition) / count($repartition);
+	}
+
+	/**
 	 * Calculates the average number of article per feed
 	 * @param float $period number used to divide the number of day in the period
 	 */

--- a/tests/app/Models/StatsDAOTest.php
+++ b/tests/app/Models/StatsDAOTest.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+
+final class StatsDAOTest extends TestCase {
+
+	public static function testCalculateEntryAverageFromRepartition(): void {
+		self::assertSame(2.0, FreshRSS_StatsDAO::calculateEntryAverageFromRepartition([0, 2, 4]));
+	}
+
+	public static function testCalculateEntryAverageFromEmptyRepartition(): void {
+		self::assertSame(0.0, FreshRSS_StatsDAO::calculateEntryAverageFromRepartition([]));
+	}
+
+	public static function testCalculateEntryAverageFromZeroRepartition(): void {
+		self::assertSame(0.0, FreshRSS_StatsDAO::calculateEntryAverageFromRepartition(array_fill(0, 24, 0)));
+	}
+}


### PR DESCRIPTION
## What changed

- Compute the article repartition averages from the repartition data displayed in each chart.
- Keep the existing database repartition queries unchanged.
- Add unit coverage for averaging repartition arrays.

## Why

The previous averages were based on the date span between the oldest and newest entries, while the charts show bucketed repartition data by hour, weekday, and month. That made the displayed average look inconsistent with the chart values.

Closes #6905

## Screenshots

Same synthetic feed data in both screenshots: 2 entries dated `2014-01-01 10:00 UTC` and `2024-01-01 10:00 UTC`. Please compare the `average: ... messages` values in each chart heading.

| Before (`upstream/edge`) | After (this PR) |
| --- | --- |
| ![Before screenshot](https://raw.githubusercontent.com/JamBalaya56562/FreshRSS/pr-8996-screenshots/pr-8996/freshrss-pr8996-before.png) | ![After screenshot](https://raw.githubusercontent.com/JamBalaya56562/FreshRSS/pr-8996-screenshots/pr-8996/freshrss-pr8996-after.png) |

| Label | Before | After |
| --- | ---: | ---: |
| Per hour | `0.00` | `0.08` |
| Per day of week | `0.00` | `0.29` |
| Per month | `0.02` | `0.18` |

## Validation

Run with Docker using `--memory=768m --cpus=1`:

- `php -l app/Models/StatsDAO.php app/Controllers/statsController.php tests/app/Models/StatsDAOTest.php`
- `phpunit --bootstrap ./tests/bootstrap.php tests/app/Models/StatsDAOTest.php`

Also ran `tests/app/Models`; unrelated existing `DatabaseDAOTest::test_strilike_MySQL` Unicode casing cases failed in the Docker PHP environment.
