### PR TITLE
cURL: describe user-settable options in a single spec map

### DIFF
--- a/app/Services/ImportService.php
+++ b/app/Services/ImportService.php
@@ -293,43 +293,9 @@ class FreshRSS_Import_Service {
 			}
 			$feed->_attribute('xPathToJson', $feed_elt['frss:xPathToJson'] ?? null);
 
-			$curl_params = [];
-			if (isset($feed_elt['frss:CURLOPT_COOKIE'])) {
-				$curl_params[CURLOPT_COOKIE] = $feed_elt['frss:CURLOPT_COOKIE'];
-			}
-			if (isset($feed_elt['frss:CURLOPT_COOKIEFILE'])) {
-				// Allow only an empty value just to enable the libcurl cookie engine
-				$curl_params[CURLOPT_COOKIEFILE] = '';
-			}
-			if (isset($feed_elt['frss:CURLOPT_FOLLOWLOCATION'])) {
-				$curl_params[CURLOPT_FOLLOWLOCATION] = (bool)$feed_elt['frss:CURLOPT_FOLLOWLOCATION'];
-			}
-			if (isset($feed_elt['frss:CURLOPT_HTTPHEADER'])) {
-				$curl_params[CURLOPT_HTTPHEADER] = preg_split('/\R/u', $feed_elt['frss:CURLOPT_HTTPHEADER']) ?: [];
-			}
-			if (isset($feed_elt['frss:CURLOPT_MAXREDIRS'])) {
-				$curl_params[CURLOPT_MAXREDIRS] = (int)$feed_elt['frss:CURLOPT_MAXREDIRS'];
-			}
-			if (isset($feed_elt['frss:CURLOPT_POST'])) {
-				$curl_params[CURLOPT_POST] = (bool)$feed_elt['frss:CURLOPT_POST'];
-			}
-			if (isset($feed_elt['frss:CURLOPT_POSTFIELDS'])) {
-				$curl_params[CURLOPT_POSTFIELDS] = $feed_elt['frss:CURLOPT_POSTFIELDS'];
-			}
-			if (isset($feed_elt['frss:CURLOPT_PROXY'])) {
-				$curl_params[CURLOPT_PROXY] = $feed_elt['frss:CURLOPT_PROXY'];
-			}
-			if (isset($feed_elt['frss:CURLOPT_PROXYTYPE'])) {
-				$curl_params[CURLOPT_PROXYTYPE] = (int)$feed_elt['frss:CURLOPT_PROXYTYPE'];
-				if ($curl_params[CURLOPT_PROXYTYPE] === 3) {	// Legacy for NONE
-					$curl_params[CURLOPT_PROXYTYPE] = -1;
-				}
-			}
-			if (isset($feed_elt['frss:CURLOPT_USERAGENT'])) {
-				$curl_params[CURLOPT_USERAGENT] = $feed_elt['frss:CURLOPT_USERAGENT'];
-			}
+			$curl_params = FreshRSS_http_Util::curlParamsFromOpml($feed_elt);
 			if (!empty($curl_params)) {
-				$feed->_attribute('curl_params', FreshRSS_http_Util::sanitizeCurlParams($curl_params));
+				$feed->_attribute('curl_params', $curl_params);
 			}
 
 			// Call the extension hook

