### PR TITLE
Simplepie: fix sanitizer whitelist stripping order

### DIFF
--- a/lib/composer.json
+++ b/lib/composer.json
@@ -18,7 +18,7 @@
 		"marienfressinaud/lib_opml": "dev-main#f0e850b6394af90b898daf0e65fcc7363457b844",
 		"phpgt/cssxpath": "v1.5.0",
 		"phpmailer/phpmailer": "7.1.1",
-		"simplepie/simplepie": "dev-freshrss#2d4c5b99b8f851b1e416b84f6a9a1e85097b9012"
+		"simplepie/simplepie": "dev-freshrss#5c4cd94907c066f1db5ccd9c6d4610ecba114e39"
 	},
 	"config": {
 		"sort-packages": true,

--- a/lib/simplepie/simplepie/src/Sanitize.php
+++ b/lib/simplepie/simplepie/src/Sanitize.php
@@ -721,16 +721,18 @@ class Sanitize implements RegistryAware
                 && !isset($this->allowed_html_elements_with_attributes[$tag])) {
                 if (!in_array($tag, ['script', 'style', 'svg', 'math', 'template'], true)) {
                     // Preserve children inside the disallowed element
-                    for ($i = $element->childNodes->length - 1; $i >= 0; $i--) {
-                        $child = $element->childNodes->item($i);
-                        if ($child === null) {
-                            continue;
-                        }
+                    $nextSibling = $element->nextSibling;
+                    while ($element->firstChild !== null) {
+                        $child = $element->firstChild;
                         if ($child instanceof \DOMText) {
                             $child->nodeValue = htmlspecialchars($child->nodeValue ?? '', ENT_QUOTES, 'UTF-8');
                         }
                         if ($parent !== null) {
-                            $parent->insertBefore($child, $element);
+                            if ($nextSibling !== null) {
+                                $parent->insertBefore($child, $nextSibling);
+                            } else {
+                                $parent->appendChild($child);
+                            }
                         }
                         $this->enforce_allowed_html_nodes($child, $allow_data_attr, $allow_aria_attr);
                     }


### PR DESCRIPTION
Includes <https://github.com/FreshRSS/simplepie/pull/85>.

Fixes <https://github.com/FreshRSS/FreshRSS/issues/9052>.

Changes proposed in this pull request:

- Children of fixed elements were added to the DOM backwards.

How to test the feature manually:

1. Add https://www.merriam-webster.com/wotd/feed/rss2
2. See that the message content is reversed without this patch
3. See that it's in the correct order with this patch

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated
