### PR TITLE
Use native loading="lazy" for article images and iframes

### DIFF
--- a/app/views/helpers/javascript_vars.phtml
+++ b/app/views/helpers/javascript_vars.phtml
@@ -23,7 +23,6 @@ echo json_encode([
 		'auto_load_more' => FreshRSS_Context::userConf()->auto_load_more && FreshRSS_Context::$sort !== 'rand',
 		'auto_actualize_feeds' => Minz_Session::paramBoolean('actualize_feeds'),
 		'nb_parallel_refresh' => max(1, FreshRSS_Context::systemConf()->nb_parallel_refresh),
-		'does_lazyload' => FreshRSS_Context::userConf()->lazyload && !Minz_Request::is('index', 'reader'), // TODO: currently no lazy-loading is being done in reader view
 		'sides_close_article' => !!FreshRSS_Context::userConf()->sides_close_article,
 		'sidebar_hidden_by_default' => !!FreshRSS_Context::userConf()->sidebar_hidden_by_default,
 		'sticky_post' => !!FreshRSS_Context::isStickyPostEnabled(),

--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -128,7 +128,7 @@ $today = @strtotime('today');
 					<?php } ?>
 				</header>
 				<div class="text"><?=
-					FreshRSS_Context::userConf()->lazyload && !FreshRSS_Context::userConf()->display_posts ?
+					FreshRSS_Context::userConf()->lazyload ?
 						lazyimg($this->entry->content($this->feed->attributeBoolean('display_enclosures') ?? true)) :
 						$this->entry->content($this->feed->attributeBoolean('display_enclosures') ?? true)
 				?></div>

--- a/app/views/index/reader.phtml
+++ b/app/views/index/reader.phtml
@@ -10,7 +10,6 @@ $slider_feed = $this->feed;
 
 call_user_func($this->callbackBeforeEntries, $this);
 
-$lazyload = FreshRSS_Context::userConf()->lazyload;
 $useKeepUnreadImportant = !FreshRSS_Context::isImportant() && !FreshRSS_Context::isFeed();
 ?>
 <main id="stream" class="reader">

--- a/lib/lib_rss.php
+++ b/lib/lib_rss.php
@@ -316,22 +316,18 @@ function cleanCache(int $hours = 720): void {
 }
 
 /**
- * Add support of image lazy loading
- * Move content from src/poster attribute to data-original
+ * Add native lazy loading to images and iframes.
  * @param string $content is the text we want to parse
  */
 function lazyimg(string $content): string {
-	return preg_replace([
-			'/<((?:img|image|iframe|track)[^>]+?)src="([^"]+)"([^>]*)>/i',
-			"/<((?:img|image|iframe|track)[^>]+?)src='([^']+)'([^>]*)>/i",
-			'/<((?:video)[^>]+?)poster="([^"]+)"([^>]*)>/i',
-			"/<((?:video)[^>]+?)poster='([^']+)'([^>]*)>/i",
-		], [
-			'<$1src="' . Minz_Url::display('/themes/icons/grey.gif') . '" data-original="$2"$3>',
-			"<$1src='" . Minz_Url::display('/themes/icons/grey.gif') . "' data-original='$2'$3>",
-			'<$1poster="' . Minz_Url::display('/themes/icons/grey.gif') . '" data-original="$2"$3>',
-			"<$1poster='" . Minz_Url::display('/themes/icons/grey.gif') . "' data-original='$2'$3>",
-		],
+	return preg_replace_callback(
+		'/<(img|iframe)\b([^>]*)>/i',
+		static function (array $matches): string {
+			if (preg_match('/\sloading\s*=/i', $matches[2])) {
+				return $matches[0];
+			}
+			return '<' . $matches[1] . ' loading="lazy"' . $matches[2] . '>';
+		},
 		$content
 	) ?? '';
 }

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -448,25 +448,10 @@ function mark_favorite(div) {
 
 const freshrssOpenArticleEvent = new Event('freshrss:openArticle', { bubbles: true, cancelable: true });
 
-function loadLazyImages(rootElement) {
-	rootElement.querySelectorAll('img[data-original], iframe[data-original], video[data-original], track[data-original]').forEach(function (el) {
-		if (el.tagName === 'VIDEO') {
-			el.poster = el.getAttribute('data-original');
-		} else {
-			el.src = el.getAttribute('data-original');
-		}
-		el.removeAttribute('data-original');
-	});
-}
-
 function toggleContent(new_active, old_active, skipping) {
 	// If skipping, move current without activating or marking as read
 	if (!new_active) {
 		return;
-	}
-
-	if (context.does_lazyload && !skipping) {
-		loadLazyImages(new_active);
 	}
 
 	const relative_move = context.current_view === 'global';
@@ -1438,7 +1423,7 @@ function init_stream(stream) {
 			// Note: Firefox Mobile saves PDFs with a filename that looks like: `temp[19 random digits].PDF` regardless of title
 			head.querySelector('title').innerText = articleTitle;
 
-			loadLazyImages(content_el);
+			content_el.querySelectorAll('img[loading], iframe[loading]').forEach(el => el.setAttribute('loading', 'eager'));
 
 			const print_frame = document.createElement('iframe');
 			print_frame.style.display = 'none';
@@ -2362,19 +2347,17 @@ function removeFirstLoadSpinner() {
 }
 
 function enforce_referrer_allowlist(stream) {
-	for (const iframe of stream.querySelectorAll('div.content iframe[src], div.content iframe[data-original]')) {
+	for (const iframe of stream.querySelectorAll('div.content iframe[src]')) {
 		let hostname;
 		try {
-			hostname = new URL(context.does_lazyload ? iframe.getAttribute('data-original') : iframe.src).hostname;
+			hostname = new URL(iframe.src).hostname;
 		} catch (_) {
 			continue;
 		}
 		if (context.send_referrer_allowlist.includes(hostname) && !iframe.hasAttribute('referrerpolicy')) {
 			iframe.setAttribute('referrerpolicy', 'strict-origin-when-cross-origin');
-			if (!context.does_lazyload) {
-				// iframe must be reloaded to apply the `referrerpolicy` change
-				iframe.src = iframe.src; // eslint-disable-line no-self-assign
-			}
+			// iframe must be reloaded to apply the `referrerpolicy` change
+			iframe.src = iframe.src; // eslint-disable-line no-self-assign
 		}
 	}
 }

--- a/tests/lib/LazyImgTest.php
+++ b/tests/lib/LazyImgTest.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Tests for the lazyimg() function of lib_rss.php
+ */
+class LazyImgTest extends \PHPUnit\Framework\TestCase {
+
+	#[DataProvider('provideContents')]
+	public function test_lazyimg(string $content, string $expected): void {
+		self::assertSame($expected, lazyimg($content));
+	}
+
+	/** @return list<array{string,string}> */
+	public static function provideContents(): array {
+		return [
+			// Adds loading="lazy" to images and iframes
+			['<img src="a.jpg">', '<img loading="lazy" src="a.jpg">'],
+			["<img src='a.jpg'>", "<img loading=\"lazy\" src='a.jpg'>"],
+			['<IMG SRC="a.jpg">', '<IMG loading="lazy" SRC="a.jpg">'],
+			['<iframe src="https://example.com/"></iframe>', '<iframe loading="lazy" src="https://example.com/"></iframe>'],
+
+			// Does not duplicate an existing loading attribute
+			['<img loading="eager" src="a.jpg">', '<img loading="eager" src="a.jpg">'],
+			['<img src="a.jpg" loading="lazy">', '<img src="a.jpg" loading="lazy">'],
+
+			// data-loading is not mistaken for the loading attribute
+			['<img data-loading="x" src="a.jpg">', '<img loading="lazy" data-loading="x" src="a.jpg">'],
+
+			// Native loading is only for img/iframe: video/track are left untouched
+			['<video poster="p.jpg"></video>', '<video poster="p.jpg"></video>'],
+			['<track src="s.vtt">', '<track src="s.vtt">'],
+
+			// Multiple tags in a fragment, mixed states
+			[
+				'<p>text <img src="a.jpg"> and <img loading="eager" src="b.jpg"></p>',
+				'<p>text <img loading="lazy" src="a.jpg"> and <img loading="eager" src="b.jpg"></p>',
+			],
+
+			// No image/iframe: content is returned unchanged
+			['<p>no media here</p>', '<p>no media here</p>'],
+			['', ''],
+		];
+	}
+}


### PR DESCRIPTION
Closes #2371. Continues / supersedes the stalled #5816.

## What

Replace FreshRSS's custom JavaScript image lazy-loading with the native HTML `loading="lazy"` attribute for article-body images and iframes.

Previously, when the `lazyload` setting was on, `lazyimg()` rewrote each `src` to a `grey.gif` placeholder and stashed the real URL in `data-original`, and client JS (`loadLazyImages`) restored it as the article became active. This replaces that whole scheme with `loading="lazy"`, letting the browser handle deferral natively.

## Addressing the review feedback on #5816

The previous review raised two points; both are handled:

1. **No duplicate `loading` attribute** — `lazyimg()` only adds `loading="lazy"` to `<img>`/`<iframe>` tags that don't already carry a `loading` attribute, so feed-supplied `loading="…"` is preserved and never doubled.
2. **The opt-out is preserved** — the `lazyload` user setting still gates the behaviour: when it's off, no `loading` attribute is added and images load eagerly, exactly as before.

## Changes

- **`lib/lib_rss.php`** — `lazyimg()` now injects `loading="lazy"` into `<img>`/`<iframe>` (skipping tags that already have a `loading` attribute) instead of the `grey.gif` + `data-original` swap. Native `loading` only applies to `img`/`iframe`, so `video`/`track` are no longer rewritten (the old placeholder swap for those is dropped).
- **`app/views/index/normal.phtml`** — the content transform is now gated on `lazyload` alone. The old `&& !display_posts` condition existed only because the JS restored images on article activation (which never happens in "display all articles expanded" mode); native lazy-loading works viewport-based, so it now benefits that mode too.
- **`app/views/helpers/javascript_vars.phtml`** — removed the now-unused `does_lazyload` flag.
- **`p/scripts/main.js`** — removed the dead `loadLazyImages()` and its call in `toggleContent()`; simplified `enforce_referrer_allowlist()` to read the real `iframe.src` (no more `data-original` branch) and always reload matching iframes to apply `referrerpolicy`. In the print/PDF path, images/iframes in the cloned content are set to `loading="eager"` so they are all loaded for the printout.

`data-original`, `does_lazyload` and `loadLazyImages` are fully retired — no dead code left behind. The `lazyload` label (`conf.reading.img_with_lazyload`, "Use lazy load mode to load pictures") still describes the behaviour, so no i18n changes.

## Tests

- Added `tests/lib/LazyImgTest.php` covering `lazyimg()`: attribute injection for img/iframe, no duplication when `loading` already present, `data-loading` not mistaken for `loading`, video/track left untouched, mixed fragments, and no-op on plain content.
- `vendor/bin/phpunit tests/lib` → **85 tests OK** (12 new).
- `php -l lib/lib_rss.php` → OK. `phpstan` on the changed files → no errors.
- `npm run eslint` → passes.
