### PR TITLE
Refactor per-feed cURL option allowlist into a data-driven map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ See also [the FreshRSS releases](https://github.com/FreshRSS/FreshRSS/releases).
 	* Improve Spanish [#8878](https://github.com/FreshRSS/FreshRSS/pull/8878)
 	* Improve Ukrainian [#8871](https://github.com/FreshRSS/FreshRSS/pull/8871)
 * Misc.
+	* Refactor the per-feed cURL option allowlist into a single data-driven map, replacing the bespoke per-option sanitizing code [#9012](https://github.com/FreshRSS/FreshRSS/pull/9012)
 	* Update to PHPMailer 7.1.1 [#9807](https://github.com/FreshRSS/FreshRSS/pull/9807)
 	* Improve PHP code [#8906](https://github.com/FreshRSS/FreshRSS/pull/8906)
 	* Fix PHPStan 2.2.2 in CLI [#8911](https://github.com/FreshRSS/FreshRSS/pull/8911)

--- a/app/Utils/httpUtil.php
+++ b/app/Utils/httpUtil.php
@@ -104,36 +104,45 @@ final class FreshRSS_http_Util {
 	}
 
 	/**
+	 * The per-feed cURL options that are allowed to be set, each mapped to a sanitizer that
+	 * receives the candidate value and returns the value to actually keep.
+	 * A single entry here drives both the allowlist and the value sanitization, instead of
+	 * a separate allowlist plus a bespoke per-option `if` chain.
+	 *
+	 * @return array<int, callable(mixed): mixed>
+	 */
+	private static function safeCurlParamSanitizers(): array {
+		return [
+			CURLOPT_COOKIE => fn(mixed $value): mixed => $value,
+			// Allow only an empty value just to enable the libcurl cookie engine
+			CURLOPT_COOKIEFILE => fn(mixed $value): string => '',
+			CURLOPT_FOLLOWLOCATION => fn(mixed $value): mixed => $value,
+			// Remove HTTP authentication headers problematic for security
+			CURLOPT_HTTPHEADER => fn(mixed $value): mixed => is_array($value)
+				? array_filter($value,
+					fn($header) => is_string($header) && !preg_match('/^(Remote[-_\s]*User|X[-_\s]*WebAuth[-_\s]*User)\\s*:/i', $header))
+				: $value,
+			CURLOPT_MAXREDIRS => fn(mixed $value): mixed => $value,
+			CURLOPT_POST => fn(mixed $value): mixed => $value,
+			CURLOPT_POSTFIELDS => fn(mixed $value): mixed => $value,
+			CURLOPT_PROXY => fn(mixed $value): mixed => $value,
+			CURLOPT_PROXYTYPE => fn(mixed $value): mixed => $value,
+			CURLOPT_USERAGENT => fn(mixed $value): mixed => $value,
+		];
+	}
+
+	/**
 	 * @param array<mixed> $curl_params
 	 * @return array<mixed>
 	 */
 	public static function sanitizeCurlParams(array $curl_params): array {
-		$safe_params = [
-			CURLOPT_COOKIE,
-			CURLOPT_COOKIEFILE,
-			CURLOPT_FOLLOWLOCATION,	// We filter this value later, only allowing `false`
-			CURLOPT_HTTPHEADER,
-			CURLOPT_MAXREDIRS,
-			CURLOPT_POST,
-			CURLOPT_POSTFIELDS,
-			CURLOPT_PROXY,
-			CURLOPT_PROXYTYPE,
-			CURLOPT_USERAGENT,
-		];
-		foreach ($curl_params as $k => $_) {
-			if (!in_array($k, $safe_params, true)) {
+		$sanitizers = self::safeCurlParamSanitizers();
+		foreach ($curl_params as $k => $v) {
+			if (!array_key_exists($k, $sanitizers)) {
 				unset($curl_params[$k]);
 				continue;
 			}
-			// Allow only an empty value just to enable the libcurl cookie engine
-			if ($k === CURLOPT_COOKIEFILE) {
-				$curl_params[$k] = '';
-			}
-			// Remove HTTP authentication headers problematic for security
-			if ($k === CURLOPT_HTTPHEADER && is_array($curl_params[$k])) {
-				$curl_params[$k] = array_filter($curl_params[$k],
-					fn($header) => is_string($header) && !preg_match('/^(Remote[-_\s]*User|X[-_\s]*WebAuth[-_\s]*User)\\s*:/i', $header));
-			}
+			$curl_params[$k] = $sanitizers[$k]($v);
 		}
 		return $curl_params;
 	}

--- a/tests/app/Utils/httpUtilTest.php
+++ b/tests/app/Utils/httpUtilTest.php
@@ -38,4 +38,38 @@ class httpUtilTest extends \PHPUnit\Framework\TestCase {
 			['ftp://example.net/feed', 'https://example.net/feed', false],
 		];
 	}
+
+	public function test_sanitizeCurlParams_whenKeyNotAllowlisted_removesIt(): void {
+		$result = FreshRSS_http_Util::sanitizeCurlParams([CURLOPT_URL => 'https://example.net/']);
+		self::assertSame([], $result);
+	}
+
+	public function test_sanitizeCurlParams_whenCookiefileSet_forcesEmptyValue(): void {
+		$result = FreshRSS_http_Util::sanitizeCurlParams([CURLOPT_COOKIEFILE => '/etc/passwd']);
+		self::assertSame('', $result[CURLOPT_COOKIEFILE]);
+	}
+
+	public function test_sanitizeCurlParams_whenHttpHeaderHasAuthOverrides_stripsThem(): void {
+		$result = FreshRSS_http_Util::sanitizeCurlParams([
+			CURLOPT_HTTPHEADER => ['Remote-User: admin', 'X-WebAuth-User: admin', 'x_webauth_user: admin', 'Accept: text/xml'],
+		]);
+		self::assertIsArray($result[CURLOPT_HTTPHEADER]);
+		self::assertSame(['Accept: text/xml'], array_values($result[CURLOPT_HTTPHEADER]));
+	}
+
+	public function test_sanitizeCurlParams_whenHttpHeaderNotArray_passesThroughUnchanged(): void {
+		$result = FreshRSS_http_Util::sanitizeCurlParams([CURLOPT_HTTPHEADER => 'not-an-array']);
+		self::assertSame('not-an-array', $result[CURLOPT_HTTPHEADER]);
+	}
+
+	public function test_sanitizeCurlParams_whenAllowlistedKeyHasNoSpecialCase_keepsValueAsIs(): void {
+		$result = FreshRSS_http_Util::sanitizeCurlParams([
+			CURLOPT_USERAGENT => 'my-agent/1.0',
+			CURLOPT_MAXREDIRS => 3,
+			CURLOPT_PROXY => 'http://proxy.example.net:8080',
+		]);
+		self::assertSame('my-agent/1.0', $result[CURLOPT_USERAGENT]);
+		self::assertSame(3, $result[CURLOPT_MAXREDIRS]);
+		self::assertSame('http://proxy.example.net:8080', $result[CURLOPT_PROXY]);
+	}
 }


### PR DESCRIPTION
## Summary

Follow-up to the discussion on #9012: replaces the flat `CURLOPT_*` allowlist plus the bespoke per-option `if` chain in `FreshRSS_http_Util::sanitizeCurlParams()` with a single map of `CURLOPT_* => sanitizer`.

Previously, adding one more allowed cURL option to `$safe_params` meant touching two places if it needed any special handling (the allowlist array, and a separate `if ($k === ...)` block). Now a single map entry drives both the allowlist and the sanitizing logic for that option.

## Changes

- `sanitizeCurlParams()` now iterates a `CURLOPT_* => callable` map instead of an allowlist array + special cases.
- Behaviour is unchanged: `CURLOPT_COOKIEFILE` is still forced to an empty value, `CURLOPT_HTTPHEADER` still strips `Remote-User`/`X-WebAuth-User` override headers (and is left untouched if not an array), and every other currently-allowed option keeps passing through as before.
- Added `tests/app/Utils/httpUtilTest.php` coverage for the allowlist, the `COOKIEFILE` and `HTTPHEADER` special cases, and plain pass-through options.

## Scope note

This only covers the `sanitizeCurlParams()` side discussed on #9012. The OPML-import side (`ImportService::pushFeed()`'s per-`frss:CURLOPT_*` `if` chain, which also does type coercion and a couple of legacy quirks like the `CURLOPT_PROXYTYPE` `3` → `-1` mapping) is a separate, larger piece of work with its own OPML-compatibility constraints, so I left it out here to keep this PR focused and reviewable.

## Validation

- `phpunit` (targeted + full suite)
- `phpcs`
- `phpstan`