### PR TITLE
Add feed website shortcut

### DIFF
--- a/app/views/helpers/index/normal/entry_header.phtml
+++ b/app/views/helpers/index/normal/entry_header.phtml
@@ -54,6 +54,9 @@
 		<a href="<?= _url('index', 'index', 'get', 'f_' . $this->feed->id()) ?>" class="item-element" title="<?= _t('gen.action.filter') ?>: <?= $this->feed->name() ?>">
 			<?php if (FreshRSS_Context::userConf()->show_favicons && 'name' !== $topline_website): ?><img class="favicon" src="<?= $this->feed->favicon() ?>" alt="✇" loading="lazy" /><?php endif; ?><?php if ('icon' !== $topline_website): ?><span class="websiteName"><?= $this->feed->name() ?></span><?php endif; ?>
 		</a>
+		<?php if ($this->feed->website() !== ''): ?>
+		<a target="_blank" rel="noreferrer" href="<?= $this->feed->website() ?>" class="item-element" title="<?= _t('gen.action.open_url') ?>"><?= _i('link') ?></a>
+		<?php endif; ?>
 		</li><?php
 	endif; ?>
 

--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -96,7 +96,7 @@ $today = @strtotime('today');
 					<?php if (FreshRSS_Context::userConf()->show_feed_name === 't') { ?>
 						<div class="website"><a href="<?= _url('index', 'index', 'get', 'f_' . $this->feed->id()) ?>" title="<?= _t('gen.action.filter') ?>">
 							<?php if (FreshRSS_Context::userConf()->show_favicons): ?>
-								<img class="favicon" src="<?= $this->feed->favicon() ?>" alt="✇" loading="lazy" /><?php
+							<img class="favicon" src="<?= $this->feed->favicon() ?>" alt="✇" loading="lazy" /><?php
 							endif; ?><span><?= $this->feed->name() ?></span></a>
 							<?php if ($this->feed->website() !== '') { ?>
 								<a class="btn" target="_blank" rel="noreferrer" href="<?= $this->feed->website() ?>" title="<?= _t('gen.action.open_url') ?>"><?= _i('link') ?></a>

--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -98,6 +98,9 @@ $today = @strtotime('today');
 							<?php if (FreshRSS_Context::userConf()->show_favicons): ?>
 								<img class="favicon" src="<?= $this->feed->favicon() ?>" alt="✇" loading="lazy" /><?php
 							endif; ?><span><?= $this->feed->name() ?></span></a>
+							<?php if ($this->feed->website() !== '') { ?>
+								<a class="btn" target="_blank" rel="noreferrer" href="<?= $this->feed->website() ?>" title="<?= _t('gen.action.open_url') ?>"><?= _i('link') ?></a>
+							<?php } ?>
 						</div>
 					<?php } ?>
 					<?php if (FreshRSS_Context::userConf()->show_tags === 'h' || FreshRSS_Context::userConf()->show_tags === 'b') {
@@ -112,8 +115,11 @@ $today = @strtotime('today');
 						<?php if (FreshRSS_Context::userConf()->show_feed_name === 'a') { ?>
 							<div class="website"><a href="<?= _url('index', 'index', 'get', 'f_' . $this->feed->id()) ?>" title="<?= _t('gen.action.filter') ?>">
 								<?php if (FreshRSS_Context::userConf()->show_favicons): ?>
-									<img class="favicon" src="<?= $this->feed->favicon() ?>" alt="✇" loading="lazy" /><?php
+								<img class="favicon" src="<?= $this->feed->favicon() ?>" alt="✇" loading="lazy" /><?php
 								endif; ?><span><?= $this->feed->name() ?></span></a>
+								<?php if ($this->feed->website() !== '') { ?>
+									<a class="btn" target="_blank" rel="noreferrer" href="<?= $this->feed->website() ?>" title="<?= _t('gen.action.open_url') ?>"><?= _i('link') ?></a>
+								<?php } ?>
 							</div>
 						<?php }
 						if (!empty($this->entry->authors())) {

--- a/app/views/index/normal.phtml
+++ b/app/views/index/normal.phtml
@@ -96,7 +96,7 @@ $today = @strtotime('today');
 					<?php if (FreshRSS_Context::userConf()->show_feed_name === 't') { ?>
 						<div class="website"><a href="<?= _url('index', 'index', 'get', 'f_' . $this->feed->id()) ?>" title="<?= _t('gen.action.filter') ?>">
 							<?php if (FreshRSS_Context::userConf()->show_favicons): ?>
-							<img class="favicon" src="<?= $this->feed->favicon() ?>" alt="✇" loading="lazy" /><?php
+								<img class="favicon" src="<?= $this->feed->favicon() ?>" alt="✇" loading="lazy" /><?php
 							endif; ?><span><?= $this->feed->name() ?></span></a>
 							<?php if ($this->feed->website() !== '') { ?>
 								<a class="btn" target="_blank" rel="noreferrer" href="<?= $this->feed->website() ?>" title="<?= _t('gen.action.open_url') ?>"><?= _i('link') ?></a>
@@ -115,7 +115,7 @@ $today = @strtotime('today');
 						<?php if (FreshRSS_Context::userConf()->show_feed_name === 'a') { ?>
 							<div class="website"><a href="<?= _url('index', 'index', 'get', 'f_' . $this->feed->id()) ?>" title="<?= _t('gen.action.filter') ?>">
 								<?php if (FreshRSS_Context::userConf()->show_favicons): ?>
-								<img class="favicon" src="<?= $this->feed->favicon() ?>" alt="✇" loading="lazy" /><?php
+									<img class="favicon" src="<?= $this->feed->favicon() ?>" alt="✇" loading="lazy" /><?php
 								endif; ?><span><?= $this->feed->name() ?></span></a>
 								<?php if ($this->feed->website() !== '') { ?>
 									<a class="btn" target="_blank" rel="noreferrer" href="<?= $this->feed->website() ?>" title="<?= _t('gen.action.open_url') ?>"><?= _i('link') ?></a>


### PR DESCRIPTION
## What changed
- Adds a direct external-link icon beside a feed name in normal reading mode.
- Covers both the initial page and dynamically rendered entries.

## Why
The feed configuration already exposes the site homepage, but reading a feed required opening the management menu first.

## Validation
- `git diff --check`
- GitHub Actions will run the PHP checks.

Closes #8841