### PR TITLE
Keep search and state filters when marking articles as read

### DIFF
--- a/app/Controllers/entryController.php
+++ b/app/Controllers/entryController.php
@@ -202,8 +202,7 @@ class FreshRSS_entry_Controller extends FreshRSS_ActionController {
 		}
 
 		if (!$this->ajax) {
-			// Preserve the active search and read/favourite state filters across the redirect,
-			// otherwise the view resets to its default after marking articles as read (issue #8671).
+			// Preserve the active search and read/favourite state filters across the redirect
 			$search = Minz_Request::paramString('search', plaintext: true);
 			if ($search !== '') {
 				$params['search'] = $search;

--- a/app/Controllers/entryController.php
+++ b/app/Controllers/entryController.php
@@ -202,6 +202,16 @@ class FreshRSS_entry_Controller extends FreshRSS_ActionController {
 		}
 
 		if (!$this->ajax) {
+			// Preserve the active search and read/favourite state filters across the redirect,
+			// otherwise the view resets to its default after marking articles as read (issue #8671).
+			$search = Minz_Request::paramString('search', plaintext: true);
+			if ($search !== '') {
+				$params['search'] = $search;
+			}
+			$stateParam = Minz_Request::paramInt('state');
+			if ($stateParam !== 0) {
+				$params['state'] = $stateParam;
+			}
 			if (FreshRSS_Context::userConf()->sticky_sort) {
 				if (Minz_Request::hasParam('order')) {
 					$params['order'] = Minz_Request::paramString('order', plaintext: true);


### PR DESCRIPTION
Closes #8671

Changes proposed in this pull request:

- Marking articles as read (e.g. "mark all as read") POSTs to `entry?a=read` and, for non-AJAX requests, redirects back to the index. That redirect rebuilt its parameters without the current `search` and `state`, so the view fell back to its default state and the active search was dropped.
- Carry `search` and `state` through the redirect, mirroring the existing `order`/`sort` handling added in #8969, so the filtered view is preserved.

How to test the feature manually:

1. On the main stream, apply a filter — e.g. switch to "Favourites", or type something into the search box.
2. Click "Mark all as read" (nav menu or the big button at the end of the stream).
3. The view keeps your filter/search instead of resetting to the default state.

Verified on a local instance (edge, Docker): `POST /i/?c=entry&a=read&get=all&search=hello&state=4` redirects to `/i/?get=all&rid=…` before this change (filter lost) and to `/i/?get=all&search=hello&state=4&rid=…` with it.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested (live redirect comparison above; `php -l` and phpcs PSR-12 clean)
- [ ] unit tests written (optional if too hard) — no existing coverage for this controller redirect path
- [x] documentation updated (n/a)
