### PR TITLE
ci: attach provenance and SBOM attestations to the published image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -94,3 +94,5 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         push: ${{ (github.ref == 'refs/heads/latest' || github.ref == 'refs/heads/edge' || startsWith(github.ref, 'refs/tags/')) && github.repository_owner == 'FreshRSS' }}
+        provenance: mode=max
+        sbom: true


### PR DESCRIPTION
Hi, and thanks for FreshRSS.

`.github/workflows/docker-publish.yml` publishes the image, but the pushed manifest carries no provenance or SBOM attestation. Someone pulling it cannot check that it was built by this workflow, from this repository, at that tag.

FreshRSS is self-hosted precisely so someone's reading list stays on their own server, and the image is what they deploy. There is nothing between the registry and that deployment which vouches for it today.

The change is two lines on the build step:

```yaml
          push: ...
          provenance: mode=max
          sbom: true
```

BuildKit attaches both to the image manifest, so they travel with the image. **No permissions change is needed** — nothing has to gain `id-token`.

```
docker buildx imagetools inspect <image>:<tag> --format '{{ json .Provenance }}'
```

Two caveats worth stating: `mode=max` records the full build including build arguments, so `provenance: true` is the smaller option if any have ever been sensitive; and attestations add an extra manifest to the index, which the registry supports.

No SLSA level claimed — the attestation is what BuildKit produces.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow myself.
