### PR TITLE
Fix HTML injection via decoded website attribute in feed menu

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -1147,9 +1147,10 @@ function init_column_categories() {
 				const id = itemId.substr(2);
 				const feed_web = a.getAttribute('data-fweb') || '';
 				const template = document.getElementById(templateId)
-					.innerHTML.replace(/------/g, id).replace('http://example.net/', feed_web);
+					.innerHTML.replace(/------/g, id);
 				div.insertAdjacentHTML('beforeend', template);
 				dropdownMenu = div.querySelector('.dropdown-menu');
+				dropdownMenu.querySelector('li.website > a').href = feed_web;
 				dropdownMenu.style.opacity = '0%'; // Hide initially to prevent dropdown flashing
 				if (feed_web == '') {
 					const website = div.querySelector('.item.link.website');


### PR DESCRIPTION
To reproduce:
1. Add a feed e.g. `https://github.com/FreshRSS/FreshRSS/releases.atom`
2. Change its website URL to `https://github.com/FreshRSS/FreshRSS/releases.atom?"><marquee>test</marquee><?x`
3. Open the feed's menu from the sidebar after saving the settings

Follow-up of https://github.com/FreshRSS/FreshRSS/pull/9146 (same issue but in a different menu)