### PR TITLE
Apply Force HTTPS to common fetches

### DIFF
--- a/app/Controllers/updateController.php
+++ b/app/Controllers/updateController.php
@@ -213,7 +213,9 @@ class FreshRSS_update_Controller extends FreshRSS_ActionController {
 				return;
 			}
 		} else {
-			$auto_update_url = FreshRSS_Context::systemConf()->auto_update_url . '/?v=' . FRESHRSS_VERSION;
+			$auto_update_url = FreshRSS_http_Util::forceHttps(
+				FreshRSS_Context::systemConf()->auto_update_url . '/?v=' . FRESHRSS_VERSION
+			);
 			Minz_Log::debug('HTTP GET ' . $auto_update_url);
 			$curlResource = curl_init($auto_update_url);
 

--- a/app/Models/SimplePieCustom.php
+++ b/app/Models/SimplePieCustom.php
@@ -265,21 +265,7 @@ final class FreshRSS_SimplePieCustom extends \SimplePie\SimplePie
 				'src',
 			],
 		]);
-		$https_domains = [];
-		$force = @file(FRESHRSS_PATH . '/force-https.default.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-		if (is_array($force)) {
-			$https_domains = array_merge($https_domains, $force);
-		}
-		$force = @file(DATA_PATH . '/force-https.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-		if (is_array($force)) {
-			$https_domains = array_merge($https_domains, $force);
-		}
-
-		// Remove whitespace and comments starting with # / ;
-		$https_domains = preg_replace('%\\s+|[\/#;].*$%', '', $https_domains) ?? $https_domains;
-		$https_domains = array_filter($https_domains, fn(string $v) => $v !== '');
-
-		$this->set_https_domains($https_domains);
+		$this->set_https_domains(FreshRSS_http_Util::loadForceHttpsDomains());
 	}
 
 	public static function sanitizeHTML(string $data, string $base = '', ?int $maxLength = null): string {

--- a/app/Utils/httpUtil.php
+++ b/app/Utils/httpUtil.php
@@ -21,6 +21,44 @@ final class FreshRSS_http_Util {
 	/** @var array<string, string[]> $resolve_ok */
 	private static array $resolve_ok = [];
 
+	/** @return string[] */
+	public static function loadForceHttpsDomains(): array {
+		$domains = [];
+		$force = @file(FRESHRSS_PATH . '/force-https.default.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+		if (is_array($force)) {
+			$domains = array_merge($domains, $force);
+		}
+		$force = @file(DATA_PATH . '/force-https.txt', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+		if (is_array($force)) {
+			$domains = array_merge($domains, $force);
+		}
+
+		// Remove whitespace and comments starting with # / ;
+		$domains = preg_replace('%\\s+|[\\/#;].*$%', '', $domains) ?? $domains;
+		$domains = array_map(static fn(string $domain): string => strtolower(trim($domain, '. ')), $domains);
+		return array_values(array_filter($domains, static fn(string $domain): bool => $domain !== ''));
+	}
+
+	/**
+	 * Force HTTPS for URLs whose host is in `force-https.default.txt` or `data/force-https.txt`.
+	 */
+	public static function forceHttps(string $url): string {
+		if (strncasecmp($url, 'http://', 7) !== 0) {
+			return $url;
+		}
+		$host = parse_url($url, PHP_URL_HOST);
+		if (!is_string($host) || $host === '') {
+			return $url;
+		}
+		$host = strtolower(trim($host, '. '));
+		foreach (self::loadForceHttpsDomains() as $domain) {
+			if ($host === $domain || str_ends_with($host, '.' . $domain)) {
+				return substr_replace($url, 's', 4, 0);
+			}
+		}
+		return $url;
+	}
+
 	private static function getRetryAfterFile(string $url, string $proxy): string {
 		$domain = parse_url($url, PHP_URL_HOST);
 		if (!is_string($domain) || $domain === '') {
@@ -431,6 +469,7 @@ final class FreshRSS_http_Util {
 	 *   * `-500` `curl_init()` failure.
 	 */
 	public static function httpGet(string $url, ?string $cachePath = null, string $type = 'html', array $attributes = [], array $curl_options = []): array {
+		$url = self::forceHttps($url);
 		$limits = FreshRSS_Context::systemConf()->limits;
 		$feed_timeout = empty($attributes['timeout']) || !is_numeric($attributes['timeout']) ? 0 : intval($attributes['timeout']);
 
@@ -592,6 +631,7 @@ final class FreshRSS_http_Util {
 				if ($location === false) {
 					$location = $url;
 				}
+				$location = self::forceHttps($location);
 				if (!self::compareURLOrigins($url, $location)) {
 					unset($curl_options[CURLOPT_COOKIE]);
 					unset($curl_options[CURLOPT_USERPWD]);

--- a/app/Utils/httpUtil.php
+++ b/app/Utils/httpUtil.php
@@ -41,6 +41,8 @@ final class FreshRSS_http_Util {
 
 	/**
 	 * Force HTTPS for URLs whose host is in `force-https.default.txt` or `data/force-https.txt`.
+	 *
+	 * @return ($url is non-empty-string ? non-empty-string : string)
 	 */
 	public static function forceHttps(string $url): string {
 		if (strncasecmp($url, 'http://', 7) !== 0) {
@@ -541,7 +543,6 @@ final class FreshRSS_http_Util {
 			$max_redirs = 4;
 		}
 		while (true) {
-			$url = is_string($url) ? $url : '';
 			$resolve = [];
 			if ($proxy === '') {
 				$resolve = self::getCurlResolveInfo($url);

--- a/lib/favicons.php
+++ b/lib/favicons.php
@@ -22,7 +22,7 @@ function isImgMime(string $content): bool {
 }
 
 function faviconCachePath(string $url): string {
-	return CACHE_PATH . '/' . sha1($url) . '.ico';
+	return CACHE_PATH . '/' . sha1(FreshRSS_http_Util::forceHttps($url)) . '.ico';
 }
 
 function searchFavicon(string $url): string {
@@ -30,6 +30,7 @@ function searchFavicon(string $url): string {
 	if ($url === '') {
 		return '';
 	}
+	$url = FreshRSS_http_Util::forceHttps($url);
 	$dom = new DOMDocument();
 	['body' => $html, 'effective_url' => $effective_url, 'fail' => $fail] =
 		FreshRSS_http_Util::httpGet($url, cachePath: CACHE_PATH . '/' . sha1($url) . '.html', type: 'html');
@@ -74,6 +75,7 @@ function searchFavicon(string $url): string {
 		if (!is_string($iri) || $iri === '') {
 			continue;
 		}
+		$iri = FreshRSS_http_Util::forceHttps($iri);
 		$favicon = FreshRSS_http_Util::httpGet($iri, faviconCachePath($iri), 'ico', curl_options: [
 			CURLOPT_REFERER => $effective_url,
 		])['body'];
@@ -93,6 +95,7 @@ function download_favicon_from_image_url(string $imageUrl, string $dest): bool {
 	if (!is_string($imageUrl) || $imageUrl === '') {
 		return false;
 	}
+	$imageUrl = FreshRSS_http_Util::forceHttps($imageUrl);
 	$favicon = FreshRSS_http_Util::httpGet($imageUrl, faviconCachePath($imageUrl), 'ico')['body'];
 	if (!isImgMime($favicon)) {
 		return false;
@@ -105,6 +108,7 @@ function download_favicon(string $url, string $dest): bool {
 	if (!is_string($url) || $url === '') {
 		return @copy(DEFAULT_FAVICON, $dest);
 	}
+	$url = FreshRSS_http_Util::forceHttps($url);
 	$favicon = searchFavicon($url);
 	if ($favicon == '') {
 		$rootUrl = preg_replace('%^(https?://[^/]+).*$%i', '$1/', $url) ?? $url;
@@ -113,7 +117,7 @@ function download_favicon(string $url, string $dest): bool {
 			$favicon = searchFavicon($url);
 		}
 		if ($favicon == '') {
-			$link = FreshRSS_http_Util::checkUrl($rootUrl . 'favicon.ico', fixScheme: false) ?: '';
+			$link = FreshRSS_http_Util::forceHttps(FreshRSS_http_Util::checkUrl($rootUrl . 'favicon.ico', fixScheme: false) ?: '');
 			$favicon = $link === '' ? '' : FreshRSS_http_Util::httpGet($link, faviconCachePath($link), 'ico', curl_options: [
 				CURLOPT_REFERER => $url,
 			])['body'];

--- a/tests/app/Utils/httpUtilTest.php
+++ b/tests/app/Utils/httpUtilTest.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\Attributes\DataProvider;
 
+require_once LIB_PATH . '/favicons.php';
+
 /**
  * Tests for FreshRSS_http_Util
  */
@@ -37,5 +39,46 @@ class httpUtilTest extends \PHPUnit\Framework\TestCase {
 			// Non-http(s) schemes are compared as-is
 			['ftp://example.net/feed', 'https://example.net/feed', false],
 		];
+	}
+
+	#[DataProvider('provideForceHttpsUrls')]
+	public function testForceHttps(string $url, string $expected): void {
+		self::assertSame($expected, FreshRSS_http_Util::forceHttps($url));
+	}
+
+	/** @return list<array{string,string}> */
+	public static function provideForceHttpsUrls(): array {
+		return [
+			['http://github.com/FreshRSS/FreshRSS', 'https://github.com/FreshRSS/FreshRSS'],
+			['http://www.github.com/FreshRSS/FreshRSS', 'https://www.github.com/FreshRSS/FreshRSS'],
+			['http://GitHub.com/FreshRSS/FreshRSS', 'https://GitHub.com/FreshRSS/FreshRSS'],
+			['https://github.com/FreshRSS/FreshRSS', 'https://github.com/FreshRSS/FreshRSS'],
+			['http://notgithub.com/FreshRSS/FreshRSS', 'http://notgithub.com/FreshRSS/FreshRSS'],
+			['http://github.com.example/FreshRSS/FreshRSS', 'http://github.com.example/FreshRSS/FreshRSS'],
+		];
+	}
+
+	public function testFaviconCacheUsesForcedHttpsUrl(): void {
+		$url = 'http://github.com/FreshRSS/FreshRSS';
+		self::assertSame(
+			CACHE_PATH . '/' . sha1('https://github.com/FreshRSS/FreshRSS') . '.ico',
+			faviconCachePath($url)
+		);
+	}
+
+	public function testHttpGetUsesForcedHttpsUrlBeforeCache(): void {
+		FreshRSS_Context::initSystem();
+		$cachePath = tempnam(sys_get_temp_dir(), 'freshrss-force-https-');
+		if ($cachePath === false) {
+			self::fail('Could not create a temporary cache file');
+		}
+		try {
+			file_put_contents($cachePath, 'cached');
+			$response = FreshRSS_http_Util::httpGet('http://github.com/FreshRSS/FreshRSS', $cachePath);
+			self::assertSame('https://github.com/FreshRSS/FreshRSS', $response['effective_url']);
+			self::assertSame(-200, $response['status']);
+		} finally {
+			@unlink($cachePath);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #7260.

## What changed

- Centralise the existing Force HTTPS domain-list parsing in `FreshRSS_http_Util`.
- Upgrade listed hosts in the shared HTTP fetch path, including redirect targets.
- Use the upgraded URL for favicon requests and cache keys.
- Apply the same policy to the release update check, the only direct HTTP request outside the shared helper.

## Why

The Force HTTPS list previously affected URLs sanitised through SimplePie but not common fetches such as favicons and Web scraping. This keeps stored URLs unchanged while upgrading only the outgoing request for configured domains.

## Validation

- Targeted PHPUnit: 19 tests, 20 assertions.
- PHP syntax checks and PHP_CodeSniffer on all changed PHP files.
- Diff-scoped security review: no reportable findings.
