### PR TITLE
Avoid missing unread cache index failures

### DIFF
--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -456,13 +456,10 @@ class FreshRSS_EntryDAO extends Minz_ModelPdo {
 	 * feeds from one category or on all feeds.
 	 */
 	protected function updateCacheUnreads(?int $catId = null, ?int $feedId = null): bool {
-		// Help MySQL/MariaDB's optimizer with the query plan:
-		$useIndex = $this->pdo->dbType() === 'mysql' ? 'USE INDEX (entry_feed_read_index)' : '';
-
 		$sql = <<<SQL
 			UPDATE `_feed`
 			SET `cache_nbUnreads`=(
-				SELECT COUNT(*) AS nbUnreads FROM `_entry` e {$useIndex}
+				SELECT COUNT(*) AS nbUnreads FROM `_entry` e
 				WHERE e.id_feed=`_feed`.id AND e.is_read=0)
 			WHERE 1=1
 			SQL;


### PR DESCRIPTION
## What changed
- Stops forcing `entry_feed_read_index` when recalculating unread-count caches.

## Why
Older upgraded MySQL/MariaDB databases can lack that historical index. The forced index hint then turns a cache refresh into a SQL error and makes read/unread views appear empty. Letting the database optimizer select an available index keeps those installations working while current schemas still retain the composite index.

## Validation
- `git diff --check`
- GitHub Actions will run the PHP test and static-analysis suite.

Closes #8492