### PR TITLE
Determine update release channel from git branch, not version string

### DIFF
--- a/app/Controllers/updateController.php
+++ b/app/Controllers/updateController.php
@@ -60,14 +60,31 @@ class FreshRSS_update_Controller extends FreshRSS_ActionController {
 		return true;
 	}
 
-	public static function getCurrentGitBranch(): string {
-		$output = [];
-		exec('git branch --show-current', $output, $return);
-		if ($return === 0) {
-			return 'git branch: ' . $output[0];
-		} else {
-			return 'git';
+	/** @return non-empty-string|null */
+	public static function gitBranchName(): ?string {
+		if (!self::isGit() || !function_exists('exec')) {
+			return null;
 		}
+		$cwd = getcwd();
+		if ($cwd !== false) {
+			chdir(FRESHRSS_PATH);
+		}
+		$output = [];
+		$return = 1;
+		exec('git branch --show-current', $output, $return);
+		if ($cwd !== false) {
+			chdir($cwd);
+		}
+		if ($return !== 0) {
+			return null;
+		}
+		$branch = trim(implode('', $output));
+		return $branch === '' ? null : $branch;
+	}
+
+	public static function getCurrentGitBranch(): string {
+		$branch = self::gitBranchName();
+		return $branch !== null ? 'git branch: ' . $branch : 'git';
 	}
 
 	public static function hasGitUpdate(): bool {
@@ -179,6 +196,10 @@ class FreshRSS_update_Controller extends FreshRSS_ActionController {
 	}
 
 	private function is_release_channel_stable(string $currentVersion): bool {
+		if (self::isGit()) {
+			$branch = self::gitBranchName();
+			return $branch !== 'edge' && $branch !== 'dev';
+		}
 		return !str_contains($currentVersion, 'dev') && !str_contains($currentVersion, 'edge');
 	}
 

--- a/app/Controllers/updateController.php
+++ b/app/Controllers/updateController.php
@@ -197,8 +197,10 @@ class FreshRSS_update_Controller extends FreshRSS_ActionController {
 
 	private function is_release_channel_stable(string $currentVersion): bool {
 		if (self::isGit()) {
-			$branch = self::gitBranchName();
-			return $branch !== 'edge' && $branch !== 'dev';
+			// The stable channel is a release checked out on a tag, i.e. a detached HEAD
+			// with no branch name. Any branch — `edge`/`dev` or a custom development
+			// branch — is the rolling channel, so only a detached HEAD is stable.
+			return self::gitBranchName() === null;
 		}
 		return !str_contains($currentVersion, 'dev') && !str_contains($currentVersion, 'edge');
 	}

--- a/app/Controllers/updateController.php
+++ b/app/Controllers/updateController.php
@@ -87,6 +87,24 @@ class FreshRSS_update_Controller extends FreshRSS_ActionController {
 		return $branch !== null ? 'git branch: ' . $branch : 'git';
 	}
 
+	/** @return bool Whether the current git HEAD is checked out directly on a (release) tag. */
+	public static function isOnGitTag(): bool {
+		if (!self::isGit() || !function_exists('exec')) {
+			return false;
+		}
+		$cwd = getcwd();
+		if ($cwd !== false) {
+			chdir(FRESHRSS_PATH);
+		}
+		$output = [];
+		$return = 1;
+		exec('git tag --points-at HEAD', $output, $return);
+		if ($cwd !== false) {
+			chdir($cwd);
+		}
+		return $return === 0 && trim(implode('', $output)) !== '';
+	}
+
 	public static function hasGitUpdate(): bool {
 		$cwd = getcwd();
 		if ($cwd === false) {
@@ -197,10 +215,9 @@ class FreshRSS_update_Controller extends FreshRSS_ActionController {
 
 	private function is_release_channel_stable(string $currentVersion): bool {
 		if (self::isGit()) {
-			// The stable channel is a release checked out on a tag, i.e. a detached HEAD
-			// with no branch name. Any branch — `edge`/`dev` or a custom development
-			// branch — is the rolling channel, so only a detached HEAD is stable.
-			return self::gitBranchName() === null;
+			// The stable channel is a release checked out directly on a tag. Any branch —
+			// `edge`/`dev` or a custom development branch — is the rolling channel.
+			return self::isOnGitTag();
 		}
 		return !str_contains($currentVersion, 'dev') && !str_contains($currentVersion, 'edge');
 	}


### PR DESCRIPTION
Fixes #5850

## Problem

On the admin **Update** page, the "Release channel" row keeps showing **Rolling release ("edge")** — with a link inviting the user to switch to the `edge` branch — even after the user has switched their git checkout back to a stable/`latest` release.

## Root cause

The release channel was derived **only from the `FRESHRSS_VERSION` string**, never from the actual git state:

```php
// before
private function is_release_channel_stable(string $currentVersion): bool {
    return !str_contains($currentVersion, 'dev') && !str_contains($currentVersion, 'edge');
}
```

After a manual `git checkout` to a release, `FRESHRSS_VERSION` (from `constants.php`) can lag the checkout — a between-releases `-dev` string, or PHP opcache still holding the previous `constants.php`. In those cases the check stays `false`, so the UI keeps advertising `edge`. `is_release_channel_stable()` is the single input to the view branch at `app/views/update/index.phtml`.

## Fix

For **git installs**, determine the channel from the checked-out git state. A stable release is checked out **directly on a release tag**, detected with `git tag --points-at HEAD`. Any branch — `edge`/`dev` or a custom development branch — is the rolling channel. Non-git (archive) installs keep the existing version-string heuristic unchanged.

```php
private function is_release_channel_stable(string $currentVersion): bool {
    if (self::isGit()) {
        // Stable = checked out directly on a release tag.
        return self::isOnGitTag();
    }
    return !str_contains($currentVersion, 'dev') && !str_contains($currentVersion, 'edge');
}
```

`isOnGitTag()` runs `git tag --points-at HEAD` — a **live git query**, so it is not affected by a stale `FRESHRSS_VERSION` / opcache (the failure mode #5850 was about). A `gitBranchName(): ?string` helper is kept for the "Release channel" display (`getCurrentGitBranch()`).

> **Review notes (thanks @Frenzie / @Inverle):** an earlier revision used `$branch !== 'edge' && $branch !== 'dev'` (which would treat a custom development branch as stable), then `gitBranchName() === null` (a detached `HEAD` as an indirect proxy for a tag). It now checks the tag directly. I did weigh going back to a `FRESHRSS_VERSION` check extended with `dev`/`alpha`/`beta`/`rc` markers — simpler, and we only ship stable tags — but that reintroduces the reliance on the version constant that was stale in #5850. Happy to switch to that if preferred.

## Behaviour before / after

| State | Actual git state | Before (pre-PR) | After |
|---|---|---|---|
| Release/`latest` (on a tag) | HEAD on a release tag | Rolling release (edge) ❌ | Stable release (latest) ✅ |
| Development checkout | `edge` branch (not a tag) | Rolling release (edge) | Rolling release (edge) (unchanged) |
| Custom branch / raw commit | any non-tag state | — | Rolling channel (**not** treated as stable) |
| Archive (non-git) install | — | version-string based | version-string based (unchanged) |

## Testing

- `php -l app/Controllers/updateController.php` — no syntax errors; `phpcs` / `phpstan` on the changed file — no errors.
- Verified against a real git repo: HEAD on a release tag → stable; on `edge` / a custom branch / a raw detached commit → rolling; non-git → version-string fallback.

Only `app/Controllers/updateController.php` changes; the view and i18n strings are untouched (`admin.update.releaseChannel.edge` / `.latest` already exist).
