### PR TITLE
Ignore empty categories when sizing export feed selector

### DIFF
--- a/app/Controllers/importExportController.php
+++ b/app/Controllers/importExportController.php
@@ -32,7 +32,10 @@ class FreshRSS_importExport_Controller extends FreshRSS_ActionController {
 	 * This action displays the main page for import / export system.
 	 */
 	public function indexAction(): void {
-		$this->view->categories = $this->categoryDAO->listCategories();
+		$this->view->categories = array_filter(
+			$this->categoryDAO->listCategories(),
+			static fn(FreshRSS_Category $category): bool => !empty($category->feeds()),
+		);
 		$this->view->feedCount = array_sum(array_map(static fn(FreshRSS_Category $category): int => count($category->feeds()), $this->view->categories));
 		FreshRSS_View::prependTitle(_t('sub.import_export.title') . ' · ');
 		$this->listSqliteArchives();

--- a/app/views/importExport/index.phtml
+++ b/app/views/importExport/index.phtml
@@ -65,9 +65,6 @@
 					<?= extension_loaded('zip') ? '' : '<option></option>' ?>
 					<?php foreach ($this->categories as $category):
 						$feeds = $category->feeds();
-						if (empty($feeds)) {
-							continue;
-						}
 					?>
 					<optgroup label="<?= $category->name() ?>">
 						<?php foreach ($feeds as $feed) { ?>


### PR DESCRIPTION
Follow-up to #9079.

## Summary

- Ignore empty categories when sizing the export feed selector.
- Keep the selector height aligned with the category headings and feeds that are actually rendered.
- Preserve the grouped export choices and export request format introduced in #9079.

## Root cause

The view skipped categories without feeds when rendering `<optgroup>` elements, but the `size` calculation counted every category returned by the DAO. Empty categories therefore increased the listbox height without adding any visible content.

## Before / After

| Before | After |
| --- | --- |
| <img width="1400" height="1000" alt="9079-followup-before-1400x1000" src="https://github.com/user-attachments/assets/f225d97f-8486-4e7d-87eb-cdafd42b53a5" /> | <img width="1400" height="1000" alt="9079-followup-after-1400x1000" src="https://github.com/user-attachments/assets/aeb254e0-6410-4f6f-a0d8-3051c5dd2c83" /> |
| `size="10"` for two category headings and two feeds, leaving unnecessary empty space. | `size="4"` for the same data, matching the four rendered rows. |

## Testing

- `make NO_DOCKER=1 test-all`
- Verified two non-empty categories plus six empty categories render with `size="4"`.
- Verified the selector remains capped at `size="10"`.
- Verified the non-Zip single-select mode has no `size` or `multiple` attribute.
- Verified the export form stays hidden when there are no feeds.
