### PR TITLE
WebSub: ignore http/https scheme difference in Self URL comparison

### DIFF
--- a/app/Utils/httpUtil.php
+++ b/app/Utils/httpUtil.php
@@ -295,6 +295,11 @@ final class FreshRSS_http_Util {
 			($url1['port'] ?? '') === ($url2['port'] ?? '');
 	}
 
+	public static function compareURLsIgnoringScheme(string $url1, string $url2): bool {
+		$stripScheme = static fn(string $url): string => preg_replace('#^https?://#i', '//', trim($url)) ?? $url;
+		return $stripScheme($url1) === $stripScheme($url2);
+	}
+
 	/**
 	 * Returns a value for CURLOPT_RESOLVE as an array, null if no allowed IPs were found, false if the domain failed to resolve.
 	 *

--- a/app/Utils/httpUtil.php
+++ b/app/Utils/httpUtil.php
@@ -295,9 +295,12 @@ final class FreshRSS_http_Util {
 			($url1['port'] ?? '') === ($url2['port'] ?? '');
 	}
 
-	public static function compareURLsIgnoringScheme(string $url1, string $url2): bool {
-		$stripScheme = static fn(string $url): string => preg_replace('#^https?://#i', '//', trim($url)) ?? $url;
-		return $stripScheme($url1) === $stripScheme($url2);
+	/**
+	 * Return 0 if values on either side are equal ignoring the HTTP vs HTTPS differences, or 1/-1 if they differ.
+	 */
+	public static function compareUrlIgnoringHttps(string $url1, string $url2): int {
+		$normalizeScheme = static fn(string $url): string => preg_replace('#^https?://#i', '//', trim($url)) ?? $url;
+		return $normalizeScheme($url1) <=> $normalizeScheme($url2);
 	}
 
 	/**

--- a/p/api/pshb.php
+++ b/p/api/pshb.php
@@ -121,14 +121,14 @@ if ($httpLink !== '' && preg_match_all('/<([^>]+)>;\\s*rel="([^"]+)"/', $httpLin
 	// }
 	if (!empty($links['self'])) {
 		$httpSelf = FreshRSS_http_Util::checkUrl($links['self']) ?: '';
-		if ($self !== '' && !FreshRSS_http_Util::compareURLsIgnoringScheme($self, $httpSelf)) {
+		if ($self !== '' && FreshRSS_http_Util::compareUrlIgnoringHttps($self, $httpSelf) !== 0) {
 			Minz_Log::warning('Warning: Self URL mismatch between XML [' . $self . '] and HTTP!: ' . $httpSelf, PSHB_LOG);
 		}
 		$self = $httpSelf;
 	}
 }
 
-if (!FreshRSS_http_Util::compareURLsIgnoringScheme($self, $canonical)) {
+if (FreshRSS_http_Util::compareUrlIgnoringHttps($self, $canonical) !== 0) {
 	//header('HTTP/1.1 422 Unprocessable Entity');
 	Minz_Log::warning('Warning: Self URL [' . $self . '] does not match registered canonical URL!: ' . $canonical, PSHB_LOG);
 	//die('Self URL does not match registered canonical URL!');

--- a/p/api/pshb.php
+++ b/p/api/pshb.php
@@ -121,14 +121,14 @@ if ($httpLink !== '' && preg_match_all('/<([^>]+)>;\\s*rel="([^"]+)"/', $httpLin
 	// }
 	if (!empty($links['self'])) {
 		$httpSelf = FreshRSS_http_Util::checkUrl($links['self']) ?: '';
-		if ($self !== '' && $self !== $httpSelf) {
+		if ($self !== '' && !FreshRSS_http_Util::compareURLsIgnoringScheme($self, $httpSelf)) {
 			Minz_Log::warning('Warning: Self URL mismatch between XML [' . $self . '] and HTTP!: ' . $httpSelf, PSHB_LOG);
 		}
 		$self = $httpSelf;
 	}
 }
 
-if ($self !== $canonical) {
+if (!FreshRSS_http_Util::compareURLsIgnoringScheme($self, $canonical)) {
 	//header('HTTP/1.1 422 Unprocessable Entity');
 	Minz_Log::warning('Warning: Self URL [' . $self . '] does not match registered canonical URL!: ' . $canonical, PSHB_LOG);
 	//die('Self URL does not match registered canonical URL!');

--- a/tests/app/Utils/httpUtilTest.php
+++ b/tests/app/Utils/httpUtilTest.php
@@ -8,18 +8,19 @@ use PHPUnit\Framework\Attributes\DataProvider;
  */
 class httpUtilTest extends \PHPUnit\Framework\TestCase {
 
-	#[DataProvider('provideUrlsIgnoringScheme')]
-	public function test_compareURLsIgnoringScheme(string $url1, string $url2, bool $expected): void {
-		self::assertSame($expected, FreshRSS_http_Util::compareURLsIgnoringScheme($url1, $url2));
+	#[DataProvider('provideUrlsIgnoringHttps')]
+	public function test_compareUrlIgnoringHttps(string $url1, string $url2, bool $expected): void {
+		self::assertEquals($expected, FreshRSS_http_Util::compareUrlIgnoringHttps($url1, $url2) === 0);
 	}
 
 	/** @return list<array{string,string,bool}> */
-	public static function provideUrlsIgnoringScheme(): array {
+	public static function provideUrlsIgnoringHttps(): array {
 		return [
 			// Only the scheme differs → equal
 			['http://www.blogger.com/feeds/1/posts', 'https://www.blogger.com/feeds/1/posts', true],
 			['https://example.net/feed.xml?a=1&b=2', 'http://example.net/feed.xml?a=1&b=2', true],
 			['HTTP://Example.net/Feed', 'https://Example.net/Feed', true],
+			['HTTPS://Example.net/Feed', 'http://Example.net/Feed', true],
 
 			// Fully identical → equal
 			['https://example.net/feed', 'https://example.net/feed', true],

--- a/tests/app/Utils/httpUtilTest.php
+++ b/tests/app/Utils/httpUtilTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Tests for FreshRSS_http_Util
+ */
+class httpUtilTest extends \PHPUnit\Framework\TestCase {
+
+	#[DataProvider('provideUrlsIgnoringScheme')]
+	public function test_compareURLsIgnoringScheme(string $url1, string $url2, bool $expected): void {
+		self::assertSame($expected, FreshRSS_http_Util::compareURLsIgnoringScheme($url1, $url2));
+	}
+
+	/** @return list<array{string,string,bool}> */
+	public static function provideUrlsIgnoringScheme(): array {
+		return [
+			// Only the scheme differs → equal
+			['http://www.blogger.com/feeds/1/posts', 'https://www.blogger.com/feeds/1/posts', true],
+			['https://example.net/feed.xml?a=1&b=2', 'http://example.net/feed.xml?a=1&b=2', true],
+			['HTTP://Example.net/Feed', 'https://Example.net/Feed', true],
+
+			// Fully identical → equal
+			['https://example.net/feed', 'https://example.net/feed', true],
+			['', '', true],
+
+			// Path differs → not equal (scheme-only tolerance must not hide real mismatches)
+			['http://example.net/a', 'https://example.net/b', false],
+			// Trailing slash is a path difference → not equal
+			['http://example.net/', 'https://example.net', false],
+			// Host differs → not equal
+			['http://a.example.net/feed', 'https://b.example.net/feed', false],
+			// Query differs → not equal
+			['https://example.net/feed?a=1', 'http://example.net/feed?a=2', false],
+			// Non-http(s) schemes are compared as-is
+			['ftp://example.net/feed', 'https://example.net/feed', false],
+		];
+	}
+}


### PR DESCRIPTION
Closes #3087

## Problem

The WebSub (PubSubHubbub) callback endpoint `p/api/pshb.php` compares the feed's declared **self URL** against the **registered canonical URL** and logs a warning when they differ:

```
Warning: Self URL [http://www.blogger.com/feeds/…] does not match registered canonical URL!: https://www.blogger.com/feeds/…
```

Many feeds serve an `http://` self URL that simply redirects to `https://` (a common security setup). In that case the two URLs differ only by scheme, yet the endpoint logs the warning on every push — spamming the PubSubHubbub log with a non-issue (#3087).

## Fix

Compare the two URLs while treating `http://` and `https://` as equivalent, so a scheme-only difference no longer triggers the warning. Everything else (host, path, query) must still match exactly, so genuine mismatches are still reported.

A small helper is added next to the existing `compareURLOrigins()` in `FreshRSS_http_Util` (which `pshb.php` already uses):

```php
public static function compareURLsIgnoringScheme(string $url1, string $url2): bool {
    $stripScheme = static fn(string $url): string => preg_replace('#^https?://#i', '//', trim($url)) ?? $url;
    return $stripScheme($url1) === $stripScheme($url2);
}
```

`compareURLOrigins()` was not reused because it ignores the path, whereas here the path/query must still be compared.

Both self-URL comparisons in `pshb.php` now go through the helper:
- the XML self vs registered canonical check (the one from the issue), and
- the XML self vs HTTP `Link` header self check just above it, which suffers from the same false positive.

## Changes

- **`app/Utils/httpUtil.php`** — add `compareURLsIgnoringScheme()`.
- **`p/api/pshb.php`** — use it for the two `Self URL … mismatch` comparisons.
- **`tests/app/Utils/httpUtilTest.php`** (new) — unit tests for the helper: scheme-only difference is equal; identical URLs equal; differing path / trailing slash / host / query are not equal; non-http(s) schemes compared as-is.

No user-facing strings change, so no i18n updates.

## Testing

- `vendor/bin/phpunit tests/app/Utils` → **22 tests OK** (11 new).
- `php -l` on both changed files → OK.
- `phpstan` on the changed files → no errors.
