### PR TITLE
Redirect away from wrong URL paths to fix displaying of relative URLs

### DIFF
--- a/lib/Minz/FrontController.php
+++ b/lib/Minz/FrontController.php
@@ -39,12 +39,15 @@ class Minz_FrontController {
 
 			Minz_Request::init();
 
+			// Build the current request's URL and forward to it directly.
+			// If needed, a redirect is issued instead to correct the public relative path.
 			$url = Minz_Url::build();
 			$url['params'] = array_merge(
 				empty($url['params']) || !is_array($url['params']) ? [] : $url['params'],
 				array_filter($_POST, 'is_string', ARRAY_FILTER_USE_KEY)
 			);
-			Minz_Request::forward($url);
+			$pathInfo = $_SERVER['PATH_INFO'] ?? $_SERVER['ORIG_PATH_INFO'] ?? '';
+			Minz_Request::forward($url, redirect: $pathInfo !== '');
 		} catch (Minz_Exception $e) {
 			Minz_Log::error($e->getMessage());
 			self::killApp($e->getMessage());

--- a/p/api/index.php
+++ b/p/api/index.php
@@ -12,6 +12,18 @@ $frameAncestors = FreshRSS_Context::systemConf()->attributeString('csp.frame-anc
 header("Content-Security-Policy: default-src 'self'; frame-ancestors $frameAncestors");
 header('X-Content-Type-Options: nosniff');
 
+// Strip path info from URL to ensure proper displaying of relative URLs
+$pathInfo = $_SERVER['PATH_INFO'] ?? $_SERVER['ORIG_PATH_INFO'] ?? '';
+if ($pathInfo !== '') {
+	$scriptName = is_string($_SERVER['SCRIPT_NAME'] ?? null) ? $_SERVER['SCRIPT_NAME'] : '';
+	$queryString = is_string($_SERVER['QUERY_STRING'] ?? null) ? $_SERVER['QUERY_STRING'] : '';
+	if ($queryString !== '') {
+		$queryString = '?' . $queryString;
+	}
+	header('Location: ' . $scriptName . $queryString);
+	exit();
+}
+
 Minz_Translate::init(Minz_Translate::getLanguage(null, Minz_Request::getPreferredLanguages(), null));
 ?>
 <!DOCTYPE html>

--- a/p/api/index.php
+++ b/p/api/index.php
@@ -12,16 +12,10 @@ $frameAncestors = FreshRSS_Context::systemConf()->attributeString('csp.frame-anc
 header("Content-Security-Policy: default-src 'self'; frame-ancestors $frameAncestors");
 header('X-Content-Type-Options: nosniff');
 
-// Strip path info from URL to ensure proper displaying of relative URLs
-$pathInfo = $_SERVER['PATH_INFO'] ?? $_SERVER['ORIG_PATH_INFO'] ?? '';
-if ($pathInfo !== '') {
-	$scriptName = is_string($_SERVER['SCRIPT_NAME'] ?? null) ? $_SERVER['SCRIPT_NAME'] : '';
-	$queryString = is_string($_SERVER['QUERY_STRING'] ?? null) ? $_SERVER['QUERY_STRING'] : '';
-	if ($queryString !== '') {
-		$queryString = '?' . $queryString;
-	}
-	header('Location: ' . $scriptName . $queryString);
-	exit();
+if (($_SERVER['PATH_INFO'] ?? $_SERVER['ORIG_PATH_INFO'] ?? '') !== '') {
+	// Do not allow trailing slashes
+	header('HTTP/1.1 400 Bad Request');
+	die('Invalid path!');
 }
 
 Minz_Translate::init(Minz_Translate::getLanguage(null, Minz_Request::getPreferredLanguages(), null));

--- a/p/api/query.php
+++ b/p/api/query.php
@@ -38,6 +38,18 @@ if (!FreshRSS_Context::hasSystemConf() || !FreshRSS_Context::systemConf()->api_e
 	die('Service Unavailable!');
 }
 
+// Strip path info from URL to ensure proper displaying of relative URLs
+$pathInfo = $_SERVER['PATH_INFO'] ?? $_SERVER['ORIG_PATH_INFO'] ?? '';
+if ($pathInfo !== '') {
+	$scriptName = is_string($_SERVER['SCRIPT_NAME'] ?? null) ? $_SERVER['SCRIPT_NAME'] : '';
+	$queryString = is_string($_SERVER['QUERY_STRING'] ?? null) ? $_SERVER['QUERY_STRING'] : '';
+	if ($queryString !== '') {
+		$queryString = '?' . $queryString;
+	}
+	header('Location: ' . $scriptName . $queryString);
+	exit();
+}
+
 FreshRSS_Context::initUser($user);
 if (!FreshRSS_Context::hasUserConf() || !FreshRSS_Context::userConf()->enabled) {
 	usleep(rand(100, 10000));	//Primitive mitigation of scanning for users

--- a/p/api/query.php
+++ b/p/api/query.php
@@ -38,16 +38,10 @@ if (!FreshRSS_Context::hasSystemConf() || !FreshRSS_Context::systemConf()->api_e
 	die('Service Unavailable!');
 }
 
-// Strip path info from URL to ensure proper displaying of relative URLs
-$pathInfo = $_SERVER['PATH_INFO'] ?? $_SERVER['ORIG_PATH_INFO'] ?? '';
-if ($pathInfo !== '') {
-	$scriptName = is_string($_SERVER['SCRIPT_NAME'] ?? null) ? $_SERVER['SCRIPT_NAME'] : '';
-	$queryString = is_string($_SERVER['QUERY_STRING'] ?? null) ? $_SERVER['QUERY_STRING'] : '';
-	if ($queryString !== '') {
-		$queryString = '?' . $queryString;
-	}
-	header('Location: ' . $scriptName . $queryString);
-	exit();
+if (($_SERVER['PATH_INFO'] ?? $_SERVER['ORIG_PATH_INFO'] ?? '') !== '') {
+	// Do not allow trailing slashes
+	header('HTTP/1.1 400 Bad Request');
+	die('Invalid path!');
 }
 
 FreshRSS_Context::initUser($user);


### PR DESCRIPTION
Examples of where this is needed:
* https://demo.freshrss.org/i/index.php/ (no CSS or JS)
* https://demo.freshrss.org/i/index.php/x/y/z?c=configure&a=reading (no CSS or JS)
* https://demo.freshrss.org/api/index.php/ (no PASS because JS doesn't load)
* etc.


Because of `index.php` being treated as a directory in those URLs, CSS and JS aren't loading properly due to them being displayed from a relative path via `Minz_Url::display()`:
```html
<link rel="stylesheet" href="../themes/Origine/origine.css?1779721222" />
```
https://github.com/FreshRSS/FreshRSS/blob/8c5bd58808fec14853e5f1b2582b14db3cdb563a/app/FreshRSS.php#L136

Also applies to all the other links on the page of course.
The URLs are displayed from the `PUBLIC_RELATIVE` constant via `Minz_Url::display()`, which is always expected to be `..`:
https://github.com/FreshRSS/FreshRSS/blob/8c5bd58808fec14853e5f1b2582b14db3cdb563a/constants.php#L25

The implemented fix redirects away from the bad URL paths, when `PATH_INFO` is not empty, to a manually built URL from `$_GET` parameters. For API pages, an error is shown instead.

