### PR TITLE
Mailer: allow disabling SMTPAutoTLS via config

### DIFF
--- a/config.default.php
+++ b/config.default.php
@@ -211,6 +211,7 @@ return [
 		'username' => '',
 		'password' => '',
 		'secure' => '', // '', 'ssl' or 'tls'
+		'auto_tls' => true, // maps to PHPMailer’s `SMTPAutoTLS`; set to false to disable opportunistic STARTTLS, e.g. when using a self-signed certificate
 		'from' => 'root@localhost',
 	],
 

--- a/docs/en/admins/05_Configuring_email_validation.md
+++ b/docs/en/admins/05_Configuring_email_validation.md
@@ -45,6 +45,7 @@ PHPMailer documentation](https://phpmailer.github.io/PHPMailer/classes/PHPMailer
 		'username' => 'alice', // or maybe alice@example.net
 		'password' => 'yoursecretpassword',
 		'secure' => 'ssl', // '', 'ssl' or 'tls'
+		'auto_tls' => true, // set to false to disable opportunistic STARTTLS, e.g. when using a self-signed certificate
 		'from' => 'alice@example.net',
 	],
 ```

--- a/lib/Minz/Configuration.php
+++ b/lib/Minz/Configuration.php
@@ -10,7 +10,8 @@ declare(strict_types=1);
  * @property string $environment
  * @property array<string,bool> $extensions_enabled
  * @property-read string $mailer
- * @property-read array{'hostname':string,'host':string,'auth':bool,'username':string,'password':string,'secure':string,'port':int,'from':string} $smtp
+ * @property-read array{'hostname':string,'host':string,'auth':bool,'username':string,'password':string,
+ *  'secure':string,'auto_tls':bool,'port':int,'from':string} $smtp
  * @property string $title
  */
 class Minz_Configuration {

--- a/lib/Minz/Mailer.php
+++ b/lib/Minz/Mailer.php
@@ -30,7 +30,7 @@ class Minz_Mailer {
 	protected $view;
 
 	private string $mailer;
-	/** @var array{'hostname':string,'host':string,'auth':bool,'username':string,'password':string,'secure':string,'port':int,'from':string} */
+	/** @var array{'hostname':string,'host':string,'auth':bool,'username':string,'password':string,'secure':string,'auto_tls':bool,'port':int,'from':string} */
 	private array $smtp_config;
 	private int $debug_level;
 
@@ -94,6 +94,7 @@ class Minz_Mailer {
 				$mail->Username = $this->smtp_config['username'];
 				$mail->Password = $this->smtp_config['password'];
 				$mail->SMTPSecure = $this->smtp_config['secure'];
+				$mail->SMTPAutoTLS = $this->smtp_config['auto_tls'];
 				$mail->Port = $this->smtp_config['port'];
 			} else {
 				$mail->isMail();


### PR DESCRIPTION
## Description

FreshRSS's mailer never sets PHPMailer's `SMTPAutoTLS`, so its default (`true`) always applies regardless of the documented `secure => ''` setting -- meaning opportunistic TLS can't actually be disabled through configuration as documented.

Adds a `smtp.auto_tls` config option (defaulting to `true`, preserving current behavior) that's threaded through to PHPMailer.

Scoped narrowly to this -- the custom root CA / Docker-image suggestion also raised in the issue is left out of scope.

Fixes #2997

## Testing

`vendor/bin/phpcs` and `vendor/bin/phpstan analyse` (whole project): no errors. Verified against a local SMTP test server with a self-signed cert that `auto_tls=false` sends unencrypted while the default preserves today's opportunistic-TLS behavior.