### PR TITLE
fix(js): use Event() constructor instead of deprecated initEvent()

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -439,8 +439,7 @@ function mark_favorite(div) {
 	}));
 }
 
-const freshrssOpenArticleEvent = document.createEvent('Event');
-freshrssOpenArticleEvent.initEvent('freshrss:openArticle', true, true);
+const freshrssOpenArticleEvent = new Event('freshrss:openArticle', { bubbles: true, cancelable: true });
 
 function loadLazyImages(rootElement) {
 	rootElement.querySelectorAll('img[data-original], iframe[data-original], video[data-original], track[data-original]').forEach(function (el) {
@@ -2247,8 +2246,7 @@ function load_more_posts() {
 	req.send();
 }
 
-const freshrssLoadMoreEvent = document.createEvent('Event');
-freshrssLoadMoreEvent.initEvent('freshrss:load-more', true, true);
+const freshrssLoadMoreEvent = new Event('freshrss:load-more', { bubbles: true, cancelable: true });
 
 function init_load_more(box) {
 	box_load_more = box;


### PR DESCRIPTION
Fixes #5152

## Changes proposed in this pull request

`document.createEvent('Event')` + `Event.initEvent()` are deprecated (https://developer.mozilla.org/en-US/docs/Web/API/Event/initEvent). This replaces the two remaining usages in `p/scripts/main.js` with the standard `new Event(name, { bubbles, cancelable })` constructor:

- `freshrss:openArticle`
- `freshrss:load-more`

Both `bubbles` and `cancelable` are kept `true`, exactly matching the previous `initEvent('…', true, true)`, so dispatch behaviour is unchanged (verified with a jsdom A/B: same type, bubbling to `document`, cancelable). This mirrors the pattern already used for `freshrss:slider-load` in `p/scripts/extra.js`, and follows @Frenzie's suggestion on the issue.

`p/scripts/` no longer uses jQuery, so the old concern about jQuery only catching the legacy syntax no longer applies — these events are dispatched to and listened for via native `addEventListener`.

## How to test manually

- Open an article in the normal/reader view (dispatches `freshrss:openArticle`).
- Scroll to load more articles (dispatches `freshrss:load-more` on `document.body`).
- Both continue to work with no console errors.

## Pull request checklist

- [x] clear commit messages
- [x] `eslint` clean
- [x] code manually tested
