### PR TITLE
Issue #9166: Detect JSON Feed URLs when subscribing via the API

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -146,6 +146,7 @@ People are sorted by name so please keep this order.
 * [jlefler](https://github.com/jlefler): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:jlefler)
 * [Joe Stump](https://github.com/joestump): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:joestump), [Web](http://stu.mp)
 * [Joel Garcia](https://github.com/joelchrono12): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:joelchrono12), [Web](https://joelchrono12.xyz)
+* [John Brayton](https://github.com/jbrayton): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:jbrayton), [Web](https://www.virtualsanity.com)
 * [Jonas Östanbäck](https://github.com/cez81): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:cez81)
 * [Jordi Garcia](https://github.com/jgtorcal): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:jgtorcal)
 * [Joris Kinable](https://github.com/jkinable): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:jkinable)

--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -452,7 +452,7 @@ final class GReaderAPI {
 							$http_auth = '';
 							try {
 								$kind = self::detectFeedKind($streamUrl);
-								FreshRSS_feed_Controller::addFeed($streamUrl, $title, $addCatId, '', $http_auth, [], $kind);
+								FreshRSS_feed_Controller::addFeed($streamUrl, $title, $addCatId, '', $http_auth, [], kind: $kind);
 								continue 2;
 							} catch (Exception $e) {
 								Minz_Log::error('subscriptionEdit error subscribe: ' . $e->getMessage(), API_LOG);
@@ -484,20 +484,8 @@ final class GReaderAPI {
 	}
 
 	/**
-	 * Detect the FreshRSS_Feed::KIND to use for a URL that is being subscribed to.
-	 *
-	 * The Google Reader API only provides a URL, with no way for the client to
-	 * specify the feed format, so we auto-detect the one non-RSS/Atom format that
-	 * is self-describing: the standard JSON Feed (https://www.jsonfeed.org/).
-	 * All other kinds require per-feed configuration (XPath, dot notation, …) that
-	 * cannot be inferred, so anything that is not a JSON Feed falls back to
-	 * KIND_RSS, which also covers RSS/Atom and HTML feed auto-discovery.
-	 *
-	 * The guess is based purely on the URL string (no network request), using the
-	 * same heuristic as the Web subscription form (see `init_json_feed_detection()`
-	 * in p/scripts/feed.js): the URL is treated as a JSON Feed when it contains
-	 * "json" as a standalone token, delimited by a word boundary or an underscore
-	 * (e.g. `…/feed.json` or `…/feed_json`, but not `…/jsonfeed`).
+	 * Guess the kind of feed (RSS/ATOM vs. JSON) based on URL.
+	 * The Google Reader API does not provide any way for the client to specify the feed format.
 	 */
 	private static function detectFeedKind(string $url): int {
 		return preg_match('/(?:\b|_)json(?:\b|_)/i', $url) === 1
@@ -511,7 +499,7 @@ final class GReaderAPI {
 			if (str_starts_with($url, 'feed/')) {
 				$url = substr($url, 5);
 			}
-			$feed = FreshRSS_feed_Controller::addFeed($url, '', 0, '', '', [], self::detectFeedKind($url));
+			$feed = FreshRSS_feed_Controller::addFeed($url, kind: self::detectFeedKind($url));
 			exit(json_encode([
 					'numResults' => 1,
 					'query' => $feed->url(),

--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -452,7 +452,7 @@ final class GReaderAPI {
 							$http_auth = '';
 							try {
 								$kind = self::detectFeedKind($streamUrl);
-								FreshRSS_feed_Controller::addFeed($streamUrl, $title, $addCatId, '', $http_auth, [], kind: $kind);
+								FreshRSS_feed_Controller::addFeed($streamUrl, $title, $addCatId, '', $http_auth, [], $kind);
 								continue 2;
 							} catch (Exception $e) {
 								Minz_Log::error('subscriptionEdit error subscribe: ' . $e->getMessage(), API_LOG);

--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -493,21 +493,16 @@ final class GReaderAPI {
 	 * cannot be inferred, so anything that is not a JSON Feed falls back to
 	 * KIND_RSS, which also covers RSS/Atom and HTML feed auto-discovery.
 	 *
-	 * The probe reuses the same on-disk HTTP cache (keyed by URL) that the
-	 * post-subscription refresh reads from, so it does not trigger an extra
-	 * network request to the feed.
+	 * The guess is based purely on the URL string (no network request), using the
+	 * same heuristic as the Web subscription form (see `init_json_feed_detection()`
+	 * in p/scripts/feed.js): the URL is treated as a JSON Feed when it contains
+	 * "json" as a standalone token, delimited by a word boundary or an underscore
+	 * (e.g. `…/feed.json` or `…/feed_json`, but not `…/jsonfeed`).
 	 */
 	private static function detectFeedKind(string $url): int {
-		try {
-			$probe = new FreshRSS_Feed($url);
-			$probe->_kind(FreshRSS_Feed::KIND_JSONFEED);
-			if ($probe->loadJson() !== null) {
-				return FreshRSS_Feed::KIND_JSONFEED;
-			}
-		} catch (Throwable $e) {
-			Minz_Log::debug('JSON Feed detection failed for ' . \SimplePie\Misc::url_remove_credentials($url) . ': ' . $e->getMessage(), API_LOG);
-		}
-		return FreshRSS_Feed::KIND_RSS;
+		return preg_match('/(?:\b|_)json(?:\b|_)/i', $url) === 1
+			? FreshRSS_Feed::KIND_JSONFEED
+			: FreshRSS_Feed::KIND_RSS;
 	}
 
 	private static function quickadd(string $url): never {

--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -451,7 +451,8 @@ final class GReaderAPI {
 						if ($feedId <= 0) {
 							$http_auth = '';
 							try {
-								FreshRSS_feed_Controller::addFeed($streamUrl, $title, $addCatId, '', $http_auth);
+								$kind = self::detectFeedKind($streamUrl);
+								FreshRSS_feed_Controller::addFeed($streamUrl, $title, $addCatId, '', $http_auth, [], $kind);
 								continue 2;
 							} catch (Exception $e) {
 								Minz_Log::error('subscriptionEdit error subscribe: ' . $e->getMessage(), API_LOG);
@@ -482,13 +483,40 @@ final class GReaderAPI {
 		exit('OK');
 	}
 
+	/**
+	 * Detect the FreshRSS_Feed::KIND to use for a URL that is being subscribed to.
+	 *
+	 * The Google Reader API only provides a URL, with no way for the client to
+	 * specify the feed format, so we auto-detect the one non-RSS/Atom format that
+	 * is self-describing: the standard JSON Feed (https://www.jsonfeed.org/).
+	 * All other kinds require per-feed configuration (XPath, dot notation, …) that
+	 * cannot be inferred, so anything that is not a JSON Feed falls back to
+	 * KIND_RSS, which also covers RSS/Atom and HTML feed auto-discovery.
+	 *
+	 * The probe reuses the same on-disk HTTP cache (keyed by URL) that the
+	 * post-subscription refresh reads from, so it does not trigger an extra
+	 * network request to the feed.
+	 */
+	private static function detectFeedKind(string $url): int {
+		try {
+			$probe = new FreshRSS_Feed($url);
+			$probe->_kind(FreshRSS_Feed::KIND_JSONFEED);
+			if ($probe->loadJson() !== null) {
+				return FreshRSS_Feed::KIND_JSONFEED;
+			}
+		} catch (Throwable $e) {
+			Minz_Log::debug('JSON Feed detection failed for ' . \SimplePie\Misc::url_remove_credentials($url) . ': ' . $e->getMessage(), API_LOG);
+		}
+		return FreshRSS_Feed::KIND_RSS;
+	}
+
 	private static function quickadd(string $url): never {
 		try {
 			$url = htmlspecialchars($url, ENT_COMPAT, 'UTF-8');
 			if (str_starts_with($url, 'feed/')) {
 				$url = substr($url, 5);
 			}
-			$feed = FreshRSS_feed_Controller::addFeed($url);
+			$feed = FreshRSS_feed_Controller::addFeed($url, '', 0, '', '', [], self::detectFeedKind($url));
 			exit(json_encode([
 					'numResults' => 1,
 					'query' => $feed->url(),


### PR DESCRIPTION
This pull request makes it possible for Google Reader API clients to subscribe to JSON feeds. It addresses issue #9166.

Changes proposed in this pull request:

- When subscribing to a JSON feed via the Google Reader API, determine whether the feed is a JSON feed. If so, set the `kind` accordingly.

How to test the feature manually:

1. Determine the URL for your server.
2. Determine the GoogleLogin `Authorization` header to use with a valid account. 
3. Try subscribing to JSON feeds using the command below, after replacing `(auth header)` with an appropriate `Authorization` header and replacing `(server) with your server URL:

```
curl -i -H (auth header) \
-d "ac=subscribe&s=feed/https://www.goldenhillsoftware.com/feed.json&t=my%20feed" \
"(server)/reader/api/0/subscription/edit"
```

4. Verify in FreshRSS that the feed has articles.
5. Unsubscribe.
6. Try to subscribe again, using `quickadd`. Do the same replacement as done in Step 3:

```
curl -i -H "(auth header)" \
-d "quickadd=feed/https://www.goldenhillsoftware.com/feed.json" \
"(server)/api/greader.php/reader/api/0/subscription/quickadd"
```

Pull request checklist:

- [ X ] clear commit messages
- [ X ] code manually tested
- [ ] unit tests written (optional if too hard)
- [ X ] documentation updated
