### PR TITLE
Docker dev newest: PHP 8.6

### DIFF
--- a/Docker/Dockerfile-Newest
+++ b/Docker/Dockerfile-Newest
@@ -6,11 +6,11 @@ SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories && \
 	apk add --no-cache \
 	tzdata \
-	apache2 php85-apache2 \
+	apache2 php86-apache2 \
 	apache-mod-auth-openidc \
-	php85 php85-curl php85-gmp php85-intl php85-mbstring php85-xml php85-zip \
-	php85-ctype php85-dom php85-fileinfo php85-iconv php85-json php85-openssl php85-phar php85-session php85-simplexml php85-xmlreader php85-xmlwriter php85-xml php85-tokenizer php85-zlib \
-	php85-pdo_sqlite php85-pdo_mysql php85-pdo_pgsql
+	php86 php86-curl php86-gmp php86-intl php86-mbstring php86-xml php86-zip \
+	php86-ctype php86-dom php86-fileinfo php86-iconv php86-json php86-openssl php86-phar php86-session php86-simplexml php86-xmlreader php86-xmlwriter php86-xml php86-tokenizer php86-zlib \
+	php86-pdo_sqlite php86-pdo_mysql php86-pdo_pgsql
 
 RUN mkdir -p /var/www/FreshRSS /run/apache2/
 WORKDIR /var/www/FreshRSS
@@ -45,8 +45,8 @@ RUN \
 	sed -r -i "/^\s*#\s*LoadModule .*mod_(deflate|expires|filter|headers|mime|remoteip|setenvif).so$/s/^\s*#//" \
 		/etc/apache2/httpd.conf && \
 	# PHP configuration
-	if [ ! -f /usr/bin/php ]; then ln -s /usr/bin/php85 /usr/bin/php; else true; fi && \
-	echo 'memory_limit = 256M' > /etc/php85/conf.d/10_memory.ini && \
+	if [ ! -f /usr/bin/php ]; then ln -s /usr/bin/php86 /usr/bin/php; else true; fi && \
+	echo 'memory_limit = 256M' > /etc/php86/conf.d/10_memory.ini && \
 	# Disable built-in FreshRSS updates when using Docker, as the full image is supposed to be updated instead.
 	sed -r -i "\\#disable_update#s#^.*#\t'disable_update' => true,#" ./config.default.php && \
 	# Configure cron job


### PR DESCRIPTION
Update our dev image `:newest` to PHP 8.6.
Tests passing.

https://php.watch/versions/8.6
https://php.watch/versions/8.6/rfcs
