### PR TITLE
Respect per-feed proxy settings when downloading favicons

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -459,11 +459,11 @@ class FreshRSS_Feed extends Minz_Model {
 			if ($txt_mtime != false &&
 				($ico_mtime == false || $ico_mtime < $txt_mtime || ($ico_mtime < time() - (14 * 86400)))) {
 				// no ico file or we should download a new one.
-				if ($feedIconUrl !== '' && download_favicon_from_image_url($feedIconUrl, $ico)) {
+				if ($feedIconUrl !== '' && download_favicon_from_image_url($feedIconUrl, $ico, $this->attributes(), $this->curlOptions())) {
 					return;
 				}
 				// Fall back to website favicon search
-				if (!download_favicon($websiteUrl, $ico)) {
+				if (!download_favicon($websiteUrl, $ico, $this->attributes(), $this->curlOptions())) {
 					touch($ico);
 				}
 			}

--- a/lib/favicons.php
+++ b/lib/favicons.php
@@ -25,14 +25,19 @@ function faviconCachePath(string $url): string {
 	return CACHE_PATH . '/' . sha1($url) . '.ico';
 }
 
-function searchFavicon(string $url): string {
+/**
+ * @param array<string,mixed> $attributes May contain user-defined cURL options in `$attributes['curl_params']`, e.g. from `Feed::attributes()`
+ * @param array<int,mixed> $curl_options Internal overrides of cURL options, e.g. from `Feed::curlOptions()`
+ */
+function searchFavicon(string $url, array $attributes = [], array $curl_options = []): string {
 	$url = trim($url);
 	if ($url === '') {
 		return '';
 	}
 	$dom = new DOMDocument();
 	['body' => $html, 'effective_url' => $effective_url, 'fail' => $fail] =
-		FreshRSS_http_Util::httpGet($url, cachePath: CACHE_PATH . '/' . sha1($url) . '.html', type: 'html');
+		FreshRSS_http_Util::httpGet($url, cachePath: CACHE_PATH . '/' . sha1($url) . '.html', type: 'html',
+			attributes: $attributes, curl_options: $curl_options);
 	if ($fail || $html === '' || !@$dom->loadHTML($html, LIBXML_NONET | LIBXML_NOERROR | LIBXML_NOWARNING)) {
 		return '';
 	}
@@ -74,9 +79,9 @@ function searchFavicon(string $url): string {
 		if (!is_string($iri) || $iri === '') {
 			continue;
 		}
-		$favicon = FreshRSS_http_Util::httpGet($iri, faviconCachePath($iri), 'ico', curl_options: [
+		$favicon = FreshRSS_http_Util::httpGet($iri, faviconCachePath($iri), 'ico', attributes: $attributes, curl_options: array_replace($curl_options, [
 			CURLOPT_REFERER => $effective_url,
-		])['body'];
+		]))['body'];
 		if (isImgMime($favicon)) {
 			return $favicon;
 		}
@@ -87,36 +92,43 @@ function searchFavicon(string $url): string {
 /**
  * Downloads a favicon directly from a known image URL (e.g. from a feed's <image><url> or icon field).
  * Returns false without any fallback if the URL does not point to a valid image.
+ *
+ * @param array<string,mixed> $attributes May contain user-defined cURL options in `$attributes['curl_params']`, e.g. from `Feed::attributes()`
+ * @param array<int,mixed> $curl_options Internal overrides of cURL options, e.g. from `Feed::curlOptions()`
  */
-function download_favicon_from_image_url(string $imageUrl, string $dest): bool {
+function download_favicon_from_image_url(string $imageUrl, string $dest, array $attributes = [], array $curl_options = []): bool {
 	$imageUrl = FreshRSS_http_Util::checkUrl($imageUrl);
 	if (!is_string($imageUrl) || $imageUrl === '') {
 		return false;
 	}
-	$favicon = FreshRSS_http_Util::httpGet($imageUrl, faviconCachePath($imageUrl), 'ico')['body'];
+	$favicon = FreshRSS_http_Util::httpGet($imageUrl, faviconCachePath($imageUrl), 'ico', $attributes, $curl_options)['body'];
 	if (!isImgMime($favicon)) {
 		return false;
 	}
 	return file_put_contents($dest, $favicon) > 0;
 }
 
-function download_favicon(string $url, string $dest): bool {
+/**
+ * @param array<string,mixed> $attributes May contain user-defined cURL options in `$attributes['curl_params']`, e.g. from `Feed::attributes()`
+ * @param array<int,mixed> $curl_options Internal overrides of cURL options, e.g. from `Feed::curlOptions()`
+ */
+function download_favicon(string $url, string $dest, array $attributes = [], array $curl_options = []): bool {
 	$url = FreshRSS_http_Util::checkUrl($url);
 	if (!is_string($url) || $url === '') {
 		return @copy(DEFAULT_FAVICON, $dest);
 	}
-	$favicon = searchFavicon($url);
+	$favicon = searchFavicon($url, $attributes, $curl_options);
 	if ($favicon == '') {
 		$rootUrl = preg_replace('%^(https?://[^/]+).*$%i', '$1/', $url) ?? $url;
 		if ($rootUrl != $url) {
 			$url = $rootUrl;
-			$favicon = searchFavicon($url);
+			$favicon = searchFavicon($url, $attributes, $curl_options);
 		}
 		if ($favicon == '') {
 			$link = FreshRSS_http_Util::checkUrl($rootUrl . 'favicon.ico', fixScheme: false) ?: '';
-			$favicon = $link === '' ? '' : FreshRSS_http_Util::httpGet($link, faviconCachePath($link), 'ico', curl_options: [
+			$favicon = $link === '' ? '' : FreshRSS_http_Util::httpGet($link, faviconCachePath($link), 'ico', $attributes, array_replace($curl_options, [
 				CURLOPT_REFERER => $url,
-			])['body'];
+			]))['body'];
 			if (!isImgMime($favicon)) {
 				$favicon = '';
 			}

--- a/p/f.php
+++ b/p/f.php
@@ -59,6 +59,9 @@ if (($ico_mtime == false || $ico_mtime < $txt_mtime || ($ico_mtime < time() - (r
 
 	// Try downloading the URL as a direct image first (e.g. from a feed's <image><url>),
 	// then fall back to HTML favicon search if it is not a valid image.
+	// TODO: This on-demand endpoint only has the favicon hash and the stored URL (no live Feed
+	// object), so a feed's per-feed proxy/cURL settings (curl_params) are not applied here yet.
+	// Fixing this would require persisting sanitized curl_options alongside the .txt file.
 	if (!download_favicon_from_image_url($url, $ico) && !download_favicon($url, $ico)) {
 		// Download failed
 		if ($ico_mtime == false) {


### PR DESCRIPTION
Fixes #8976

Changes proposed in this pull request:

- The favicon download functions in `lib/favicons.php` (`searchFavicon()`, `download_favicon()`, `download_favicon_from_image_url()`) now accept the feed's HTTP `attributes` and `curl_options`, and forward them to `FreshRSS_http_Util::httpGet()`.
- `Feed::faviconPrepare()` passes `$this->attributes()` and `$this->curlOptions()` through, the same way `Feed::loadJson()` and the XPath loader already do for regular feed content fetches.

This means a feed configured with a per-feed proxy (or other `curl_params`, such as a custom user agent or cookie) will now use that same configuration when FreshRSS downloads its favicon, instead of only using it for the feed content itself.

Scope note: the on-demand `/p/f.php` endpoint (used to lazily (re)download a favicon on request) only has the favicon hash and a stored URL in a `.txt` file, with no live `Feed` object to read `curl_params` from. Applying per-feed proxy settings there would require persisting sanitized `curl_options` alongside that file, which felt like a bigger change than this bug warrants. I left a `// TODO` there noting it as a known follow-up rather than bundling it into this fix.

How to test the feature manually:

1. Configure a feed with a proxy under its subscription settings (`curl_params` / proxy address field).
2. Trigger a favicon refresh for that feed (e.g. via `cli/actualize-user.php` or by re-adding the feed).
3. Confirm the favicon request goes out through the configured proxy.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (no existing test infrastructure covers favicon downloading, which performs live HTTP/cURL calls)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).