### PR TITLE
Fix sharing menu conflicts with extensions

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -804,7 +804,7 @@ async function show_labels_menu(el) {
 
 function show_share_menu(el) {
 	const div = el.parentElement;
-	const dropdownMenu = div.querySelector('.dropdown-menu');
+	const dropdownMenu = div.querySelector(':scope > .dropdown-menu');
 
 	if (!dropdownMenu) {
 		const itemId = el.closest('.flux').dataset.entry;


### PR DESCRIPTION
## Summary

- Detect only the share menu that belongs directly to the share dropdown.

## Why

An extension can add an unrelated nested `.dropdown-menu`. The previous descendant selector then skipped share-menu creation, leaving share URL placeholders unreplaced.

Fixes #7820.

## Testing

- `npm run eslint -- p/scripts/main.js`
- `git diff --check edge...HEAD`