### PR TITLE
Improve Greek (el) translation

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -229,7 +229,7 @@ Voir le [dépôt dédié à ces extensions](https://github.com/FreshRSS/Extensio
 | - | - | - |
 | Čeština (cs) | ￭￭￭￭￭￭￭￭･･ 81% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fcs+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Deutsch (de) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fde+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Ελληνικά (el) | ￭￭￭￭￭￭￭･･･ 73% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fel+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Ελληνικά (el) | ￭￭￭￭￭￭￭･･･ 76% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fel+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (en) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Español (es) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ See the [repository dedicated to those extensions](https://github.com/FreshRSS/E
 | - | - | - |
 | Čeština (cs) | ￭￭￭￭￭￭￭￭･･ 81% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fcs+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Deutsch (de) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fde+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Ελληνικά (el) | ￭￭￭￭￭￭￭･･･ 73% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fel+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Ελληνικά (el) | ￭￭￭￭￭￭￭･･･ 76% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fel+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (en) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Español (es) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |

--- a/app/i18n/el/index.php
+++ b/app/i18n/el/index.php
@@ -92,41 +92,41 @@ return array(
 			),
 			'date_asc' => 'Publication date 1→9',	// TODO
 			'date_desc' => 'Publication date 9→1',	// TODO
-			'desc' => 'Descending',	// TODO
+			'desc' => 'Φθίνουσα',
 			'f' => array(
 				'name_asc' => 'Feed title A→Z',	// TODO
 				'name_desc' => 'Feed title Z→A',	// TODO
 			),
 			'id_asc' => 'Freshly received last',	// TODO
 			'id_desc' => 'Freshly received first',	// TODO
-			'length_asc' => 'Content length 1→9',	// TODO
-			'length_desc' => 'Content length 9→1',	// TODO
-			'link_asc' => 'Link A→Z',	// TODO
-			'link_desc' => 'Link Z→A',	// TODO
+			'length_asc' => 'Μήκος περιεχομένου 1→9',
+			'length_desc' => 'Μήκος περιεχομένου 9→1',
+			'link_asc' => 'Σύνδεσμος Α→Ω',
+			'link_desc' => 'Σύνδεσμος Ω→Α',
 			'primary' => array(
-				'_' => 'Sorting criterion',	// TODO
+				'_' => 'Κριτήριο ταξινόμησης',
 				'help' => 'Sorting by <em>received</em> date is recommended in most cases, for consistency and performance',	// TODO
 			),
-			'rand' => 'Random order',	// TODO
+			'rand' => 'Τυχαία σειρά',
 			'secondary' => array(
-				'_' => 'Secondary sorting criterion',	// TODO
+				'_' => 'Δευτερεύον κριτήριο ταξινόμησης',
 				'help' => 'Only relevant when the primary sorting criterion is categories or feeds titles',	// TODO
 			),
-			'title_asc' => 'Title A→Z',	// TODO
-			'title_desc' => 'Title Z→A',	// TODO
+			'title_asc' => 'Τίτλος Α→Ω',
+			'title_desc' => 'Τίτλος Ω→Α',
 			'user_modified_asc' => 'User modified 1→9',	// TODO
 			'user_modified_desc' => 'User modified 9→1',	// TODO
 		),
-		'starred' => 'Show favourites',	// TODO
-		'stats' => 'Statistics',	// TODO
-		'subscription' => 'Subscription management',	// TODO
-		'unread' => 'Show unread',	// TODO
+		'starred' => 'Εμφάνιση αγαπημένων',
+		'stats' => 'Στατιστικά',
+		'subscription' => 'Διαχείριση συνδρομών',
+		'unread' => 'Εμφάνιση μη αναγνωσμένων',
 	),
-	'share' => 'Share',	// TODO
+	'share' => 'Κοινοποίηση',
 	'tag' => array(
-		'related' => 'Article tags',	// TODO
+		'related' => 'Ετικέτες άρθρου',
 	),
 	'tos' => array(
-		'title' => 'Terms of Service',	// TODO
+		'title' => 'Όροι Χρήσης',
 	),
 );

