### PR TITLE
Complete Polish reading translations

### DIFF
--- a/app/i18n/pl/conf.php
+++ b/app/i18n/pl/conf.php
@@ -38,7 +38,7 @@ return array(
 			'help' => 'Wyłącznie dla kompatybilnych wyglądów',
 			'no' => 'Wyłączony',
 		),
-		'display_enclosures' => 'Show enclosures',	// TODO
+		'display_enclosures' => 'Pokaż załączniki',
 		'icon' => array(
 			'bottom_line' => 'Dolny margines',
 			'display_authors' => 'Autorzy',
@@ -57,11 +57,11 @@ return array(
 		'show_nav_buttons' => 'Pokaż przyciski nawigacyjne',
 		'show_title_unread' => 'Pokaż liczbę nieprzeczytanych wiadomości w tytule',
 		'show_unread_count' => array(
-			'_' => 'Show unread counts in sidebar',	// TODO
-			'all' => 'For all categories and feeds',	// TODO
-			'important' => 'For important feeds only',	// TODO
-			'important_locked' => 'Important feeds always show their unread count.',	// TODO
-			'none' => 'Never',	// TODO
+			'_' => 'Pokaż liczbę nieprzeczytanych na pasku bocznym',
+			'all' => 'Dla wszystkich kategorii i kanałów',
+			'important' => 'Tylko dla ważnych kanałów',
+			'important_locked' => 'Ważne kanały zawsze pokazują liczbę nieprzeczytanych.',
+			'none' => 'Nigdy',
 		),
 		'sidebar_hidden_by_default' => 'Ukryj pasek boczny domyślnie',
 		'theme' => array(
@@ -312,8 +312,8 @@ return array(
 			'when' => 'Oznacz wiadomość jako ulubioną…',
 		),
 		'sticky_post' => 'Przesuń wiadomość na górę strony po otworzeniu',
-		'sticky_sort' => 'Zachowaj ręczną kolejność sortowania podczas nawigacji',	// DIRTY
-		'sticky_sort_help' => 'Określa, czy ostatnia ręczna kolejność sortowania pozostaje aktywna, czy każda kategoria lub kanał zawsze używa własnego ustawienia domyślnego lub globalnego.',	// DIRTY
+		'sticky_sort' => 'Zachowaj niestandardową kolejność sortowania podczas nawigacji',
+		'sticky_sort_help' => 'Określa, czy ostatnia niestandardowa kolejność sortowania pozostaje aktywna, czy każda kategoria lub kanał zawsze używa własnego ustawienia domyślnego lub globalnego.',
 		'title' => 'Czytanie',
 		'view' => array(
 			'default' => 'Domyślny widok',

--- a/app/i18n/pl/gen.php
+++ b/app/i18n/pl/gen.php
@@ -180,14 +180,14 @@ return array(
 		'confirm_exit_slider' => 'Czy na pewno chcesz odrzucić niezapisane ustawienia?',
 		'feedback' => array(
 			'body_new_articles' => array(
-				0 => 'W FreshRSS znajduje się %d wiadomości do przeczytania.',	// DIRTY
-				1 => 'W FreshRSS znajduje się %d wiadomości do przeczytania.',	// DIRTY
-				2 => 'W FreshRSS znajduje się %d wiadomości do przeczytania.',	// DIRTY
+				0 => 'W FreshRSS jest %d nowy artykuł do przeczytania.',
+				1 => 'W FreshRSS są %d nowe artykuły do przeczytania.',
+				2 => 'W FreshRSS jest %d nowych artykułów do przeczytania.',
 			),
 			'body_unread_articles' => array(
-				0 => '(Nieprzeczytane: %d)',	// DIRTY
-				1 => '(Nieprzeczytane: %d)',	// DIRTY
-				2 => '(Nieprzeczytane: %d)',	// DIRTY
+				0 => '(Nieprzeczytany: %d)',
+				1 => '(Nieprzeczytane: %d)',
+				2 => '(Nieprzeczytanych: %d)',
 			),
 			'request_failed' => 'Zapytanie nie powiodło się. Może to być spowodowane problemami z łącznością z internetem.',
 			'title_new_articles' => 'FreshRSS: nowe wiadomości!',


### PR DESCRIPTION
## Summary
- translate enclosure and unread-count sidebar settings to Polish
- align the custom-sort setting with current terminology
- complete Polish plural forms for new and unread article notifications

## Validation
- `git diff --check`