### PR TITLE
Fix “mark as read older than…” widening the active search

### DIFF
--- a/app/Models/BooleanSearch.php
+++ b/app/Models/BooleanSearch.php
@@ -432,8 +432,30 @@ class FreshRSS_BooleanSearch implements \Stringable {
 		return $this->operator;
 	}
 
-	/** @param FreshRSS_BooleanSearch|FreshRSS_Search $search */
+	/**
+	 * Wrap the existing searches in a single BooleanSearch if needed,
+	 * so that another search can be added as an additional restriction (AND)
+	 * instead of being combined by OR with the existing sibling searches.
+	 */
+	private function wrapSearches(): void {
+		if (count($this->searches) > 1 || (count($this->searches) > 0 && $this->searches[0] instanceof FreshRSS_Search)) {
+			$wrap = new FreshRSS_BooleanSearch('');
+			foreach ($this->searches as $existingSearch) {
+				$wrap->add($existingSearch);
+			}
+			if (count($wrap->searches) > 0) {
+				$this->searches = [$wrap];
+			}
+		}
+	}
+
+	/**
+	 * Add a search at the beginning of the Boolean expression, as an additional restriction (AND).
+	 * @param FreshRSS_BooleanSearch|FreshRSS_Search $search
+	 */
 	public function prepend(FreshRSS_BooleanSearch|FreshRSS_Search $search): void {
+		// Sibling searches are combined by OR, so the existing expression must be wrapped first
+		$this->wrapSearches();
 		array_unshift($this->searches, $search);
 	}
 
@@ -472,16 +494,7 @@ class FreshRSS_BooleanSearch implements \Stringable {
 			}
 		}
 
-		if (count($result->searches) > 1 || (count($result->searches) > 0 && $result->searches[0] instanceof FreshRSS_Search)) {
-			// Wrap the existing searches in a new BooleanSearch if needed
-			$wrap = new FreshRSS_BooleanSearch('');
-			foreach ($result->searches as $existingSearch) {
-				$wrap->add($existingSearch);
-			}
-			if (count($wrap->searches) > 0) {
-				$result->searches = [$wrap];
-			}
-		}
+		$result->wrapSearches();
 		array_unshift($result->searches, $search);
 		return $result;
 	}

