### PR TITLE
Dispatch a JS event when an entry finishes being marked read/unread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ See also [the FreshRSS releases](https://github.com/FreshRSS/FreshRSS/releases).
 * Features
 	* New option to hide badges showing number of unread articles (*Phantom Obligation*) [#8844](https://github.com/FreshRSS/FreshRSS/pull/8844)
 	* New option to keep or not the custom sort order when navigating between categories and feeds [#8969](https://github.com/FreshRSS/FreshRSS/pull/8969)
+	* New `freshrss:entryStateChange` JavaScript event for extensions, dispatched when an article has finished being marked as read/unread [#8862](https://github.com/FreshRSS/FreshRSS/issues/8862)
 * Bug fixing
 	* Fix lost elements while parsing search query [#8884](https://github.com/FreshRSS/FreshRSS/pull/8884)
 * CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ See also [the FreshRSS releases](https://github.com/FreshRSS/FreshRSS/releases).
 * Features
 	* New option to hide badges showing number of unread articles (*Phantom Obligation*) [#8844](https://github.com/FreshRSS/FreshRSS/pull/8844)
 	* New option to keep or not the custom sort order when navigating between categories and feeds [#8969](https://github.com/FreshRSS/FreshRSS/pull/8969)
-	* New `freshrss:entryStateChange` JavaScript event for extensions, dispatched when an article has finished being marked as read/unread [#8862](https://github.com/FreshRSS/FreshRSS/issues/8862)
 * Bug fixing
 	* Fix lost elements while parsing search query [#8884](https://github.com/FreshRSS/FreshRSS/pull/8884)
 * CLI
@@ -32,6 +31,8 @@ See also [the FreshRSS releases](https://github.com/FreshRSS/FreshRSS/releases).
 	* Always jump article to top when header is offscreen, also when **Stick the article to the top when opened* is disabled [#8870](https://github.com/FreshRSS/FreshRSS/pull/8870)
 	* Fix padding for `.nav_menu` in Alternative-Dark, Flat, and Nord themes [#8901](https://github.com/FreshRSS/FreshRSS/pull/8901)
 	* Various UI and style improvements: [#8823](https://github.com/FreshRSS/FreshRSS/pull/8823), [#8824](https://github.com/FreshRSS/FreshRSS/pull/8824)
+* Extensions
+	* New `freshrss:entryStateChange` JavaScript event for extensions, dispatched when an article has finished being marked as read/unread [#8862](https://github.com/FreshRSS/FreshRSS/pull/9031)
 * I18n
 	* Improve Hungarian [#8879](https://github.com/FreshRSS/FreshRSS/pull/8879)
 	* Improve Italian [#8880](https://github.com/FreshRSS/FreshRSS/pull/8880)

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -105,6 +105,7 @@ People are sorted by name so please keep this order.
 * [FromTheMoon85](https://github.com/FromTheMoon85): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:FromTheMoon85)
 * [Gabriele Biggio](https://github.com/gabbihive): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:gabbihive)
 * [Gaurav Thakur](https://github.com/notfoss): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:notfoss), [Web](https://blog.notfoss.com/)
+* [Gerard Alvear](https://github.com/Elgeryy1): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Elgeryy1)
 * [Gianni Scolaro](https://github.com/giannidsp): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:giannidsp)
 * [Glyn Normington](https://github.com/glyn): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:glyn), [Web](https://underlap.org/)
 * [Gregor Nathanael Meyer](https://github.com/spackmat): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:spackmat), [Web](https://der-meyer.de)

--- a/docs/en/developers/03_Backend/05_Extensions.md
+++ b/docs/en/developers/03_Backend/05_Extensions.md
@@ -225,6 +225,7 @@ if (document.readyState && document.readyState !== 'loading' && typeof window.co
 The following events are available:
 
 * `freshrss:globalContextLoaded`: will be dispatched after load the global `context` variable, useful for referencing variables injected with the `Minz_HookType::JsVars` hook.
+* `freshrss:entryStateChange`: will be dispatched on `document` after an entry has finished being marked as read or unread (i.e. once the underlying AJAX request has completed). The `detail` property of the event contains `id` (the entry ID) and `isRead` (the new read state). Useful for extensions that display their own read/unread indicator outside of the main article list, e.g. in a custom reading pane.
 
 ### Injecting CDN content
 

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -289,6 +289,13 @@ async function send_mark_read_queue(queue, asRead, callback) {
 			incUnreadsFeed(div, feed_id, inc);
 		}
 		delete pending_entries['flux_' + queue[i]];
+		// Let extensions know an entry finished being marked as read/unread, e.g. to update icons outside of `div` (#8862)
+		document.dispatchEvent(new CustomEvent('freshrss:entryStateChange', {
+			detail: {
+				id: queue[i],
+				isRead: !div.classList.contains('not_read'),
+			},
+		}));
 	}
 	faviconNbUnread();
 	if (json.tags) {

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -289,7 +289,7 @@ async function send_mark_read_queue(queue, asRead, callback) {
 			incUnreadsFeed(div, feed_id, inc);
 		}
 		delete pending_entries['flux_' + queue[i]];
-		// Let extensions know an entry finished being marked as read/unread, e.g. to update icons outside of `div` (#8862)
+		// Let extensions know an entry finished being marked as read/unread
 		document.dispatchEvent(new CustomEvent('freshrss:entryStateChange', {
 			detail: {
 				id: queue[i],


### PR DESCRIPTION
## Summary

Fixes #8862.

Extensions that render their own read/unread indicator outside of the main article list (e.g. a custom reading pane, like the ThreePanesView extension mentioned in the issue) have no way to know when a mark read/unread AJAX request completes, so their own UI can get stuck (e.g. a spinner that never resets).

This dispatches a `freshrss:entryStateChange` event on `document` in `send_mark_read_queue()` in `p/scripts/main.js`, once the read/unread state has actually been toggled for an entry. The event's `detail` contains `id` (entry id) and `isRead` (new state).

This follows the naming and dispatch convention already used for the other undocumented/documented `freshrss:*` events in the same file (`freshrss:globalContextLoaded`, `freshrss:openArticle`, `freshrss:load-more`), and covers every code path that toggles read state through this function: single-entry marking, batched marking, and keyboard-shortcut/auto-mark-on-scroll actions all funnel through `send_mark_read_queue()`.

Also documented the new event in `docs/en/developers/03_Backend/05_Extensions.md` and added a changelog entry.

## Test plan

- [x] `npm run eslint` passes on `p/scripts/main.js`
- [x] `npm run markdownlint` passes on the changed docs/changelog files
- [ ] Manually verified in a browser that the event fires with the correct `id`/`isRead` when marking an entry read/unread (single and batch)