### PR TITLE
Docker: use double quotes for CRON_MIN examples

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -32,12 +32,14 @@ Example running FreshRSS (or scroll down to the [Docker Compose](#docker-compose
 docker run -d --restart unless-stopped --log-opt max-size=10m \
   -p 8080:80 \
   -e TZ=Europe/Paris \
-  -e 'CRON_MIN=1,31' \
+  -e "CRON_MIN=1,31" \
   -v freshrss_data:/var/www/FreshRSS/data \
   -v freshrss_extensions:/var/www/FreshRSS/extensions \
   --name freshrss \
   freshrss/freshrss
 ```
+
+> ℹ️ Use double quotes (`"..."`), not single quotes, around `CRON_MIN` values such as `"CRON_MIN=1,31"`. Single quotes are not stripped by Windows `cmd.exe` and end up included in the variable, whereas double quotes work correctly on Linux/macOS shells, PowerShell, and `cmd.exe` alike.
 
 * Exposing on port 8080
 * With a [server timezone](http://php.net/timezones) (default is `UTC`)
@@ -142,7 +144,7 @@ docker run --rm \
   -p 8080:80 \
   -e FRESHRSS_ENV=development \
   -e TZ=Europe/Paris \
-  -e 'CRON_MIN=1,31' \
+  -e "CRON_MIN=1,31" \
   -v $(pwd):/var/www/FreshRSS \
   -v freshrss_data:/var/www/FreshRSS/data \
   --name freshrss \
@@ -608,12 +610,12 @@ There are no less than 3 options. Pick a single one.
 Easiest, built-in solution, also used already in the examples above
 (but your Docker instance will have a second process in the background, without monitoring).
 Just pass the environment variable `CRON_MIN` to your `docker run` command,
-containing a valid cron minute definition such as `'13,43'` (recommended) or `'*/20'`.
+containing a valid cron minute definition such as `"13,43"` (recommended) or `"*/20"`.
 Not passing the `CRON_MIN` environment variable – or setting it to empty string – will disable the cron daemon.
 
 ```sh
 docker run ... \
-  -e 'CRON_MIN=13,43' \
+  -e "CRON_MIN=13,43" \
   --name freshrss freshrss/freshrss
 ```
 
@@ -641,7 +643,7 @@ See cron option 1 for customising the cron schedule.
 docker run -d --restart unless-stopped --log-opt max-size=10m \
   -v freshrss_data:/var/www/FreshRSS/data \
   -v freshrss_extensions:/var/www/FreshRSS/extensions \
-  -e 'CRON_MIN=17,47' \
+  -e "CRON_MIN=17,47" \
   --net freshrss-network \
   --name freshrss_cron freshrss/freshrss \
   cron -f
@@ -667,7 +669,7 @@ docker run -d --restart unless-stopped --log-opt max-size=10m \
 docker run -d --restart unless-stopped --log-opt max-size=10m \
   -v freshrss_data:/var/www/FreshRSS/data \
   -v freshrss_extensions:/var/www/FreshRSS/extensions \
-  -e 'CRON_MIN=27,57' \
+  -e "CRON_MIN=27,57" \
   --net freshrss-network \
   --name freshrss_cron freshrss/freshrss:alpine \
   crond -f -d 6

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -32,14 +32,12 @@ Example running FreshRSS (or scroll down to the [Docker Compose](#docker-compose
 docker run -d --restart unless-stopped --log-opt max-size=10m \
   -p 8080:80 \
   -e TZ=Europe/Paris \
-  -e "CRON_MIN=1,31" \
+  -e CRON_MIN=1,31 \
   -v freshrss_data:/var/www/FreshRSS/data \
   -v freshrss_extensions:/var/www/FreshRSS/extensions \
   --name freshrss \
   freshrss/freshrss
 ```
-
-> ℹ️ Use double quotes (`"..."`), not single quotes, around `CRON_MIN` values such as `"CRON_MIN=1,31"`. Single quotes are not stripped by Windows `cmd.exe` and end up included in the variable, whereas double quotes work correctly on Linux/macOS shells, PowerShell, and `cmd.exe` alike.
 
 * Exposing on port 8080
 * With a [server timezone](http://php.net/timezones) (default is `UTC`)
@@ -144,7 +142,7 @@ docker run --rm \
   -p 8080:80 \
   -e FRESHRSS_ENV=development \
   -e TZ=Europe/Paris \
-  -e "CRON_MIN=1,31" \
+  -e CRON_MIN=1,31 \
   -v $(pwd):/var/www/FreshRSS \
   -v freshrss_data:/var/www/FreshRSS/data \
   --name freshrss \
@@ -610,12 +608,12 @@ There are no less than 3 options. Pick a single one.
 Easiest, built-in solution, also used already in the examples above
 (but your Docker instance will have a second process in the background, without monitoring).
 Just pass the environment variable `CRON_MIN` to your `docker run` command,
-containing a valid cron minute definition such as `"13,43"` (recommended) or `"*/20"`.
+containing a valid cron minute definition such as `13,43` (recommended) or `*/20`.
 Not passing the `CRON_MIN` environment variable – or setting it to empty string – will disable the cron daemon.
 
 ```sh
 docker run ... \
-  -e "CRON_MIN=13,43" \
+  -e CRON_MIN=13,43 \
   --name freshrss freshrss/freshrss
 ```
 
@@ -643,7 +641,7 @@ See cron option 1 for customising the cron schedule.
 docker run -d --restart unless-stopped --log-opt max-size=10m \
   -v freshrss_data:/var/www/FreshRSS/data \
   -v freshrss_extensions:/var/www/FreshRSS/extensions \
-  -e "CRON_MIN=17,47" \
+  -e CRON_MIN=17,47 \
   --net freshrss-network \
   --name freshrss_cron freshrss/freshrss \
   cron -f
@@ -669,7 +667,7 @@ docker run -d --restart unless-stopped --log-opt max-size=10m \
 docker run -d --restart unless-stopped --log-opt max-size=10m \
   -v freshrss_data:/var/www/FreshRSS/data \
   -v freshrss_extensions:/var/www/FreshRSS/extensions \
-  -e "CRON_MIN=27,57" \
+  -e CRON_MIN=27,57 \
   --net freshrss-network \
   --name freshrss_cron freshrss/freshrss:alpine \
   crond -f -d 6

--- a/docs/en/admins/08_FeedUpdates.md
+++ b/docs/en/admins/08_FeedUpdates.md
@@ -13,14 +13,12 @@ FreshRSS is updated by the `./app/actualize_script.php` script. Knowing this, we
 Easiest, built-in solution, also used already in the examples above
 (but your Docker instance will have a second process in the background, without monitoring).
 Just pass the environment variable `CRON_MIN` to your `docker run` command,
-containing a valid cron minute definition such as `"13,43"` (recommended) or `"*/20"`.
+containing a valid cron minute definition such as `13,43` (recommended) or `*/20`.
 Not passing the `CRON_MIN` environment variable – or setting it to empty string – will disable the cron daemon.
-
-> ℹ️ Use double quotes (`"..."`), not single quotes, around `CRON_MIN` values such as `"CRON_MIN=13,43"`. Single quotes are not stripped by Windows `cmd.exe` and end up included in the variable, whereas double quotes work correctly on Linux/macOS shells, PowerShell, and `cmd.exe` alike.
 
 ```sh
 docker run ... \
-  -e "CRON_MIN=13,43" \
+  -e CRON_MIN=13,43 \
   --name freshrss freshrss/freshrss
 ```
 

--- a/docs/en/admins/08_FeedUpdates.md
+++ b/docs/en/admins/08_FeedUpdates.md
@@ -13,12 +13,14 @@ FreshRSS is updated by the `./app/actualize_script.php` script. Knowing this, we
 Easiest, built-in solution, also used already in the examples above
 (but your Docker instance will have a second process in the background, without monitoring).
 Just pass the environment variable `CRON_MIN` to your `docker run` command,
-containing a valid cron minute definition such as `'13,43'` (recommended) or `'*/20'`.
+containing a valid cron minute definition such as `"13,43"` (recommended) or `"*/20"`.
 Not passing the `CRON_MIN` environment variable – or setting it to empty string – will disable the cron daemon.
+
+> ℹ️ Use double quotes (`"..."`), not single quotes, around `CRON_MIN` values such as `"CRON_MIN=13,43"`. Single quotes are not stripped by Windows `cmd.exe` and end up included in the variable, whereas double quotes work correctly on Linux/macOS shells, PowerShell, and `cmd.exe` alike.
 
 ```sh
 docker run ... \
-  -e 'CRON_MIN=13,43' \
+  -e "CRON_MIN=13,43" \
   --name freshrss freshrss/freshrss
 ```
 


### PR DESCRIPTION
## Description

The Docker Quick Run / cron examples use single-quoted `-e 'CRON_MIN=1,31'`. This works on Linux/macOS shells and PowerShell, but not on Windows `cmd.exe`, which does not strip single quotes from arguments — they end up included literally in the variable, so the cron job never gets scheduled correctly. Using `-e CRON_MIN=*/20` (no quotes) works, which was the original report.

This switches all the affected examples in `Docker/README.md` and `docs/en/admins/08_FeedUpdates.md` to double quotes, which work consistently across Linux/macOS shells, PowerShell, and cmd.exe, and adds a short note explaining why.

Fixes #4818

## Testing

Verified directly on Windows: `docker run --rm -e 'CRON_MIN=1,31' alpine env` via `cmd.exe` yields the broken literal `'CRON_MIN=1,31'` as the variable, while the double-quoted form yields a clean `CRON_MIN=1,31` in cmd.exe, PowerShell, and bash alike.

`npm run markdownlint`: 0 errors.