--- a/app/Models/BooleanSearch.php
+++ b/app/Models/BooleanSearch.php
@@ -434,8 +434,7 @@ class FreshRSS_BooleanSearch implements \Stringable {
 
 	/**
 	 * Wrap the existing searches in a single BooleanSearch if needed,
-	 * so that another search can be added as an additional restriction (AND)
-	 * instead of being combined by OR with the existing sibling searches.
+	 * so that another search can be added as an additional restriction (AND).
 	 */
 	private function wrapSearches(): void {
 		if (count($this->searches) > 1 || (count($this->searches) > 0 && $this->searches[0] instanceof FreshRSS_Search)) {
@@ -454,7 +453,6 @@ class FreshRSS_BooleanSearch implements \Stringable {
 	 * @param FreshRSS_BooleanSearch|FreshRSS_Search $search
 	 */
 	public function prepend(FreshRSS_BooleanSearch|FreshRSS_Search $search): void {
-		// Sibling searches are combined by OR, so the existing expression must be wrapped first
 		$this->wrapSearches();
 		array_unshift($this->searches, $search);
 	}

--- a/app/Models/EntryDAO.php
+++ b/app/Models/EntryDAO.php
@@ -970,7 +970,7 @@ class FreshRSS_EntryDAO extends Minz_ModelPdo {
 
 				if ($filterSearch !== '') {
 					if ($search !== '') {
-						$search .= $filter->operator();
+						$search = rtrim($search) . ' ' . $filter->operator();
 					} elseif (in_array($filter->operator(), ['AND NOT', 'OR NOT'], true)) {
 						// Special case if we start with a negation (there is already the default AND before)
 						$search .= ' NOT';

--- a/tests/app/Models/BooleanSearchTest.php
+++ b/tests/app/Models/BooleanSearchTest.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class BooleanSearchTest extends \PHPUnit\Framework\TestCase {
+
+	/**
+	 * `FreshRSS_BooleanSearch::prepend()` is used to restrict an existing search with an extra condition,
+	 * such as the maximum publication date of the “mark as read → articles older than one day/week” action.
+	 * Sibling searches are combined by OR, so the extra condition must not end up as one more OR term.
+	 * @return list<array{string,string,list<string|int>}>
+	 */
+	public static function providePrependMaxPubdate(): array {
+		return [
+			['', '(e.date <= ?)', [1700000000]],
+			['intitle:sale', '(e.date <= ?)AND ((e.title LIKE ?))', [1700000000, '%sale%']],
+			['intitle:a OR intitle:b', '(e.date <= ?)AND ((e.title LIKE ?) OR (e.title LIKE ?))', [1700000000, '%a%', '%b%']],
+		];
+	}
+
+	/** @param list<string|int> $expectedValues */
+	#[DataProvider('providePrependMaxPubdate')]
+	public function test_prepend_restrictsTheSearchInsteadOfWideningIt(string $input, string $expectedSql, array $expectedValues): void {
+		$booleanSearch = new FreshRSS_BooleanSearch($input);
+		$maxPubdate = new FreshRSS_Search('');
+		$maxPubdate->setMaxPubdate(1700000000);
+		$booleanSearch->prepend($maxPubdate);
+
+		[$values, $sql] = FreshRSS_EntryDAO::sqlBooleanSearch('e.', $booleanSearch);
+		self::assertSame($expectedSql, trim($sql));
+		self::assertSame($expectedValues, $values);
+	}
+}

--- a/tests/app/Models/BooleanSearchTest.php
+++ b/tests/app/Models/BooleanSearchTest.php
@@ -8,7 +8,6 @@ final class BooleanSearchTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * `FreshRSS_BooleanSearch::prepend()` is used to restrict an existing search with an extra condition,
 	 * such as the maximum publication date of the “mark as read → articles older than one day/week” action.
-	 * Sibling searches are combined by OR, so the extra condition must not end up as one more OR term.
 	 * @return list<array{string,string,list<string|int>}>
 	 */
 	public static function providePrependMaxPubdate(): array {

--- a/tests/app/Models/BooleanSearchTest.php
+++ b/tests/app/Models/BooleanSearchTest.php
@@ -14,8 +14,8 @@ final class BooleanSearchTest extends \PHPUnit\Framework\TestCase {
 	public static function providePrependMaxPubdate(): array {
 		return [
 			['', '(e.date <= ?)', [1700000000]],
-			['intitle:sale', '(e.date <= ?)AND ((e.title LIKE ?))', [1700000000, '%sale%']],
-			['intitle:a OR intitle:b', '(e.date <= ?)AND ((e.title LIKE ?) OR (e.title LIKE ?))', [1700000000, '%a%', '%b%']],
+			['intitle:sale', '(e.date <= ?) AND ((e.title LIKE ?))', [1700000000, '%sale%']],
+			['intitle:a OR intitle:b', '(e.date <= ?) AND ((e.title LIKE ?) OR (e.title LIKE ?))', [1700000000, '%a%', '%b%']],
 		];
 	}
 


### PR DESCRIPTION
Fixes the "Mark as read → Articles older than one day / one week" action marking far more than requested when a search is active.

Sibling searches of a `FreshRSS_BooleanSearch` are combined by OR (`BooleanSearch::__toString()`, and "Searches are combined by OR" in `EntryDAO::sqlBooleanSearch()`). `prepend()` added the maximum publication date as one such sibling, so it widened the selection instead of restricting it:

```
search='cats'         → (e.date <= ?) OR (…content… LIKE '%cats%')
search='cats OR dogs' → (e.date <= ?) OR (…'%cats%') OR (…'%dogs%')
```

`nav_menu.phtml` puts `search` and `maxPubDate` on the same mark-as-read URL, so with any search active and the stream sorted by publication date the action marks as read every article older than the cut-off (search ignored) **plus** every article matching the search at any date. The `idMax` path used when sorting by ID is not affected.

`enforce()` already had the correct behaviour (wrap the existing expression, then prepend) and is used that way in `indexController`. This moves that wrapping into a small private helper shared by `enforce()` and `prepend()`, so both combine with AND:

```
search='cats'         → (e.date <= ?) AND ((…'%cats%'))
search='cats OR dogs' → (e.date <= ?) AND ((…'%cats%') OR (…'%dogs%'))
search=''             → (e.date <= ?)          (unchanged)
```

`prepend()` has a single caller, `entryController::readAction()`, added together with `prepend()` itself in #8163. `enforce()` output is unchanged — the generated SQL, bound values and `__toString()` were diffed across 14 query shapes × 2 injected search types before and after, identical.

How to test manually:
1. Configuration → Reading → sort by publication date.
2. Type something in the search box that matches only some articles.
3. Mark as read → "Articles older than one day". Only articles that match the search *and* are older than the cut-off are marked read.

Checklist:
- [x] clear commit messages
- [x] code manually tested
- [x] unit tests written (`tests/app/Models/BooleanSearchTest.php`, asserts the generated SQL for empty / flat / OR searches)
- [x] documentation updated (n/a)

Written with assistance from Claude (Anthropic); fail-before/pass-after verified, plus the full suite (667 tests), phpstan and phpcs.
