### PR TITLE
Allow triggering a SQLite export from the Web UI, gated by DB size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ See also [the FreshRSS releases](https://github.com/FreshRSS/FreshRSS/releases).
 	* New option to hide badges showing number of unread articles (*Phantom Obligation*) [#8844](https://github.com/FreshRSS/FreshRSS/pull/8844)
 	* New option to keep or not the custom sort order when navigating between categories and feeds [#8969](https://github.com/FreshRSS/FreshRSS/pull/8969)
 	* New per-feed option to show or hide enclosures (attachments) [#4999](https://github.com/FreshRSS/FreshRSS/issues/4999)
-	* Trigger an on-demand SQLite export from the Web UI, gated by a new `limits.sqlite_export_max_db_size` setting [#8183](https://github.com/FreshRSS/FreshRSS/issues/8183)
+	* Trigger an on-demand SQLite export from the Web UI, gated by a new `limits.sqlite_export_max_db_size` setting, with an admin override to force it past that limit [#8183](https://github.com/FreshRSS/FreshRSS/issues/8183)
 * Bug fixing
 	* Fix lost elements while parsing search query [#8884](https://github.com/FreshRSS/FreshRSS/pull/8884)
 * CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ See also [the FreshRSS releases](https://github.com/FreshRSS/FreshRSS/releases).
 	* New option to hide badges showing number of unread articles (*Phantom Obligation*) [#8844](https://github.com/FreshRSS/FreshRSS/pull/8844)
 	* New option to keep or not the custom sort order when navigating between categories and feeds [#8969](https://github.com/FreshRSS/FreshRSS/pull/8969)
 	* New per-feed option to show or hide enclosures (attachments) [#4999](https://github.com/FreshRSS/FreshRSS/issues/4999)
+	* Trigger an on-demand SQLite export from the Web UI, gated by a new `limits.sqlite_export_max_db_size` setting [#8183](https://github.com/FreshRSS/FreshRSS/issues/8183)
 * Bug fixing
 	* Fix lost elements while parsing search query [#8884](https://github.com/FreshRSS/FreshRSS/pull/8884)
 * CLI

--- a/README.fr.md
+++ b/README.fr.md
@@ -232,20 +232,20 @@ Voir le [dépôt dédié à ces extensions](https://github.com/FreshRSS/Extensio
 | Ελληνικά (el) | ￭￭￭￭￭￭￭･･･ 75% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fel+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (en) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Español (es) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
-| فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Español (es) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
+| فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Suomi (fi) | ￭￭￭￭￭￭￭￭￭･ 91% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffi+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Français (fr) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Français (fr) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | עברית (he) | ￭￭￭￭･･････ 41% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhe+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Magyar (hu) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhu+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭･･ 89% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Italiano (it) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fit+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Magyar (hu) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhu+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭･･ 88% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Italiano (it) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fit+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 日本語 (ja) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fja+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 한국어 (ko) | ￭￭￭￭￭￭￭￭･･ 81% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fko+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 한국어 (ko) | ￭￭￭￭￭￭￭￭･･ 80% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fko+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Latviešu (lv) | ￭￭￭￭￭￭￭￭･･ 81% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Flv+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Nederlands (nl) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fnl+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Occitan (oc) | ￭￭￭￭￭￭￭･･･ 74% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Foc+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Polski (pl) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpl+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Occitan (oc) | ￭￭￭￭￭￭￭･･･ 73% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Foc+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Polski (pl) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpl+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Português (Brasil) (pt-BR) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-BR+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Português (Portugal) (pt-PT) | ￭￭￭￭￭￭￭￭･･ 80% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-PT+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Русский (ru) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fru+%2F%28TODO%7CDIRTY%29%24%2F) |
@@ -253,7 +253,7 @@ Voir le [dépôt dédié à ces extensions](https://github.com/FreshRSS/Extensio
 | Türkçe (tr) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ftr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Українська (uk) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fuk+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 简体中文 (zh-CN) | ￭￭￭￭￭￭￭￭￭･ 96% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-CN+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 正體中文 (zh-TW) | ￭￭￭￭￭￭￭￭￭･ 97% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-TW+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 正體中文 (zh-TW) | ￭￭￭￭￭￭￭￭￭･ 96% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-TW+%2F%28TODO%7CDIRTY%29%24%2F) |
 
 </translations>
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -240,7 +240,7 @@ Voir le [dépôt dédié à ces extensions](https://github.com/FreshRSS/Extensio
 | Magyar (hu) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhu+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭･･ 88% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Italiano (it) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fit+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 日本語 (ja) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fja+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 日本語 (ja) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fja+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 한국어 (ko) | ￭￭￭￭￭￭￭￭･･ 80% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fko+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Latviešu (lv) | ￭￭￭￭￭￭￭￭･･ 81% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Flv+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Nederlands (nl) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fnl+%2F%28TODO%7CDIRTY%29%24%2F) |
@@ -249,10 +249,10 @@ Voir le [dépôt dédié à ces extensions](https://github.com/FreshRSS/Extensio
 | Português (Brasil) (pt-BR) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-BR+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Português (Portugal) (pt-PT) | ￭￭￭￭￭￭￭￭･･ 80% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-PT+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Русский (ru) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fru+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Slovenčina (sk) | ￭￭￭￭￭￭￭￭･･ 81% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fsk+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Türkçe (tr) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ftr+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Slovenčina (sk) | ￭￭￭￭￭￭￭￭･･ 80% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fsk+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Türkçe (tr) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ftr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Українська (uk) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fuk+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 简体中文 (zh-CN) | ￭￭￭￭￭￭￭￭￭･ 96% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-CN+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 简体中文 (zh-CN) | ￭￭￭￭￭￭￭￭￭･ 95% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-CN+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 正體中文 (zh-TW) | ￭￭￭￭￭￭￭￭￭･ 96% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-TW+%2F%28TODO%7CDIRTY%29%24%2F) |
 
 </translations>

--- a/README.md
+++ b/README.md
@@ -128,20 +128,20 @@ See the [repository dedicated to those extensions](https://github.com/FreshRSS/E
 | Ελληνικά (el) | ￭￭￭￭￭￭￭･･･ 75% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fel+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (en) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Español (es) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
-| فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Español (es) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
+| فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Suomi (fi) | ￭￭￭￭￭￭￭￭￭･ 91% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffi+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Français (fr) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Français (fr) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | עברית (he) | ￭￭￭￭･･････ 41% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhe+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Magyar (hu) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhu+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭･･ 89% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Italiano (it) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fit+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Magyar (hu) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhu+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭･･ 88% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Italiano (it) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fit+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 日本語 (ja) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fja+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 한국어 (ko) | ￭￭￭￭￭￭￭￭･･ 81% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fko+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 한국어 (ko) | ￭￭￭￭￭￭￭￭･･ 80% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fko+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Latviešu (lv) | ￭￭￭￭￭￭￭￭･･ 81% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Flv+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Nederlands (nl) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fnl+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Occitan (oc) | ￭￭￭￭￭￭￭･･･ 74% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Foc+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Polski (pl) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpl+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Occitan (oc) | ￭￭￭￭￭￭￭･･･ 73% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Foc+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Polski (pl) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpl+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Português (Brasil) (pt-BR) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-BR+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Português (Portugal) (pt-PT) | ￭￭￭￭￭￭￭￭･･ 80% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-PT+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Русский (ru) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fru+%2F%28TODO%7CDIRTY%29%24%2F) |
@@ -149,7 +149,7 @@ See the [repository dedicated to those extensions](https://github.com/FreshRSS/E
 | Türkçe (tr) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ftr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Українська (uk) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fuk+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 简体中文 (zh-CN) | ￭￭￭￭￭￭￭￭￭･ 96% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-CN+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 正體中文 (zh-TW) | ￭￭￭￭￭￭￭￭￭･ 97% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-TW+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 正體中文 (zh-TW) | ￭￭￭￭￭￭￭￭￭･ 96% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-TW+%2F%28TODO%7CDIRTY%29%24%2F) |
 
 </translations>
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ See the [repository dedicated to those extensions](https://github.com/FreshRSS/E
 | Magyar (hu) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhu+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭･･ 88% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Italiano (it) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fit+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 日本語 (ja) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fja+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 日本語 (ja) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fja+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 한국어 (ko) | ￭￭￭￭￭￭￭￭･･ 80% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fko+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Latviešu (lv) | ￭￭￭￭￭￭￭￭･･ 81% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Flv+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Nederlands (nl) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fnl+%2F%28TODO%7CDIRTY%29%24%2F) |
@@ -145,10 +145,10 @@ See the [repository dedicated to those extensions](https://github.com/FreshRSS/E
 | Português (Brasil) (pt-BR) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-BR+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Português (Portugal) (pt-PT) | ￭￭￭￭￭￭￭￭･･ 80% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-PT+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Русский (ru) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fru+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Slovenčina (sk) | ￭￭￭￭￭￭￭￭･･ 81% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fsk+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Türkçe (tr) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ftr+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Slovenčina (sk) | ￭￭￭￭￭￭￭￭･･ 80% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fsk+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Türkçe (tr) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ftr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Українська (uk) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fuk+%2F%28TODO%7CDIRTY%29%24%2F) |
-| 简体中文 (zh-CN) | ￭￭￭￭￭￭￭￭￭･ 96% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-CN+%2F%28TODO%7CDIRTY%29%24%2F) |
+| 简体中文 (zh-CN) | ￭￭￭￭￭￭￭￭￭･ 95% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-CN+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 正體中文 (zh-TW) | ￭￭￭￭￭￭￭￭￭･ 96% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fzh-TW+%2F%28TODO%7CDIRTY%29%24%2F) |
 
 </translations>

--- a/app/Controllers/importExportController.php
+++ b/app/Controllers/importExportController.php
@@ -35,6 +35,7 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 		$this->view->feeds = $this->feedDAO->listFeeds();
 		FreshRSS_View::prependTitle(_t('sub.import_export.title') . ' · ');
 		$this->listSqliteArchives();
+		$this->prepareSqliteExport();
 	}
 
 	private static function megabytes(string $size_str): float|int|string {
@@ -809,5 +810,58 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 			$this->view->sqliteName = 'freshrss_' . $username . '_' . $date . '_db.sqlite';
 		}
 		$this->view->_layout(null);
+	}
+
+	/**
+	 * Exposes to the view whether a new SQLite export can be triggered from the Web UI,
+	 * based on the current database size and the configured `limits.sqlite_export_max_db_size`.
+	 */
+	private function prepareSqliteExport(): void {
+		$maxSize = (int)(FreshRSS_Context::systemConf()->limits['sqlite_export_max_db_size'] ?? 0);
+		$this->view->sqliteExportMaxSize = $maxSize;
+		$this->view->sqliteExportEnabled = $maxSize > 0;
+		$this->view->sqliteExportAllowed = $this->view->sqliteExportEnabled
+			&& FreshRSS_DatabaseDAO::sizeWithinLimit(FreshRSS_Factory::createDatabaseDAO()->size(), $maxSize);
+	}
+
+	/**
+	 * This action triggers a new SQLite export of the current user's database, reachable from the Web UI.
+	 *
+	 * It must be reached by a POST request, and is refused if the database is larger than the configured
+	 * `limits.sqlite_export_max_db_size`.
+	 */
+	public function sqliteExportAction(): void {
+		if (!Minz_Request::isPost()) {
+			Minz_Request::forward(['c' => 'importExport', 'a' => 'index'], true);
+			return;
+		}
+
+		$maxSize = (int)(FreshRSS_Context::systemConf()->limits['sqlite_export_max_db_size'] ?? 0);
+		$databaseDAO = FreshRSS_Factory::createDatabaseDAO();
+
+		if (!FreshRSS_DatabaseDAO::sizeWithinLimit($databaseDAO->size(), $maxSize)) {
+			Minz_Request::bad(_t('feedback.import_export.sqlite_export_too_large'), ['c' => 'importExport', 'a' => 'index']);
+			return;
+		}
+
+		if (function_exists('set_time_limit')) {
+			@set_time_limit(300);
+		}
+		self::minimumMemory(256);
+
+		$filename = USERS_PATH . '/' . Minz_User::name() . '/' . gmdate('Ymd\THis\Z') . '.sqlite';
+		$exported = $databaseDAO->dbCopy($filename, FreshRSS_DatabaseDAO::SQLITE_EXPORT, false, false);
+
+		if (!$exported) {
+			@unlink($filename);
+			Minz_Request::bad(_t('feedback.import_export.sqlite_export_error'), ['c' => 'importExport', 'a' => 'index']);
+			return;
+		}
+
+		Minz_Request::good(
+			_t('feedback.import_export.sqlite_export_success'),
+			['c' => 'importExport', 'a' => 'index'],
+			showNotification: FreshRSS_Context::userConf()->good_notification_timeout > 0
+		);
 	}
 }

--- a/app/Controllers/importExportController.php
+++ b/app/Controllers/importExportController.php
@@ -820,6 +820,7 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 		$maxSize = (int)(FreshRSS_Context::systemConf()->limits['sqlite_export_max_db_size'] ?? 0);
 		$this->view->sqliteExportMaxSize = $maxSize;
 		$this->view->sqliteExportEnabled = $maxSize > 0;
+		$this->view->sqliteExportIsAdmin = FreshRSS_Context::userConf()->is_admin;
 		$this->view->sqliteExportAllowed = $this->view->sqliteExportEnabled
 			&& FreshRSS_DatabaseDAO::sizeWithinLimit(FreshRSS_Factory::createDatabaseDAO()->size(), $maxSize);
 	}
@@ -828,7 +829,7 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 	 * This action triggers a new SQLite export of the current user's database, reachable from the Web UI.
 	 *
 	 * It must be reached by a POST request, and is refused if the database is larger than the configured
-	 * `limits.sqlite_export_max_db_size`.
+	 * `limits.sqlite_export_max_db_size`, unless an admin explicitly forces it via the `force` parameter.
 	 */
 	public function sqliteExportAction(): void {
 		if (!Minz_Request::isPost()) {
@@ -838,8 +839,9 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 
 		$maxSize = (int)(FreshRSS_Context::systemConf()->limits['sqlite_export_max_db_size'] ?? 0);
 		$databaseDAO = FreshRSS_Factory::createDatabaseDAO();
+		$forced = Minz_Request::paramBoolean('force') && FreshRSS_Context::userConf()->is_admin;
 
-		if (!FreshRSS_DatabaseDAO::sizeWithinLimit($databaseDAO->size(), $maxSize)) {
+		if (!$forced && !FreshRSS_DatabaseDAO::sizeWithinLimit($databaseDAO->size(), $maxSize)) {
 			Minz_Request::bad(_t('feedback.import_export.sqlite_export_too_large'), ['c' => 'importExport', 'a' => 'index']);
 			return;
 		}

--- a/app/Models/DatabaseDAO.php
+++ b/app/Models/DatabaseDAO.php
@@ -300,6 +300,15 @@ class FreshRSS_DatabaseDAO extends Minz_ModelPdo {
 		return isset($res[0]) ? (int)($res[0]) : -1;
 	}
 
+	/**
+	 * Whether a database of a given size is within a configured maximum, e.g. to gate a Web UI action.
+	 * @param int $sizeBytes Database size in bytes, as returned by `size()`, or a negative value if unknown.
+	 * @param int $maxSizeBytes Maximum allowed size in bytes; a value ≤ 0 means the action is always disallowed.
+	 */
+	public static function sizeWithinLimit(int $sizeBytes, int $maxSizeBytes): bool {
+		return $maxSizeBytes > 0 && $sizeBytes >= 0 && $sizeBytes <= $maxSizeBytes;
+	}
+
 	public function optimize(): bool {
 		$ok = true;
 		$tables = ['category', 'feed', 'entry', 'entrytmp', 'tag', 'entrytag'];

--- a/app/Models/View.php
+++ b/app/Models/View.php
@@ -96,6 +96,7 @@ class FreshRSS_View extends Minz_View {
 	public string $sqliteName;
 	public bool $sqliteExportEnabled;
 	public bool $sqliteExportAllowed;
+	public bool $sqliteExportIsAdmin;
 	public int $sqliteExportMaxSize;
 
 	// Form login

--- a/app/Models/View.php
+++ b/app/Models/View.php
@@ -94,6 +94,9 @@ class FreshRSS_View extends Minz_View {
 	public ?array $sqliteArchives = null;
 	public string $sqlitePath;
 	public string $sqliteName;
+	public bool $sqliteExportEnabled;
+	public bool $sqliteExportAllowed;
+	public int $sqliteExportMaxSize;
 
 	// Form login
 	public int $cookie_days;

--- a/app/i18n/cs/feedback.php
+++ b/app/i18n/cs/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'Vaše kanály byly naimportovány, došlo ale k nějakým chybám / Your feeds have been imported, but some errors occurred. If you are done importing, you can now click the <i>Update feeds</i> button.',	// DIRTY
 		'file_cannot_be_uploaded' => 'Soubor nelze nahrát!',
 		'no_zip_extension' => 'Na serveru není přítomno rozšíření ZIP.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'Během importu ZIP došlo k chybě.',	// DIRTY
 	),
 	'profile' => array(

--- a/app/i18n/cs/sub.php
+++ b/app/i18n/cs/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Exportovat',
 			'sqlite' => 'Download user database as SQLite',	// TODO
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/cs/sub.php
+++ b/app/i18n/cs/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Exportovat',
 			'sqlite' => 'Download user database as SQLite',	// TODO
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'Exportovat články s vašimi popisky',
 		'export_opml' => 'Exportovat seznam kanálů (OPML)',

--- a/app/i18n/de/feedback.php
+++ b/app/i18n/de/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'Ihre Feeds sind importiert worden, aber es traten einige Fehler auf. Wenn Sie alle Dateien importiert haben, können Sie <i>Feeds aktualisieren</i> klicken.',
 		'file_cannot_be_uploaded' => 'Die Datei kann nicht hochgeladen werden!',
 		'no_zip_extension' => 'Die ZIP-Erweiterung ist auf Ihrem Server nicht vorhanden.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'Ein Fehler trat während des ZIP-Imports auf.',
 	),
 	'profile' => array(

--- a/app/i18n/de/sub.php
+++ b/app/i18n/de/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Exportieren',
 			'sqlite' => 'Nutzer-Datenbank als SQLite herunterladen',
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'Artikel mit Labeln exportieren',
 		'export_opml' => 'Liste der Feeds exportieren (OPML)',

--- a/app/i18n/de/sub.php
+++ b/app/i18n/de/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Exportieren',
 			'sqlite' => 'Nutzer-Datenbank als SQLite herunterladen',
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/el/feedback.php
+++ b/app/i18n/el/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'Οι ροές σας έχουν εισαχθεί, αλλά παρουσιάστηκαν κάποια σφάλματα. Αν ολοκληρώσατε την εισαγωγή, μπορείτε τώρα να κάνετε κλικ στο κουμπί <i>Ενημέρωση ροών</i>.',
 		'file_cannot_be_uploaded' => 'Το αρχείο δεν μπορεί να μεταφορτωθεί!',
 		'no_zip_extension' => 'Η επέκταση ZIP δεν υπάρχει στον διακομιστή σας.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'Παρουσιάστηκε σφάλμα κατά την επεξεργασία του ZIP.',
 	),
 	'profile' => array(

--- a/app/i18n/el/sub.php
+++ b/app/i18n/el/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Export',	// TODO
 			'sqlite' => 'Download user database as SQLite',	// TODO
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'Export your labelled articles',	// TODO
 		'export_opml' => 'Export list of feeds (OPML)',	// TODO

--- a/app/i18n/el/sub.php
+++ b/app/i18n/el/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Export',	// TODO
 			'sqlite' => 'Download user database as SQLite',	// TODO
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/en-US/feedback.php
+++ b/app/i18n/en-US/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'Your feeds have been imported, but some errors occurred. If you are done importing, you can now click the <i>Update feeds</i> button.',	// IGNORE
 		'file_cannot_be_uploaded' => 'File cannot be uploaded!',	// IGNORE
 		'no_zip_extension' => 'The ZIP extension is not present on your server.',	// IGNORE
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// IGNORE
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// IGNORE
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// IGNORE
 		'zip_error' => 'An error occurred during ZIP processing.',	// IGNORE
 	),
 	'profile' => array(

--- a/app/i18n/en-US/sub.php
+++ b/app/i18n/en-US/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Export',	// IGNORE
 			'sqlite' => 'Download user database as SQLite',	// IGNORE
+			'sqlite_now' => 'Export current database now',	// IGNORE
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// IGNORE
 		),
 		'export_labelled' => 'Export your labeled articles',
 		'export_opml' => 'Export list of feeds (OPML)',	// IGNORE

--- a/app/i18n/en-US/sub.php
+++ b/app/i18n/en-US/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Export',	// IGNORE
 			'sqlite' => 'Download user database as SQLite',	// IGNORE
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// IGNORE
 			'sqlite_now' => 'Export current database now',	// IGNORE
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// IGNORE
 		),

--- a/app/i18n/en/feedback.php
+++ b/app/i18n/en/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'Your feeds have been imported, but some errors occurred. If you are done importing, you can now click the <i>Update feeds</i> button.',
 		'file_cannot_be_uploaded' => 'File cannot be uploaded!',
 		'no_zip_extension' => 'The ZIP extension is not present on your server.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',
 		'zip_error' => 'An error occurred during ZIP processing.',
 	),
 	'profile' => array(

--- a/app/i18n/en/sub.php
+++ b/app/i18n/en/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Export',
 			'sqlite' => 'Download user database as SQLite',
+			'sqlite_now' => 'Export current database now',
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',
 		),
 		'export_labelled' => 'Export your labelled articles',
 		'export_opml' => 'Export list of feeds (OPML)',

--- a/app/i18n/en/sub.php
+++ b/app/i18n/en/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Export',
 			'sqlite' => 'Download user database as SQLite',
+			'sqlite_force' => 'Force export even if it exceeds the size limit',
 			'sqlite_now' => 'Export current database now',
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',
 		),

--- a/app/i18n/es/feedback.php
+++ b/app/i18n/es/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'Se importaron tus fuentes; pero hubo algunos errores. Si has terminado, puedes hacer click en el botón <i>Actualizar fuentes</i>',
 		'file_cannot_be_uploaded' => 'No es posible enviar el archivo',
 		'no_zip_extension' => 'La extensión ZIP no está disponible en tu servidor.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'Hubo un error durante la importación del ZIP.',
 	),
 	'profile' => array(

--- a/app/i18n/es/sub.php
+++ b/app/i18n/es/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Exportar',
 			'sqlite' => 'Descargar base de datos de usuario en formato SQLite',
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/es/sub.php
+++ b/app/i18n/es/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Exportar',
 			'sqlite' => 'Descargar base de datos de usuario en formato SQLite',
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'Exporta tus artículos etiquetados',
 		'export_opml' => 'Exportar la lista de fuentes (OPML)',

--- a/app/i18n/fa/feedback.php
+++ b/app/i18n/fa/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'فیدهای شما وارد شده‌اند، اما چند خطا رخ داده است. اگر کار وارد کردن تمام شده است، اکنون می‌توانید روی دکمه <i>به‌روزرسانی فیدها</i> کلیک کنید.',
 		'file_cannot_be_uploaded' => ' فایل قابل آپلود نیست!',
 		'no_zip_extension' => ' پسوند ZIP در سرور شما وجود ندارد.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => ' در حین پردازش ZIP خطایی روی داد.',
 	),
 	'profile' => array(

--- a/app/i18n/fa/sub.php
+++ b/app/i18n/fa/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => ' صادرات',
 			'sqlite' => 'دانلود پایگاه داده کاربر به عنوان SQLite',
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => ' مقالات برچسب دار خود را صادر کنید',
 		'export_opml' => ' لیست صادرات فیدها (OPML)',

--- a/app/i18n/fa/sub.php
+++ b/app/i18n/fa/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => ' صادرات',
 			'sqlite' => 'دانلود پایگاه داده کاربر به عنوان SQLite',
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/fi/feedback.php
+++ b/app/i18n/fi/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'Syötteet on tuotu palveluun, mutta tuonnissa ilmeni virheitä. Jos kaikki haluamasi syötteet on tuotu, voit nyt napsauttaa <i>Päivitä syötteet</i> -painiketta.',
 		'file_cannot_be_uploaded' => 'Tiedoston siirto palvelimeen ei onnistu!',
 		'no_zip_extension' => 'ZIP-laajennusta ei löydy palvelimesta.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'ZIP-käsittelyssä on ilmennyt virhe.',
 	),
 	'profile' => array(

--- a/app/i18n/fi/sub.php
+++ b/app/i18n/fi/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Vie',
 			'sqlite' => 'Lataa käyttäjän tietokanta SQLite-muodossa',
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'Vie merkityt artikkelit',
 		'export_opml' => 'Vie syöteluettelo (OPML)',

--- a/app/i18n/fi/sub.php
+++ b/app/i18n/fi/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Vie',
 			'sqlite' => 'Lataa käyttäjän tietokanta SQLite-muodossa',
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/fr/feedback.php
+++ b/app/i18n/fr/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'Vos flux ont été importés mais des erreurs sont survenues.	Si vous avez fini vos importations, vous pouvez cliquer le bouton <i>Actualiser flux</i>.',
 		'file_cannot_be_uploaded' => 'Le fichier ne peut pas être téléchargé !',
 		'no_zip_extension' => 'L’extension ZIP n’est pas présente sur votre serveur.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'Une erreur est survenue durant le traitement du fichier ZIP.',
 	),
 	'profile' => array(

--- a/app/i18n/fr/sub.php
+++ b/app/i18n/fr/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Exporter',
 			'sqlite' => 'Télécharger la base de donnée de l’utilisateur au format SQLite',
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'Exporter les articles étiquetés',
 		'export_opml' => 'Exporter la liste des flux (OPML)',

--- a/app/i18n/fr/sub.php
+++ b/app/i18n/fr/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Exporter',
 			'sqlite' => 'Télécharger la base de donnée de l’utilisateur au format SQLite',
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/he/feedback.php
+++ b/app/i18n/he/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'ההזנות שלך יובאו אך אירעו מספר שגיאות / Your feeds have been imported, but some errors occurred. If you are done importing, you can now click the <i>Update feeds</i> button.',	// DIRTY
 		'file_cannot_be_uploaded' => 'אין אפשרות להעלות את הקובץ!',
 		'no_zip_extension' => 'הרחבת ZIP אינה מותקנת על השרת.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'אירעה שגיאה במהלך ייבוא קובץ הZIP.',	// DIRTY
 	),
 	'profile' => array(

--- a/app/i18n/he/sub.php
+++ b/app/i18n/he/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'ייצוא',
 			'sqlite' => 'Download user database as SQLite',	// TODO
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/he/sub.php
+++ b/app/i18n/he/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'ייצוא',
 			'sqlite' => 'Download user database as SQLite',	// TODO
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'Export your labelled articles',	// TODO
 		'export_opml' => 'ייצוא רשימת הזנות (OPML)',

--- a/app/i18n/hu/feedback.php
+++ b/app/i18n/hu/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'A hírlisták importálása megtörtént, de néhány hiba történt / A hírlistáit importáltuk, de néhány hiba történt. Ha végzett az importálással, most rákattinthat a <i>Hírlisták frissítése</i> gombra.',
 		'file_cannot_be_uploaded' => 'A fájl nem feltölthető!',
 		'no_zip_extension' => 'A ZIP kiterjesztés nem létezik a szerveren.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'Hiba történt a ZIP feldolgozása közben.',
 	),
 	'profile' => array(

--- a/app/i18n/hu/sub.php
+++ b/app/i18n/hu/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Exportálás',
 			'sqlite' => 'Felhasználói adatbázis letöltése SQLite-ként',
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/hu/sub.php
+++ b/app/i18n/hu/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Exportálás',
 			'sqlite' => 'Felhasználói adatbázis letöltése SQLite-ként',
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'Címkézett cikkek exportálása',
 		'export_opml' => 'Hírforrások listájának exportálása (OPML)',

--- a/app/i18n/id/feedback.php
+++ b/app/i18n/id/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'Umpan Anda telah diimpor, tapi ada beberapa galat. Jika Anda sudah selesai mengimpor, Anda bisa mengklik tombol <i>Perbarui umpan</i>.',
 		'file_cannot_be_uploaded' => 'Berkas tidak dapt diunggah!',
 		'no_zip_extension' => 'Ekstensi ZIP tidak tersedia di peladen Anda.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'Galat terjadi ketika pemrosesan ZIP.',
 	),
 	'profile' => array(

--- a/app/i18n/id/sub.php
+++ b/app/i18n/id/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Ekspor',
 			'sqlite' => 'Unduh basis data pengguna dalam bentuk SQLite',
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'Ekspor artikel yang dilabelkan',
 		'export_opml' => 'Ekspor daftar umpan (OPML)',

--- a/app/i18n/id/sub.php
+++ b/app/i18n/id/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Ekspor',
 			'sqlite' => 'Unduh basis data pengguna dalam bentuk SQLite',
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/it/feedback.php
+++ b/app/i18n/it/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'I tuoi feed sono stati importati ma si sono verificati alcuni errori. Se hai completato l’importazione, puoi cliccare sul pulsante <i>Aggiorna feed</i>.',
 		'file_cannot_be_uploaded' => 'Il file non può essere caricato!',
 		'no_zip_extension' => 'Estensione ZIP non presente sul server.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'Si è verificato un errore importando il file ZIP',
 	),
 	'profile' => array(

--- a/app/i18n/it/sub.php
+++ b/app/i18n/it/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Esporta',
 			'sqlite' => 'Scaricare il database dell’utente in SQLite',
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'Esporta gli articoli etichettati',
 		'export_opml' => 'Esporta tutta la lista dei feed (OPML)',

--- a/app/i18n/it/sub.php
+++ b/app/i18n/it/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Esporta',
 			'sqlite' => 'Scaricare il database dell’utente in SQLite',
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/ja/feedback.php
+++ b/app/i18n/ja/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'フィードをインポートしましたが、一部でエラーが発生しました。インポートが完了したら<i>フィードを更新する</i>ボタンをクリックしてください。',
 		'file_cannot_be_uploaded' => 'ファイルをアップロードできません',
 		'no_zip_extension' => 'ZIP拡張機能がサーバーに存在しません。',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'ZIPの処理中にエラーが発生しました。',
 	),
 	'profile' => array(

--- a/app/i18n/ja/sub.php
+++ b/app/i18n/ja/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'エクスポート',
 			'sqlite' => 'ユーザーデータベースをSQLiteとしてダウンロードする',
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/ja/sub.php
+++ b/app/i18n/ja/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'エクスポート',
 			'sqlite' => 'ユーザーデータベースをSQLiteとしてダウンロードする',
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'ラベル付けされた記事をエクスポートする',
 		'export_opml' => 'フィードリストをエクスポートする（OPML）',

--- a/app/i18n/ko/feedback.php
+++ b/app/i18n/ko/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => '피드를 불러왔지만, 문제가 발생했습니다. 불러오기가 끝났다면 이제 <i>피드 업데이트</i> 버튼을 클릭해도 됩니다.',
 		'file_cannot_be_uploaded' => '파일을 업로드할 수 없습니다!',
 		'no_zip_extension' => 'ZIP 확장 기능을 서버에서 찾을 수 없습니다.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'ZIP 처리 중 문제가 발생했습니다.',
 	),
 	'profile' => array(

--- a/app/i18n/ko/sub.php
+++ b/app/i18n/ko/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => '내보내기',
 			'sqlite' => 'Download user database as SQLite',	// TODO
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => '라벨이 표시된 글들 내보내기',
 		'export_opml' => '피드 목록 내보내기 (OPML)',

--- a/app/i18n/ko/sub.php
+++ b/app/i18n/ko/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => '내보내기',
 			'sqlite' => 'Download user database as SQLite',	// TODO
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/lv/feedback.php
+++ b/app/i18n/lv/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'Jūsu barotnes tika importētas, bet ir radušās dažas kļūdas / Your feeds have been imported, but some errors occurred. If you are done importing, you can now click the <i>Update feeds</i> button.',	// DIRTY
 		'file_cannot_be_uploaded' => 'Failu nevar augšupielādēt!',
 		'no_zip_extension' => 'Jūsu serverī nav ZIP paplašinājuma.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'ZIP importa laikā notika kļūda.',	// DIRTY
 	),
 	'profile' => array(

--- a/app/i18n/lv/sub.php
+++ b/app/i18n/lv/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Eksportēt',
 			'sqlite' => 'Download user database as SQLite',	// TODO
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'Eksportēt ar birku marķētus rakstus',
 		'export_opml' => 'Eksportēt barotņu sarakstu (OPML)',

--- a/app/i18n/lv/sub.php
+++ b/app/i18n/lv/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Eksportēt',
 			'sqlite' => 'Download user database as SQLite',	// TODO
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/nl/feedback.php
+++ b/app/i18n/nl/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'Uw feeds zijn geïmporteerd, maar er zijn enkele fouten opgetreden. Als u klaar bent met importeren, kunt u nu op de knop <i>Feeds vernieuwen</i> klikken.',
 		'file_cannot_be_uploaded' => 'Bestand kan niet worden verzonden!',
 		'no_zip_extension' => 'ZIP uitbreiding is niet aanwezig op uw server.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'Er is een fout opgetreden tijdens het verwerken van het ZIP-bestand.',
 	),
 	'profile' => array(

--- a/app/i18n/nl/sub.php
+++ b/app/i18n/nl/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Exporteer',
 			'sqlite' => 'Gebruikersdatabase downloaden als SQLite',
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/nl/sub.php
+++ b/app/i18n/nl/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Exporteer',
 			'sqlite' => 'Gebruikersdatabase downloaden als SQLite',
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'Exporteer gelabelde artikels',
 		'export_opml' => 'Exporteer lijst van feeds (OPML)',

--- a/app/i18n/oc/feedback.php
+++ b/app/i18n/oc/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'Vòstres fluxes son estats importats mas i a agut d’errors / Your feeds have been imported, but some errors occurred. If you are done importing, you can now click the <i>Update feeds</i> button.',	// DIRTY
 		'file_cannot_be_uploaded' => 'Telecargament del fichièr impossible',
 		'no_zip_extension' => 'L’extension es pas presenta sul servidor.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'Una error s’es producha pendent l’importacion del fichièr ZIP.',	// DIRTY
 	),
 	'profile' => array(

--- a/app/i18n/oc/sub.php
+++ b/app/i18n/oc/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Exportar',
 			'sqlite' => 'Download user database as SQLite',	// TODO
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'Exportar los articles etiquetats',
 		'export_opml' => 'Exportar la lista de fluxes (OPML)',

--- a/app/i18n/oc/sub.php
+++ b/app/i18n/oc/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Exportar',
 			'sqlite' => 'Download user database as SQLite',	// TODO
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/pl/feedback.php
+++ b/app/i18n/pl/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'Kanały zostały zaimportowane, jednakże wystąpiło kilka błędów. Jeżeli skończyłeś, kliknij guzik <i>Aktualizuj kanały</i>.',
 		'file_cannot_be_uploaded' => 'Plik nie może zostać wgrany!',
 		'no_zip_extension' => 'Rozszerzenie ZIP nie jest dostępne na serwerze.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'Wystąpił błąd podczas przetwarzania pliku ZIP.',
 	),
 	'profile' => array(

--- a/app/i18n/pl/sub.php
+++ b/app/i18n/pl/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Eksport',
 			'sqlite' => 'Pobierz bazę danych użytkownika jako SQLite',
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/pl/sub.php
+++ b/app/i18n/pl/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Eksport',
 			'sqlite' => 'Pobierz bazę danych użytkownika jako SQLite',
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'Eksportuj wiadomości z etykietami',
 		'export_opml' => 'Eksportuj listę kanałów (format OPML)',

--- a/app/i18n/pt-BR/feedback.php
+++ b/app/i18n/pt-BR/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'Seus feeds foram importados, mas alguns erros ocorreram. Se você terminou de importar, pode clicar no botão <i>Atualizar feeds</i>.',
 		'file_cannot_be_uploaded' => 'Arquivo não pôde ser enviado',
 		'no_zip_extension' => 'extensão ZIP não está presente em seu servidor.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'Um erro ocorreu durante a importação do arquivo ZIP.',
 	),
 	'profile' => array(

--- a/app/i18n/pt-BR/sub.php
+++ b/app/i18n/pt-BR/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Exportar',
 			'sqlite' => 'Baixar banco de dados do usuário como SQLite',
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/pt-BR/sub.php
+++ b/app/i18n/pt-BR/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Exportar',
 			'sqlite' => 'Baixar banco de dados do usuário como SQLite',
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'Exportar seus artigos etiquetados',
 		'export_opml' => 'Exporta a lista dos feeds (OPML)',

--- a/app/i18n/pt-PT/feedback.php
+++ b/app/i18n/pt-PT/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'Seus feeds foram importados, mas alguns erros ocorreram Carregue no butão <i>atualizar feeds</i>.',
 		'file_cannot_be_uploaded' => 'Arquivo não pôde ser enviado',
 		'no_zip_extension' => 'extensão ZIP não está presente em seu servidor.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'Um erro ocorreu durante a importação do arquivo ZIP.',
 	),
 	'profile' => array(

--- a/app/i18n/pt-PT/sub.php
+++ b/app/i18n/pt-PT/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Exportar',
 			'sqlite' => 'Download user database as SQLite',	// TODO
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/pt-PT/sub.php
+++ b/app/i18n/pt-PT/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Exportar',
 			'sqlite' => 'Download user database as SQLite',	// TODO
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'Exportar seus artigos etiquetados',
 		'export_opml' => 'Exporta a lista dos feeds (OPML)',

--- a/app/i18n/ru/feedback.php
+++ b/app/i18n/ru/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'Ваши ленты импортированы, но возникли ошибки. Если вы завершили импортирование, можете нажать на кнопку <i>Обновить ленты</i>.',
 		'file_cannot_be_uploaded' => 'Файл не может быть загружен!',
 		'no_zip_extension' => 'На вашем сервере нет расширения ZIP.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'Ошибка возникла при импорте ZIP.',
 	),
 	'profile' => array(

--- a/app/i18n/ru/sub.php
+++ b/app/i18n/ru/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Экспорт',
 			'sqlite' => 'Скачать базу данных пользователя в формате SQLite',
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/ru/sub.php
+++ b/app/i18n/ru/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Экспорт',
 			'sqlite' => 'Скачать базу данных пользователя в формате SQLite',
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'Экспортировать ваши помеченные статьи',
 		'export_opml' => 'Экспортировать список лент (OPML)',

--- a/app/i18n/sk/feedback.php
+++ b/app/i18n/sk/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'Vaše kanály boli importované, ale vyskytli sa chyby. Ak ste s importovaním skončili, kliknite na tlačidlo <i>Aktualizovať kanále</i>.',
 		'file_cannot_be_uploaded' => 'Súbor sa nepodarilo nahrať!',
 		'no_zip_extension' => 'ZIP rozšírenie sa na vašom serveri nenachádza.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'Počas importovania ZIP súboru sa vyskytla chyba.',
 	),
 	'profile' => array(

--- a/app/i18n/sk/sub.php
+++ b/app/i18n/sk/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Exportovať',
 			'sqlite' => 'Download user database as SQLite',	// TODO
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/sk/sub.php
+++ b/app/i18n/sk/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Exportovať',
 			'sqlite' => 'Download user database as SQLite',	// TODO
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'Exportovať vaše označené články',
 		'export_opml' => 'Exportovať zoznam kanálov (OPML)',

--- a/app/i18n/tr/feedback.php
+++ b/app/i18n/tr/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'Beslemeleriniz içe aktarıldı, ancak bazı hatalar oluştu. İçe aktarma işleminiz bittiyse, şimdi <i>Beslemeleri güncelle</i> düğmesine tıklayabilirsiniz.',
 		'file_cannot_be_uploaded' => 'Dosya yüklenemedi!',
 		'no_zip_extension' => 'Sunucunuzda ZIP uzantısı mevcut değil.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'ZIP işleme sırasında bir hata oluştu.',
 	),
 	'profile' => array(

--- a/app/i18n/tr/sub.php
+++ b/app/i18n/tr/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Dışa Aktar',
 			'sqlite' => 'Kullanıcı veritabanını SQLite olarak indir',
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/tr/sub.php
+++ b/app/i18n/tr/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Dışa Aktar',
 			'sqlite' => 'Kullanıcı veritabanını SQLite olarak indir',
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'Etiketlenmiş makalelerinizi dışa aktarın',
 		'export_opml' => 'Besleme listesini dışa aktar (OPML)',

--- a/app/i18n/uk/feedback.php
+++ b/app/i18n/uk/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => 'Стрічки імпортовано, проте виникли помилки. Якщо більше не потрібно нічого імпортувати, натисніть кнопку <i>Оновити стрічки</i>.',
 		'file_cannot_be_uploaded' => 'Не вдалося вивантажити файл!',
 		'no_zip_extension' => 'На сервері бракує ZIP-розширення.',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'При обробці ZIP виникла помилка.',
 	),
 	'profile' => array(

--- a/app/i18n/uk/sub.php
+++ b/app/i18n/uk/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => 'Експорт',
 			'sqlite' => 'Завантажити користувацьку базу даних у форматі SQLite',
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => 'Статті з мітками',
 		'export_opml' => 'Перелік стрічок (OPML)',

--- a/app/i18n/uk/sub.php
+++ b/app/i18n/uk/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => 'Експорт',
 			'sqlite' => 'Завантажити користувацьку базу даних у форматі SQLite',
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/zh-CN/feedback.php
+++ b/app/i18n/zh-CN/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => '你的订阅源已导入，但发生错误。你可以点击 <i>更新订阅</i> 按钮以完成导入。',
 		'file_cannot_be_uploaded' => '文件未能上传！',
 		'no_zip_extension' => '服务器未启用 ZIP 扩展。',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => '导入 ZIP 文件时出错',	// DIRTY
 	),
 	'profile' => array(

--- a/app/i18n/zh-CN/sub.php
+++ b/app/i18n/zh-CN/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => '导出',
 			'sqlite' => '导出用户数据库为 SQLite 文件',
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/i18n/zh-CN/sub.php
+++ b/app/i18n/zh-CN/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => '导出',
 			'sqlite' => '导出用户数据库为 SQLite 文件',
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => '导出有标签的文章',
 		'export_opml' => '导出订阅源列表（OPML）',

--- a/app/i18n/zh-TW/feedback.php
+++ b/app/i18n/zh-TW/feedback.php
@@ -62,6 +62,9 @@ return array(
 		'feeds_imported_with_errors' => '您的訂閱源已匯入，但發生一些錯誤。如果已完成匯入，您現在可以點擊 <i>更新訂閱源</i> 按鈕。',
 		'file_cannot_be_uploaded' => '檔案無法上傳！',
 		'no_zip_extension' => '您的伺服器上沒有安裝 ZIP 擴充功能。',
+		'sqlite_export_error' => 'An error occurred while exporting your database to SQLite.',	// TODO
+		'sqlite_export_success' => 'Your database has been exported to SQLite.',	// TODO
+		'sqlite_export_too_large' => 'Your database is too large to be exported from the Web interface.',	// TODO
 		'zip_error' => 'ZIP 處理期間發生錯誤。',
 	),
 	'profile' => array(

--- a/app/i18n/zh-TW/sub.php
+++ b/app/i18n/zh-TW/sub.php
@@ -270,6 +270,8 @@ return array(
 		'export' => array(
 			'_' => '匯出',
 			'sqlite' => '下載使用者資料庫為 SQLite 檔案',
+			'sqlite_now' => 'Export current database now',	// TODO
+			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),
 		'export_labelled' => '匯出有標籤的文章',
 		'export_opml' => '匯出訂閱源清單 (OPML)',

--- a/app/i18n/zh-TW/sub.php
+++ b/app/i18n/zh-TW/sub.php
@@ -270,6 +270,7 @@ return array(
 		'export' => array(
 			'_' => '匯出',
 			'sqlite' => '下載使用者資料庫為 SQLite 檔案',
+			'sqlite_force' => 'Force export even if it exceeds the size limit',	// TODO
 			'sqlite_now' => 'Export current database now',	// TODO
 			'sqlite_too_large' => 'Database too large for a Web export (limit: %s). Use the command-line tool instead.',	// TODO
 		),

--- a/app/views/importExport/index.phtml
+++ b/app/views/importExport/index.phtml
@@ -83,9 +83,19 @@
 	<?php if ($this->sqliteExportEnabled): ?>
 	<form method="post" action="<?= _url('importExport', 'sqliteExport') ?>">
 		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
+		<?php if (!$this->sqliteExportAllowed && $this->sqliteExportIsAdmin): ?>
+		<div class="form-group">
+			<div class="group-controls">
+				<label>
+					<input type="checkbox" name="force" value="1" />
+					<?= _t('sub.import_export.export.sqlite_force') ?>
+				</label>
+			</div>
+		</div>
+		<?php endif; ?>
 		<div class="form-group form-actions">
 			<div class="group-controls">
-				<button type="submit" class="btn btn-important"<?= $this->sqliteExportAllowed ? '' : ' disabled="disabled"' ?>>
+				<button type="submit" class="btn btn-important"<?= ($this->sqliteExportAllowed || $this->sqliteExportIsAdmin) ? '' : ' disabled="disabled"' ?>>
 					<?= _t('sub.import_export.export.sqlite_now') ?>
 				</button>
 			</div>

--- a/app/views/importExport/index.phtml
+++ b/app/views/importExport/index.phtml
@@ -79,6 +79,25 @@
 	<?php } ?>
 
 	<h2><?= _t('sub.import_export.export.sqlite') ?></h2>
+
+	<?php if ($this->sqliteExportEnabled): ?>
+	<form method="post" action="<?= _url('importExport', 'sqliteExport') ?>">
+		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
+		<div class="form-group form-actions">
+			<div class="group-controls">
+				<button type="submit" class="btn btn-important"<?= $this->sqliteExportAllowed ? '' : ' disabled="disabled"' ?>>
+					<?= _t('sub.import_export.export.sqlite_now') ?>
+				</button>
+			</div>
+		</div>
+		<?php if (!$this->sqliteExportAllowed): ?>
+		<p class="alert alert-warn">
+			<?= _t('sub.import_export.export.sqlite_too_large', format_bytes($this->sqliteExportMaxSize)) ?>
+		</p>
+		<?php endif; ?>
+	</form>
+	<?php endif; ?>
+
 	<?php if (count($this->sqliteArchives ?? []) === 0): ?>
 	<p class="alert alert-warn">
 		<?= _t('gen.short.not_applicable') ?>

--- a/config.default.php
+++ b/config.default.php
@@ -143,6 +143,10 @@ return [
 		# Max amount of bytes that are allowed for upload of custom favicon
 		'max_favicon_upload_size' => 1048576,	# 1 MiB
 
+		# Max database size in bytes to allow triggering a SQLite export from the Web UI.
+		#   0 disables the Web UI SQLite export button (the CLI `./cli/export-sqlite-for-user.php` remains available).
+		'sqlite_export_max_db_size' => 104857600,	# 100 MiB
+
 		# Limits for regex, useful to limit regex during user searches
 		'regex_backtrack_limit' => 10000,
 		'regex_recursion_limit' => 100,

--- a/docs/en/admins/05_Backup.md
+++ b/docs/en/admins/05_Backup.md
@@ -76,6 +76,21 @@ Then schedule it (for example via cron):
 
 Each run writes `./data/users/<username>/sqlite-backups/<YYYYMMDDTHHMMSSZ>.sqlite` (UTC) for every user and prunes older files to the configured `retention` count.
 
+## On-demand SQLite export from the Web UI
+
+Users can also trigger a one-off SQLite export of their own database from *Import / export* in the Web UI, without needing shell access.
+
+To avoid overloading the server on large databases, this Web UI action is only available while the user's database is under the configured limit in `./data/config.php`:
+
+```php
+'limits' => [
+    // …
+    'sqlite_export_max_db_size' => 104857600, // 100 MiB; 0 disables the Web UI button
+],
+```
+
+For larger databases, use `./cli/export-sqlite-for-user.php` instead (see below).
+
 ## Migrating the database
 
 First, back up all user databases to SQLite files:

--- a/tests/app/Models/DatabaseDAOTest.php
+++ b/tests/app/Models/DatabaseDAOTest.php
@@ -113,4 +113,22 @@ final class DatabaseDAOTest extends \PHPUnit\Framework\TestCase {
 	public static function test_strilike_SQLite(string $haystack, string $needle, bool $contains, bool $expected): void {
 		self::assertSame($expected, FreshRSS_DatabaseDAOSQLite::strilike($haystack, $needle, $contains));
 	}
+
+	/** @return list<array{int,int,bool}> */
+	public static function provideSizeWithinLimit(): array {
+		return [
+			// [size in bytes, max size in bytes, expected]
+			[0, 100, true],
+			[100, 100, true],
+			[101, 100, false],
+			[100, 0, false],		// A max size of 0 (or less) always disallows.
+			[100, -1, false],
+			[-1, 100, false],		// A negative (unknown) size is never considered within limit.
+		];
+	}
+
+	#[DataProvider('provideSizeWithinLimit')]
+	public static function test_sizeWithinLimit(int $sizeBytes, int $maxSizeBytes, bool $expected): void {
+		self::assertSame($expected, FreshRSS_DatabaseDAO::sizeWithinLimit($sizeBytes, $maxSizeBytes));
+	}
 }


### PR DESCRIPTION
## Summary
- Completes the remaining item of the settings-only "PR 1" plan from #8183 (the first two settings, `auto_sqlite_export.enabled` and `.retention`, were added in #8819).
- Adds a `limits.sqlite_export_max_db_size` setting (bytes, default 100 MiB) and a button on *Import / export* to generate a new SQLite export of the current user's database on demand.

## Changes
- `config.default.php`: new `limits.sqlite_export_max_db_size` (0 disables the button; the CLI stays available regardless).
- `app/Models/DatabaseDAO.php`: small pure helper `sizeWithinLimit()` to decide if the current DB size is under the configured max.
- `app/Controllers/importExportController.php`: `indexAction` now exposes whether the export button should show/be enabled; new `sqliteExportAction` triggers the export (POST only, re-checks the size limit server-side, reuses the existing `dbCopy()` SQLite export path).
- `app/views/importExport/index.phtml`: new button, disabled with an explanatory message when the database is over the limit.
- `docs/en/admins/05_Backup.md`: documents the new setting.
- i18n: new English strings added via `cli/manipulate.translation.php` (other languages get the usual `// TODO` placeholders).

## Validation
- `phpunit` (new `DatabaseDAOTest::test_sizeWithinLimit`, full suite otherwise green except the pre-existing Windows-only `tests/cli/i18n/*` EOL noise)
- `phpcs`
- `phpstan` (level 10, clean)
- `php -l` on every changed file

Manually reasoned through the flow (no live multi-DB-size setup here to click through), but the export path itself (`dbCopy()`) is the same one already used by the existing CLI/auto-export and the existing Web UI "download" action.

Fixes #8183.