### PR TITLE
Prevent cached subscription slider content

### DIFF
--- a/p/scripts/extra.js
+++ b/p/scripts/extra.js
@@ -342,7 +342,7 @@ function open_slider_listener(ev) {
 			const req = new XMLHttpRequest();
 			slider_content.innerHTML = '';
 			slider.classList.add('sliding');
-			const ahref = a.href + '&ajax=1#slider';
+			const ahref = a.href + '&ajax=1&_=' + Date.now() + '#slider';
 			req.open('GET', ahref, true);
 			req.responseType = 'document';
 			req.onload = function (e) {


### PR DESCRIPTION
## Summary

- Add a unique query parameter to slider AJAX requests.

## Why

A cached GET response can reopen subscription settings with stale values and make a later form submission appear to overwrite changes. The timestamp makes each slider request distinct for intermediaries that cache dynamic pages.

Fixes #7723.

## Testing

- `npm run eslint -- p/scripts/extra.js`
- `git diff --check edge...HEAD`