### PR TITLE
Security: Use hash_equals() for GReader API token comparison

### DIFF
--- a/p/api/greader.php
+++ b/p/api/greader.php
@@ -192,7 +192,7 @@ final class GReaderAPI {
 						Minz_Log::warning('Invalid API user ' . $user . ': configuration cannot be found.');
 						self::unauthorized();
 					}
-					if ($headerAuthX[1] === sha1(FreshRSS_Context::systemConf()->salt . $user . FreshRSS_Context::userConf()->apiPasswordHash)) {
+					if (hash_equals(sha1(FreshRSS_Context::systemConf()->salt . $user . FreshRSS_Context::userConf()->apiPasswordHash), $headerAuthX[1])) {
 						return $user;
 					} else {
 						Minz_Log::warning('Invalid API authorisation for user ' . $user);


### PR DESCRIPTION
GReaderAPI::authorizationToUser() compared the long-lived GReader bearer token with the non-constant-time === operator instead of hash_equals(), unlike every other token/secret comparison in the codebase (Auth::checkCsrfProtection(), FeverAPI, the OPML/RSS feed token check, and the short-lived GReader token check a few lines below in the same file), all of which already use hash_equals().

This brings the long-lived token check in line with the existing hash_equals(sha1(...), $token) pattern already used for the short-lived token a few lines below.

By @senti-man
