### PR TITLE
Fix article hover date visibility

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1511,7 +1511,7 @@ a.website:hover .favicon {
 }
 
 .flux:not(.current):hover .flux_header.has-date .item .title {
-	grid-column: 1 / -1;
+	padding-right: 0.5rem;
 	z-index: 2;
 }
 

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1511,7 +1511,7 @@ a.website:hover .favicon {
 }
 
 .flux:not(.current):hover .flux_header.has-date .item .title {
-	grid-column: 1 / -1;
+	padding-left: 0.5rem;
 	z-index: 2;
 }
 


### PR DESCRIPTION
## Summary

- Keep the article title in its own grid area on hover when the article row also shows a date.
- Restore a small spacing between the hovered title and the date.
- Regenerate the RTL stylesheet counterpart.

Fixes #8994

## Screenshots

<img width="1400" height="780" alt="image" src="https://github.com/user-attachments/assets/abda14ae-8f0a-473e-9cdc-c5e3bb0f8a78" />

The comparison uses a synthetic hover fixture with FreshRSS article-row DOM and theme CSS, so no local feed data is included.

## Testing

- `npm run rtlcss`
- `npx stylelint p/themes/base-theme/frss.css p/themes/base-theme/frss.rtl.css`
- Visual verification with a synthetic hover fixture using the FreshRSS article-row DOM and theme CSS for Origine-compact and Ansum.
