### PR TITLE
Exclude hidden feeds from global view counts

### DIFF
--- a/app/views/index/global.phtml
+++ b/app/views/index/global.phtml
@@ -56,8 +56,9 @@
 		FreshRSS_Context::isStateEnabled(FreshRSS_Entry::STATE_NOT_READ)));
 
 	foreach ($this->categories as $cat) {
-		$feeds = $this->feedIdsMatching === null ? $cat->feeds() :
-			array_filter($cat->feeds(), fn(FreshRSS_Feed $feed): bool => !empty($this->feedIdsMatching[$feed->id()]));
+		$feeds = array_filter($cat->feeds(), fn(FreshRSS_Feed $feed): bool =>
+			$feed->priority() >= FreshRSS_Feed::PRIORITY_FEED &&
+			($this->feedIdsMatching === null || !empty($this->feedIdsMatching[$feed->id()])));
 		$url_base['params']['get'] = 'c_' . $cat->id();
 
 		if (!empty($feeds)) {
@@ -65,12 +66,12 @@
 			$catMatchingCount = $cat->nbNotRead();
 			if ($this->feedIdsMatching !== null) {
 				$catMatchingCount = 0;
-				foreach ($cat->feeds() as $feed) {
+				foreach ($feeds as $feed) {
 					$catMatchingCount += $this->feedIdsMatching[$feed->id()] ?? 0;
 				}
 			} elseif ($showTotalArticles) {
 				$catMatchingCount = 0;
-				foreach ($cat->feeds() as $feed) {
+				foreach ($feeds as $feed) {
 					$catMatchingCount += $feed->nbEntries();
 				}
 			}
@@ -82,9 +83,6 @@
 		<ul class="box-content scrollbar-thin">
 			<?php
 				foreach ($feeds as $feed) {
-					if ($feed->priority() < FreshRSS_Feed::PRIORITY_FEED) {
-						continue;
-					}
 					$feedMatchingCount = $this->feedIdsMatching === null
 						? ($showTotalArticles ? $feed->nbEntries() : $feed->nbNotRead())
 						: ($this->feedIdsMatching[$feed->id()] ?? 0);


### PR DESCRIPTION
Follow-up to #9132

## Summary

- Exclude feeds below `FreshRSS_Feed::PRIORITY_FEED` from the global view.
- Reuse the same filtered feed list for category visibility, category counts, and feed rendering.
- Keep the existing behavior for visible feeds and unread counts.

## Root cause

The global view skipped hidden feeds only while rendering feed rows. Category visibility and `STATE_ALL` totals still used every feed in the category, so hidden entries inflated category counts and categories containing only hidden feeds rendered as empty boxes.

## Before / After

| Before | After |
| --- | --- |
| `Mixed visibility` reports 8 articles while its only visible feed reports 3, and `Hidden only` appears as an empty category with 4 articles.<br><br><img width="650" alt="Before: hidden feeds inflate global view counts" src="https://github.com/user-attachments/assets/b581b65a-1316-404f-8215-b29ebb686090" /> | `Mixed visibility` reports the same 3 articles as its visible feed, and `Hidden only` is omitted.<br><br><img width="650" alt="After: global view counts only visible feeds" src="https://github.com/user-attachments/assets/fb1ee306-1859-4900-b031-4d4d78e5c821" /> |

## Testing

- Verified the before/after behavior with the same SQLite data, Origine theme, English locale, and 1400×1000 viewport.
- Verified that a search matching only hidden-feed entries renders no empty category.
- Verified that the normal unread view remains at 3 for both the visible category and feed.
- `composer run-script phtml-lint`
- `composer run-script phpcs`
- `composer run-script phpstan`
- `composer run-script phpunit` (664 tests, 1231 assertions)
- `make test-all`
