### PR TITLE
Complete German admin translations

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -228,7 +228,7 @@ Voir le [dépôt dédié à ces extensions](https://github.com/FreshRSS/Extensio
 | Langage | Progression | |
 | - | - | - |
 | Čeština (cs) | ￭￭￭￭￭￭￭￭･･ 81% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fcs+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Deutsch (de) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fde+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Deutsch (de) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fde+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Ελληνικά (el) | ￭￭￭￭￭￭￭･･･ 75% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fel+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (en) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ See the [repository dedicated to those extensions](https://github.com/FreshRSS/E
 | Language | Progress | |
 | - | - | - |
 | Čeština (cs) | ￭￭￭￭￭￭￭￭･･ 81% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fcs+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Deutsch (de) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fde+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Deutsch (de) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fde+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Ελληνικά (el) | ￭￭￭￭￭￭￭･･･ 75% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fel+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (en) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |

--- a/app/i18n/de/admin.php
+++ b/app/i18n/de/admin.php
@@ -92,12 +92,12 @@ return array(
 		'force_email_validation' => 'E-Mail-Adressprüfung erzwingen',
 		'instance-name' => 'Bezeichnung',
 		'internal-host-allowlist' => array(
-			'_' => 'Internal host allowlist',	// TODO
-			'help' => 'One entry per line:<ul><li>A <code>host:port</code>. For instance <code>127.0.0.1:8080</code> or <code>rss-bridge:80</code></li><li>A CIDR notation. For instance <code>0.0.0.0/0</code> to allow any IPv4, <code>::/0</code> to allow any IPv6</li><li>A <code>*</code> to allow any host (unsafe)</li></ul>',	// TODO
+			'_' => 'Liste erlaubter interner Hosts',
+			'help' => 'Ein Eintrag pro Zeile:<ul><li>Ein <code>Host:Port</code>. Zum Beispiel <code>127.0.0.1:8080</code> oder <code>rss-bridge:80</code></li><li>Eine CIDR-Notation. Zum Beispiel <code>0.0.0.0/0</code>, um jede IPv4-Adresse zu erlauben, oder <code>::/0</code>, um jede IPv6-Adresse zu erlauben</li><li>Ein <code>*</code>, um jeden Host zu erlauben (unsicher)</li></ul>',
 		),
 		'max-categories' => 'Anzahl erlaubter Kategorien pro Benutzer',
 		'max-feeds' => 'Anzahl erlaubter Feeds pro Benutzer',
-		'override-by-env-var' => 'This setting is set by the environment variable <kbd>%s</kbd>.',	// TODO
+		'override-by-env-var' => 'Diese Einstellung wird durch die Umgebungsvariable <kbd>%s</kbd> gesetzt.',
 		'registration' => array(
 			'number' => 'Maximale Anzahl von Accounts',
 			'select' => array(

--- a/app/i18n/de/conf.php
+++ b/app/i18n/de/conf.php
@@ -38,7 +38,7 @@ return array(
 			'help' => 'Nur für kompatible Themes',
 			'no' => 'Nein',
 		),
-		'display_enclosures' => 'Show enclosures',	// TODO
+		'display_enclosures' => 'Anhänge anzeigen',
 		'icon' => array(
 			'bottom_line' => 'Fußzeile',
 			'display_authors' => 'Autoren',
@@ -57,11 +57,11 @@ return array(
 		'show_nav_buttons' => 'Navigationsschaltflächen anzeigen',
 		'show_title_unread' => 'Anzahl ungelesener Artikel im Titel anzeigen',
 		'show_unread_count' => array(
-			'_' => 'Show unread counts in sidebar',	// TODO
-			'all' => 'For all categories and feeds',	// TODO
-			'important' => 'For important feeds only',	// TODO
-			'important_locked' => 'Important feeds always show their unread count.',	// TODO
-			'none' => 'Never',	// TODO
+			'_' => 'Anzahl ungelesener Artikel in der Seitenleiste anzeigen',
+			'all' => 'Für alle Kategorien und Feeds',
+			'important' => 'Nur für wichtige Feeds',
+			'important_locked' => 'Wichtige Feeds zeigen immer ihre Anzahl ungelesener Artikel an.',
+			'none' => 'Nie',
 		),
 		'sidebar_hidden_by_default' => 'Seitenleiste standardmäßig ausblenden',
 		'theme' => array(
@@ -312,8 +312,8 @@ return array(
 			'when' => 'Artikel als Favorit markieren…',
 		),
 		'sticky_post' => 'Wenn geöffnet, den Artikel ganz oben anheften',
-		'sticky_sort' => 'Manuelle Sortierung bei der Navigation beibehalten',	// DIRTY
-		'sticky_sort_help' => 'Legt fest, ob die letzte manuelle Sortierung aktiv bleibt oder ob jede Kategorie bzw. jeder Feed immer die eigene Standard- oder globale Einstellung verwendet.',	// DIRTY
+		'sticky_sort' => 'Benutzerdefinierte Sortierung bei der Navigation beibehalten',
+		'sticky_sort_help' => 'Legt fest, ob die letzte benutzerdefinierte Sortierung aktiv bleibt oder ob jede Kategorie bzw. jeder Feed immer die eigene Standard- oder globale Einstellung verwendet.',
 		'title' => 'Lesen',
 		'view' => array(
 			'default' => 'Standard-Ansicht',

--- a/app/i18n/de/gen.php
+++ b/app/i18n/de/gen.php
@@ -174,12 +174,12 @@ return array(
 		'confirm_exit_slider' => 'Sollen die nicht gespeicherten Einstellungen wirklich verworfen werden?',
 		'feedback' => array(
 			'body_new_articles' => array(
-				0 => 'Es gibt %d neuen Artikel zum Lesen auf FreshRSS.',	// DIRTY
-				1 => 'Es gibt %d neue Artikel zum Lesen auf FreshRSS.',	// DIRTY
+				0 => 'Es gibt %d neuen Artikel auf FreshRSS zu lesen.',
+				1 => 'Es gibt %d neue Artikel auf FreshRSS zu lesen.',
 			),
 			'body_unread_articles' => array(
-				0 => '(Ungelesen: %d)',	// DIRTY
-				1 => '(Ungelesen: %d)',	// DIRTY
+				0 => '(Ungelesen: %d)',
+				1 => '(Ungelesen: %d)',
 			),
 			'request_failed' => 'Eine Anfrage ist fehlgeschlagen, dies könnte durch Probleme mit der Internetverbindung verursacht worden sein.',
 			'title_new_articles' => 'FreshRSS: neue Artikel!',


### PR DESCRIPTION
## Summary
- translate internal-host access controls and environment override copy to German
- localize unread-count sidebar settings and current custom-sort terminology
- complete new-article notification grammar

## Validation
- `git diff --check`