### PR TITLE
Add Readeck as a sharing method

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -234,7 +234,7 @@ Voir le [dépôt dédié à ces extensions](https://github.com/FreshRSS/Extensio
 | English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Español (es) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
 | فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Suomi (fi) | ￭￭￭￭￭￭￭￭￭･ 92% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffi+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Suomi (fi) | ￭￭￭￭￭￭￭￭￭･ 91% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffi+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Français (fr) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | עברית (he) | ￭￭￭￭･･････ 41% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhe+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Magyar (hu) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhu+%2F%28TODO%7CDIRTY%29%24%2F) |

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ See the [repository dedicated to those extensions](https://github.com/FreshRSS/E
 | English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Español (es) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
 | فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Suomi (fi) | ￭￭￭￭￭￭￭￭￭･ 92% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffi+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Suomi (fi) | ￭￭￭￭￭￭￭￭￭･ 91% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffi+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Français (fr) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | עברית (he) | ￭￭￭￭･･････ 41% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhe+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Magyar (hu) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhu+%2F%28TODO%7CDIRTY%29%24%2F) |

--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -100,9 +100,9 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 
 	/**
 	 * Build the extra origins allowed by the Content-Security-Policy connect-src
-	 * directive so that client-side sharing requests (e.g. Readeck) are not
-	 * blocked. Origins are derived from the base URL of every configured share
-	 * that uses the 'token' form. Returns e.g. "'self' https://readeck.example".
+	 * directive so that client-side sharing requests are not blocked.
+	 * Origins are derived from the base URL of every configured share
+	 * that uses the 'token' form. Returns e.g. "'self' https://bookmarks.example".
 	 */
 	private static function shareConnectSrc(): string {
 		// Shares are normally loaded later, in FreshRSS::preLayout(); make sure

--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -99,6 +99,40 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 	}
 
 	/**
+	 * Build the extra origins allowed by the Content-Security-Policy connect-src
+	 * directive so that client-side sharing requests (e.g. Readeck) are not
+	 * blocked. Origins are derived from the base URL of every configured share
+	 * that uses the 'token' form. Returns e.g. "'self' https://readeck.example".
+	 */
+	private static function shareConnectSrc(): string {
+		// Shares are normally loaded later, in FreshRSS::preLayout(); make sure
+		// they are available here so FreshRSS_Share::get() can resolve the form type.
+		if (FreshRSS_Share::enum() === []) {
+			FreshRSS_Share::load(join_path(APP_PATH, 'shares.php'));
+		}
+		$origins = [];
+		foreach (FreshRSS_Context::userConf()->sharing as $share_options) {
+			if (empty($share_options['type']) || empty($share_options['url'])) {
+				continue;
+			}
+			$share = FreshRSS_Share::get($share_options['type']);
+			if ($share === null || $share->formType() !== 'token') {
+				continue;
+			}
+			$parts = parse_url($share_options['url']);
+			if (!is_array($parts) || empty($parts['scheme']) || empty($parts['host'])) {
+				continue;
+			}
+			$origin = $parts['scheme'] . '://' . $parts['host'];
+			if (!empty($parts['port'])) {
+				$origin .= ':' . $parts['port'];
+			}
+			$origins[$origin] = true;
+		}
+		return rtrim("'self' " . implode(' ', array_keys($origins)));
+	}
+
+	/**
 	 * This action displays the normal view of FreshRSS.
 	 */
 	public function normalAction(): void {
@@ -131,6 +165,7 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 
 		$this->_csp([
 			'default-src' => "'self'",
+			'connect-src' => self::shareConnectSrc(),
 			'frame-src' => '*',
 			'img-src' => '* data: blob:',
 			'frame-ancestors' => FreshRSS_Context::systemConf()->attributeString('csp.frame-ancestors') ?? "'none'",
@@ -234,6 +269,7 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 
 		$this->_csp([
 			'default-src' => "'self'",
+			'connect-src' => self::shareConnectSrc(),
 			'frame-src' => '*',
 			'img-src' => '* data: blob:',
 			'frame-ancestors' => FreshRSS_Context::systemConf()->attributeString('csp.frame-ancestors') ?? "'none'",

--- a/app/Models/Share.php
+++ b/app/Models/Share.php
@@ -13,7 +13,7 @@ class FreshRSS_Share {
 
 	/**
 	 * Register a new sharing option.
-	 * @param array{type:string,url:string,transform?:array<callable>|array<string,array<callable>>,field?:string,help?:string,form?:'simple'|'advanced',
+	 * @param array{type:string,url:string,transform?:array<callable>|array<string,array<callable>>,field?:string,help?:string,form?:'simple'|'advanced'|'token',
 	 *	method?:'GET'|'POST',HTMLtag?:'button',deprecated?:bool} $share_options is an array defining the share option.
 	 */
 	public static function register(array $share_options): void {
@@ -50,7 +50,7 @@ class FreshRSS_Share {
 				continue;
 			}
 			$share_options['type'] = $share_type;
-			/** @var array{type:string,url:string,transform?:array<callable>|array<string,array<callable>>,field?:string,help?:string,form?:'simple'|'advanced',
+			/** @var array{type:string,url:string,transform?:array<callable>|array<string,array<callable>>,field?:string,help?:string,form?:'simple'|'advanced'|'token',
 			 *	method?:'GET'|'POST',HTMLtag?:'button',deprecated?:bool} $share_options */
 			self::register($share_options);
 		}
@@ -75,11 +75,12 @@ class FreshRSS_Share {
 	}
 	private readonly string $name;
 	/**
-	 * @phpstan-var 'simple'|'advanced'
+	 * @phpstan-var 'simple'|'advanced'|'token'
 	 */
 	private readonly string $form_type;
 	private ?string $custom_name = null;
 	private ?string $base_url = null;
+	private ?string $token = null;
 	private ?string $id = null;
 	private ?string $title = null;
 	private ?string $link = null;
@@ -93,9 +94,9 @@ class FreshRSS_Share {
 	 * @param string $type is a unique string defining the kind of share option.
 	 * @param string $url_transform defines the url format to use in order to share.
 	 * @param array<callable>|array<string,array<callable>> $transforms is an array of transformations to apply on link and title.
-	 * @param 'simple'|'advanced' $form_type defines which form we have to use to complete. "simple"
+	 * @param 'simple'|'advanced'|'token' $form_type defines which form we have to use to complete. "simple"
 	 *        is typically for a centralized service while "advanced" is for
-	 *        decentralized ones.
+	 *        decentralized ones. "token" is like "advanced" but also asks for an API token.
 	 * @param string $help_url is an optional url to give help on this option.
 	 * @param 'GET'|'POST' $method defines the sharing method (GET or POST)
 	 * @param 'button'|null $HTMLtag
@@ -113,7 +114,7 @@ class FreshRSS_Share {
 	) {
 		$this->name = _t('gen.share.' . $this->type);
 
-		if (!in_array($form_type, ['simple', 'advanced'], true)) {
+		if (!in_array($form_type, ['simple', 'advanced', 'token'], true)) {
 			$form_type = 'simple';
 		}
 		$this->form_type = $form_type;
@@ -126,7 +127,7 @@ class FreshRSS_Share {
 	/**
 	 * Update a FreshRSS_Share object with information from an array.
 	 * @param array<string,string> $options is a list of information to update where keys should be
-	 *        in this list: name, url, id, title, link.
+	 *        in this list: name, url, id, title, link, token, method, field.
 	 */
 	public function update(array $options): void {
 		foreach ($options as $key => $value) {
@@ -145,6 +146,9 @@ class FreshRSS_Share {
 					break;
 				case 'link':
 					$this->link = $value;
+					break;
+				case 'token':
+					$this->token = $value;
 					break;
 				case 'method':
 					$this->method = strcasecmp($value, 'POST') === 0 ? 'POST' : 'GET';
@@ -181,10 +185,18 @@ class FreshRSS_Share {
 
 	/**
 	 * Return the current form type of the share option.
-	 * @return 'simple'|'advanced'
+	 * @return 'simple'|'advanced'|'token'
 	 */
 	public function formType(): string {
 		return $this->form_type;
+	}
+
+	/**
+	 * Return the API token of the share option. It’s null for shares that do
+	 * not use the 'token' form.
+	 */
+	public function token(): ?string {
+		return $this->token;
 	}
 
 	/**

--- a/app/i18n/cs/conf.php
+++ b/app/i18n/cs/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Odebrat metodu sdílení',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Zobrazený název pro sdílení',
+		'share_token' => 'API token',	// TODO
 		'share_url' => 'Použitá adresa URL pro sdílení',
 		'title' => 'Sdílení',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/cs/gen.php
+++ b/app/i18n/cs/gen.php
@@ -317,6 +317,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'Tisknout',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Freigabedienst entfernen',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Anzuzeigender Freigabename',
+		'share_token' => 'API token',	// TODO
 		'share_url' => 'Zu verwendende Freigabe-URL',
 		'title' => 'Teilen',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/de/gen.php
+++ b/app/i18n/de/gen.php
@@ -309,6 +309,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'Drucken',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/el/conf.php
+++ b/app/i18n/el/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Αφαίρεση μεθόδου κοινοποίησης',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Όνομα κοινοποίησης προς εμφάνιση',
+		'share_token' => 'API token',	// TODO
 		'share_url' => 'URL κοινοποίησης προς χρήση',
 		'title' => 'Κοινοποίηση',
 		'twitter' => 'Twitter',	// IGNORE

--- a/app/i18n/el/gen.php
+++ b/app/i18n/el/gen.php
@@ -309,6 +309,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'Εκτύπωση',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/en-US/conf.php
+++ b/app/i18n/en-US/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Remove sharing method',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Share name to display',	// IGNORE
+		'share_token' => 'API token',	// IGNORE
 		'share_url' => 'Share URL to use',	// IGNORE
 		'title' => 'Sharing',	// IGNORE
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/en-US/gen.php
+++ b/app/i18n/en-US/gen.php
@@ -309,6 +309,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'Print',	// IGNORE
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/en/conf.php
+++ b/app/i18n/en/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Remove sharing method',
 		'shaarli' => 'Shaarli',
 		'share_name' => 'Share name to display',
+		'share_token' => 'API token',
 		'share_url' => 'Share URL to use',
 		'title' => 'Sharing',
 		'twitter' => 'Twitter',

--- a/app/i18n/en/gen.php
+++ b/app/i18n/en/gen.php
@@ -309,6 +309,7 @@ return array(
 		'pinterest' => 'Pinterest',
 		'print' => 'Print',
 		'raindrop' => 'Raindrop.io',
+		'readeck' => 'Readeck',
 		'reddit' => 'Reddit',
 		'shaarli' => 'Shaarli',
 		'telegram' => 'Telegram',

--- a/app/i18n/es/conf.php
+++ b/app/i18n/es/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Quitar métodos para compartir artículos',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Compartir nombre a mostrar',
+		'share_token' => 'API token',	// TODO
 		'share_url' => 'Compartir URL a usar',
 		'title' => 'Compartir',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/es/gen.php
+++ b/app/i18n/es/gen.php
@@ -309,6 +309,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'Imprimir',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/fa/conf.php
+++ b/app/i18n/fa/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => ' روش اشتراک گذاری را حذف کنید',
 		'shaarli' => ' شعرلی',
 		'share_name' => ' نام اشتراک گذاری برای نمایش',
+		'share_token' => 'API token',	// TODO
 		'share_url' => ' URL را برای استفاده به اشتراک بگذارید',
 		'title' => ' اشتراک گذاری',
 		'twitter' => ' توییتر',

--- a/app/i18n/fa/gen.php
+++ b/app/i18n/fa/gen.php
@@ -309,6 +309,7 @@ return array(
 		'pinterest' => ' پینترست',
 		'print' => ' چاپ',
 		'raindrop' => ' Raindrop.io',
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => ' Reddit',
 		'shaarli' => ' شعرلی',
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/fi/conf.php
+++ b/app/i18n/fi/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Poista jakamistapa',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Näytettävä jakamistavan nimi',
+		'share_token' => 'API token',	// TODO
 		'share_url' => 'Käytettävä jakamistavan URL-osoite',
 		'title' => 'Jakaminen',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/fi/gen.php
+++ b/app/i18n/fi/gen.php
@@ -309,6 +309,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'Tulostus',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/fr/conf.php
+++ b/app/i18n/fr/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Supprimer la méthode de partage',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Nom du partage à afficher',
+		'share_token' => 'API token',	// TODO
 		'share_url' => 'URL du partage à utiliser',
 		'title' => 'Partage',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/fr/conf.php
+++ b/app/i18n/fr/conf.php
@@ -335,7 +335,7 @@ return array(
 		'remove' => 'Supprimer la méthode de partage',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Nom du partage à afficher',
-		'share_token' => 'API token',	// TODO
+		'share_token' => 'Jeton d’API',
 		'share_url' => 'URL du partage à utiliser',
 		'title' => 'Partage',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/fr/gen.php
+++ b/app/i18n/fr/gen.php
@@ -309,6 +309,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'Imprimer',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/he/conf.php
+++ b/app/i18n/he/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Remove sharing method',	// TODO
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'שיתוף שם לתצוגה',
+		'share_token' => 'API token',	// TODO
 		'share_url' => 'לשימוש שתפו URL',
 		'title' => 'שיתוף',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/he/gen.php
+++ b/app/i18n/he/gen.php
@@ -309,6 +309,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'הדפסה',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/hu/conf.php
+++ b/app/i18n/hu/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Megosztási mód eltávolítása',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Megosztás neve',
+		'share_token' => 'API token',	// TODO
 		'share_url' => 'URL megosztása a használathoz',
 		'title' => 'Sharing',	// IGNORE
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/hu/gen.php
+++ b/app/i18n/hu/gen.php
@@ -309,6 +309,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'Print',	// IGNORE
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/id/conf.php
+++ b/app/i18n/id/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Hapus layanan berbagi',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Nama layanan untuk ditampilkan',
+		'share_token' => 'API token',	// TODO
 		'share_url' => 'URL berbagi yang digunakan',
 		'title' => 'Berbagi',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/id/gen.php
+++ b/app/i18n/id/gen.php
@@ -301,6 +301,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'Cetak',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/it/conf.php
+++ b/app/i18n/it/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Rimuovi metodo di condivisione',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Nome condivisione',
+		'share_token' => 'API token',	// TODO
 		'share_url' => 'URL condivisione',
 		'title' => 'Condividi',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/it/gen.php
+++ b/app/i18n/it/gen.php
@@ -309,6 +309,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'Stampa',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/ja/conf.php
+++ b/app/i18n/ja/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => '共有先を削除する',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => '共有先',
+		'share_token' => 'API token',	// TODO
 		'share_url' => '共有URL',
 		'title' => '共有',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/ja/gen.php
+++ b/app/i18n/ja/gen.php
@@ -301,6 +301,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => '印刷',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/ko/conf.php
+++ b/app/i18n/ko/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => '공유 방법 삭제',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => '표시할 이름',
+		'share_token' => 'API token',	// TODO
 		'share_url' => '사용할 공유 URL',
 		'title' => '공유',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/ko/gen.php
+++ b/app/i18n/ko/gen.php
@@ -301,6 +301,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => '인쇄',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/lv/conf.php
+++ b/app/i18n/lv/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Noņemt dalīšanās metodi',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Rādāmā dalīšanās nosaukums',
+		'share_token' => 'API token',	// TODO
 		'share_url' => 'Dalīšanās URL, ko izmantot',
 		'title' => 'Dalīšanās',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/lv/gen.php
+++ b/app/i18n/lv/gen.php
@@ -317,6 +317,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'Drukāt',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/nl/conf.php
+++ b/app/i18n/nl/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Deelmethode verwijderen',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Gedeelde naam om weer te geven',
+		'share_token' => 'API token',	// TODO
 		'share_url' => 'Deel URL voor gebruik',
 		'title' => 'Delen',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/nl/gen.php
+++ b/app/i18n/nl/gen.php
@@ -309,6 +309,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'Print',	// IGNORE
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/oc/conf.php
+++ b/app/i18n/oc/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Suprimir lo metòde de partatge',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Nom del partatge de mostrar',
+		'share_token' => 'API token',	// TODO
 		'share_url' => 'URL del partatge d’utilizar',
 		'title' => 'Partatge',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/oc/gen.php
+++ b/app/i18n/oc/gen.php
@@ -309,6 +309,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'Imprimir',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/pl/conf.php
+++ b/app/i18n/pl/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Usuń sposób na podanie dalej wiadomości',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Wyświetlana nazwa serwisu',
+		'share_token' => 'API token',	// TODO
 		'share_url' => 'Adres API serwisu',
 		'title' => 'Udostępnianie',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/pl/gen.php
+++ b/app/i18n/pl/gen.php
@@ -317,6 +317,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'Wydruk',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/pt-BR/conf.php
+++ b/app/i18n/pt-BR/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Remover método de compartilhamento',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Nome de visualização para compartilhar',
+		'share_token' => 'API token',	// TODO
 		'share_url' => 'URL utilizada para compartilhar',
 		'title' => 'Compartilhando',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/pt-BR/gen.php
+++ b/app/i18n/pt-BR/gen.php
@@ -309,6 +309,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'Imprimir',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/pt-PT/conf.php
+++ b/app/i18n/pt-PT/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Remover método de partilha',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Nome de visualização para partilhar',
+		'share_token' => 'API token',	// TODO
 		'share_url' => 'URL utilizada para partilha',
 		'title' => 'Partilhar',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/pt-PT/gen.php
+++ b/app/i18n/pt-PT/gen.php
@@ -309,6 +309,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'Imprimir',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/ru/conf.php
+++ b/app/i18n/ru/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Удалить способ обмена',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Отображаемое имя',
+		'share_token' => 'API token',	// TODO
 		'share_url' => 'Используемый URL',
 		'title' => 'Обмен',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/ru/gen.php
+++ b/app/i18n/ru/gen.php
@@ -317,6 +317,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'Распечатать',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/sk/conf.php
+++ b/app/i18n/sk/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Odstrániť spôsob zdieľania',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Meno pre zobrazenie',
+		'share_token' => 'API token',	// TODO
 		'share_url' => 'Zdieľaný odkaz',
 		'title' => 'Zdieľanie',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/sk/gen.php
+++ b/app/i18n/sk/gen.php
@@ -317,6 +317,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'Print',	// IGNORE
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/tr/conf.php
+++ b/app/i18n/tr/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Paylaşım yöntemini kaldır',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Görüntülenecek paylaşım adı',
+		'share_token' => 'API token',	// TODO
 		'share_url' => 'Kullanılacak paylaşım URL’si',
 		'title' => 'Paylaşım',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/tr/gen.php
+++ b/app/i18n/tr/gen.php
@@ -309,6 +309,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'Yazdır',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/uk/conf.php
+++ b/app/i18n/uk/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => 'Вилучити спосіб поширення',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => 'Підпис у меню',
+		'share_token' => 'API token',	// TODO
 		'share_url' => 'URL-адреса поширення',
 		'title' => 'Поширення',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/uk/gen.php
+++ b/app/i18n/uk/gen.php
@@ -317,6 +317,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => 'Друк',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/zh-CN/conf.php
+++ b/app/i18n/zh-CN/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => '删除分享方式',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => '显示名称',
+		'share_token' => 'API token',	// TODO
 		'share_url' => '用于分享的 URL',
 		'title' => '分享',
 		'twitter' => 'X (Twitter)',	// IGNORE

--- a/app/i18n/zh-CN/gen.php
+++ b/app/i18n/zh-CN/gen.php
@@ -301,6 +301,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => '打印',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/i18n/zh-TW/conf.php
+++ b/app/i18n/zh-TW/conf.php
@@ -335,6 +335,7 @@ return array(
 		'remove' => '移除分享方式',
 		'shaarli' => 'Shaarli',	// IGNORE
 		'share_name' => '要顯示的分享名稱',
+		'share_token' => 'API token',	// TODO
 		'share_url' => '要使用的分享 URL',
 		'title' => '分享',
 		'twitter' => 'Twitter',	// IGNORE

--- a/app/i18n/zh-TW/gen.php
+++ b/app/i18n/zh-TW/gen.php
@@ -303,6 +303,7 @@ return array(
 		'pinterest' => 'Pinterest',	// IGNORE
 		'print' => '列印',
 		'raindrop' => 'Raindrop.io',	// IGNORE
+		'readeck' => 'Readeck',	// IGNORE
 		'reddit' => 'Reddit',	// IGNORE
 		'shaarli' => 'Shaarli',	// IGNORE
 		'telegram' => 'Telegram',	// IGNORE

--- a/app/shares.php
+++ b/app/shares.php
@@ -27,7 +27,8 @@ declare(strict_types=1);
  *     configurable, 'advanced' is used when the name and the location are
  *     configurable, 'token' additionally lets the user configure an API token
  *     that is sent as an 'Authorization: Bearer' header by a client-side
- *     request (see the data-type handler in main.js).
+ *     request posting the link as JSON (see the data-token handler in main.js).
+ *   - 'field' is the name of the field holding the link, for shares sent by POST.
  *   - 'method' is the HTTP method (POST or GET) used to share a link.
  */
 
@@ -204,6 +205,7 @@ return [
 		'HTMLtag' => 'button',
 		'url' => '~URL~/api/bookmarks',
 		'transform' => [],
+		'field' => 'url',
 		'help' => 'https://readeck.org/en/docs/api',
 		'form' => 'token',
 		'method' => 'POST',

--- a/app/shares.php
+++ b/app/shares.php
@@ -23,8 +23,11 @@ declare(strict_types=1);
  *   - 'transform' is an array of transformation to apply on links and titles
  *   - 'help' is a URL to a help page (mandatory for form = 'advanced')
  *   - 'form' is the type of form to display during configuration. It’s either
- *     'simple' or 'advanced'. 'simple' is used when only the name is configurable,
- *     'advanced' is used when the name and the location are configurable.
+ *     'simple', 'advanced' or 'token'. 'simple' is used when only the name is
+ *     configurable, 'advanced' is used when the name and the location are
+ *     configurable, 'token' additionally lets the user configure an API token
+ *     that is sent as an 'Authorization: Bearer' header by a client-side
+ *     request (see the data-type handler in main.js).
  *   - 'method' is the HTTP method (POST or GET) used to share a link.
  */
 
@@ -196,6 +199,14 @@ return [
 		'transform' => ['rawurlencode'],
 		'form' => 'simple',
 		'method' => 'GET',
+	],
+	'readeck' => [
+		'HTMLtag' => 'button',
+		'url' => '~URL~/api/bookmarks',
+		'transform' => [],
+		'help' => 'https://readeck.org/en/docs/api',
+		'form' => 'token',
+		'method' => 'POST',
 	],
 	'reddit' => [
 		'url' => 'https://www.reddit.com/submit?url=~LINK~',

--- a/app/views/configure/integration.phtml
+++ b/app/views/configure/integration.phtml
@@ -51,6 +51,36 @@
 				</div>
 			</fieldset>
 		</template>
+		<template id="token-share">
+			<fieldset class="group-share dragbox">
+				<legend draggable="true">##label##</legend>
+				<input type="hidden" id="share_##key##_type" name="share[##key##][type]" value="##type##" data-leave-validation="" />
+				<div class="form-group" id="group-share-##key##">
+					<label class="group-name" for="share_##key##_name"><?= _t('conf.sharing.share_name') ?></label>
+					<div class="group-controls">
+						<input type="text" id="share_##key##_name" name="share[##key##][name]" value="##label##" />
+					</div>
+				</div>
+				<div class="form-group">
+					<label class="group-name" for="share_##key##_url"><?= _t('conf.sharing.share_url') ?></label>
+					<div class="group-controls">
+						<input type="url" id="share_##key##_url" name="share[##key##][url]" class="long" value="" required />
+						<p class="help"><?= _i('help') ?> <a href="##help##" target="_blank" rel="noreferrer"><?= _t('conf.sharing.more_information') ?></a></p>
+					</div>
+				</div>
+				<div class="form-group">
+					<label class="group-name" for="share_##key##_token"><?= _t('conf.sharing.share_token') ?></label>
+					<div class="group-controls">
+						<input type="password" id="share_##key##_token" name="share[##key##][token]" class="long" value="" autocomplete="off" />
+					</div>
+				</div>
+				<div class="form-group">
+					<div class="group-controls">
+						<button type="button" class="remove btn btn-attention" title="<?= _t('conf.sharing.remove') ?>"><?= _t('gen.action.remove') ?></button>
+					</div>
+				</div>
+			</fieldset>
+		</template>
 
 		<?php
 			foreach (FreshRSS_Context::userConf()->sharing as $key => $share_options) {
@@ -63,8 +93,10 @@
 		<fieldset class="group-share dragbox" id="group-share-<?= $key ?>">
 			<legend draggable="true"><?= $share->name(true) ?></legend>
 			<input type="hidden" id="share_<?= $key ?>_type" name="share[<?= $key ?>][type]" value="<?= $share->type() ?>" />
+			<?php if ($share->formType() !== 'token') { ?>
 			<input type="hidden" id="share_<?= $key ?>_method" name="share[<?= $key ?>][method]" value="<?= $share->method() ?>" />
 			<input type="hidden" id="share_<?= $key ?>_field" name="share[<?= $key ?>][field]" value="<?= $share->field() ?>" />
+			<?php } ?>
 
 			<?php if ($share->isDeprecated()) { ?>
 			<div class="prompt alert alert-warn">
@@ -82,7 +114,7 @@
 			</div>
 
 			<div class="form-group">
-				<?php if ($share->formType() === 'advanced') { ?>
+				<?php if ($share->formType() === 'advanced' || $share->formType() === 'token') { ?>
 					<label class="group-name" for="share_<?= $key ?>_url">
 						<?= _t('conf.sharing.share_url') ?>
 					</label>
@@ -96,6 +128,17 @@
 					</div>
 				<?php } ?>
 			</div>
+
+			<?php if ($share->formType() === 'token') { ?>
+			<div class="form-group">
+				<label class="group-name" for="share_<?= $key ?>_token">
+					<?= _t('conf.sharing.share_token') ?>
+				</label>
+				<div class="group-controls">
+					<input type="password" id="share_<?= $key ?>_token" name="share[<?= $key ?>][token]" class="long" value="<?= htmlspecialchars($share->token() ?? '', ENT_QUOTES) ?>" autocomplete="off" />
+				</div>
+			</div>
+			<?php } ?>
 
 			<div class="form-group">
 				<div class="group-controls">

--- a/app/views/configure/integration.phtml
+++ b/app/views/configure/integration.phtml
@@ -93,10 +93,8 @@
 		<fieldset class="group-share dragbox" id="group-share-<?= $key ?>">
 			<legend draggable="true"><?= $share->name(true) ?></legend>
 			<input type="hidden" id="share_<?= $key ?>_type" name="share[<?= $key ?>][type]" value="<?= $share->type() ?>" />
-			<?php if ($share->formType() !== 'token') { ?>
 			<input type="hidden" id="share_<?= $key ?>_method" name="share[<?= $key ?>][method]" value="<?= $share->method() ?>" />
 			<input type="hidden" id="share_<?= $key ?>_field" name="share[<?= $key ?>][field]" value="<?= $share->field() ?>" />
-			<?php } ?>
 
 			<?php if ($share->isDeprecated()) { ?>
 			<div class="prompt alert alert-warn">

--- a/app/views/helpers/index/normal/entry_share_menu.phtml
+++ b/app/views/helpers/index/normal/entry_share_menu.phtml
@@ -24,8 +24,9 @@
 			$share->update($share_options);
 			?><li class="item share<?= $cssClass ?>"><?php
 				if ('token' === $share->formType()):
-					// Client-side authenticated request (e.g. Readeck), see the data-type handler in main.js
-					?><button type="button" class="as-link" data-url="<?= $share->url() ?>" data-type="<?= $share->type() ?>" data-link="<?= $link ?>" data-token="<?= htmlspecialchars($share->token() ?? '') ?>"><?= $share->name() ?></button><?php
+					// Client-side request authenticated by a bearer token, see the data-token handler in main.js
+					?><button type="button" class="as-link" data-url="<?= $share->url() ?>" data-type="<?= $share->type() ?>" data-link="<?= $link ?>"
+						data-field="<?= $share->field() ?>" data-token="<?= htmlspecialchars($share->token() ?? '') ?>"><?= $share->name() ?></button><?php
 				elseif ('GET' === $share->method()):
 					if ($share->HTMLtag() !== 'button') {
 						?><a target="_blank" rel="noreferrer" href="<?= $share->url() ?>" data-type="<?= $share->type() ?>"><?= $share->name() ?></a><?php

--- a/app/views/helpers/index/normal/entry_share_menu.phtml
+++ b/app/views/helpers/index/normal/entry_share_menu.phtml
@@ -23,7 +23,10 @@
 			$share_options['title'] = $title;
 			$share->update($share_options);
 			?><li class="item share<?= $cssClass ?>"><?php
-				if ('GET' === $share->method()):
+				if ('token' === $share->formType()):
+					// Client-side authenticated request (e.g. Readeck), see the data-type handler in main.js
+					?><button type="button" class="as-link" data-url="<?= $share->url() ?>" data-type="<?= $share->type() ?>" data-link="<?= $link ?>" data-token="<?= htmlspecialchars($share->token() ?? '') ?>"><?= $share->name() ?></button><?php
+				elseif ('GET' === $share->method()):
 					if ($share->HTMLtag() !== 'button') {
 						?><a target="_blank" rel="noreferrer" href="<?= $share->url() ?>" data-type="<?= $share->type() ?>"><?= $share->name() ?></a><?php
 					} else {

--- a/docs/en/users/08_sharing_services.md
+++ b/docs/en/users/08_sharing_services.md
@@ -32,6 +32,7 @@ FreshRSS has the option to share links with a bunch of services.
 | Pinterest         | Is an image sharing and social media service designed to enable saving and discovery of information| [Website](https://pinterest.com/), [Wikipedia](https://en.wikipedia.org/wiki/Pinterest) | |
 | Pocket            | Social bookmarking (previous "Read it Later", owned by Mozilla) | [Website](https://getpocket.com), [Wikipedia](https://en.wikipedia.org/wiki/Pocket_(service)) | |
 | Raindrop.io       | All-in-one bookmark manager                          | [Website](https://raindrop.io/)| |
+| Readeck           | Self-hosted bookmark and "read-it-later" application  | [Website](https://readeck.org/) | Requires the Readeck base URL and an [API token](https://readeck.org/en/docs/api). The article is sent by a request from your browser, so your Readeck instance must allow cross-origin requests (CORS) from your FreshRSS origin. |
 | Reddit            | A network of communities where people can dive into their interests, hobbies and passions| [Website](https://www.reddit.com/), [Wikipedia](https://en.wikipedia.org/wiki/Reddit)| |
 | Shaarli           | Self-hosted minimalist bookmark manager and link sharing service | [Website](https://shaarli.readthedocs.io/) | |
 | Telegram          | Social network                         | [Website](https://telegram.org), [Wikipedia](https://en.wikipedia.org/wiki/Telegram_(software)) | |

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1525,8 +1525,8 @@ function init_stream(stream) {
 			return false;
 		}
 
-		el = ev.target.closest('.item.share > button[data-type="readeck"]');
-		if (el) {	// Share to Readeck through its API (Authorization: Bearer + JSON body)
+		el = ev.target.closest('.item.share > button[data-token]');
+		if (el) {	// Share by POST to an API authenticated by a bearer token (see the `token` form in shares.php)
 			const button = el;
 			fetch(button.dataset.url, {
 				method: 'POST',
@@ -1534,10 +1534,10 @@ function init_stream(stream) {
 					'Authorization': 'Bearer ' + button.dataset.token,
 					'Content-Type': 'application/json',
 				},
-				body: JSON.stringify({ url: button.dataset.link }),
+				body: JSON.stringify({ [button.dataset.field]: button.dataset.link }),
 			}).then(response => {
 				if (!response.ok) {
-					console.log('Readeck share failed with HTTP status ' + response.status);
+					console.log('Share failed with HTTP status ' + response.status);
 				}
 				toggleClass(button, response.ok ? 'ok' : 'error');
 			}).catch(error => {

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1525,6 +1525,28 @@ function init_stream(stream) {
 			return false;
 		}
 
+		el = ev.target.closest('.item.share > button[data-type="readeck"]');
+		if (el) {	// Share to Readeck through its API (Authorization: Bearer + JSON body)
+			const button = el;
+			fetch(button.dataset.url, {
+				method: 'POST',
+				headers: {
+					'Authorization': 'Bearer ' + button.dataset.token,
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({ url: button.dataset.link }),
+			}).then(response => {
+				if (!response.ok) {
+					console.log('Readeck share failed with HTTP status ' + response.status);
+				}
+				toggleClass(button, response.ok ? 'ok' : 'error');
+			}).catch(error => {
+				console.log(error);
+				toggleClass(button, 'error');
+			});
+			return false;
+		}
+
 		el = ev.target.closest('.item.share > a[href="POST"]');
 		if (el) {	// Share by POST
 			const f = el.parentElement.querySelector('form');


### PR DESCRIPTION
Closes #6998

Supersedes the stalled #7092, whose author became unresponsive and whose change did not work: it only added a `method => POST` entry to `app/shares.php`, but FreshRSS had no way to authenticate the request (as noted in that PR's review).

Readeck can only add a bookmark from another site through its REST API — `POST {baseURL}/api/bookmarks` with an `Authorization: Bearer <token>` header and a JSON body. There is no browser-openable "add bookmark" URL, so the usual "open a share URL" mechanism used by every other service cannot work for it. See the measurements below for why the web endpoint is not an alternative.

Changes proposed in this pull request:

- Introduce a new `'token'` share form type (name + base URL + API token) in `app/shares.php` and `FreshRSS_Share`, reusable by any future token-authenticated service.
- Add a generic click handler in `p/scripts/main.js` that posts the article link with `Authorization: Bearer` ([RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750)) and a JSON body. It is keyed on the presence of `data-token` and takes the JSON field name from the existing `field` share option, so **no service name appears in core JS** and a future token-authenticated service is just an entry in `shares.php`.
- Extend the `connect-src` Content-Security-Policy directive with the origins of the configured token shares, otherwise the browser would block the request before it is even sent.
- Add **Readeck** using this form type, the `conf.sharing.share_token` label and the `gen.share.readeck` name to all locales, and document the service.

## Why not a plain POST form to Readeck's web endpoint

@Inverle helpfully pointed at [a Readeck comment](https://codeberg.org/readeck/readeck/issues/709#issuecomment-10735763) describing `POST {baseURL}/bookmarks` with a `url` field and no API token, which would have needed no new core code at all. I ran a Readeck container to check, and it cannot work from FreshRSS:

| Request | Result |
|---|---|
| Session cookie, **no `Origin` header** | `303` → `/bookmarks/<id>` — created, no CSRF token needed |
| No session cookie | Not created |
| Session cookie, **`Origin: https://freshrss.example.com`** | **`403 Forbidden`** |

Readeck rejects cross-origin form posts, and its session cookie is `SameSite=Lax`, so it would not be sent on a cross-site POST anyway. The linked use case works because a Firefox search shortcut is an address-bar navigation, which sends no `Origin` header at all; a form submitted from a FreshRSS page always sends one. FreshRSS and Readeck are always different origins, so this applies to same-site deployments too.

## How to test the feature manually

1. Go to Settings → Sharing, add **Readeck**, fill in the Readeck base URL and an API token, then save.
2. Open an article's share menu and click **Readeck**.
3. The article is saved to Readeck; the button turns green on success and red on failure.

Note: the request is made from the browser, so the Readeck instance must allow cross-origin requests (CORS) from the FreshRSS origin. This is documented in `docs/en/users/08_sharing_services.md`. The API token is stored in the user configuration and rendered into the share menu (`data-token`), which is inherent to this browser-side approach.

## Pull request checklist

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated
