### PR TITLE
Fix extension settings cancel action

### DIFF
--- a/app/views/helpers/extension/configure.phtml
+++ b/app/views/helpers/extension/configure.phtml
@@ -8,7 +8,7 @@
 		throw new FreshRSS_Context_Exception('Extension not initialised!');
 	}
 ?>
-<div class="post">
+<div class="post extension-configure">
 	<h2>
 		<?= $this->extension->getName() ?> (<?= $this->extension->getVersion() ?>) —
 		<?= $this->extension->isEnabled() ? _t('admin.extensions.enabled') : _t('admin.extensions.disabled') ?>

--- a/p/scripts/extra.js
+++ b/p/scripts/extra.js
@@ -387,12 +387,10 @@ function init_slider(slider) {
 
 	document.getElementById('close-slider').addEventListener('click', close_slider_listener);
 	document.querySelector('#slider .toggle_aside').addEventListener('click', close_slider_listener);
-	slider.querySelectorAll('.extension-configure button[type="reset"], .extension-configure input[type="reset"]').forEach(button => {
-		button.addEventListener('click', ev => {
-			if (close_slider_listener(ev)) {
-				location.hash = 'close';
-			}
-		});
+	slider.addEventListener('click', ev => {
+		if (ev.target.closest('.extension-configure button[type="reset"], .extension-configure input[type="reset"]') && close_slider_listener(ev)) {
+			location.hash = 'close';
+		}
 	});
 
 	if (slider.children.length > 0) {

--- a/p/scripts/extra.js
+++ b/p/scripts/extra.js
@@ -387,6 +387,13 @@ function init_slider(slider) {
 
 	document.getElementById('close-slider').addEventListener('click', close_slider_listener);
 	document.querySelector('#slider .toggle_aside').addEventListener('click', close_slider_listener);
+	slider.querySelectorAll('.extension-configure button[type="reset"], .extension-configure input[type="reset"]').forEach(button => {
+		button.addEventListener('click', ev => {
+			if (close_slider_listener(ev)) {
+				location.hash = 'close';
+			}
+		});
+	});
 
 	if (slider.children.length > 0) {
 		const slider_scrollTop = sessionStorage.getItem('FreshRSS_slider_scrollTop');


### PR DESCRIPTION
Closes #3662. Closes the extension settings slider when its reset/cancel control is used while preserving unsaved-change confirmation. Tests: php -l, node --check, git diff --check.