### PR TITLE
Fix Safari unread count repaint

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2308,6 +2308,7 @@ html.slider-active {
 	min-width: 2rem;
 	display: block;
 	content: attr(data-unread);
+	transform: translateZ(0);
 	position: absolute;
 	top: 0;
 	right: 0.75rem;

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2308,6 +2308,7 @@ html.slider-active {
 	min-width: 2rem;
 	display: block;
 	content: attr(data-unread);
+	/* Forces Safari to repaint this badge when `data-unread` changes; without it, Safari can leave the old count on screen until an unrelated repaint (e.g. hover). */
 	transform: translateZ(0);
 	position: absolute;
 	top: 0;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2308,6 +2308,7 @@ html.slider-active {
 	min-width: 2rem;
 	display: block;
 	content: attr(data-unread);
+	transform: translateZ(0);
 	position: absolute;
 	top: 0;
 	left: 0.75rem;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2308,6 +2308,7 @@ html.slider-active {
 	min-width: 2rem;
 	display: block;
 	content: attr(data-unread);
+	/* Forces Safari to repaint this badge when `data-unread` changes; without it, Safari can leave the old count on screen until an unrelated repaint (e.g. hover). */
 	transform: translateZ(0);
 	position: absolute;
 	top: 0;


### PR DESCRIPTION
## Summary

Force Safari to repaint the sidebar unread count after its `data-unread` value changes.

## Changes

- Add the minimal CSS transform workaround in the base and RTL themes.

## Validation

- ESLint
- Stylelint
- `git diff --check`

Safari itself was not available for direct testing.

Fixes #8249