### PR TITLE
Use :user-invalid instead of :invalid for form field styling

### DIFF
--- a/p/themes/Ansum/_forms.css
+++ b/p/themes/Ansum/_forms.css
@@ -94,6 +94,12 @@ input:focus, select:focus, textarea:focus {
 	border-color: var(--main-first);
 }
 
+input:-moz-ui-invalid, select:-moz-ui-invalid {
+	color: var(--alert-bg);
+	border-color: var(--alert-bg);
+	box-shadow: none;
+}
+
 input:user-invalid, select:user-invalid {
 	color: var(--alert-bg);
 	border-color: var(--alert-bg);

--- a/p/themes/Ansum/_forms.css
+++ b/p/themes/Ansum/_forms.css
@@ -94,12 +94,6 @@ input:focus, select:focus, textarea:focus {
 	border-color: var(--main-first);
 }
 
-input:-moz-ui-invalid, select:-moz-ui-invalid {
-	color: var(--alert-bg);
-	border-color: var(--alert-bg);
-	box-shadow: none;
-}
-
 input:user-invalid, select:user-invalid {
 	color: var(--alert-bg);
 	border-color: var(--alert-bg);

--- a/p/themes/Ansum/_forms.css
+++ b/p/themes/Ansum/_forms.css
@@ -94,7 +94,7 @@ input:focus, select:focus, textarea:focus {
 	border-color: var(--main-first);
 }
 
-input:invalid, select:invalid {
+input:user-invalid, select:user-invalid {
 	color: var(--alert-bg);
 	border-color: var(--alert-bg);
 	box-shadow: none;

--- a/p/themes/Ansum/_forms.rtl.css
+++ b/p/themes/Ansum/_forms.rtl.css
@@ -94,6 +94,12 @@ input:focus, select:focus, textarea:focus {
 	border-color: var(--main-first);
 }
 
+input:-moz-ui-invalid, select:-moz-ui-invalid {
+	color: var(--alert-bg);
+	border-color: var(--alert-bg);
+	box-shadow: none;
+}
+
 input:user-invalid, select:user-invalid {
 	color: var(--alert-bg);
 	border-color: var(--alert-bg);

--- a/p/themes/Ansum/_forms.rtl.css
+++ b/p/themes/Ansum/_forms.rtl.css
@@ -94,12 +94,6 @@ input:focus, select:focus, textarea:focus {
 	border-color: var(--main-first);
 }
 
-input:-moz-ui-invalid, select:-moz-ui-invalid {
-	color: var(--alert-bg);
-	border-color: var(--alert-bg);
-	box-shadow: none;
-}
-
 input:user-invalid, select:user-invalid {
 	color: var(--alert-bg);
 	border-color: var(--alert-bg);

--- a/p/themes/Ansum/_forms.rtl.css
+++ b/p/themes/Ansum/_forms.rtl.css
@@ -94,7 +94,7 @@ input:focus, select:focus, textarea:focus {
 	border-color: var(--main-first);
 }
 
-input:invalid, select:invalid {
+input:user-invalid, select:user-invalid {
 	color: var(--alert-bg);
 	border-color: var(--alert-bg);
 	box-shadow: none;

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -54,6 +54,12 @@ input:focus, select:focus, textarea:focus {
 	border-color: #2980b9;
 }
 
+input:-moz-ui-invalid, select:-moz-ui-invalid {
+	color: #f00;
+	border-color: #f00;
+	box-shadow: none;
+}
+
 input:user-invalid, select:user-invalid {
 	color: #f00;
 	border-color: #f00;

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -54,12 +54,6 @@ input:focus, select:focus, textarea:focus {
 	border-color: #2980b9;
 }
 
-input:-moz-ui-invalid, select:-moz-ui-invalid {
-	color: #f00;
-	border-color: #f00;
-	box-shadow: none;
-}
-
 input:user-invalid, select:user-invalid {
 	color: #f00;
 	border-color: #f00;

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -54,7 +54,7 @@ input:focus, select:focus, textarea:focus {
 	border-color: #2980b9;
 }
 
-input:invalid, select:invalid {
+input:user-invalid, select:user-invalid {
 	color: #f00;
 	border-color: #f00;
 	box-shadow: none;

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -54,6 +54,12 @@ input:focus, select:focus, textarea:focus {
 	border-color: #2980b9;
 }
 
+input:-moz-ui-invalid, select:-moz-ui-invalid {
+	color: #f00;
+	border-color: #f00;
+	box-shadow: none;
+}
+
 input:user-invalid, select:user-invalid {
 	color: #f00;
 	border-color: #f00;

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -54,12 +54,6 @@ input:focus, select:focus, textarea:focus {
 	border-color: #2980b9;
 }
 
-input:-moz-ui-invalid, select:-moz-ui-invalid {
-	color: #f00;
-	border-color: #f00;
-	box-shadow: none;
-}
-
 input:user-invalid, select:user-invalid {
 	color: #f00;
 	border-color: #f00;

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -54,7 +54,7 @@ input:focus, select:focus, textarea:focus {
 	border-color: #2980b9;
 }
 
-input:invalid, select:invalid {
+input:user-invalid, select:user-invalid {
 	color: #f00;
 	border-color: #f00;
 	box-shadow: none;

--- a/p/themes/Mapco/_forms.css
+++ b/p/themes/Mapco/_forms.css
@@ -94,6 +94,12 @@ input:focus, select:focus, textarea:focus {
 	border-color: var(--main-first);
 }
 
+input:-moz-ui-invalid, select:-moz-ui-invalid {
+	color: var(--alert-bg);
+	border-color: var(--alert-bg);
+	box-shadow: none;
+}
+
 input:user-invalid, select:user-invalid {
 	color: var(--alert-bg);
 	border-color: var(--alert-bg);

--- a/p/themes/Mapco/_forms.css
+++ b/p/themes/Mapco/_forms.css
@@ -94,12 +94,6 @@ input:focus, select:focus, textarea:focus {
 	border-color: var(--main-first);
 }
 
-input:-moz-ui-invalid, select:-moz-ui-invalid {
-	color: var(--alert-bg);
-	border-color: var(--alert-bg);
-	box-shadow: none;
-}
-
 input:user-invalid, select:user-invalid {
 	color: var(--alert-bg);
 	border-color: var(--alert-bg);

--- a/p/themes/Mapco/_forms.css
+++ b/p/themes/Mapco/_forms.css
@@ -94,7 +94,7 @@ input:focus, select:focus, textarea:focus {
 	border-color: var(--main-first);
 }
 
-input:invalid, select:invalid {
+input:user-invalid, select:user-invalid {
 	color: var(--alert-bg);
 	border-color: var(--alert-bg);
 	box-shadow: none;

--- a/p/themes/Mapco/_forms.rtl.css
+++ b/p/themes/Mapco/_forms.rtl.css
@@ -94,6 +94,12 @@ input:focus, select:focus, textarea:focus {
 	border-color: var(--main-first);
 }
 
+input:-moz-ui-invalid, select:-moz-ui-invalid {
+	color: var(--alert-bg);
+	border-color: var(--alert-bg);
+	box-shadow: none;
+}
+
 input:user-invalid, select:user-invalid {
 	color: var(--alert-bg);
 	border-color: var(--alert-bg);

--- a/p/themes/Mapco/_forms.rtl.css
+++ b/p/themes/Mapco/_forms.rtl.css
@@ -94,12 +94,6 @@ input:focus, select:focus, textarea:focus {
 	border-color: var(--main-first);
 }
 
-input:-moz-ui-invalid, select:-moz-ui-invalid {
-	color: var(--alert-bg);
-	border-color: var(--alert-bg);
-	box-shadow: none;
-}
-
 input:user-invalid, select:user-invalid {
 	color: var(--alert-bg);
 	border-color: var(--alert-bg);

--- a/p/themes/Mapco/_forms.rtl.css
+++ b/p/themes/Mapco/_forms.rtl.css
@@ -94,7 +94,7 @@ input:focus, select:focus, textarea:focus {
 	border-color: var(--main-first);
 }
 
-input:invalid, select:invalid {
+input:user-invalid, select:user-invalid {
 	color: var(--alert-bg);
 	border-color: var(--alert-bg);
 	box-shadow: none;

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -133,9 +133,9 @@ input, select, textarea {
 	line-height: 1;
 }
 
-input:invalid,
-select:invalid,
-textarea:invalid {
+input:user-invalid,
+select:user-invalid,
+textarea:user-invalid {
 	border-color: var(--red);
 }
 

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -133,6 +133,12 @@ input, select, textarea {
 	line-height: 1;
 }
 
+input:-moz-ui-invalid,
+select:-moz-ui-invalid,
+textarea:-moz-ui-invalid {
+	border-color: var(--red);
+}
+
 input:user-invalid,
 select:user-invalid,
 textarea:user-invalid {

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -133,12 +133,6 @@ input, select, textarea {
 	line-height: 1;
 }
 
-input:-moz-ui-invalid,
-select:-moz-ui-invalid,
-textarea:-moz-ui-invalid {
-	border-color: var(--red);
-}
-
 input:user-invalid,
 select:user-invalid,
 textarea:user-invalid {

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -133,9 +133,9 @@ input, select, textarea {
 	line-height: 1;
 }
 
-input:invalid,
-select:invalid,
-textarea:invalid {
+input:user-invalid,
+select:user-invalid,
+textarea:user-invalid {
 	border-color: var(--red);
 }
 

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -133,6 +133,12 @@ input, select, textarea {
 	line-height: 1;
 }
 
+input:-moz-ui-invalid,
+select:-moz-ui-invalid,
+textarea:-moz-ui-invalid {
+	border-color: var(--red);
+}
+
 input:user-invalid,
 select:user-invalid,
 textarea:user-invalid {

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -133,12 +133,6 @@ input, select, textarea {
 	line-height: 1;
 }
 
-input:-moz-ui-invalid,
-select:-moz-ui-invalid,
-textarea:-moz-ui-invalid {
-	border-color: var(--red);
-}
-
 input:user-invalid,
 select:user-invalid,
 textarea:user-invalid {

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -138,6 +138,11 @@ input:focus, select:focus, textarea:focus, input[type="password"]:focus + .toggl
 	outline: none;
 }
 
+input:-moz-ui-invalid, select:-moz-ui-invalid {
+	border-color: var(--form-element-border-color-invalid);
+	box-shadow: 0 0 2px 2px var(--form-element-invalid-box-shadow-color-inset) inset;
+}
+
 input:user-invalid, select:user-invalid {
 	border-color: var(--form-element-border-color-invalid);
 	box-shadow: 0 0 2px 2px var(--form-element-invalid-box-shadow-color-inset) inset;

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -138,11 +138,6 @@ input:focus, select:focus, textarea:focus, input[type="password"]:focus + .toggl
 	outline: none;
 }
 
-input:-moz-ui-invalid, select:-moz-ui-invalid {
-	border-color: var(--form-element-border-color-invalid);
-	box-shadow: 0 0 2px 2px var(--form-element-invalid-box-shadow-color-inset) inset;
-}
-
 input:user-invalid, select:user-invalid {
 	border-color: var(--form-element-border-color-invalid);
 	box-shadow: 0 0 2px 2px var(--form-element-invalid-box-shadow-color-inset) inset;

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -138,7 +138,7 @@ input:focus, select:focus, textarea:focus, input[type="password"]:focus + .toggl
 	outline: none;
 }
 
-input:invalid, select:invalid {
+input:user-invalid, select:user-invalid {
 	border-color: var(--form-element-border-color-invalid);
 	box-shadow: 0 0 2px 2px var(--form-element-invalid-box-shadow-color-inset) inset;
 }

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -138,6 +138,11 @@ input:focus, select:focus, textarea:focus, input[type="password"]:focus + .toggl
 	outline: none;
 }
 
+input:-moz-ui-invalid, select:-moz-ui-invalid {
+	border-color: var(--form-element-border-color-invalid);
+	box-shadow: 0 0 2px 2px var(--form-element-invalid-box-shadow-color-inset) inset;
+}
+
 input:user-invalid, select:user-invalid {
 	border-color: var(--form-element-border-color-invalid);
 	box-shadow: 0 0 2px 2px var(--form-element-invalid-box-shadow-color-inset) inset;

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -138,11 +138,6 @@ input:focus, select:focus, textarea:focus, input[type="password"]:focus + .toggl
 	outline: none;
 }
 
-input:-moz-ui-invalid, select:-moz-ui-invalid {
-	border-color: var(--form-element-border-color-invalid);
-	box-shadow: 0 0 2px 2px var(--form-element-invalid-box-shadow-color-inset) inset;
-}
-
 input:user-invalid, select:user-invalid {
 	border-color: var(--form-element-border-color-invalid);
 	box-shadow: 0 0 2px 2px var(--form-element-invalid-box-shadow-color-inset) inset;

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -138,7 +138,7 @@ input:focus, select:focus, textarea:focus, input[type="password"]:focus + .toggl
 	outline: none;
 }
 
-input:invalid, select:invalid {
+input:user-invalid, select:user-invalid {
 	border-color: var(--form-element-border-color-invalid);
 	box-shadow: 0 0 2px 2px var(--form-element-invalid-box-shadow-color-inset) inset;
 }

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -129,6 +129,11 @@ input:focus, select:focus, textarea:focus {
 	border-color: var(--border-color-grey-dark);
 }
 
+input:-moz-ui-invalid, select:-moz-ui-invalid {
+	border-color: var(--invalid-box-border-color);
+	box-shadow: 0 0 2px 2px var(--invalid-box-shadow-color) inset;
+}
+
 input:user-invalid, select:user-invalid {
 	border-color: var(--invalid-box-border-color);
 	box-shadow: 0 0 2px 2px var(--invalid-box-shadow-color) inset;

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -129,11 +129,6 @@ input:focus, select:focus, textarea:focus {
 	border-color: var(--border-color-grey-dark);
 }
 
-input:-moz-ui-invalid, select:-moz-ui-invalid {
-	border-color: var(--invalid-box-border-color);
-	box-shadow: 0 0 2px 2px var(--invalid-box-shadow-color) inset;
-}
-
 input:user-invalid, select:user-invalid {
 	border-color: var(--invalid-box-border-color);
 	box-shadow: 0 0 2px 2px var(--invalid-box-shadow-color) inset;

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -129,7 +129,7 @@ input:focus, select:focus, textarea:focus {
 	border-color: var(--border-color-grey-dark);
 }
 
-input:invalid, select:invalid {
+input:user-invalid, select:user-invalid {
 	border-color: var(--invalid-box-border-color);
 	box-shadow: 0 0 2px 2px var(--invalid-box-shadow-color) inset;
 }

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -129,6 +129,11 @@ input:focus, select:focus, textarea:focus {
 	border-color: var(--border-color-grey-dark);
 }
 
+input:-moz-ui-invalid, select:-moz-ui-invalid {
+	border-color: var(--invalid-box-border-color);
+	box-shadow: 0 0 2px 2px var(--invalid-box-shadow-color) inset;
+}
+
 input:user-invalid, select:user-invalid {
 	border-color: var(--invalid-box-border-color);
 	box-shadow: 0 0 2px 2px var(--invalid-box-shadow-color) inset;

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -129,11 +129,6 @@ input:focus, select:focus, textarea:focus {
 	border-color: var(--border-color-grey-dark);
 }
 
-input:-moz-ui-invalid, select:-moz-ui-invalid {
-	border-color: var(--invalid-box-border-color);
-	box-shadow: 0 0 2px 2px var(--invalid-box-shadow-color) inset;
-}
-
 input:user-invalid, select:user-invalid {
 	border-color: var(--invalid-box-border-color);
 	box-shadow: 0 0 2px 2px var(--invalid-box-shadow-color) inset;

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -129,7 +129,7 @@ input:focus, select:focus, textarea:focus {
 	border-color: var(--border-color-grey-dark);
 }
 
-input:invalid, select:invalid {
+input:user-invalid, select:user-invalid {
 	border-color: var(--invalid-box-border-color);
 	box-shadow: 0 0 2px 2px var(--invalid-box-shadow-color) inset;
 }

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -170,6 +170,14 @@ label {
 		outline: none;
 	}
 
+	&:-moz-ui-invalid {
+		padding-left: 5px;
+		color: var(--color-text-bad);
+		border-left-color: var(--color-border-bad);
+		border-left-width: 5px;
+		box-shadow: none;
+	}
+
 	&:user-invalid {
 		padding-left: 5px;
 		color: var(--color-text-bad);

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -170,7 +170,7 @@ label {
 		outline: none;
 	}
 
-	&:invalid {
+	&:user-invalid {
 		padding-left: 5px;
 		color: var(--color-text-bad);
 		border-left-color: var(--color-border-bad);

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -170,14 +170,6 @@ label {
 		outline: none;
 	}
 
-	&:-moz-ui-invalid {
-		padding-left: 5px;
-		color: var(--color-text-bad);
-		border-left-color: var(--color-border-bad);
-		border-left-width: 5px;
-		box-shadow: none;
-	}
-
 	&:user-invalid {
 		padding-left: 5px;
 		color: var(--color-text-bad);

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -170,7 +170,7 @@ label {
 		outline: none;
 	}
 
-	&:invalid {
+	&:user-invalid {
 		padding-right: 5px;
 		color: var(--color-text-bad);
 		border-right-color: var(--color-border-bad);

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -170,14 +170,6 @@ label {
 		outline: none;
 	}
 
-	&:-moz-ui-invalid {
-		padding-right: 5px;
-		color: var(--color-text-bad);
-		border-right-color: var(--color-border-bad);
-		border-right-width: 5px;
-		box-shadow: none;
-	}
-
 	&:user-invalid {
 		padding-right: 5px;
 		color: var(--color-text-bad);

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -170,6 +170,14 @@ label {
 		outline: none;
 	}
 
+	&:-moz-ui-invalid {
+		padding-right: 5px;
+		color: var(--color-text-bad);
+		border-right-color: var(--color-border-bad);
+		border-right-width: 5px;
+		box-shadow: none;
+	}
+
 	&:user-invalid {
 		padding-right: 5px;
 		color: var(--color-text-bad);

--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -39,6 +39,9 @@ option {
 input:focus, select:focus, textarea:focus {
 }
 
+input:-moz-ui-invalid, select:-moz-ui-invalid {
+}
+
 input:user-invalid, select:user-invalid {
 }
 

--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -39,9 +39,6 @@ option {
 input:focus, select:focus, textarea:focus {
 }
 
-input:-moz-ui-invalid, select:-moz-ui-invalid {
-}
-
 input:user-invalid, select:user-invalid {
 }
 

--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -39,7 +39,7 @@ option {
 input:focus, select:focus, textarea:focus {
 }
 
-input:invalid, select:invalid {
+input:user-invalid, select:user-invalid {
 }
 
 input:disabled, select:disabled {

--- a/p/themes/base-theme/base.rtl.css
+++ b/p/themes/base-theme/base.rtl.css
@@ -39,6 +39,9 @@ option {
 input:focus, select:focus, textarea:focus {
 }
 
+input:-moz-ui-invalid, select:-moz-ui-invalid {
+}
+
 input:user-invalid, select:user-invalid {
 }
 

--- a/p/themes/base-theme/base.rtl.css
+++ b/p/themes/base-theme/base.rtl.css
@@ -39,9 +39,6 @@ option {
 input:focus, select:focus, textarea:focus {
 }
 
-input:-moz-ui-invalid, select:-moz-ui-invalid {
-}
-
 input:user-invalid, select:user-invalid {
 }
 

--- a/p/themes/base-theme/base.rtl.css
+++ b/p/themes/base-theme/base.rtl.css
@@ -39,7 +39,7 @@ option {
 input:focus, select:focus, textarea:focus {
 }
 
-input:invalid, select:invalid {
+input:user-invalid, select:user-invalid {
 }
 
 input:disabled, select:disabled {

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -373,10 +373,6 @@ textarea[rows="2"] {
 	height: 4em;
 }
 
-textarea:-moz-ui-invalid {
-	border: 2px dashed var(--frss-border-color-error);
-}
-
 textarea:user-invalid {
 	border: 2px dashed var(--frss-border-color-error);
 }

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -373,7 +373,7 @@ textarea[rows="2"] {
 	height: 4em;
 }
 
-textarea:invalid {
+textarea:user-invalid {
 	border: 2px dashed var(--frss-border-color-error);
 }
 

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -373,6 +373,10 @@ textarea[rows="2"] {
 	height: 4em;
 }
 
+textarea:-moz-ui-invalid {
+	border: 2px dashed var(--frss-border-color-error);
+}
+
 textarea:user-invalid {
 	border: 2px dashed var(--frss-border-color-error);
 }

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -373,10 +373,6 @@ textarea[rows="2"] {
 	height: 4em;
 }
 
-textarea:-moz-ui-invalid {
-	border: 2px dashed var(--frss-border-color-error);
-}
-
 textarea:user-invalid {
 	border: 2px dashed var(--frss-border-color-error);
 }

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -373,7 +373,7 @@ textarea[rows="2"] {
 	height: 4em;
 }
 
-textarea:invalid {
+textarea:user-invalid {
 	border: 2px dashed var(--frss-border-color-error);
 }
 

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -373,6 +373,10 @@ textarea[rows="2"] {
 	height: 4em;
 }
 
+textarea:-moz-ui-invalid {
+	border: 2px dashed var(--frss-border-color-error);
+}
+
 textarea:user-invalid {
 	border: 2px dashed var(--frss-border-color-error);
 }


### PR DESCRIPTION
## Description

Required form fields (e.g. the admin "Add user" username field) show a red border immediately on page load, before the user has interacted with them, because every theme styles the bare `:invalid` pseudo-class unconditionally.

This was attempted before in #3724, but was closed over a browser-support concern for `:user-invalid` (only matches after interaction, not on load). That concern is resolved now -- `:user-invalid` has ~89% global support across all evergreen browsers.

Fixes #3647

## Testing

`.rtl.css` files regenerated via `npm run rtlcss`, `npm run stylelint`: no errors. Verified in a local instance: the add-user form shows no red border on load, turns red after leaving an invalid field, clears when corrected.