### PR TITLE
Fix favicon fetching ignoring feed-level proxy settings (#8976)

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -448,22 +448,36 @@ class FreshRSS_Feed extends Minz_Model {
 		}
 		$url = $feedIconUrl !== '' ? $feedIconUrl : $websiteUrl;
 
-		$txt = FAVICONS_DIR . $this->hashFavicon() . '.txt';
+		$hash = $this->hashFavicon();
+		$txt = FAVICONS_DIR . $hash . '.txt';
 		if (@file_get_contents($txt) !== $url) {
 			file_put_contents($txt, $url);
 		}
+
+		// Persist feed-level cURL parameters (e.g. proxy) so p/f.php can use them when fetching lazily.
+		$curl_params = FreshRSS_http_Util::sanitizeCurlParams($this->attributeArray('curl_params') ?? []);
+		$proxy_file = FAVICONS_DIR . $hash . '.proxy';
+		if ($curl_params !== []) {
+			$encoded = json_encode($curl_params, JSON_UNESCAPED_SLASHES);
+			if (is_string($encoded) && @file_get_contents($proxy_file) !== $encoded) {
+				file_put_contents($proxy_file, $encoded);
+			}
+		} elseif (file_exists($proxy_file)) {
+			@unlink($proxy_file);
+		}
+
 		if (FreshRSS_Context::$isCli || $force) {
-			$ico = FAVICONS_DIR . $this->hashFavicon() . '.ico';
+			$ico = FAVICONS_DIR . $hash . '.ico';
 			$ico_mtime = @filemtime($ico);
 			$txt_mtime = @filemtime($txt);
 			if ($txt_mtime != false &&
 				($ico_mtime == false || $ico_mtime < $txt_mtime || ($ico_mtime < time() - (14 * 86400)))) {
 				// no ico file or we should download a new one.
-				if ($feedIconUrl !== '' && download_favicon_from_image_url($feedIconUrl, $ico)) {
+				if ($feedIconUrl !== '' && download_favicon_from_image_url($feedIconUrl, $ico, $curl_params)) {
 					return;
 				}
 				// Fall back to website favicon search
-				if (!download_favicon($websiteUrl, $ico)) {
+				if (!download_favicon($websiteUrl, $ico, $curl_params)) {
 					touch($ico);
 				}
 			}
@@ -477,6 +491,7 @@ class FreshRSS_Feed extends Minz_Model {
 		$path = DATA_PATH . '/favicons/' . $hash;
 		@unlink($path . '.ico');
 		@unlink($path . '.txt');
+		@unlink($path . '.proxy');
 	}
 	public function favicon(bool $absolute = false): string {
 		$hash = $this->hashFavicon();

--- a/lib/favicons.php
+++ b/lib/favicons.php
@@ -25,14 +25,18 @@ function faviconCachePath(string $url): string {
 	return CACHE_PATH . '/' . sha1($url) . '.ico';
 }
 
-function searchFavicon(string $url): string {
+/**
+ * @param array<mixed> $curl_params Feed-level cURL parameters (e.g. proxy settings)
+ */
+function searchFavicon(string $url, array $curl_params = []): string {
 	$url = trim($url);
 	if ($url === '') {
 		return '';
 	}
 	$dom = new DOMDocument();
+	$attributes = $curl_params !== [] ? ['curl_params' => $curl_params] : [];
 	['body' => $html, 'effective_url' => $effective_url, 'fail' => $fail] =
-		FreshRSS_http_Util::httpGet($url, cachePath: CACHE_PATH . '/' . sha1($url) . '.html', type: 'html');
+		FreshRSS_http_Util::httpGet($url, cachePath: CACHE_PATH . '/' . sha1($url) . '.html', type: 'html', attributes: $attributes);
 	if ($fail || $html === '' || !@$dom->loadHTML($html, LIBXML_NONET | LIBXML_NOERROR | LIBXML_NOWARNING)) {
 		return '';
 	}
@@ -74,7 +78,7 @@ function searchFavicon(string $url): string {
 		if (!is_string($iri) || $iri === '') {
 			continue;
 		}
-		$favicon = FreshRSS_http_Util::httpGet($iri, faviconCachePath($iri), 'ico', curl_options: [
+		$favicon = FreshRSS_http_Util::httpGet($iri, faviconCachePath($iri), 'ico', attributes: $attributes, curl_options: [
 			CURLOPT_REFERER => $effective_url,
 		])['body'];
 		if (isImgMime($favicon)) {
@@ -87,34 +91,40 @@ function searchFavicon(string $url): string {
 /**
  * Downloads a favicon directly from a known image URL (e.g. from a feed's <image><url> or icon field).
  * Returns false without any fallback if the URL does not point to a valid image.
+ * @param array<mixed> $curl_params Feed-level cURL parameters (e.g. proxy settings)
  */
-function download_favicon_from_image_url(string $imageUrl, string $dest): bool {
+function download_favicon_from_image_url(string $imageUrl, string $dest, array $curl_params = []): bool {
 	$imageUrl = FreshRSS_http_Util::checkUrl($imageUrl);
 	if (!is_string($imageUrl) || $imageUrl === '') {
 		return false;
 	}
-	$favicon = FreshRSS_http_Util::httpGet($imageUrl, faviconCachePath($imageUrl), 'ico')['body'];
+	$attributes = $curl_params !== [] ? ['curl_params' => $curl_params] : [];
+	$favicon = FreshRSS_http_Util::httpGet($imageUrl, faviconCachePath($imageUrl), 'ico', attributes: $attributes)['body'];
 	if (!isImgMime($favicon)) {
 		return false;
 	}
 	return file_put_contents($dest, $favicon) > 0;
 }
 
-function download_favicon(string $url, string $dest): bool {
+/**
+ * @param array<mixed> $curl_params Feed-level cURL parameters (e.g. proxy settings)
+ */
+function download_favicon(string $url, string $dest, array $curl_params = []): bool {
 	$url = FreshRSS_http_Util::checkUrl($url);
 	if (!is_string($url) || $url === '') {
 		return @copy(DEFAULT_FAVICON, $dest);
 	}
-	$favicon = searchFavicon($url);
+	$attributes = $curl_params !== [] ? ['curl_params' => $curl_params] : [];
+	$favicon = searchFavicon($url, $curl_params);
 	if ($favicon == '') {
 		$rootUrl = preg_replace('%^(https?://[^/]+).*$%i', '$1/', $url) ?? $url;
 		if ($rootUrl != $url) {
 			$url = $rootUrl;
-			$favicon = searchFavicon($url);
+			$favicon = searchFavicon($url, $curl_params);
 		}
 		if ($favicon == '') {
 			$link = FreshRSS_http_Util::checkUrl($rootUrl . 'favicon.ico', fixScheme: false) ?: '';
-			$favicon = $link === '' ? '' : FreshRSS_http_Util::httpGet($link, faviconCachePath($link), 'ico', curl_options: [
+			$favicon = $link === '' ? '' : FreshRSS_http_Util::httpGet($link, faviconCachePath($link), 'ico', attributes: $attributes, curl_options: [
 				CURLOPT_REFERER => $url,
 			])['body'];
 			if (!isImgMime($favicon)) {

--- a/p/f.php
+++ b/p/f.php
@@ -57,9 +57,20 @@ if (($ico_mtime == false || $ico_mtime < $txt_mtime || ($ico_mtime < time() - (r
 		exit();
 	}
 
+	// Load feed-level cURL parameters (e.g. proxy) persisted alongside the favicon metadata.
+	$proxy_file = FAVICONS_DIR . $id . '.proxy';
+	$curl_params = [];
+	$proxy_raw = @file_get_contents($proxy_file);
+	if (is_string($proxy_raw) && $proxy_raw !== '') {
+		$decoded = json_decode($proxy_raw, true);
+		if (is_array($decoded)) {
+			$curl_params = FreshRSS_http_Util::sanitizeCurlParams($decoded);
+		}
+	}
+
 	// Try downloading the URL as a direct image first (e.g. from a feed's <image><url>),
 	// then fall back to HTML favicon search if it is not a valid image.
-	if (!download_favicon_from_image_url($url, $ico) && !download_favicon($url, $ico)) {
+	if (!download_favicon_from_image_url($url, $ico, $curl_params) && !download_favicon($url, $ico, $curl_params)) {
 		// Download failed
 		if ($ico_mtime == false) {
 			show_default_favicon(86400);

--- a/tests/app/Models/FeedFaviconTest.php
+++ b/tests/app/Models/FeedFaviconTest.php
@@ -1,0 +1,203 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Tests for favicon proxy persistence in Feed::faviconPrepare() and Feed::faviconDelete()
+ * Covers the fix for issue #8976: favicons were not fetched using the per-feed proxy.
+ */
+final class FeedFaviconTest extends \PHPUnit\Framework\TestCase {
+	private string $tmpDir = '';
+
+	protected function setUp(): void {
+		// Create a temporary directory to act as FAVICONS_DIR for tests that write files directly
+		$this->tmpDir = sys_get_temp_dir() . '/freshrss_favicon_test_' . uniqid();
+		mkdir($this->tmpDir, 0777, true);
+
+		// Point the FAVICONS_DIR constant to our temp dir by patching the data path
+		// We test the proxy file logic via the actual DATA_PATH/favicons directory
+		if (!is_dir(DATA_PATH . '/favicons')) {
+			mkdir(DATA_PATH . '/favicons', 0777, true);
+		}
+
+		// Ensure a minimal system conf is available (needed by hashFavicon -> salt)
+		if (!FreshRSS_Context::hasSystemConf()) {
+			FreshRSS_Context::$system_conf = FreshRSS_SystemConfiguration::init(
+				FRESHRSS_PATH . '/config.default.php',
+				FRESHRSS_PATH . '/config.default.php'
+			);
+		}
+	}
+
+	protected function tearDown(): void {
+		// Clean up temp dir
+		foreach (glob($this->tmpDir . '/*') ?: [] as $file) {
+			@unlink($file);
+		}
+		@rmdir($this->tmpDir);
+	}
+
+	// -------------------------------------------------------------------------
+	// faviconPrepare: .proxy file management
+	// -------------------------------------------------------------------------
+
+	public function test_faviconPrepare_withProxy_writesProxyFile(): void {
+		$feed = new FreshRSS_Feed('https://example.net/feed', false);
+		$feed->_website('https://example.net/');
+		$feed->_attribute('curl_params', [CURLOPT_PROXY => 'http://proxy.example.com:3128']);
+
+		$feed->faviconPrepare();
+
+		$proxyFile = FAVICONS_DIR . $feed->hashFavicon() . '.proxy';
+		self::assertFileExists($proxyFile, '.proxy file should be created when curl_params has a proxy');
+
+		$decoded = json_decode((string) file_get_contents($proxyFile), true);
+		self::assertIsArray($decoded);
+		self::assertArrayHasKey(CURLOPT_PROXY, $decoded);
+		self::assertSame('http://proxy.example.com:3128', $decoded[CURLOPT_PROXY]);
+
+		// Cleanup
+		@unlink($proxyFile);
+		@unlink(FAVICONS_DIR . $feed->hashFavicon() . '.txt');
+	}
+
+	public function test_faviconPrepare_withoutProxy_doesNotWriteProxyFile(): void {
+		$feed = new FreshRSS_Feed('https://no-proxy.example.net/feed', false);
+		$feed->_website('https://no-proxy.example.net/');
+
+		$feed->faviconPrepare();
+
+		$proxyFile = FAVICONS_DIR . $feed->hashFavicon() . '.proxy';
+		self::assertFileDoesNotExist($proxyFile, '.proxy file should NOT be created when no curl_params');
+
+		// Cleanup
+		@unlink(FAVICONS_DIR . $feed->hashFavicon() . '.txt');
+	}
+
+	public function test_faviconPrepare_removesStaleProxyFile_whenProxyCleared(): void {
+		$feed = new FreshRSS_Feed('https://stale-proxy.example.net/feed', false);
+		$feed->_website('https://stale-proxy.example.net/');
+		$feed->_attribute('curl_params', [CURLOPT_PROXY => 'http://old-proxy.example.com:3128']);
+
+		// First prepare — creates .proxy
+		$feed->faviconPrepare();
+		$hash = $feed->hashFavicon();
+		$proxyFile = FAVICONS_DIR . $hash . '.proxy';
+		self::assertFileExists($proxyFile);
+
+		// Remove proxy from feed attributes — hash will change because proxyParam() changes
+		// so we test stale removal by manually placing a .proxy and then calling with empty curl_params
+		$feedNoProxy = new FreshRSS_Feed('https://stale-proxy2.example.net/feed', false);
+		$feedNoProxy->_website('https://stale-proxy2.example.net/');
+		// Pre-plant a stale .proxy file at the hash location for this no-proxy feed
+		$staleProxyFile = FAVICONS_DIR . $feedNoProxy->hashFavicon() . '.proxy';
+		file_put_contents($staleProxyFile, '{"' . CURLOPT_PROXY . '":"http://old.com:80"}');
+
+		$feedNoProxy->faviconPrepare();
+
+		self::assertFileDoesNotExist($staleProxyFile, 'Stale .proxy file should be removed when feed has no proxy');
+
+		// Cleanup
+		@unlink($proxyFile);
+		@unlink(FAVICONS_DIR . $hash . '.txt');
+		@unlink(FAVICONS_DIR . $feedNoProxy->hashFavicon() . '.txt');
+	}
+
+	// -------------------------------------------------------------------------
+	// faviconDelete: cleans up .proxy alongside .ico and .txt
+	// -------------------------------------------------------------------------
+
+	public function test_faviconDelete_removesProxyFile(): void {
+		// Plant fake files
+		$hash = str_pad('abcdef01', 8, '0');
+		$base = DATA_PATH . '/favicons/' . $hash;
+		file_put_contents($base . '.ico', 'fake');
+		file_put_contents($base . '.txt', 'https://example.net/');
+		file_put_contents($base . '.proxy', '{}');
+
+		FreshRSS_Feed::faviconDelete($hash);
+
+		self::assertFileDoesNotExist($base . '.ico');
+		self::assertFileDoesNotExist($base . '.txt');
+		self::assertFileDoesNotExist($base . '.proxy');
+	}
+
+	public function test_faviconDelete_invalidHash_doesNothing(): void {
+		// Should not throw or error on invalid hash
+		FreshRSS_Feed::faviconDelete('../../../etc/passwd');
+		FreshRSS_Feed::faviconDelete('');
+		self::assertTrue(true); // just verifying no exception
+	}
+
+	// -------------------------------------------------------------------------
+	// favicons.php functions accept $curl_params parameter
+	// -------------------------------------------------------------------------
+
+	public function test_download_favicon_from_image_url_acceptsCurlParams(): void {
+		require_once LIB_PATH . '/favicons.php';
+
+		// Function must accept $curl_params without error
+		// We pass an invalid URL so it returns false without making HTTP calls
+		$result = download_favicon_from_image_url('not-a-valid-url', $this->tmpDir . '/test.ico', [CURLOPT_PROXY => 'http://proxy:3128']);
+		self::assertFalse($result, 'Should return false for invalid URL');
+	}
+
+	public function test_download_favicon_acceptsCurlParams(): void {
+		require_once LIB_PATH . '/favicons.php';
+
+		$dest = $this->tmpDir . '/favicon_proxy_test.ico';
+		// Pass an empty string URL — should copy default favicon and return true (or false if DEFAULT_FAVICON not readable)
+		// Either way, the function must not throw on receiving $curl_params
+		try {
+			download_favicon('', $dest, [CURLOPT_PROXY => 'http://proxy:3128']);
+			self::assertTrue(true);
+		} catch (\Throwable $e) {
+			self::fail('download_favicon() should accept $curl_params without throwing: ' . $e->getMessage());
+		}
+	}
+
+	public function test_searchFavicon_acceptsCurlParams(): void {
+		require_once LIB_PATH . '/favicons.php';
+
+		// Empty URL returns '' immediately, so this just verifies the signature
+		$result = searchFavicon('', [CURLOPT_PROXY => 'http://proxy:3128']);
+		self::assertSame('', $result);
+	}
+
+	// -------------------------------------------------------------------------
+	// p/f.php proxy loading logic (unit test for the JSON decode pattern)
+	// -------------------------------------------------------------------------
+
+	public function test_proxyFileJson_roundtrip(): void {
+		// Verify that the JSON written by faviconPrepare can be read back and sanitized
+		$curl_params = FreshRSS_http_Util::sanitizeCurlParams([CURLOPT_PROXY => 'http://proxy.test:8080']);
+
+		$proxyFile = $this->tmpDir . '/roundtrip.proxy';
+		$encoded = json_encode($curl_params, JSON_UNESCAPED_SLASHES);
+		self::assertIsString($encoded);
+		file_put_contents($proxyFile, $encoded);
+
+		// Simulate what p/f.php does
+		$proxy_raw = file_get_contents($proxyFile);
+		self::assertIsString($proxy_raw);
+		$decoded = json_decode($proxy_raw, true);
+		self::assertIsArray($decoded);
+		$restored = FreshRSS_http_Util::sanitizeCurlParams($decoded);
+
+		self::assertArrayHasKey(CURLOPT_PROXY, $restored);
+		self::assertSame('http://proxy.test:8080', $restored[CURLOPT_PROXY]);
+	}
+
+	public function test_proxyFileJson_emptyFile_yieldsEmptyArray(): void {
+		$proxy_raw = '';
+		$curl_params = [];
+		if (is_string($proxy_raw) && $proxy_raw !== '') {
+			$decoded = json_decode($proxy_raw, true);
+			if (is_array($decoded)) {
+				$curl_params = FreshRSS_http_Util::sanitizeCurlParams($decoded);
+			}
+		}
+		self::assertSame([], $curl_params);
+	}
+}


### PR DESCRIPTION
Favicons were being fetched without applying the per-feed proxy configured in feed settings. This happened because:

- lib/favicons.php functions had no way to receive proxy/curl_params
- p/f.php (the lazy browser-triggered path) had no access to the feed object at all, only the favicon hash

Fix:
- Add \ parameter to searchFavicon(), download_favicon(), and download_favicon_from_image_url() in lib/favicons.php, forwarded to httpGet() via \['curl_params']
- In Feed::faviconPrepare(), persist sanitized curl_params to a companion {hash}.proxy JSON file alongside {hash}.txt, and pass them directly when downloading in CLI/force mode
- In p/f.php, read the .proxy file to restore curl_params before calling the download functions
- In Feed::faviconDelete(), also remove the .proxy file on cleanup

Fixes #8976

Closes #

Changes proposed in this pull request:

-
-
-

How to test the feature manually:

1.
2.
3.

Pull request checklist:

- [ ] clear commit messages
- [ ] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
