### PR TITLE
Limit Nord title hover transition to work around Chromium bug

### DIFF
--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -815,7 +815,7 @@ li.item.active {
 
 .flux:not(.current):hover .item .title {
 	background: var(--accent-bg);
-	transition: .3s;
+	transition: background-color .3s;
 }
 
 .flux .flux_header .item .title {

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -815,7 +815,7 @@ li.item.active {
 
 .flux:not(.current):hover .item .title {
 	background: var(--accent-bg);
-	transition: .3s;
+	transition: background-color .3s;
 }
 
 .flux .flux_header .item .title {


### PR DESCRIPTION
## Summary

- limit the Nord theme title hover transition to the background color
- avoid transitioning layout-related properties for RTL titles in Chromium

## Validation

- `npx stylelint p/themes/Nord/nord.css p/themes/Nord/nord.rtl.css`
- `git diff --check`

Fixes #8075.
