### PR TITLE
Minz: Skip loading JS/CSS asset if it's already in the list

### DIFF
--- a/lib/Minz/View.php
+++ b/lib/Minz/View.php
@@ -225,6 +225,11 @@ class Minz_View {
 		if ($url === '') {
 			return;
 		}
+		foreach (self::$styles as $style) {
+			if (strtolower($style['url']) === strtolower($url)) {
+				return;
+			}
+		}
 		array_unshift(self::$styles, [
 			'url' => $url,
 			'media' => $media,
@@ -238,6 +243,11 @@ class Minz_View {
 	public static function appendStyle(string $url, string $media = 'all', bool $cond = false): void {
 		if ($url === '') {
 			return;
+		}
+		foreach (self::$styles as $style) {
+			if (strtolower($style['url']) === strtolower($url)) {
+				return;
+			}
 		}
 		self::$styles[] = [
 			'url' => $url,
@@ -306,6 +316,11 @@ class Minz_View {
 		if ($url === '') {
 			return;
 		}
+		foreach (self::$scripts as $script) {
+			if (strtolower($script['url']) === strtolower($url)) {
+				return;
+			}
+		}
 		array_unshift(self::$scripts, [
 			'url' => $url,
 			'defer' => $defer,
@@ -324,6 +339,11 @@ class Minz_View {
 	public static function appendScript(string $url, bool $cond = false, bool $defer = true, bool $async = true, string $id = ''): void {
 		if ($url === '') {
 			return;
+		}
+		foreach (self::$scripts as $script) {
+			if (strtolower($script['url']) === strtolower($url)) {
+				return;
+			}
 		}
 		self::$scripts[] = [
 			'url' => $url,

--- a/lib/Minz/View.php
+++ b/lib/Minz/View.php
@@ -226,7 +226,7 @@ class Minz_View {
 			return;
 		}
 		foreach (self::$styles as $style) {
-			if (strtolower($style['url']) === strtolower($url)) {
+			if ($style['url'] === $url) {
 				return;
 			}
 		}
@@ -245,7 +245,7 @@ class Minz_View {
 			return;
 		}
 		foreach (self::$styles as $style) {
-			if (strtolower($style['url']) === strtolower($url)) {
+			if ($style['url'] === $url) {
 				return;
 			}
 		}
@@ -317,7 +317,7 @@ class Minz_View {
 			return;
 		}
 		foreach (self::$scripts as $script) {
-			if (strtolower($script['url']) === strtolower($url)) {
+			if ($script['url'] === $url) {
 				return;
 			}
 		}
@@ -341,7 +341,7 @@ class Minz_View {
 			return;
 		}
 		foreach (self::$scripts as $script) {
-			if (strtolower($script['url']) === strtolower($url)) {
+			if ($script['url'] === $url) {
 				return;
 			}
 		}


### PR DESCRIPTION
Fixes `Uncaught SyntaxError: redeclaration of const freshrssSliderLoadEvent` error shown in console on e.g. `/i/?c=subscription&id=1` due to https://github.com/FreshRSS/FreshRSS/pull/8973