### PR TITLE
Fix auto-share shortcut on first use

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -873,7 +873,7 @@ function auto_share(key) {
 	if (!share) {
 		return;
 	}
-	let shares = share.parentElement.querySelectorAll('.dropdown-menu .item [data-type]');
+	let shares;
 	if (typeof key === 'undefined') {
 		show_share_menu(share);
 		shares = share.parentElement.querySelectorAll('.dropdown-menu .item [data-type]');
@@ -896,6 +896,7 @@ function auto_share(key) {
 			return;
 		}
 	}
+	shares = share.parentElement.querySelectorAll('.dropdown-menu .item [data-type]');
 	// Trigger selected share action and hide the share div
 	key = parseInt(key);
 	if (key <= shares.length) {

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -873,9 +873,10 @@ function auto_share(key) {
 	if (!share) {
 		return;
 	}
-	const shares = share.parentElement.querySelectorAll('.dropdown-menu .item [data-type]');
+	let shares = share.parentElement.querySelectorAll('.dropdown-menu .item [data-type]');
 	if (typeof key === 'undefined') {
 		show_share_menu(share);
+		shares = share.parentElement.querySelectorAll('.dropdown-menu .item [data-type]');
 
 		// Display the share div
 		location.hash = share.id;


### PR DESCRIPTION
## Summary

- Re-read the share actions after creating the lazy-loaded share menu.
- Restore the documented one-key share behavior when exactly one action is configured.

## Why

The shortcut checked the action count before it built the menu. On first use it therefore found no action and required a second press.

Fixes #7299.

## Testing

- `npm run eslint -- p/scripts/main.js`
- `git diff --check edge...HEAD`