### PR TITLE
Redirect after saving user CSS/JS so changes apply immediately

### DIFF
--- a/lib/core-extensions/UserCSS/extension.php
+++ b/lib/core-extensions/UserCSS/extension.php
@@ -25,6 +25,11 @@ final class UserCSSExtension extends Minz_Extension {
 			$css_rules = Minz_Request::paramString('css-rules', plaintext: true);
 			$this->saveFile(self::FILENAME, $css_rules);
 			FreshRSS_UserDAO::touch();
+			// Redirect (Post/Redirect/Get) so the next page is built after the save,
+			// with a fresh cache-busting URL for the updated stylesheet
+			Minz_Request::good(_t('feedback.conf.updated'), [
+				'c' => 'extension', 'a' => 'configure', 'params' => ['e' => $this->getName()],
+			]);
 		}
 
 		$this->css_rules = '';

--- a/lib/core-extensions/UserCSS/metadata.json
+++ b/lib/core-extensions/UserCSS/metadata.json
@@ -2,7 +2,7 @@
 	"name": "User CSS",
 	"author": "hkcomori, Marien Fressinaud",
 	"description": "Give possibility to overwrite the CSS with a user-specific rules.",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"entrypoint": "UserCSS",
 	"type": "user"
 }

--- a/lib/core-extensions/UserJS/extension.php
+++ b/lib/core-extensions/UserJS/extension.php
@@ -29,6 +29,11 @@ final class UserJSExtension extends Minz_Extension {
 			$js_rules = Minz_Request::paramString('js-rules', plaintext: true);
 			$this->saveFile(self::FILENAME, $js_rules);
 			FreshRSS_UserDAO::touch();
+			// Redirect (Post/Redirect/Get) so the next page is built after the save,
+			// with a fresh cache-busting URL for the updated script
+			Minz_Request::good(_t('feedback.conf.updated'), [
+				'c' => 'extension', 'a' => 'configure', 'params' => ['e' => $this->getName()],
+			]);
 		}
 
 		$this->js_rules = '';

--- a/lib/core-extensions/UserJS/metadata.json
+++ b/lib/core-extensions/UserJS/metadata.json
@@ -2,7 +2,7 @@
 	"name": "User JS",
 	"author": "hkcomori, Frans de Jonge",
 	"description": "Apply user JS.",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"entrypoint": "UserJS",
 	"type": "user"
 }


### PR DESCRIPTION
Saving custom CSS/JS rendered the response from the pre-save state (no Post/Redirect/Get), so the cache-busting URL for the stylesheet was stale and the change only appeared after a manual reload, which reads as erratic behaviour.

Redirect back to the extension config after saving (mirroring the `Minz_Request::good()` PRG pattern used elsewhere, e.g. `apiController`/`updateController`), so the next page is built after the save with a fresh cache-busting URL for the updated stylesheet/script. Applied to both User CSS and User JS extensions; version bumped in both metadata.json.

Verified with `php -l` on both changed files.

Fixes #8795