### PR TITLE
Complete Spanish admin translations

### DIFF
--- a/app/i18n/es/admin.php
+++ b/app/i18n/es/admin.php
@@ -92,12 +92,12 @@ return array(
 		'force_email_validation' => 'Forzar la validación de direcciones de correo electrónico',
 		'instance-name' => 'Nombre de la fuente',
 		'internal-host-allowlist' => array(
-			'_' => 'Internal host allowlist',	// TODO
-			'help' => 'One entry per line:<ul><li>A <code>host:port</code>. For instance <code>127.0.0.1:8080</code> or <code>rss-bridge:80</code></li><li>A CIDR notation. For instance <code>0.0.0.0/0</code> to allow any IPv4, <code>::/0</code> to allow any IPv6</li><li>A <code>*</code> to allow any host (unsafe)</li></ul>',	// TODO
+			'_' => 'Lista de permitidos de hosts internos',
+			'help' => 'Una entrada por línea:<ul><li>Un <code>host:puerto</code>. Por ejemplo, <code>127.0.0.1:8080</code> o <code>rss-bridge:80</code></li><li>Una notación CIDR. Por ejemplo, <code>0.0.0.0/0</code> para permitir cualquier IPv4, <code>::/0</code> para permitir cualquier IPv6</li><li>Un <code>*</code> para permitir cualquier host (inseguro)</li></ul>',
 		),
 		'max-categories' => 'Límite de categorías por usuario',
 		'max-feeds' => 'Límite de fuentes por usuario',
-		'override-by-env-var' => 'This setting is set by the environment variable <kbd>%s</kbd>.',	// TODO
+		'override-by-env-var' => 'Esta opción la establece la variable de entorno <kbd>%s</kbd>.',
 		'registration' => array(
 			'number' => 'Número máximo de cuentas',
 			'select' => array(

--- a/app/i18n/es/conf.php
+++ b/app/i18n/es/conf.php
@@ -312,8 +312,8 @@ return array(
 			'when' => 'Marca un artículo como favorito…',
 		),
 		'sticky_post' => 'Fijar el artículo a la parte superior al abrirlo',
-		'sticky_sort' => 'Mantener el orden de clasificación manual durante la navegación',	// DIRTY
-		'sticky_sort_help' => 'Determina si se mantiene activo el último orden de clasificación manual o si cada categoría o fuente usa siempre su propia configuración predeterminada o global.',	// DIRTY
+		'sticky_sort' => 'Mantener el orden de clasificación personalizado durante la navegación',
+		'sticky_sort_help' => 'Determina si se mantiene activo el último orden de clasificación personalizado o si cada categoría o fuente usa siempre su propia configuración predeterminada o global.',
 		'title' => 'Lectura',
 		'view' => array(
 			'default' => 'Vista por defecto',

--- a/app/i18n/es/gen.php
+++ b/app/i18n/es/gen.php
@@ -174,12 +174,12 @@ return array(
 		'confirm_exit_slider' => '¿Estás seguro de que quieres descartar los cambios no guardados?',
 		'feedback' => array(
 			'body_new_articles' => array(
-				0 => 'Hay %d artículo nuevo para leer en FreshRSS.',	// DIRTY
-				1 => 'Hay %d nuevos artículos para leer en FreshRSS.',	// DIRTY
+				0 => 'Hay %d artículo nuevo para leer en FreshRSS.',
+				1 => 'Hay %d artículos nuevos para leer en FreshRSS.',
 			),
 			'body_unread_articles' => array(
-				0 => '(No leídos: %d)',	// DIRTY
-				1 => '(No leídos: %d)',	// DIRTY
+				0 => '(sin leer: %d)',
+				1 => '(sin leer: %d)',
 			),
 			'request_failed' => 'La petición ha fallado. Puede ser debido a problemas de conexión a internet.',
 			'title_new_articles' => 'FreshRSS: ¡nuevos artículos!',


### PR DESCRIPTION
## What changed
- Translates the Spanish internal-host allowlist configuration and its help text.
- Completes adjacent Spanish notification and reading-setting strings.

## Validation
- `git diff --check`
- GitHub Actions will validate translation syntax and generated status.