### PR TITLE
Fix: --db-prefix silently drops following CLI flags

### DIFF
--- a/cli/do-install.php
+++ b/cli/do-install.php
@@ -58,7 +58,7 @@ $cliOptions = new class extends CliOptionsParser {
 		$this->addOption('dbUser', (new CliOption('db-user')));
 		$this->addOption('dbPassword', (new CliOption('db-password')));
 		$this->addOption('dbBase', (new CliOption('db-base')));
-		$this->addOption('dbPrefix', (new CliOption('db-prefix'))->withValueOptional());
+		$this->addOption('dbPrefix', (new CliOption('db-prefix'))->withValueRequired());
 		parent::__construct();
 	}
 };

--- a/cli/reconfigure.php
+++ b/cli/reconfigure.php
@@ -54,7 +54,7 @@ $cliOptions = new class extends CliOptionsParser {
 		$this->addOption('dbUser', (new CliOption('db-user')));
 		$this->addOption('dbPassword', (new CliOption('db-password')));
 		$this->addOption('dbBase', (new CliOption('db-base')));
-		$this->addOption('dbPrefix', (new CliOption('db-prefix'))->withValueOptional());
+		$this->addOption('dbPrefix', (new CliOption('db-prefix'))->withValueRequired());
 		parent::__construct();
 	}
 };


### PR DESCRIPTION
`--db-prefix` used to be defined with an optional value (`::`), but PHP's getopt() only accepts a value for an optional-value long option via `--db-prefix=value`, never the documented `--db-prefix value` form.

Passing it space-separated leaves the value as an unrecognized argument and silently drops every flag that follows (e.g. --disable_update) from getopt()'s result.

Revert to a somewhat required value (`:`), which still allows an empty prefix via `--db-prefix ''`.

Closes https://github.com/NixOS/nixpkgs/issues/530367

Changes proposed in this pull request:

- deprecate `--db-prefix=test_` (nowhere documented this way) and allow `--db-prefix test_`

How to test the feature manually:

1. run it

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).

AI assisted. found it via nixpkgs.
