### PR TITLE
Fix SQL errors breaking regular-expression search on MySQL / MariaDB

### DIFF
--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -1226,7 +1226,7 @@ class FreshRSS_EntryDAO extends Minz_ModelPdo {
 			if ($filter->getIntextRegex() !== null) {
 				if (static::isCompressed()) {	// MySQL-only
 					foreach ($filter->getIntextRegex() as $content) {
-						$sub_search .= 'AND ' . static::sqlRegex("UNCOMPRESS({$alias}content_bin)", $content, $values) . ') ';
+						$sub_search .= 'AND ' . static::sqlRegex("UNCOMPRESS({$alias}content_bin)", $content, $values) . ' ';
 					}
 				} else {
 					foreach ($filter->getIntextRegex() as $content) {
@@ -1295,7 +1295,7 @@ class FreshRSS_EntryDAO extends Minz_ModelPdo {
 			if ($filter->getNotIntextRegex() !== null) {
 				if (static::isCompressed()) {	// MySQL-only
 					foreach ($filter->getNotIntextRegex() as $content) {
-						$sub_search .= 'AND NOT ' . static::sqlRegex("UNCOMPRESS({$alias}content_bin)", $content, $values) . ') ';
+						$sub_search .= 'AND NOT ' . static::sqlRegex("UNCOMPRESS({$alias}content_bin)", $content, $values) . ' ';
 					}
 				} else {
 					foreach ($filter->getNotIntextRegex() as $content) {
@@ -1365,7 +1365,7 @@ class FreshRSS_EntryDAO extends Minz_ModelPdo {
 				foreach ($filter->getNotSearchRegex() as $search_value) {
 					if (static::isCompressed()) {	// MySQL-only
 						$sub_search .= 'AND NOT ' . static::sqlRegex($alias . 'title', $search_value, $values) .
-							' ANT NOT ' . static::sqlRegex("UNCOMPRESS({$alias}content_bin)", $search_value, $values) . ' ';
+							' AND NOT ' . static::sqlRegex("UNCOMPRESS({$alias}content_bin)", $search_value, $values) . ' ';
 					} else {
 						$sub_search .= 'AND NOT ' . static::sqlRegex($alias . 'title', $search_value, $values) .
 							' AND NOT ' . static::sqlRegex($alias . 'content', $search_value, $values) . ' ';

--- a/tests/app/Models/SearchTest.php
+++ b/tests/app/Models/SearchTest.php
@@ -1007,8 +1007,18 @@ final class SearchTest extends \PHPUnit\Framework\TestCase {
 			],
 			[
 				'intext:/^ab$/m',
-				'(UNCOMPRESS(e.content_bin) REGEXP ?))',
+				'(UNCOMPRESS(e.content_bin) REGEXP ?)',
 				['(?-i)(?m)^ab$']
+			],
+			[
+				'-intext:/^ab$/m',
+				'(NOT UNCOMPRESS(e.content_bin) REGEXP ?)',
+				['(?-i)(?m)^ab$']
+			],
+			[
+				'-/^ab$/',
+				'(NOT e.title REGEXP ? AND NOT UNCOMPRESS(e.content_bin) REGEXP ?)',
+				['(?-i)^ab$', '(?-i)^ab$']
 			],
 		];
 	}
@@ -1045,8 +1055,18 @@ final class SearchTest extends \PHPUnit\Framework\TestCase {
 			],
 			[
 				'intext:/^ab$/m',
-				"(REGEXP_LIKE(UNCOMPRESS(e.content_bin),?,'mc')))",
+				"(REGEXP_LIKE(UNCOMPRESS(e.content_bin),?,'mc'))",
 				['^ab$']
+			],
+			[
+				'-intext:/^ab$/m',
+				"(NOT REGEXP_LIKE(UNCOMPRESS(e.content_bin),?,'mc'))",
+				['^ab$']
+			],
+			[
+				'-/^ab$/',
+				"(NOT REGEXP_LIKE(e.title,?,'c') AND NOT REGEXP_LIKE(UNCOMPRESS(e.content_bin),?,'c'))",
+				['^ab$', '^ab$']
 			],
 		];
 	}


### PR DESCRIPTION
Regular-expression searches are broken for all MySQL and MariaDB users (the compressed `content_bin` path, `isCompressed() === true`): three of the four regex constructions in `FreshRSS_EntryDAO::sqlBooleanSearch()` generate invalid SQL, the query fails, and the search silently returns zero articles (the SQL error only appears in the user log).

* `intext:/regex/` appends a stray closing parenthesis after `sqlRegex(...)` → MySQL error 1248 *Every derived table must have its own alias*
* `-intext:/regex/` has the same stray parenthesis
* `-/regex/` emits `' ANT NOT '` instead of `' AND NOT '` → MySQL error 1064

`sqlRegex()` already returns a balanced expression (`REGEXP_LIKE(expr,?,'flags')` on MySQL, `expr REGEXP ?` on MariaDB), so no extra parenthesis is needed — matching the SQLite/PostgreSQL branches, which are correct. This also affects filter actions and API searches using regexes, not just the search box.

The existing MySQL/MariaDB unit tests for `intext:/regex/` had captured the buggy unbalanced SQL as their expected strings; they are corrected, and new cases are added for `-intext:/regex/` and `-/regex/` on both flavours.

Tested live on MySQL 8 (FreshRSS edge Docker + real feed, 10 articles of which 8 contain "highlights"):

| search | before | after |
|---|---|---|
| `intext:/highlights/` | 0 articles + SQL error 1248 | 8 articles |
| `-/highlights/` | 0 articles + SQL error 1064 | 2 articles |
| `-intext:/highlights/` | 0 articles + SQL error 1248 | 2 articles |
| `intext:/HIGHLIGHTS/i` vs `/HIGHLIGHTS/` | — | 8 vs 0 (flags OK) |

`tests/app/Models/SearchTest.php`: 253 tests, 513 assertions OK. Found by code audit; written with the help of AI (Claude), personally reviewed and live-tested.
