### PR TITLE
Keep Dynamic OPML feed URLs on redirects

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -673,7 +673,7 @@ class FreshRSS_Feed extends Minz_Model {
 				}
 
 				$clean_url = \SimplePie\Misc::url_remove_credentials($subscribe_url);
-				if ($subscribe_url !== '' && $subscribe_url !== $url) {
+				if ($subscribe_url !== '' && $subscribe_url !== $url && $this->category()?->kind() !== FreshRSS_Category::KIND_DYNAMIC_OPML) {
 					$this->_url($clean_url);
 				}
 


### PR DESCRIPTION
## Summary

- keep the URL declared by a Dynamic OPML when its feed endpoint redirects permanently
- prevent the next Dynamic OPML refresh from muting the redirected feed and creating a duplicate

## Validation

- `git diff --check`

PHP and Composer are not available in this Windows environment; the repository CI will run the PHP test suite.

Fixes #8619.
Fixes #6673.
