### PR TITLE
Preserve commas in author names

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -568,7 +568,7 @@ class FreshRSS_Entry extends Minz_Model {
 				$value = preg_split('/\s*[;]\s*/', $value, -1, PREG_SPLIT_NO_EMPTY) ?: [];
 				$value = Minz_Helper::htmlspecialchars_utf8($value);
 			} else {
-				$value = preg_split('/\s*[,]\s*/', $value, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+				$value = [$value];
 			}
 		}
 		$this->authors = $value;

--- a/tests/app/Models/EntryTest.php
+++ b/tests/app/Models/EntryTest.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+final class EntryTest extends \PHPUnit\Framework\TestCase {
+	public static function testAuthorsKeepsCommaContainingNameAsSingleAuthor(): void {
+		$entry = new FreshRSS_Entry(authors: 'Smith, John');
+		self::assertSame(['Smith, John'], $entry->authors());
+	}
+
+	public static function testAuthorsKeepsCommaSeparatedListAsSingleAuthor(): void {
+		// Known trade-off: a feed genuinely listing two authors separated only by a comma
+		// is now treated as one author, since comma is no longer used as a separator.
+		$entry = new FreshRSS_Entry(authors: 'Alice, Bob');
+		self::assertSame(['Alice, Bob'], $entry->authors());
+	}
+
+	public static function testAuthorsStillSplitsOnSemicolon(): void {
+		$entry = new FreshRSS_Entry(authors: 'Alice; Bob');
+		self::assertSame(['Alice', 'Bob'], $entry->authors());
+	}
+
+	public static function testAuthorsSplitsOnSemicolonWhilePreservingCommasWithinEachName(): void {
+		$entry = new FreshRSS_Entry(authors: 'Smith, John; Doe, Jane');
+		self::assertSame(['Smith, John', 'Doe, Jane'], $entry->authors());
+	}
+
+	public static function testAuthorsAsStringPrependsSemicolonSeparator(): void {
+		$entry = new FreshRSS_Entry(authors: 'Smith, John');
+		self::assertSame(';Smith, John', $entry->authors(true));
+	}
+}


### PR DESCRIPTION
Fixes #7909.

FreshRSS stores multiple authors separated by semicolons. A comma is valid inside a single creator name (for example, `Family name, Given name`) and must not turn it into two authors.

Validation:
- `git diff --check`
- PHP is unavailable in this Windows environment; GitHub Actions will run the project checks.