### PR TITLE
Document OpenBSD httpd API configuration

### DIFF
--- a/docs/en/admins/01_Index.md
+++ b/docs/en/admins/01_Index.md
@@ -32,8 +32,8 @@ Learn how to install, update, and backup FreshRSS, as well as how to use the com
 ### Web server configuration
 
 * [Apache/Nginx configuration files](10_ServerConfig.md)
-* [Reverse proxy with Caddy](Caddy.md)
 * [OpenBSD httpd](OpenBSD-httpd.md)
+* [Reverse proxy with Caddy](Caddy.md)
 
 ### Special server information
 

--- a/docs/en/admins/01_Index.md
+++ b/docs/en/admins/01_Index.md
@@ -33,10 +33,10 @@ Learn how to install, update, and backup FreshRSS, as well as how to use the com
 
 * [Apache/Nginx configuration files](10_ServerConfig.md)
 * [Reverse proxy with Caddy](Caddy.md)
+* [OpenBSD httpd](OpenBSD-httpd.md)
 
 ### Special server information
 
 * [Installation on Debian 9/Ubuntu 16.04](06_LinuxInstall.md)
 * [Installation on cloud providers](14_CloudProviders.md)
 * [Updating on Debian 9/Ubuntu 16.04](07_LinuxUpdate.md)
-

--- a/docs/en/admins/OpenBSD-httpd.md
+++ b/docs/en/admins/OpenBSD-httpd.md
@@ -1,0 +1,33 @@
+# OpenBSD httpd configuration
+
+OpenBSD `httpd(8)` does not use `.htaccess` files. The following example
+serves the public `p/` directory and passes the Google Reader API path to
+PHP-FPM with `PATH_INFO` preserved:
+
+```httpd
+server "rss.example.net" {
+	listen on * tls port 443
+	root "/var/www/htdocs/FreshRSS/p"
+
+	tls certificate "/etc/ssl/rss.example.net.fullchain.pem"
+	tls key "/etc/ssl/private/rss.example.net.key"
+
+	location match "^/api/greader\\.php(/.*)?$" {
+		fastcgi socket "/run/php-fpm.sock"
+		fastcgi param PATH_INFO "/api/greader.php"
+	}
+
+	location match "^/(.*\\.php)(/.*)?$" {
+		fastcgi socket "/run/php-fpm.sock"
+		fastcgi param SCRIPT_FILENAME "/var/www/htdocs/FreshRSS/p/$1"
+		fastcgi param PATH_INFO "$2"
+	}
+}
+```
+
+Adjust the document root, PHP-FPM socket, and certificate paths for the local
+installation. Set FreshRSS `base_url` to the public HTTPS URL, then verify the
+API endpoint at `/api/greader.php`.
+
+The `PATH_INFO` parameters are important: FreshRSS uses the path after
+`greader.php` to route Google Reader API requests.

--- a/docs/en/admins/OpenBSD-httpd.md
+++ b/docs/en/admins/OpenBSD-httpd.md
@@ -32,11 +32,11 @@ API endpoint at `/api/greader.php`.
 The `PATH_INFO` parameters are important: FreshRSS uses the path after
 `greader.php` to route Google Reader API requests.
 
-## Caching
+## HTTP caching
 
 Unlike the bundled Apache configuration, OpenBSD `httpd` does not read the
-project's `.htaccess` file. Confirm the cache policy of the server or reverse
-proxy used in front of FreshRSS: static versioned assets such as CSS,
-JavaScript, fonts, and images may be cached, but do not cache PHP pages or API
-responses. If cache-control headers are required at the web-server layer, add
-them in the reverse proxy responsible for that policy.
+project’s [`.htaccess` file](https://github.com/FreshRSS/FreshRSS/blob/edge/p/.htaccess).
+Confirm the HTTP cache policy of the server or reverse
+proxy used in front of FreshRSS: static assets such as CSS,
+JavaScript, fonts, and images should be cached, but do not cache PHP pages or API
+responses.

--- a/docs/en/admins/OpenBSD-httpd.md
+++ b/docs/en/admins/OpenBSD-httpd.md
@@ -31,3 +31,12 @@ API endpoint at `/api/greader.php`.
 
 The `PATH_INFO` parameters are important: FreshRSS uses the path after
 `greader.php` to route Google Reader API requests.
+
+## Caching
+
+Unlike the bundled Apache configuration, OpenBSD `httpd` does not read the
+project's `.htaccess` file. Confirm the cache policy of the server or reverse
+proxy used in front of FreshRSS: static versioned assets such as CSS,
+JavaScript, fonts, and images may be cached, but do not cache PHP pages or API
+responses. If cache-control headers are required at the web-server layer, add
+them in the reverse proxy responsible for that policy.


### PR DESCRIPTION
Closes #7493. Adds an OpenBSD httpd example for FreshRSS with PATH_INFO preserved for the Google Reader API. Tests: markdownlint and git diff --check.