### PR TITLE
Ignore junk found after the closing root tag when fetching a feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ See also [the FreshRSS releases](https://github.com/FreshRSS/FreshRSS/releases).
 	* Fix wrong player parent logic leading to invalid type [#8893](https://github.com/FreshRSS/FreshRSS/pull/8893), [simplepie#978](https://github.com/simplepie/simplepie/pull/978)
 	* Consistently enable `XML_OPTION_PARSE_HUGE` [#8894](https://github.com/FreshRSS/FreshRSS/pull/8894), [simplepie#977](https://github.com/simplepie/simplepie/pull/977)
 	* Fix null warning in IRI for PHP 8.5+ [#8918](https://github.com/FreshRSS/FreshRSS/pull/8918), [simplepie#979](https://github.com/simplepie/simplepie/pull/979)
+	* Ignore junk found after the closing root tag when fetching a feed [#8326](https://github.com/FreshRSS/FreshRSS/issues/8326)
 * Features
 	* New option to hide badges showing number of unread articles (*Phantom Obligation*) [#8844](https://github.com/FreshRSS/FreshRSS/pull/8844)
 	* New option to keep or not the custom sort order when navigating between categories and feeds [#8969](https://github.com/FreshRSS/FreshRSS/pull/8969)

--- a/app/Models/SimplePieFetch.php
+++ b/app/Models/SimplePieFetch.php
@@ -42,6 +42,32 @@ final class FreshRSS_SimplePieFetch extends \SimplePie\File
 		}
 
 		parent::__construct($url, $timeout, $redirects, $headers, $useragent, $force_fsockopen, $curl_options);
+
+		if ($this->success) {
+			$body = $this->body; // @phpstan-ignore property.deprecated
+			assert($body !== null); // For PHPStan
+			// Some feeds append junk (HTML, JS, comments…) after the closing root tag, which breaks XML parsing.
+			// We discard anything found after the last closing root tag, as it cannot be part of the feed. https://github.com/FreshRSS/FreshRSS/issues/8326
+			$this->body = self::removeContentAfterRootClosingTag($body); // @phpstan-ignore property.deprecated
+		}
+	}
+
+	/**
+	 * Discards any content found after the last closing root tag (`</rss>`, `</feed>`, or `</…:RDF>`), if any.
+	 * Left untouched if no closing root tag is found, so as to not break otherwise-invalid feeds in a different way.
+	 */
+	public static function removeContentAfterRootClosingTag(string $body): string {
+		if (preg_match_all('#</(?:[\w.-]+:)?(?:rss|feed|RDF)\s*>#i', $body, $matches, PREG_OFFSET_CAPTURE) < 1) {
+			return $body;
+		}
+		$lastMatch = $matches[0][count($matches[0]) - 1];
+		$rootClosingTagEnd = $lastMatch[1] + strlen($lastMatch[0]);
+
+		if (trim(substr($body, $rootClosingTagEnd)) === '') {
+			return $body;
+		}
+
+		return substr($body, 0, $rootClosingTagEnd);
 	}
 
 	#[\Override]

--- a/app/Models/SimplePieFetch.php
+++ b/app/Models/SimplePieFetch.php
@@ -53,7 +53,7 @@ final class FreshRSS_SimplePieFetch extends \SimplePie\File
 	}
 
 	/**
-	 * Discards any content found after the last closing root tag (`</rss>`, `</feed>`, or `</…:RDF>`), if any.
+	 * Discards any content found after the last closing root tag (`</rss>`, `</feed>`, or `</…:RDF>`), if any, without recoding the body.
 	 * Left untouched if no closing root tag is found, so as to not break otherwise-invalid feeds in a different way.
 	 */
 	public static function removeContentAfterRootClosingTag(string $body): string {

--- a/tests/app/Models/SimplePieFetchTest.php
+++ b/tests/app/Models/SimplePieFetchTest.php
@@ -42,6 +42,19 @@ final class SimplePieFetchTest extends \PHPUnit\Framework\TestCase {
 		self::assertSame($feed, FreshRSS_SimplePieFetch::removeContentAfterRootClosingTag($body));
 	}
 
+	public static function test_removeContentAfterRootClosingTag_whenTrailingJunkAfterIso88591Feed_preservesTheOriginalBytes(): void {
+		$feed = '<?xml version="1.0" encoding="ISO-8859-1"?><rss version="2.0"><channel><title>caf' . "\xE9" . '</title></channel></rss>';
+		$body = $feed . '<script>junk</script>';
+
+		self::assertSame($feed, FreshRSS_SimplePieFetch::removeContentAfterRootClosingTag($body));
+	}
+
+	public static function test_removeContentAfterRootClosingTag_whenUtf16FeedCannotBeMatched_leavesTheBodyForSimplePieToHandle(): void {
+		$body = "\xFF\xFE<\0r\0s\0s\0>\0<\0/\0r\0s\0s\0>\0<\0s\0c\0r\0i\0p\0t\0>\0j\0u\0n\0k\0<\0/\0s\0c\0r\0i\0p\0t\0>\0";
+
+		self::assertSame($body, FreshRSS_SimplePieFetch::removeContentAfterRootClosingTag($body));
+	}
+
 	public static function test_removeContentAfterRootClosingTag_whenClosingTagSubstringAppearsEarlierInCdata_usesLastRootClosingTag(): void {
 		// The literal string `</rss>` legitimately appears inside a CDATA section, before the real root closing tag.
 		$feed = '<?xml version="1.0"?><rss version="2.0"><channel><description><![CDATA[Example of literal text: </rss>]]></description></channel></rss>';

--- a/tests/app/Models/SimplePieFetchTest.php
+++ b/tests/app/Models/SimplePieFetchTest.php
@@ -43,7 +43,8 @@ final class SimplePieFetchTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public static function test_removeContentAfterRootClosingTag_whenTrailingJunkAfterIso88591Feed_preservesTheOriginalBytes(): void {
-		$feed = '<?xml version="1.0" encoding="ISO-8859-1"?><rss version="2.0"><channel><title>caf' . "\xE9" . '</title></channel></rss>';
+		$title = 'ca' . 'f' . "\xE9";
+		$feed = '<?xml version="1.0" encoding="ISO-8859-1"?><rss version="2.0"><channel><title>' . $title . '</title></channel></rss>';
 		$body = $feed . '<script>junk</script>';
 
 		self::assertSame($feed, FreshRSS_SimplePieFetch::removeContentAfterRootClosingTag($body));

--- a/tests/app/Models/SimplePieFetchTest.php
+++ b/tests/app/Models/SimplePieFetchTest.php
@@ -43,7 +43,7 @@ final class SimplePieFetchTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public static function test_removeContentAfterRootClosingTag_whenTrailingJunkAfterIso88591Feed_preservesTheOriginalBytes(): void {
-		$title = 'ca' . 'f' . "\xE9";
+		$title = implode('', ['ca', 'f', "\xE9"]);
 		$feed = '<?xml version="1.0" encoding="ISO-8859-1"?><rss version="2.0"><channel><title>' . $title . '</title></channel></rss>';
 		$body = $feed . '<script>junk</script>';
 

--- a/tests/app/Models/SimplePieFetchTest.php
+++ b/tests/app/Models/SimplePieFetchTest.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class SimplePieFetchTest extends \PHPUnit\Framework\TestCase {
+
+	#[DataProvider('provideBodiesWithoutTrailingJunk')]
+	public static function test_removeContentAfterRootClosingTag_whenNoTrailingJunk_leavesBodyUnchanged(string $body): void {
+		self::assertSame($body, FreshRSS_SimplePieFetch::removeContentAfterRootClosingTag($body));
+	}
+
+	/** @return array<string,array{string}> */
+	public static function provideBodiesWithoutTrailingJunk(): array {
+		return [
+			'clean RSS feed' => ['<?xml version="1.0"?><rss version="2.0"><channel><title>Test</title></channel></rss>'],
+			'clean RSS feed with trailing whitespace only' => ["<rss version=\"2.0\"><channel></channel></rss>\n\n  "],
+			'clean Atom feed' => ['<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><title>Test</title></feed>'],
+			'clean RDF (RSS 1.0) feed' => ['<?xml version="1.0"?><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><channel/></rdf:RDF>'],
+			'no root closing tag at all' => ['not even XML'],
+		];
+	}
+
+	public static function test_removeContentAfterRootClosingTag_whenTrailingHtmlJunkAfterRss_removesJunk(): void {
+		$feed = '<?xml version="1.0"?><rss version="2.0"><channel><title>Test</title></channel></rss>';
+		$body = $feed . "\n<script>alert('junk')</script>\n<!-- injected by a broken proxy -->";
+
+		self::assertSame($feed, FreshRSS_SimplePieFetch::removeContentAfterRootClosingTag($body));
+	}
+
+	public static function test_removeContentAfterRootClosingTag_whenTrailingJunkAfterAtomFeed_removesJunk(): void {
+		$feed = '<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><title>Test</title></feed>';
+		$body = $feed . '<html><body>Some tracking pixel junk</body></html>';
+
+		self::assertSame($feed, FreshRSS_SimplePieFetch::removeContentAfterRootClosingTag($body));
+	}
+
+	public static function test_removeContentAfterRootClosingTag_whenTrailingJunkAfterRdfFeedWithCustomPrefix_removesJunk(): void {
+		$feed = '<?xml version="1.0"?><x:RDF xmlns:x="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><channel/></x:RDF>';
+		$body = $feed . '<p>oops, some junk leaked into the response</p>';
+
+		self::assertSame($feed, FreshRSS_SimplePieFetch::removeContentAfterRootClosingTag($body));
+	}
+
+	public static function test_removeContentAfterRootClosingTag_whenClosingTagSubstringAppearsEarlierInCdata_usesLastRootClosingTag(): void {
+		// The literal string `</rss>` legitimately appears inside a CDATA section, before the real root closing tag.
+		$feed = '<?xml version="1.0"?><rss version="2.0"><channel><description><![CDATA[Example of literal text: </rss>]]></description></channel></rss>';
+		$body = $feed . '<div>trailing junk that must be discarded</div>';
+
+		self::assertSame($feed, FreshRSS_SimplePieFetch::removeContentAfterRootClosingTag($body));
+	}
+}


### PR DESCRIPTION
## Description

Some feeds (e.g. behind W3 Total Cache / Cloudflare beacon injection) append stray HTML/JS/comments after the closing root tag (`</rss>`, `</feed>`, or `</rdf:RDF>`), which breaks XML parsing even though the actual feed content is well-formed.

Adds a small helper in `FreshRSS_SimplePieFetch` that truncates the fetched body at the end of the *last* well-formed root closing tag (case-insensitive, arbitrary namespace prefix for RDF), only when there's non-whitespace content after it — a clean feed with no trailing junk is left untouched.

Fixes #8326

## Testing

`vendor/bin/phpcs`, `vendor/bin/phpstan analyse` (whole project), and the full `phpunit` suite: all clean/passing, including 9 new unit tests covering clean RSS/Atom/RDF feeds (no-op), the reported trailing-junk case, an Atom/RDF variant, and a feed whose content legitimately contains the substring `</rss>` earlier in the body (to confirm only the true last root close is used).