### PR TITLE
Add optional feed argument to actualize_script.php

### DIFF
--- a/app/actualize_script.php
+++ b/app/actualize_script.php
@@ -9,11 +9,34 @@ ob_start();
 
 $begin_date = date_create('now');
 
+// Optional feed ID argument.
+// If none given, all feeds are updated.
+$feedId = null;
+if ($argc > 2) {
+	fwrite(STDERR, "actualize_script.php takes at most one feed ID as an argument, aborting\n");
+	die();
+}
+if ($argc == 2) {
+	$feedId = filter_var($argv[1], FILTER_VALIDATE_INT, [
+		'options' => ['min_range' => 1],
+	]);
+
+	if (!$feedId) {
+		fwrite(STDERR, 'Invalid feed ID ' . $argv[1] . "\n");
+		die();
+	}
+}
+
 // Set the header params ($_GET) to call the FRSS application.
+if ($feedId) {
+	$_GET['id'] = $feedId;
+	$_GET['maxFeeds'] = 1;
+} else {
+	$_GET['maxFeeds'] = PHP_INT_MAX;
+}
 $_GET['c'] = 'feed';
 $_GET['a'] = 'actualize';
 $_GET['ajax'] = 1;
-$_GET['maxFeeds'] = PHP_INT_MAX;
 $_SERVER['HTTP_HOST'] = '';
 
 $app = new FreshRSS();


### PR DESCRIPTION
Changes proposed in this pull request:

Adds an optional argument to the script to allow updating a particular feed, instead of all of them. This makes it easier to update specific feeds via cron and other local utilities. (My personal motivation is to add a bit of privacy to updates so they aren't as obviously linked, but this is also useful for other reasons, e.g. if you have too many feeds to feasibly update at once.)

How to test the feature manually:

1. apply patch
2. look up currently valid feed ID
3. call `actualize_script.php 123`

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

I'll update the documentation if I get the go-ahead on this being desirable, and can add a test if requested and not too difficult.