### PR TITLE
Refactor to use CSRF field directly instead of borrowing it from a form

### DIFF
--- a/app/layout/aside_configure.phtml
+++ b/app/layout/aside_configure.phtml
@@ -2,9 +2,6 @@
 	declare(strict_types=1);
 ?>
 <nav class="nav nav-list aside" id="aside_feed">
-	<form id="post-csrf" method="post">
-		<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
-	</form>
 	<a class="toggle_aside" href="#close"><?= _i('close') ?></a>
 
 	<ul>
@@ -22,8 +19,11 @@
 					<a href="<?= _url('user', 'profile') ?>"><?= _t('gen.menu.user_profile') ?></a>
 				</li>
 				<li class="item">
-					<button class="as-link signout" form="post-csrf" formaction="<?=
-						FreshRSS_auth_Controller::getLogoutUrl() ?>"><?= _t('gen.auth.logout'); ?><?= _i('logout') ?></button>
+					<form method="POST">
+						<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
+						<button class="as-link signout" formaction="<?=
+							FreshRSS_auth_Controller::getLogoutUrl() ?>"><?= _t('gen.auth.logout'); ?><?= _i('logout') ?></button>
+					</form>
 				</li>
 			</ul>
 		</li>

--- a/app/layout/header.phtml
+++ b/app/layout/header.phtml
@@ -53,9 +53,6 @@
 
 	<?php if (FreshRSS_Auth::hasAccess()) { ?>
 	<nav class="item configure">
-		<form id="post-csrf" method="post">
-			<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
-		</form>
 		<div class="dropdown">
 			<div id="dropdown-configure" class="dropdown-target"></div>
 			<a class="btn dropdown-toggle" href="#dropdown-configure"><?= _i('configure') ?></a>
@@ -70,7 +67,10 @@
 						<li class="item"><a href="<?= _url('user', 'profile') ?>"><?= _t('gen.menu.user_profile') ?></a></li>
 						<?php if (FreshRSS_Auth::accessNeedsAction()): ?>
 						<li class="item">
-							<button class="as-link signout" form="post-csrf" formaction="<?= _url('auth', 'logout') ?>"><?= _t('gen.auth.logout'); ?><?= _i('logout') ?></button>
+							<form method="POST">
+								<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
+								<button class="as-link signout" formaction="<?= _url('auth', 'logout') ?>"><?= _t('gen.auth.logout'); ?><?= _i('logout') ?></button>
+							</form>
 						</li>
 						<?php else: ?>
 						<li class="item"><span class="signout">(<?= htmlspecialchars(Minz_User::name() ?? '', ENT_NOQUOTES, 'UTF-8') ?>)</span></li>

--- a/app/layout/nav_menu.phtml
+++ b/app/layout/nav_menu.phtml
@@ -98,7 +98,12 @@
 					$url_query['c'] = 'configure';
 					$url_query['a'] = 'bookmarkQuery';
 				?>
-				<li class="item<?= $classSeparator ?>"><button class="as-link" form="post-csrf" formaction="<?= Minz_Url::display($url_query) ?>" type="submit"><?= _i('bookmark-add') ?> <?= _t('index.menu.bookmark_query') ?></button></li>
+				<li class="item<?= $classSeparator ?>">
+					<form method="POST">
+						<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
+						<button class="as-link" formaction="<?= Minz_Url::display($url_query) ?>" type="submit"><?= _i('bookmark-add') ?> <?= _t('index.menu.bookmark_query') ?></button>
+					</form>
+				</li>
 			</ul>
 			<a class="dropdown-close" href="#close">❌</a>
 		</div>

--- a/p/themes/Alternative-Dark/adark.css
+++ b/p/themes/Alternative-Dark/adark.css
@@ -323,7 +323,7 @@ a:hover > .spinner {
 }
 
 .nav-list .item > a,
-.nav-list .item > .as-link {
+.nav-list .item .as-link {
 	padding: 0 1rem;
 }
 
@@ -368,7 +368,7 @@ a:hover > .spinner {
 
 .dropdown-menu .item > a,
 .dropdown-menu .item > span,
-.dropdown-menu .item > .as-link {
+.dropdown-menu .item .as-link {
 	padding: 0 22px;
 	line-height: 2.5;
 	font-size: inherit;
@@ -376,7 +376,7 @@ a:hover > .spinner {
 
 .dropdown-menu .dropdown-section .item > a,
 .dropdown-menu .dropdown-section .item > span,
-.dropdown-menu .dropdown-section .item > .as-link {
+.dropdown-menu .dropdown-section .item .as-link {
 	padding-left: 2rem;
 }
 
@@ -386,8 +386,8 @@ a:hover > .spinner {
 
 .dropdown-menu .item > a:focus,
 .dropdown-menu .item > a:hover,
-.dropdown-menu .item > button:focus:not([disabled]),
-.dropdown-menu .item > button:hover:not([disabled]),
+.dropdown-menu .item button:focus:not([disabled]),
+.dropdown-menu .item button:hover:not([disabled]),
 .dropdown-menu .item > label:focus:not(.noHover),
 .dropdown-menu .item > label:hover:not(.noHover) {
 	background: var(--background-color-hover);

--- a/p/themes/Alternative-Dark/adark.rtl.css
+++ b/p/themes/Alternative-Dark/adark.rtl.css
@@ -323,7 +323,7 @@ a:hover > .spinner {
 }
 
 .nav-list .item > a,
-.nav-list .item > .as-link {
+.nav-list .item .as-link {
 	padding: 0 1rem;
 }
 
@@ -368,7 +368,7 @@ a:hover > .spinner {
 
 .dropdown-menu .item > a,
 .dropdown-menu .item > span,
-.dropdown-menu .item > .as-link {
+.dropdown-menu .item .as-link {
 	padding: 0 22px;
 	line-height: 2.5;
 	font-size: inherit;
@@ -376,7 +376,7 @@ a:hover > .spinner {
 
 .dropdown-menu .dropdown-section .item > a,
 .dropdown-menu .dropdown-section .item > span,
-.dropdown-menu .dropdown-section .item > .as-link {
+.dropdown-menu .dropdown-section .item .as-link {
 	padding-right: 2rem;
 }
 
@@ -386,8 +386,8 @@ a:hover > .spinner {
 
 .dropdown-menu .item > a:focus,
 .dropdown-menu .item > a:hover,
-.dropdown-menu .item > button:focus:not([disabled]),
-.dropdown-menu .item > button:hover:not([disabled]),
+.dropdown-menu .item button:focus:not([disabled]),
+.dropdown-menu .item button:hover:not([disabled]),
 .dropdown-menu .item > label:focus:not(.noHover),
 .dropdown-menu .item > label:hover:not(.noHover) {
 	background: var(--background-color-hover);

--- a/p/themes/Ansum/_components.css
+++ b/p/themes/Ansum/_components.css
@@ -53,7 +53,7 @@
 
 		& > a,
 		& > span,
-		& > .as-link {
+		& .as-link {
 			padding: 0 2rem;
 			color: var(--main-font-color);
 			font-size: inherit;
@@ -65,7 +65,7 @@
 		}
 
 		& > a,
-		& > .as-link {
+		& .as-link {
 			&:not(.addItem):hover {
 				background: var(--main-first);
 				color: var(--white);

--- a/p/themes/Ansum/_components.rtl.css
+++ b/p/themes/Ansum/_components.rtl.css
@@ -53,7 +53,7 @@
 
 		& > a,
 		& > span,
-		& > .as-link {
+		& .as-link {
 			padding: 0 2rem;
 			color: var(--main-font-color);
 			font-size: inherit;
@@ -65,7 +65,7 @@
 		}
 
 		& > a,
-		& > .as-link {
+		& .as-link {
 			&:not(.addItem):hover {
 				background: var(--main-first);
 				color: var(--white);

--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -313,8 +313,8 @@ button.as-link[disabled] {
 
 .dropdown-menu .item > a:focus,
 .dropdown-menu .item > a:hover,
-.dropdown-menu .item > button:focus:not([disabled]),
-.dropdown-menu .item > button:hover:not([disabled]),
+.dropdown-menu .item button:focus:not([disabled]),
+.dropdown-menu .item button:hover:not([disabled]),
 .dropdown-menu .item > label:focus:not(.noHover),
 .dropdown-menu .item > label:hover:not(.noHover) {
 	background-color: var(--dark-background-color-blue);

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -313,8 +313,8 @@ button.as-link[disabled] {
 
 .dropdown-menu .item > a:focus,
 .dropdown-menu .item > a:hover,
-.dropdown-menu .item > button:focus:not([disabled]),
-.dropdown-menu .item > button:hover:not([disabled]),
+.dropdown-menu .item button:focus:not([disabled]),
+.dropdown-menu .item button:hover:not([disabled]),
 .dropdown-menu .item > label:focus:not(.noHover),
 .dropdown-menu .item > label:hover:not(.noHover) {
 	background-color: var(--dark-background-color-blue);

--- a/p/themes/Flat/flat.css
+++ b/p/themes/Flat/flat.css
@@ -268,7 +268,7 @@ th {
 }
 
 .nav-list .item > a,
-.nav-list .item > .as-link {
+.nav-list .item .as-link {
 	padding: 0 1rem;
 }
 
@@ -319,7 +319,7 @@ th {
 
 .dropdown-menu .item > a,
 .dropdown-menu .item > span,
-.dropdown-menu .item > .as-link {
+.dropdown-menu .item .as-link {
 	padding: 0 22px;
 	line-height: 2.5em;
 	font-size: inherit;
@@ -327,7 +327,7 @@ th {
 
 .dropdown-menu .dropdown-section .item > a,
 .dropdown-menu .dropdown-section .item > span,
-.dropdown-menu .dropdown-section .item > .as-link {
+.dropdown-menu .dropdown-section .item .as-link {
 	padding-left: 2rem;
 }
 
@@ -337,8 +337,8 @@ th {
 
 .dropdown-menu .item > a:focus,
 .dropdown-menu .item > a:hover,
-.dropdown-menu .item > button:focus:not([disabled]),
-.dropdown-menu .item > button:hover:not([disabled]),
+.dropdown-menu .item button:focus:not([disabled]),
+.dropdown-menu .item button:hover:not([disabled]),
 .dropdown-menu .item > label:focus:not(.noHover),
 .dropdown-menu .item > label:hover:not(.noHover) {
 	background: #2980b9;

--- a/p/themes/Flat/flat.rtl.css
+++ b/p/themes/Flat/flat.rtl.css
@@ -268,7 +268,7 @@ th {
 }
 
 .nav-list .item > a,
-.nav-list .item > .as-link {
+.nav-list .item .as-link {
 	padding: 0 1rem;
 }
 
@@ -319,7 +319,7 @@ th {
 
 .dropdown-menu .item > a,
 .dropdown-menu .item > span,
-.dropdown-menu .item > .as-link {
+.dropdown-menu .item .as-link {
 	padding: 0 22px;
 	line-height: 2.5em;
 	font-size: inherit;
@@ -327,7 +327,7 @@ th {
 
 .dropdown-menu .dropdown-section .item > a,
 .dropdown-menu .dropdown-section .item > span,
-.dropdown-menu .dropdown-section .item > .as-link {
+.dropdown-menu .dropdown-section .item .as-link {
 	padding-right: 2rem;
 }
 
@@ -337,8 +337,8 @@ th {
 
 .dropdown-menu .item > a:focus,
 .dropdown-menu .item > a:hover,
-.dropdown-menu .item > button:focus:not([disabled]),
-.dropdown-menu .item > button:hover:not([disabled]),
+.dropdown-menu .item button:focus:not([disabled]),
+.dropdown-menu .item button:hover:not([disabled]),
 .dropdown-menu .item > label:focus:not(.noHover),
 .dropdown-menu .item > label:hover:not(.noHover) {
 	background: #2980b9;

--- a/p/themes/Mapco/_components.css
+++ b/p/themes/Mapco/_components.css
@@ -53,7 +53,7 @@
 
 		> a,
 		> span,
-		> .as-link {
+		.as-link {
 			padding: 0 2rem;
 			color: var(--main-font-color);
 			font-size: inherit;
@@ -65,7 +65,7 @@
 		}
 
 		> a,
-		> .as-link {
+		.as-link {
 			&:not(.addItem):hover {
 				background: var(--main-first);
 				color: var(--white);

--- a/p/themes/Mapco/_components.rtl.css
+++ b/p/themes/Mapco/_components.rtl.css
@@ -53,7 +53,7 @@
 
 		> a,
 		> span,
-		> .as-link {
+		.as-link {
 			padding: 0 2rem;
 			color: var(--main-font-color);
 			font-size: inherit;
@@ -65,7 +65,7 @@
 		}
 
 		> a,
-		> .as-link {
+		.as-link {
 			&:not(.addItem):hover {
 				background: var(--main-first);
 				color: var(--white);

--- a/p/themes/Nord/nord.css
+++ b/p/themes/Nord/nord.css
@@ -373,7 +373,7 @@ svg:hover {
 
 .dropdown-menu .item > a,
 .dropdown-menu .item > span,
-.dropdown-menu .item > .as-link {
+.dropdown-menu .item .as-link {
 	padding: 0 22px;
 	line-height: 2.5em;
 	font-size: inherit;
@@ -382,7 +382,7 @@ svg:hover {
 
 .dropdown-menu .dropdown-section .item > a,
 .dropdown-menu .dropdown-section .item > span,
-.dropdown-menu .dropdown-section .item > .as-link {
+.dropdown-menu .dropdown-section .item .as-link {
 	padding-left: 2rem;
 }
 
@@ -392,8 +392,8 @@ svg:hover {
 
 .dropdown-menu .item > a:focus,
 .dropdown-menu .item > a:hover,
-.dropdown-menu .item > button:focus:not([disabled]),
-.dropdown-menu .item > button:hover:not([disabled]),
+.dropdown-menu .item button:focus:not([disabled]),
+.dropdown-menu .item button:hover:not([disabled]),
 .dropdown-menu .item > label:focus:not(.noHover),
 .dropdown-menu .item > label:hover:not(.noHover) {
 	background-color: var(--light-bg);
@@ -1105,7 +1105,7 @@ optgroup::before {
 }
 
 .nav-list .item > a,
-.nav-list .item > .as-link {
+.nav-list .item .as-link {
 	padding: 0 1rem;
 }
 
@@ -1131,10 +1131,10 @@ optgroup::before {
 
 .dropdown-menu > .item > a,
 .dropdown-menu > .item > span,
-.dropdown-menu > .item > .as-link,
+.dropdown-menu > .item .as-link,
 .dropdown-menu > .item > ul > .item > a,
 .dropdown-menu > .item > ul > .item > span,
-.dropdown-menu > .item > ul > .item > .as-link {
+.dropdown-menu > .item > ul > .item .as-link {
 	color: var(--text-accent) !important;
 }
 

--- a/p/themes/Nord/nord.rtl.css
+++ b/p/themes/Nord/nord.rtl.css
@@ -373,7 +373,7 @@ svg:hover {
 
 .dropdown-menu .item > a,
 .dropdown-menu .item > span,
-.dropdown-menu .item > .as-link {
+.dropdown-menu .item .as-link {
 	padding: 0 22px;
 	line-height: 2.5em;
 	font-size: inherit;
@@ -382,7 +382,7 @@ svg:hover {
 
 .dropdown-menu .dropdown-section .item > a,
 .dropdown-menu .dropdown-section .item > span,
-.dropdown-menu .dropdown-section .item > .as-link {
+.dropdown-menu .dropdown-section .item .as-link {
 	padding-right: 2rem;
 }
 
@@ -392,8 +392,8 @@ svg:hover {
 
 .dropdown-menu .item > a:focus,
 .dropdown-menu .item > a:hover,
-.dropdown-menu .item > button:focus:not([disabled]),
-.dropdown-menu .item > button:hover:not([disabled]),
+.dropdown-menu .item button:focus:not([disabled]),
+.dropdown-menu .item button:hover:not([disabled]),
 .dropdown-menu .item > label:focus:not(.noHover),
 .dropdown-menu .item > label:hover:not(.noHover) {
 	background-color: var(--light-bg);
@@ -1105,7 +1105,7 @@ optgroup::before {
 }
 
 .nav-list .item > a,
-.nav-list .item > .as-link {
+.nav-list .item .as-link {
 	padding: 0 1rem;
 }
 
@@ -1131,10 +1131,10 @@ optgroup::before {
 
 .dropdown-menu > .item > a,
 .dropdown-menu > .item > span,
-.dropdown-menu > .item > .as-link,
+.dropdown-menu > .item .as-link,
 .dropdown-menu > .item > ul > .item > a,
 .dropdown-menu > .item > ul > .item > span,
-.dropdown-menu > .item > ul > .item > .as-link {
+.dropdown-menu > .item > ul > .item .as-link {
 	color: var(--text-accent) !important;
 }
 

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -403,7 +403,7 @@ button:hover .icon,
 }
 
 .nav-list .item > a,
-.nav-list .item > .as-link,
+.nav-list .item .as-link,
 .nav-list .item > span,
 .nav-list .item > div {
 	padding: 0 1rem;
@@ -455,7 +455,7 @@ button:hover .icon,
 
 .dropdown-menu .item > a,
 .dropdown-menu .item > span,
-.dropdown-menu .item > .as-link {
+.dropdown-menu .item .as-link {
 	padding: 0 22px;
 	line-height: 2.5;
 	font-size: inherit;
@@ -463,7 +463,7 @@ button:hover .icon,
 
 .dropdown-menu .dropdown-section .item > a,
 .dropdown-menu .dropdown-section .item > span,
-.dropdown-menu .dropdown-section .item > .as-link {
+.dropdown-menu .dropdown-section .item .as-link {
 	padding-left: 2rem;
 }
 
@@ -473,8 +473,8 @@ button:hover .icon,
 
 .dropdown-menu .item > a:focus,
 .dropdown-menu .item > a:hover,
-.dropdown-menu .item > button:focus:not([disabled]),
-.dropdown-menu .item > button:hover:not([disabled]),
+.dropdown-menu .item button:focus:not([disabled]),
+.dropdown-menu .item button:hover:not([disabled]),
 .dropdown-menu .item > label:focus:not(.noHover),
 .dropdown-menu .item > label:hover:not(.noHover) {
 	background-color: var(--contrast-background-color-active);

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -403,7 +403,7 @@ button:hover .icon,
 }
 
 .nav-list .item > a,
-.nav-list .item > .as-link,
+.nav-list .item .as-link,
 .nav-list .item > span,
 .nav-list .item > div {
 	padding: 0 1rem;
@@ -455,7 +455,7 @@ button:hover .icon,
 
 .dropdown-menu .item > a,
 .dropdown-menu .item > span,
-.dropdown-menu .item > .as-link {
+.dropdown-menu .item .as-link {
 	padding: 0 22px;
 	line-height: 2.5;
 	font-size: inherit;
@@ -463,7 +463,7 @@ button:hover .icon,
 
 .dropdown-menu .dropdown-section .item > a,
 .dropdown-menu .dropdown-section .item > span,
-.dropdown-menu .dropdown-section .item > .as-link {
+.dropdown-menu .dropdown-section .item .as-link {
 	padding-right: 2rem;
 }
 
@@ -473,8 +473,8 @@ button:hover .icon,
 
 .dropdown-menu .item > a:focus,
 .dropdown-menu .item > a:hover,
-.dropdown-menu .item > button:focus:not([disabled]),
-.dropdown-menu .item > button:hover:not([disabled]),
+.dropdown-menu .item button:focus:not([disabled]),
+.dropdown-menu .item button:hover:not([disabled]),
 .dropdown-menu .item > label:focus:not(.noHover),
 .dropdown-menu .item > label:hover:not(.noHover) {
 	background-color: var(--contrast-background-color-active);

--- a/p/themes/Pafat/pafat.css
+++ b/p/themes/Pafat/pafat.css
@@ -322,7 +322,7 @@ th {
 }
 
 .nav-list .item > a,
-.nav-list .item > .as-link {
+.nav-list .item .as-link {
 	padding: 0 1rem;
 }
 
@@ -368,7 +368,7 @@ th {
 
 .dropdown-menu .item > a,
 .dropdown-menu .item > span,
-.dropdown-menu .item > .as-link {
+.dropdown-menu .item .as-link {
 	padding: 0 22px;
 	line-height: 2.5;
 	color: var(--font-color-grey);
@@ -377,7 +377,7 @@ th {
 
 .dropdown-menu .dropdown-section .item > a,
 .dropdown-menu .dropdown-section .item > span,
-.dropdown-menu .dropdown-section .item > .as-link {
+.dropdown-menu .dropdown-section .item .as-link {
 	padding-left: 2rem;
 }
 
@@ -387,8 +387,8 @@ th {
 
 .dropdown-menu .item > a:focus,
 .dropdown-menu .item > a:hover,
-.dropdown-menu .item > button:focus:not([disabled]),
-.dropdown-menu .item > button:hover:not([disabled]),
+.dropdown-menu .item button:focus:not([disabled]),
+.dropdown-menu .item button:hover:not([disabled]),
 .dropdown-menu .item > label:focus:not(.noHover),
 .dropdown-menu .item > label:hover:not(.noHover) {
 	background-color: var(--background-color-grey-hover);

--- a/p/themes/Pafat/pafat.rtl.css
+++ b/p/themes/Pafat/pafat.rtl.css
@@ -322,7 +322,7 @@ th {
 }
 
 .nav-list .item > a,
-.nav-list .item > .as-link {
+.nav-list .item .as-link {
 	padding: 0 1rem;
 }
 
@@ -368,7 +368,7 @@ th {
 
 .dropdown-menu .item > a,
 .dropdown-menu .item > span,
-.dropdown-menu .item > .as-link {
+.dropdown-menu .item .as-link {
 	padding: 0 22px;
 	line-height: 2.5;
 	color: var(--font-color-grey);
@@ -377,7 +377,7 @@ th {
 
 .dropdown-menu .dropdown-section .item > a,
 .dropdown-menu .dropdown-section .item > span,
-.dropdown-menu .dropdown-section .item > .as-link {
+.dropdown-menu .dropdown-section .item .as-link {
 	padding-right: 2rem;
 }
 
@@ -387,8 +387,8 @@ th {
 
 .dropdown-menu .item > a:focus,
 .dropdown-menu .item > a:hover,
-.dropdown-menu .item > button:focus:not([disabled]),
-.dropdown-menu .item > button:hover:not([disabled]),
+.dropdown-menu .item button:focus:not([disabled]),
+.dropdown-menu .item button:hover:not([disabled]),
 .dropdown-menu .item > label:focus:not(.noHover),
 .dropdown-menu .item > label:hover:not(.noHover) {
 	background-color: var(--background-color-grey-hover);

--- a/p/themes/Swage/swage.css
+++ b/p/themes/Swage/swage.css
@@ -357,7 +357,7 @@ form {
 		}
 
 		> a,
-		> .as-link {
+		.as-link {
 			padding: 0 1.5rem;
 		}
 
@@ -385,7 +385,7 @@ form {
 	background-color: var(--color-background-nav-darker);
 
 	.item > a,
-	.item > .as-link,
+	.item .as-link,
 	.item > span {
 		width: 96% !important;
 	}
@@ -438,7 +438,7 @@ form {
 		font-size: var(--font-size-dropdown);
 		line-height: var(--line-height-dropdown);
 
-		> :is(a, .as-link, span, button) {
+		> :is(a, .as-link, span), :is(button) {
 			padding: var(--padding-dropdown);
 			color: var(--color-text-light);
 			font-size: var(--font-size-dropdown);
@@ -450,7 +450,7 @@ form {
 			white-space: nowrap;
 		}
 
-		> :is(a, button):hover {
+		> :is(a):hover, :is(button):hover {
 			background-color: var(--color-background-nav);
 			color: var(--color-text-light);
 		}

--- a/p/themes/Swage/swage.rtl.css
+++ b/p/themes/Swage/swage.rtl.css
@@ -357,7 +357,7 @@ form {
 		}
 
 		> a,
-		> .as-link {
+		.as-link {
 			padding: 0 1.5rem;
 		}
 
@@ -385,7 +385,7 @@ form {
 	background-color: var(--color-background-nav-darker);
 
 	.item > a,
-	.item > .as-link,
+	.item .as-link,
 	.item > span {
 		width: 96% !important;
 	}
@@ -438,7 +438,7 @@ form {
 		font-size: var(--font-size-dropdown);
 		line-height: var(--line-height-dropdown);
 
-		> :is(a, .as-link, span, button) {
+		> :is(a, .as-link, span), :is(button) {
 			padding: var(--padding-dropdown);
 			color: var(--color-text-light);
 			font-size: var(--font-size-dropdown);
@@ -450,7 +450,7 @@ form {
 			white-space: nowrap;
 		}
 
-		> :is(a, button):hover {
+		> :is(a):hover, :is(button):hover {
 			background-color: var(--color-background-nav);
 			color: var(--color-text-light);
 		}

--- a/p/themes/base-theme/base.css
+++ b/p/themes/base-theme/base.css
@@ -176,7 +176,7 @@ th {
 }
 
 .nav-list .item > a,
-.nav-list .item > .as-link {
+.nav-list .item .as-link {
 	padding: 0 10px;
 }
 
@@ -223,7 +223,7 @@ th {
 
 .dropdown-menu > .item > a,
 .dropdown-menu > .item > span,
-.dropdown-menu > .item > .as-link {
+.dropdown-menu > .item .as-link {
 	padding: 0 22px;
 	line-height: 2.5;
 }

--- a/p/themes/base-theme/base.rtl.css
+++ b/p/themes/base-theme/base.rtl.css
@@ -176,7 +176,7 @@ th {
 }
 
 .nav-list .item > a,
-.nav-list .item > .as-link {
+.nav-list .item .as-link {
 	padding: 0 10px;
 }
 
@@ -223,7 +223,7 @@ th {
 
 .dropdown-menu > .item > a,
 .dropdown-menu > .item > span,
-.dropdown-menu > .item > .as-link {
+.dropdown-menu > .item .as-link {
 	padding: 0 22px;
 	line-height: 2.5;
 }

--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -408,7 +408,7 @@ input[type="checkbox"] {
 }
 
 .dropdown-menu .item > a:hover,
-.dropdown-menu .item > button:hover {
+.dropdown-menu .item button:hover {
 	text-decoration: none;
 }
 
@@ -749,7 +749,7 @@ input[type="checkbox"]:focus-visible {
 
 .nav-list .item,
 .nav-list .item > a,
-.nav-list .item > .as-link,
+.nav-list .item .as-link,
 .nav-list .item > span {
 	display: block;
 	overflow: hidden;
@@ -870,7 +870,7 @@ input[type="checkbox"]:focus-visible {
 }
 
 .dropdown-menu .item > a,
-.dropdown-menu .item > .as-link,
+.dropdown-menu .item .as-link,
 .dropdown-menu .item > span {
 	display: block;
 	width: 100%;

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -408,7 +408,7 @@ input[type="checkbox"] {
 }
 
 .dropdown-menu .item > a:hover,
-.dropdown-menu .item > button:hover {
+.dropdown-menu .item button:hover {
 	text-decoration: none;
 }
 
@@ -749,7 +749,7 @@ input[type="checkbox"]:focus-visible {
 
 .nav-list .item,
 .nav-list .item > a,
-.nav-list .item > .as-link,
+.nav-list .item .as-link,
 .nav-list .item > span {
 	display: block;
 	overflow: hidden;
@@ -870,7 +870,7 @@ input[type="checkbox"]:focus-visible {
 }
 
 .dropdown-menu .item > a,
-.dropdown-menu .item > .as-link,
+.dropdown-menu .item .as-link,
 .dropdown-menu .item > span {
 	display: block;
 	width: 100%;


### PR DESCRIPTION
HTML injections outside of a form with a `_csrf` field set, could instead refer to the CSRF token form with a payload such as:
```html
<button form="post-csrf" formaction="./i/?c=auth&a=logout" formmethod="post">Continue reading</button>
```
While the `post-csrf` form is useful for reducing the amount of code needed (no need to repeat the `_csrf` field in forms), I don't think it's worth the added security risk.