### PR TITLE
Fix `.dockerignore` being ignored during build in CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -85,6 +85,7 @@ jobs:
     - name: Build and push Docker images
       uses: docker/build-push-action@v7
       with:
+        context: . # Switching from git context to path context, needed for .dockerignore to be applied. See: https://github.com/docker/build-push-action#git-context
         file: ${{ matrix.file }}
         platforms: linux/amd64,linux/arm/v7,linux/arm64
         build-args: |


### PR DESCRIPTION
For example:

https://github.com/FreshRSS/FreshRSS/blob/f201061345fdacd8492e853053a63adb5686cd59/.dockerignore#L6

`/docs/` is included in `.dockerignore`, but currently if you check `docker exec freshrss ls -la`, you'll notice `/docs/` is being listed despite that.

This is because we are using git context for the build instead of path context, see: https://github.com/docker/build-push-action#git-context

Compare the runs https://github.com/Inverle/FreshRSS/actions/runs/28884689769/job/85681744466 and https://github.com/Inverle/FreshRSS/actions/runs/28885427454/job/85684280287 by CTRL+F'ing for `.dockerignore` in the `Build and push Docker images` step.
In the second run, a line `#5 [internal] load .dockerignore` is printed, but not in the first run without `context: .`

Additionally, it can be confirmed this fix is working by checking the `ghcr.io/inverle/freshrss:docker-testing-alpine` image for the `/docs/` directory.