--- a/app/Utils/httpUtil.php
+++ b/app/Utils/httpUtil.php
@@ -120,6 +120,8 @@ final class FreshRSS_http_Util {
 			CURLOPT_COOKIEFILE => ['name' => 'COOKIEFILE', 'type' => 'flag'],
 			CURLOPT_FOLLOWLOCATION => ['name' => 'FOLLOWLOCATION', 'type' => 'bool'],	// We filter this value later, only allowing `false`
 			CURLOPT_HTTPHEADER => ['name' => 'HTTPHEADER', 'type' => 'lines'],
+			CURLOPT_IPRESOLVE => ['name' => 'IPRESOLVE', 'type' => 'int',
+				'values' => [CURL_IPRESOLVE_WHATEVER, CURL_IPRESOLVE_V4, CURL_IPRESOLVE_V6]],
 			CURLOPT_MAXREDIRS => ['name' => 'MAXREDIRS', 'type' => 'int'],
 			CURLOPT_POST => ['name' => 'POST', 'type' => 'bool'],
 			CURLOPT_POSTFIELDS => ['name' => 'POSTFIELDS', 'type' => 'string'],

--- a/app/Utils/httpUtil.php
+++ b/app/Utils/httpUtil.php
@@ -104,38 +104,114 @@ final class FreshRSS_http_Util {
 	}
 
 	/**
+	 * The per-feed cURL options a user is allowed to set, keyed by cURL option.
+	 * Adding a new user-settable cURL option only requires a new entry here.
+	 *   - `name` is the suffix of the matching OPML attribute, e.g. `COOKIE` for `frss:CURLOPT_COOKIE`;
+	 *   - `type` is how the value is represented in OPML: `flag` is an option whose mere presence is
+	 *     meaningful, `lines` is a list of strings serialised as one line each;
+	 *   - `values` is the exhaustive list of accepted values, when the option only takes a few.
+	 * This is a method rather than a constant because `CURLOPT_*` are run-time constants
+	 * from ext-curl, and not all of them exist in every libcurl build.
+	 * @return array<int,array{name:non-empty-string,type:'string'|'int'|'bool'|'flag'|'lines',values?:list<int>}>
+	 */
+	private static function curlParamSpecs(): array {
+		return [
+			CURLOPT_COOKIE => ['name' => 'COOKIE', 'type' => 'string'],
+			CURLOPT_COOKIEFILE => ['name' => 'COOKIEFILE', 'type' => 'flag'],
+			CURLOPT_FOLLOWLOCATION => ['name' => 'FOLLOWLOCATION', 'type' => 'bool'],	// We filter this value later, only allowing `false`
+			CURLOPT_HTTPHEADER => ['name' => 'HTTPHEADER', 'type' => 'lines'],
+			CURLOPT_MAXREDIRS => ['name' => 'MAXREDIRS', 'type' => 'int'],
+			CURLOPT_POST => ['name' => 'POST', 'type' => 'bool'],
+			CURLOPT_POSTFIELDS => ['name' => 'POSTFIELDS', 'type' => 'string'],
+			CURLOPT_PROXY => ['name' => 'PROXY', 'type' => 'string'],
+			CURLOPT_PROXYTYPE => ['name' => 'PROXYTYPE', 'type' => 'int'],
+			CURLOPT_USERAGENT => ['name' => 'USERAGENT', 'type' => 'string'],
+		];
+	}
+
+	/**
+	 * Drop the cURL options that a user is not allowed to set, and normalise the values of those they are.
 	 * @param array<mixed> $curl_params
 	 * @return array<mixed>
 	 */
 	public static function sanitizeCurlParams(array $curl_params): array {
-		$safe_params = [
-			CURLOPT_COOKIE,
-			CURLOPT_COOKIEFILE,
-			CURLOPT_FOLLOWLOCATION,	// We filter this value later, only allowing `false`
-			CURLOPT_HTTPHEADER,
-			CURLOPT_MAXREDIRS,
-			CURLOPT_POST,
-			CURLOPT_POSTFIELDS,
-			CURLOPT_PROXY,
-			CURLOPT_PROXYTYPE,
-			CURLOPT_USERAGENT,
-		];
-		foreach ($curl_params as $k => $_) {
-			if (!in_array($k, $safe_params, true)) {
+		$specs = self::curlParamSpecs();
+		foreach ($curl_params as $k => $value) {
+			$spec = is_int($k) ? ($specs[$k] ?? null) : null;
+			if ($spec === null) {
 				unset($curl_params[$k]);
 				continue;
 			}
-			// Allow only an empty value just to enable the libcurl cookie engine
-			if ($k === CURLOPT_COOKIEFILE) {
-				$curl_params[$k] = '';
+			if (isset($spec['values']) && !in_array($value, $spec['values'], true)) {
+				unset($curl_params[$k]);
+				continue;
 			}
-			// Remove HTTP authentication headers problematic for security
-			if ($k === CURLOPT_HTTPHEADER && is_array($curl_params[$k])) {
-				$curl_params[$k] = array_filter($curl_params[$k],
+			if ($spec['type'] === 'flag') {
+				// Allow only an empty value just to enable the libcurl cookie engine
+				$curl_params[$k] = '';
+			} elseif ($spec['type'] === 'lines' && is_array($value)) {
+				// Remove HTTP authentication headers problematic for security
+				$curl_params[$k] = array_filter($value,
 					fn($header) => is_string($header) && !preg_match('/^(Remote[-_\s]*User|X[-_\s]*WebAuth[-_\s]*User)\\s*:/i', $header));
 			}
 		}
 		return $curl_params;
+	}
+
+	/**
+	 * Extract the user-settable cURL options from the `frss:CURLOPT_*` attributes of an OPML outline.
+	 * @param array<string,string> $outline An OPML element (must be a feed element).
+	 * @return array<mixed> Sanitised cURL options, ready to be stored in the `curl_params` feed attribute.
+	 */
+	public static function curlParamsFromOpml(array $outline): array {
+		$curl_params = [];
+		foreach (self::curlParamSpecs() as $option => $spec) {
+			$value = $outline['frss:CURLOPT_' . $spec['name']] ?? null;
+			if ($value === null) {
+				continue;
+			}
+			$curl_params[$option] = match ($spec['type']) {
+				'flag' => '',
+				'lines' => preg_split('/\R/u', $value) ?: [],
+				'int' => (int)$value,
+				'bool' => (bool)$value,
+				default => $value,
+			};
+			if ($option === CURLOPT_PROXYTYPE && $curl_params[$option] === 3) {	// Legacy for NONE
+				$curl_params[$option] = -1;
+			}
+		}
+		return self::sanitizeCurlParams($curl_params);
+	}
+
+	/**
+	 * Render user-settable cURL options as the `frss:CURLOPT_*` attributes of an OPML outline.
+	 * @param array<mixed> $curl_params The `curl_params` feed attribute.
+	 * @return array<string,string|int|bool> Attributes to merge into the OPML outline.
+	 */
+	public static function curlParamsToOpml(array $curl_params): array {
+		$outline = [];
+		foreach (self::curlParamSpecs() as $option => $spec) {
+			if (!isset($curl_params[$option])) {
+				continue;
+			}
+			$value = $curl_params[$option];
+			if ($spec['type'] === 'flag') {
+				// The value is empty, so export the mere presence of the option instead
+				$outline['frss:CURLOPT_' . $spec['name']] = true;
+			} elseif ($spec['type'] === 'lines') {
+				$lines = is_array($value) ? implode("\n", array_filter($value, 'is_string')) : '';
+				if ($lines !== '') {
+					$outline['frss:CURLOPT_' . $spec['name']] = $lines;
+				}
+			} elseif (is_string($value) || is_int($value) || is_bool($value)) {
+				if ($option === CURLOPT_PROXYTYPE && $value === 3) {	// Legacy for NONE
+					$value = -1;
+				}
+				$outline['frss:CURLOPT_' . $spec['name']] = $value;
+			}
+		}
+		return $outline;
 	}
 
 	private static function idn_to_puny(string $url): string {

--- a/app/Utils/httpUtil.php
+++ b/app/Utils/httpUtil.php
@@ -146,7 +146,9 @@ final class FreshRSS_http_Util {
 				unset($curl_params[$k]);
 				continue;
 			}
-			if ($spec['type'] === 'flag') {
+			if ($k === CURLOPT_PROXYTYPE && $value === 3) {	// Legacy for NONE
+				$curl_params[$k] = -1;
+			} elseif ($spec['type'] === 'flag') {
 				// Allow only an empty value just to enable the libcurl cookie engine
 				$curl_params[$k] = '';
 			} elseif ($spec['type'] === 'lines' && is_array($value)) {
@@ -177,9 +179,6 @@ final class FreshRSS_http_Util {
 				'bool' => (bool)$value,
 				default => $value,
 			};
-			if ($option === CURLOPT_PROXYTYPE && $curl_params[$option] === 3) {	// Legacy for NONE
-				$curl_params[$option] = -1;
-			}
 		}
 		return self::sanitizeCurlParams($curl_params);
 	}
@@ -205,9 +204,6 @@ final class FreshRSS_http_Util {
 					$outline['frss:CURLOPT_' . $spec['name']] = $lines;
 				}
 			} elseif (is_string($value) || is_int($value) || is_bool($value)) {
-				if ($option === CURLOPT_PROXYTYPE && $value === 3) {	// Legacy for NONE
-					$value = -1;
-				}
 				$outline['frss:CURLOPT_' . $spec['name']] = $value;
 			}
 		}

--- a/app/views/helpers/export/opml.phtml
+++ b/app/views/helpers/export/opml.phtml
@@ -121,30 +121,8 @@ function feedsToOutlines(array $feeds, bool $excludeMutedFeeds = false, bool $in
 
 		$curl_params = FreshRSS_http_Util::sanitizeCurlParams($feed->attributeArray('curl_params') ?? []);
 		// NB: Only include sensitive cURL parameters for private exports, not for public shares
-		if ($includeSensitiveCurlParams && !empty($curl_params)) {
-			$outline['frss:CURLOPT_COOKIE'] = $curl_params[CURLOPT_COOKIE] ?? null;
-			$outline['frss:CURLOPT_COOKIEFILE'] = $curl_params[CURLOPT_COOKIEFILE] ?? null;
-			$outline['frss:CURLOPT_FOLLOWLOCATION'] = $curl_params[CURLOPT_FOLLOWLOCATION] ?? null;
-			$outline['frss:CURLOPT_MAXREDIRS'] = $curl_params[CURLOPT_MAXREDIRS] ?? null;
-			$outline['frss:CURLOPT_POST'] = $curl_params[CURLOPT_POST] ?? null;
-			$outline['frss:CURLOPT_POSTFIELDS'] = $curl_params[CURLOPT_POSTFIELDS] ?? null;
-			$outline['frss:CURLOPT_PROXY'] = $curl_params[CURLOPT_PROXY] ?? null;
-			$outline['frss:CURLOPT_PROXYTYPE'] = $curl_params[CURLOPT_PROXYTYPE] ?? null;
-			if ($outline['frss:CURLOPT_PROXYTYPE'] === 3) {	// Legacy for NONE
-				$outline['frss:CURLOPT_PROXYTYPE'] = -1;
-			}
-			$outline['frss:CURLOPT_USERAGENT'] = $curl_params[CURLOPT_USERAGENT] ?? null;
-
-			if (!empty($curl_params[CURLOPT_HTTPHEADER]) && is_array($curl_params[CURLOPT_HTTPHEADER])) {
-				$headers = '';
-				foreach ($curl_params[CURLOPT_HTTPHEADER] as $header) {
-					if (is_string($header)) {
-						$headers .= $header . "\n";
-					}
-				}
-				$headers = trim($headers);
-				$outline['frss:CURLOPT_HTTPHEADER'] = $headers;
-			}
+		if ($includeSensitiveCurlParams) {
+			$outline = array_merge($outline, FreshRSS_http_Util::curlParamsToOpml($curl_params));
 		}
 
 		// Remove null or invalid attributes

--- a/app/views/helpers/feed/update.phtml
+++ b/app/views/helpers/feed/update.phtml
@@ -852,9 +852,6 @@
 					<select name="proxy_type" id="proxy_type"><?php
 						defined('CURLPROXY_HTTPS') or define('CURLPROXY_HTTPS', 2);	// Compatibility cURL 7.51
 						$type = $curlParams[CURLOPT_PROXYTYPE] ?? '';
-						if ($type === 3) {	// Legacy for NONE
-							$type = -1;
-						}
 						foreach (['' => '', -1 => 'NONE', CURLPROXY_HTTP => 'HTTP', CURLPROXY_HTTPS => 'HTTPS',
 							CURLPROXY_SOCKS4 => 'SOCKS4', CURLPROXY_SOCKS4A => 'SOCKS4A', CURLPROXY_SOCKS5 => 'SOCKS5',
 							CURLPROXY_SOCKS5_HOSTNAME => 'SOCKS5H'] as $k => $v) {

--- a/docs/en/developers/OPML.md
+++ b/docs/en/developers/OPML.md
@@ -80,6 +80,7 @@ A number of [cURL options](https://curl.se/libcurl/c/curl_easy_setopt.html) are 
 * `frss:CURLOPT_COOKIEFILE`
 * `frss:CURLOPT_FOLLOWLOCATION`
 * `frss:CURLOPT_HTTPHEADER`
+* `frss:CURLOPT_IPRESOLVE`: `0` to use whichever IP version is available (default), `1` to force IPv4, `2` to force IPv6.
 * `frss:CURLOPT_MAXREDIRS`
 * `frss:CURLOPT_POST`
 * `frss:CURLOPT_POSTFIELDS`

--- a/tests/app/Utils/httpUtilTest.php
+++ b/tests/app/Utils/httpUtilTest.php
@@ -38,4 +38,48 @@ class httpUtilTest extends \PHPUnit\Framework\TestCase {
 			['ftp://example.net/feed', 'https://example.net/feed', false],
 		];
 	}
+
+	/**
+	 * @param array<mixed> $curlParams
+	 * @param array<mixed> $expected
+	 */
+	#[DataProvider('provideCurlParamsToSanitize')]
+	public function test_sanitizeCurlParams(array $curlParams, array $expected): void {
+		self::assertSame($expected, FreshRSS_http_Util::sanitizeCurlParams($curlParams));
+	}
+
+	/** @return list<array{array<mixed>,array<mixed>}> */
+	public static function provideCurlParamsToSanitize(): array {
+		return [
+			// Allowed options are kept as-is
+			[[CURLOPT_USERAGENT => 'FreshRSS'], [CURLOPT_USERAGENT => 'FreshRSS']],
+			[[CURLOPT_MAXREDIRS => 5], [CURLOPT_MAXREDIRS => 5]],
+			[[], []],
+
+			// Options outside the allowlist are dropped, whatever else is present
+			[[CURLOPT_USERPWD => 'user:password'], []],
+			[[CURLOPT_COOKIEJAR => '/tmp/evil'], []],
+			[[CURLOPT_USERAGENT => 'FreshRSS', CURLOPT_USERPWD => 'user:password'], [CURLOPT_USERAGENT => 'FreshRSS']],
+			// Non-integer keys are never valid cURL options
+			[['CURLOPT_USERAGENT' => 'FreshRSS'], []],
+
+			// The cookie file is only ever enabled, never given a path
+			[[CURLOPT_COOKIEFILE => '/etc/passwd'], [CURLOPT_COOKIEFILE => '']],
+
+			// Headers granting authentication are removed, the others are kept
+			[[CURLOPT_HTTPHEADER => ['Accept: application/atom+xml', 'Remote-User: admin']],
+				[CURLOPT_HTTPHEADER => [0 => 'Accept: application/atom+xml']]],
+			[[CURLOPT_HTTPHEADER => ['X-WebAuth-User: admin', 'remote_user: admin', 'X-Custom: 1']],
+				[CURLOPT_HTTPHEADER => [2 => 'X-Custom: 1']]],
+
+			// The legacy proxy type 3 (NONE) is normalised to -1
+			[[CURLOPT_PROXYTYPE => 3], [CURLOPT_PROXYTYPE => -1]],
+			[[CURLOPT_PROXYTYPE => CURLPROXY_SOCKS5], [CURLOPT_PROXYTYPE => CURLPROXY_SOCKS5]],
+
+			// Options declaring accepted values reject anything else
+			[[CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V6], [CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V6]],
+			[[CURLOPT_IPRESOLVE => 42], []],
+			[[CURLOPT_IPRESOLVE => '1'], []],
+		];
+	}
 }


### PR DESCRIPTION
Follow-up to https://github.com/FreshRSS/FreshRSS/pull/9012#issuecomment-5015382053, where @Alkarex asked for ideas to allow setting more cURL parameters without having to list them all in our code base. This is that idea made concrete, so it can be judged on the diff rather than in the abstract.

## Changes proposed in this pull request

The list of per-feed cURL options a user may set was hand-repeated in three places: the sanitiser allowlist, the OPML import chain and the OPML export chain. They are now described once, in `FreshRSS_http_Util::curlParamSpecs()`, and those three are driven from it:

```php
CURLOPT_COOKIE => ['name' => 'COOKIE', 'type' => 'string'],
CURLOPT_COOKIEFILE => ['name' => 'COOKIEFILE', 'type' => 'flag'],
CURLOPT_HTTPHEADER => ['name' => 'HTTPHEADER', 'type' => 'lines'],
CURLOPT_IPRESOLVE => ['name' => 'IPRESOLVE', 'type' => 'int',
    'values' => [CURL_IPRESOLVE_WHATEVER, CURL_IPRESOLVE_V4, CURL_IPRESOLVE_V6]],
...
```

`name` is the suffix of the OPML attribute, `type` how the value is represented in OPML, and `values` the accepted values. Two new helpers, `curlParamsFromOpml()` and `curlParamsToOpml()`, keep the whole enumeration inside `httpUtil`, so `ImportService` and the OPML export are one line each.

Adding a user-settable cURL option is now a single entry. The last commit demonstrates it with `CURLOPT_IPRESOLVE`, which #9012 is about: the entry alone gives it the allowlist, the value validation and the OPML round-trip. **I deliberately did not add the form control** — that part belongs to #9012 and to @Elgeryy1.

`values` is new capability: the allowlist could only ever say *which* options were permitted, never *which values*. Options taking only a few values are now checked.

The other commits are separable. The legacy `CURLOPT_PROXYTYPE` value 3 (NONE) was remapped to -1 in three places; it is now normalised in `sanitizeCurlParams()`, which every reader already goes through. Drop that commit if you would rather keep it as it is.

### Bug fixed along the way

`frss:CURLOPT_COOKIEFILE` was never actually exported. Its value is forced to an empty string to enable the libcurl cookie engine, and the export filter drops empty values — so the setting was silently lost on an OPML round-trip, even though the import side handled it. Exporting it as a flag fixes the round-trip.

### What this does not do

The two feed forms also enumerate these options, but they are not a 1:1 mapping and I do not think generating them is worth the abstraction: proxy is two controls writing two cURL keys plus a `-1` sentinel, method/POST is two controls writing three keys with a cross-field side effect (a JSON body injects a `Content-Type` into the header key), redirects is one field writing both `CURLOPT_MAXREDIRS` and `CURLOPT_FOLLOWLOCATION`, and the cookie-file checkbox stores an empty string. The forms stay hand-written.

`ssl_verify` and `timeout` also stay as they are: each expands to several cURL options, so a 1:1 map cannot express them.

Unrelated but noted while reading: the system-wide `curl_options` overrides per-feed options in `httpGet()`, while per-feed wins in `SimplePieCustom`. Left alone here, as changing it would change behaviour.

## How to test

`sanitizeCurlParams()` had no tests; the last commit adds them (allowlist, cookie file, authentication headers, legacy proxy type, accepted values).

An OPML round-trip of a feed using every option — including the cookie engine — returns exactly the stored `curl_params`. `composer test` passes (671 tests, phpcs, PHPStan level 10).

Note on merge order: if this lands first, #9012 can drop its bespoke `ipresolve` attribute and keep only the form control. If #9012 lands first, I will happily migrate it onto the spec map here.

## Pull request checklist

- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written
- [x] documentation updated
