### PR TITLE
Prefer OS-bundled Japanese fonts when UI language is Japanese

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -64,6 +64,12 @@ html, body {
 	font-size: 100%;
 }
 
+html:lang(ja) body {
+	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial",
+		"Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic", "Meiryo",
+		"Osaka", "Noto Sans CJK JP", "Noto Sans JP", sans-serif;
+}
+
 button, input, select, textarea {
 	font-family: inherit;
 }

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -64,6 +64,12 @@ html, body {
 	font-size: 100%;
 }
 
+html:lang(ja) body {
+	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial",
+		"Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic", "Meiryo",
+		"Osaka", "Noto Sans CJK JP", "Noto Sans JP", sans-serif;
+}
+
 button, input, select, textarea {
 	font-family: inherit;
 }


### PR DESCRIPTION
## What

Add a `:lang(ja)`-scoped `font-family` to the shared `p/themes/base-theme/frss.css` so that, when the UI language is Japanese, kanji/kana render with OS-bundled Japanese fonts instead of falling back to the generic `sans-serif` (which, on systems whose default sans-serif is a Chinese font, renders Han characters with Chinese glyph variants).

```css
html:lang(ja) body {
	font-family: "OpenSans", "Cantarell", "Helvetica", "Arial",
		"Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic", "Meiryo",
		"Osaka", "Noto Sans CJK JP", "Noto Sans JP", sans-serif;
}
```

## Why / background

This revives the intent of the long-stalled **#5671** ("add Japanese to font-family").

- The original PR added `"Osaka"` in front of the Chinese fonts (`PingFang SC` / `Microsoft YaHei`) that were in the stack at the time. Those Chinese fonts have since been removed from the codebase, so today the stack is just `"OpenSans", "Cantarell", "Helvetica", "Arial", sans-serif` and Japanese users simply fall back to the OS default `sans-serif`.
- Latin fonts stay first, so Latin text is unchanged (still `OpenSans`); the Japanese fonts are only reached as a fallback for kana/kanji.

## Addressing the original review feedback

The review on #5671 asked for more than `Osaka` alone and for cross-platform, default-installed fonts. The stack here covers the major platforms with system fonts (no bundling required):

- **macOS / iOS**: Hiragino Sans, Hiragino Kaku Gothic ProN, Osaka
- **Windows**: Yu Gothic, Meiryo
- **Android / ChromeOS / Linux**: Noto Sans CJK JP, Noto Sans JP

## Why `:lang(ja)`-scoped instead of a global change

Adding Japanese fonts unconditionally to the global stack would make Chinese (`zh-CN` / `zh-TW`) users see Japanese glyph variants for shared Han characters — the mirror image of the problem this fixes. Scoping to `:lang(ja)` (the UI language set on `<html lang="…">` in `app/layout/layout.phtml`) applies Japanese fonts only for Japanese UIs and leaves all other languages untouched.

## Implementation notes

- The rule lives in `frss.css`, which is loaded by **every** theme (via the `_frss.css` entry in each theme's `metadata.json`), so a single addition covers all themes.
- Selector specificity of `html:lang(ja) body` (0,1,2) is higher than the per-theme `html, body` / `body` rules, so it wins across all bundled themes without editing each theme file.
- `frss.rtl.css` is regenerated with `npm run rtlcss` (font-family is not affected by RTL flipping).

## Testing

- `npm run stylelint` passes.
- Verified `<html lang="ja">` is emitted for the Japanese UI language; the computed `body` `font-family` includes the Japanese stack under `lang=ja` and is unchanged for other languages.

Closes the goal of #5671.
