### PR TITLE
Add Jam Balaya to CREDITS

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -136,6 +136,7 @@ People are sorted by name so please keep this order.
 * [Jackson Culbreth](https://github.com/culbrethj): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:culbrethj)
 * [jaden](https://github.com/jaden): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:jaden)
 * [Jake Mannens](https://github.com/jakem72360): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:jakem72360)
+* [Jam Balaya](https://github.com/JamBalaya56562): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:JamBalaya56562)
 * [James Frost](https://github.com/Fraetor): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:Fraetor), [Web](https://www.frost.cx/)
 * [Jamie Slome](https://github.com/JamieSlome): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:JamieSlome), [Web](https://418sec.com/)
 * [Jan Lukas Gernert](https://github.com/jangernert): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:jangernert)


### PR DESCRIPTION
## Summary

- Add Jam Balaya to `CREDITS.md` after the contribution merged in #9152.

## Context

This was requested by @Alkarex after #9152 was merged.

## Testing

- `markdownlint-cli2 --no-globs CREDITS.md`
