### PR TITLE
Complete Italian admin translations

### DIFF
--- a/app/i18n/it/admin.php
+++ b/app/i18n/it/admin.php
@@ -92,12 +92,12 @@ return array(
 		'force_email_validation' => 'Forza la validazione dell’indirizzo mail',
 		'instance-name' => 'Nome istanza',
 		'internal-host-allowlist' => array(
-			'_' => 'Internal host allowlist',	// TODO
-			'help' => 'One entry per line:<ul><li>A <code>host:port</code>. For instance <code>127.0.0.1:8080</code> or <code>rss-bridge:80</code></li><li>A CIDR notation. For instance <code>0.0.0.0/0</code> to allow any IPv4, <code>::/0</code> to allow any IPv6</li><li>A <code>*</code> to allow any host (unsafe)</li></ul>',	// TODO
+			'_' => 'Elenco di host interni consentiti',
+			'help' => 'Una voce per riga:<ul><li>Un <code>host:porta</code>. Ad esempio <code>127.0.0.1:8080</code> o <code>rss-bridge:80</code></li><li>Una notazione CIDR. Ad esempio <code>0.0.0.0/0</code> per consentire qualsiasi IPv4, <code>::/0</code> per consentire qualsiasi IPv6</li><li>Un <code>*</code> per consentire qualsiasi host (non sicuro)</li></ul>',
 		),
 		'max-categories' => 'Limite categorie per utente',
 		'max-feeds' => 'Limite feeds per utente',
-		'override-by-env-var' => 'This setting is set by the environment variable <kbd>%s</kbd>.',	// TODO
+		'override-by-env-var' => 'Questa impostazione è definita dalla variabile d’ambiente <kbd>%s</kbd>.',
 		'registration' => array(
 			'number' => 'Numero massimo di profili',
 			'select' => array(

--- a/app/i18n/it/conf.php
+++ b/app/i18n/it/conf.php
@@ -312,8 +312,8 @@ return array(
 			'when' => 'Segna un articolo come preferito…',
 		),
 		'sticky_post' => 'Blocca il contenuto a inizio pagina quando aperto',
-		'sticky_sort' => 'Mantieni l’ordinamento manuale durante la navigazione',	// DIRTY
-		'sticky_sort_help' => 'Determina se l’ultimo ordinamento manuale rimane attivo oppure se ogni categoria o feed usa sempre la propria impostazione predefinita o globale.',	// DIRTY
+		'sticky_sort' => 'Mantieni l’ordinamento personalizzato durante la navigazione',
+		'sticky_sort_help' => 'Determina se l’ultimo ordinamento personalizzato rimane attivo oppure se ogni categoria o feed usa sempre la propria impostazione predefinita o globale.',
 		'title' => 'Lettura',
 		'view' => array(
 			'default' => 'Visualizzazione predefinita',

--- a/app/i18n/it/gen.php
+++ b/app/i18n/it/gen.php
@@ -174,12 +174,12 @@ return array(
 		'confirm_exit_slider' => 'Sei sicuro di voler perdere le impostazioni non salvate?',
 		'feedback' => array(
 			'body_new_articles' => array(
-				0 => 'C\'è %d nuovo articolo da leggere.',	// DIRTY
-				1 => 'Ci sono %d nuovi articoli da leggere.',	// DIRTY
+				0 => 'C\'è %d nuovo articolo da leggere su FreshRSS.',
+				1 => 'Ci sono %d nuovi articoli da leggere su FreshRSS.',
 			),
 			'body_unread_articles' => array(
-				0 => '(non letti: %d)',	// DIRTY
-				1 => '(non letti: %d)',	// DIRTY
+				0 => '(non letto: %d)',
+				1 => '(non letti: %d)',
 			),
 			'request_failed' => 'Richiesta fallita, probabilmente a causa di problemi di connessione',
 			'title_new_articles' => 'Feed RSS Reader: nuovi articoli!',


### PR DESCRIPTION
## Summary
- translate the internal-host allowlist administration copy to Italian
- complete Italian notifications for newly fetched and unread articles
- align the Italian custom sort wording with the current feature terminology

## Validation
- `git diff --check`

Closes no issue.