### PR TITLE
Persist sort selected from navigation menu

### DIFF
--- a/app/Controllers/indexController.php
+++ b/app/Controllers/indexController.php
@@ -8,6 +8,22 @@ class FreshRSS_index_Controller extends FreshRSS_ActionController {
 
 	#[\Override]
 	public function firstAction(): void {
+		if (Minz_Request::isPost() && Minz_Request::paramBoolean('saveSort') && FreshRSS_Auth::hasAccess()) {
+			$sort = Minz_Request::paramString('sort', plaintext: true);
+			$order = Minz_Request::paramString('order', plaintext: true);
+			if (in_array($sort, ['id', 'c.name', 'date', 'f.name', 'lastUserModified', 'length', 'link', 'title'], true) &&
+				in_array($order, ['ASC', 'DESC'], true)) {
+				$userConf = FreshRSS_Context::userConf();
+				$userConf->sort = $sort;
+				$userConf->sort_order = $order;
+				$userConf->save();
+			}
+
+			$url = Minz_Request::currentRequest();
+			unset($url['params']['saveSort'], $url['params']['sort'], $url['params']['order']);
+			Minz_Request::forward($url, true);
+		}
+
 		$this->view->html_url = Minz_Url::display(['c' => 'index', 'a' => 'index'], 'html', 'root');
 	}
 

--- a/app/Models/UserConfiguration.php
+++ b/app/Models/UserConfiguration.php
@@ -59,7 +59,7 @@ declare(strict_types=1);
  * @property bool $sidebar_hidden_by_default
  * @property 'big'|'small'|'none' $mark_read_button
  * @property 'ASC'|'DESC' $sort_order
- * @property 'id'|'c.name'|'date'|'f.name'|'length'|'link'|'rand'|'title' $sort
+ * @property 'id'|'c.name'|'date'|'f.name'|'lastUserModified'|'length'|'link'|'rand'|'title' $sort
  * @property 'ASC'|'DESC' $secondary_sort_order
  * @property 'id'|'date'|'link'|'title' $secondary_sort
  * @property array<int,array<string,string>> $sharing

--- a/app/layout/nav_menu.phtml
+++ b/app/layout/nav_menu.phtml
@@ -240,7 +240,7 @@
 		<div class="dropdown">
 			<div id="dropdown-sort" class="dropdown-target"></div>
 			<a id="toggle-order" class="dropdown-toggle btn" href="#dropdown-sort" title="<?= _t('index.menu.sort.primary') ?>"><?= _i($icon) ?></a>
-			<ul class="dropdown-menu" role="radiogroup">
+			<ul id="sort-options" class="dropdown-menu" role="radiogroup">
 				<li class="item" role="radio" aria-checked="<?= FreshRSS_Context::$order === 'DESC' && FreshRSS_Context::$sort === 'id' ? 'true' : 'false' ?>">
 					<a href="<?= Minz_Url::display($url_order, amend: ['params' => ['sort' => 'id', 'order' => 'DESC']]) ?>"><?= _t('index.menu.sort.id_desc') ?></a></li>
 				<li class="item" role="radio" aria-checked="<?= FreshRSS_Context::$order === 'DESC' && FreshRSS_Context::$sort === 'date' ? 'true' : 'false' ?>">

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -2390,6 +2390,7 @@ function init_normal() {
 	init_stream(stream);
 	enforce_referrer_allowlist(stream);
 	init_actualize();
+	init_persist_sort();
 	faviconNbUnread();
 
 	// Keep exact sidebar scroll state for specific navigations
@@ -2430,6 +2431,25 @@ function init_normal() {
 				send_mark_queue_tick(null);
 			}
 		}
+	});
+}
+
+function init_persist_sort() {
+	const sortOptions = document.getElementById('sort-options');
+	const form = document.getElementById('post-csrf');
+	if (!sortOptions || !form) {
+		return;
+	}
+	sortOptions.addEventListener('click', (event) => {
+		const link = event.target.closest('a[href]');
+		if (!link || !sortOptions.contains(link)) {
+			return;
+		}
+		event.preventDefault();
+		const url = new URL(link.href, window.location.href);
+		url.searchParams.set('saveSort', '1');
+		form.action = url.href;
+		form.submit();
 	});
 }
 


### PR DESCRIPTION
## Summary

- persist the sort and order selected in the navigation menu for authenticated users
- keep ordinary sort URLs as non-persistent navigation overrides
- use the existing CSRF-protected form for the persistence request

## Validation

- `node --check p/scripts/main.js`
- `git diff --check`

PHP and Composer are not available in this Windows environment; repository CI will run PHP checks.

Fixes #8227.
