### PR TITLE
Fix weird hover issues on overflowing .item-element.title

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -1516,11 +1516,6 @@ a.website:hover .favicon {
 	font-weight: bold;
 }
 
-.flux:not(.current):hover .flux_header.has-date .item .title {
-	padding-right: 0.5rem;
-	z-index: 2;
-}
-
 .flux:not(.current):hover .item .title {
 	background-color: inherit;
 }
@@ -1581,6 +1576,7 @@ a.website:hover .favicon {
 	grid-template-columns: minmax(0, 1fr) auto;
 	grid-template-areas: "title date"
 		"summary .";
+	column-gap: 0.5rem;
 	align-content: center;
 }
 

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -1516,11 +1516,6 @@ a.website:hover .favicon {
 	font-weight: bold;
 }
 
-.flux:not(.current):hover .flux_header.has-date .item .title {
-	padding-left: 0.5rem;
-	z-index: 2;
-}
-
 .flux:not(.current):hover .item .title {
 	background-color: inherit;
 }
@@ -1581,6 +1576,7 @@ a.website:hover .favicon {
 	grid-template-columns: minmax(0, 1fr) auto;
 	grid-template-areas: "title date"
 		"summary .";
+	column-gap: 0.5rem;
 	align-content: center;
 }
 


### PR DESCRIPTION
Just remove the entire leftover bunch from the pre-grid CSS.

Fix #8075.

@Alkarex Please verify vis-à-vis #8997 but I see no difference with or without those lines in Origine-Compact. That's something pre-grid afaict.

How to test the feature manually:

Hover on a piece of text overflow.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

# Before 
(also happens in LTR, just slightly less bothersome)
<img width="982" height="276" alt="image" src="https://github.com/user-attachments/assets/2ecd3d1d-3943-4397-afcf-2eca53c0874d" />

# After 
<img width="997" height="332" alt="image" src="https://github.com/user-attachments/assets/5f5e964e-3de3-4745-b8b2-5f5877adaefe" />