--- a/app/i18n/el/install.php
+++ b/app/i18n/el/install.php
@@ -51,18 +51,18 @@ return array(
 			'ok' => 'Τα δικαιώματα στον κατάλογο δεδομένων (data) είναι εντάξει.',
 		),
 		'database-connection' => array(
-			'nok' => 'Database connection error.',	// TODO
-			'ok' => 'Database connection is good.',	// TODO
+			'nok' => 'Σφάλμα σύνδεσης με τη βάση δεδομένων.',
+			'ok' => 'Η σύνδεση με τη βάση δεδομένων είναι εντάξει.',
 		),
 		'database-table' => array(
-			'nok' => 'Database table "%s" is incomplete.',	// TODO
-			'ok' => 'Database table "%s" is good.',	// TODO
+			'nok' => 'Ο πίνακας «%s» της βάσης δεδομένων είναι ελλιπής.',
+			'ok' => 'Ο πίνακας «%s» της βάσης δεδομένων είναι εντάξει.',
 		),
 		'database-tables' => array(
-			'nok' => 'Some database tables are missing.',	// TODO
-			'ok' => 'All database tables exist.',	// TODO
+			'nok' => 'Λείπουν ορισμένοι πίνακες της βάσης δεδομένων.',
+			'ok' => 'Όλοι οι πίνακες της βάσης δεδομένων υπάρχουν.',
 		),
-		'database-title' => 'Database',	// TODO
+		'database-title' => 'Βάση δεδομένων',
 		'dom' => array(
 			'nok' => 'Δεν βρέθηκε η απαιτούμενη βιβλιοθήκη για περιήγηση στο DOM.',
 			'ok' => 'Βρέθηκε η απαιτούμενη βιβλιοθήκη για περιήγηση στο DOM.',
@@ -77,8 +77,8 @@ return array(
 		),
 		'files' => 'Εγκατάσταση αρχείων',
 		'intl' => array(
-			'nok' => 'Cannot find the recommended library php-intl for internationalisation.',	// TODO
-			'ok' => 'You have the recommended library php-intl for internationalisation.',	// TODO
+			'nok' => 'Δεν βρέθηκε η συνιστώμενη βιβλιοθήκη php-intl για τη διεθνοποίηση.',
+			'ok' => 'Έχετε τη συνιστώμενη βιβλιοθήκη php-intl για τη διεθνοποίηση.',
 		),
 		'json' => array(
 			'nok' => 'Δεν βρέθηκε η συνιστώμενη βιβλιοθήκη για ανάλυση JSON.',
@@ -93,14 +93,14 @@ return array(
 			'ok' => 'Βρέθηκε η απαιτούμενη βιβλιοθήκη για regular expressions (php-pcre).',
 		),
 		'pdo-mysql' => array(
-			'nok' => 'Cannot find the required PDO driver for MySQL/MariaDB.',	// TODO
+			'nok' => 'Δεν βρέθηκε το απαιτούμενο πρόγραμμα οδήγησης PDO για MySQL/MariaDB.',
 		),
 		'pdo-pgsql' => array(
-			'nok' => 'Cannot find the required PDO driver for PostgreSQL.',	// TODO
+			'nok' => 'Δεν βρέθηκε το απαιτούμενο πρόγραμμα οδήγησης PDO για PostgreSQL.',
 		),
 		'pdo-sqlite' => array(
-			'nok' => 'Cannot find the PDO driver for SQLite.',	// TODO
-			'ok' => 'You have the PDO driver for SQLite.',	// TODO
+			'nok' => 'Δεν βρέθηκε το πρόγραμμα οδήγησης PDO για SQLite.',
+			'ok' => 'Έχετε το πρόγραμμα οδήγησης PDO για SQLite.',
 		),
 		'pdo' => array(
 			'nok' => 'Δεν βρέθηκε ο PDO ή ένας από τους υποστηριζόμενους οδηγούς (pdo_sqlite, pdo_pgsql, pdo_mysql).',


### PR DESCRIPTION
Changes proposed in this pull request:

- Completes the Greek translation of install.php
- Translates the reading-view sorting and menu strings in index.php

How to test the feature manually:

1. Set the interface language to Greek (Ελληνικά)
2. Check the install pages and the reading-view sorting/menu entries

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated