### PR TITLE
Sort labels with locale-aware collation

### DIFF
--- a/app/Models/TagDAO.php
+++ b/app/Models/TagDAO.php
@@ -233,7 +233,9 @@ class FreshRSS_TagDAO extends Minz_ModelPdo {
 		$res = $this->fetchAssoc($sql);
 		if ($res !== null) {
 			/** @var list<array{id:int,name:string,unreads:int}> $res */
-			return self::daoToTags($res);
+			$tags = self::daoToTags($res);
+			uasort($tags, static fn(FreshRSS_Tag $a, FreshRSS_Tag $b) => FreshRSS_Context::localeCompare($a->name(), $b->name()));
+			return $tags;
 		} else {
 			$info = $this->pdo->errorInfo();
 			Minz_Log::error('SQL error ' . __METHOD__ . json_encode($info));


### PR DESCRIPTION
## Description

Three of the four sub-items in this issue (styling, slider-based edit, missing page title) were already fixed by #6212. This finishes the last one: labels were sorted in raw SQL (ASCII/case-sensitive), not locale-aware.

Applies the same `FreshRSS_Context::localeCompare()` sort that was just added for categories, feeds, and shares in #8985, to label sorting too.

Fixes #6211

## Testing

`vendor/bin/phpcs` and `vendor/bin/phpstan analyse` (whole project): no errors. Verified manually with mixed-case/accented label names.