### PR TITLE
Block CGNAT (RFC6598) and NAT64 (RFC6052) ranges in SSRF guard

### DIFF
--- a/app/Utils/httpUtil.php
+++ b/app/Utils/httpUtil.php
@@ -12,12 +12,12 @@ final class FreshRSS_http_Util {
 		'169.254.0.0/16', // RFC3927
 		'0.0.0.0/8',      // RFC5735
 		'240.0.0.0/4',    // RFC1112
-		'100.64.0.0/10',  // RFC6598 (CGNAT / shared address space, e.g. Tailscale)
+		'100.64.0.0/10',  // RFC6598 (Shared Address Space of Carrier-Grade NAT)
 		'::1/128',        // Loopback
 		'fc00::/7',       // Unique Local Address
 		'fe80::/10',      // Link Local Address
 		'::ffff:0:0/96',  // IPv4 translations
-		'64:ff9b::/96',   // RFC6052 (NAT64 well-known prefix; maps IPv4 incl. internal/metadata)
+		'64:ff9b::/96',   // RFC6052 (IPv6 Addressing of IPv4/IPv6 Translators, NAT64)
 		'::/128',         // Unspecified address
 	];
 	/** @var array<string, string[]> $resolve_ok */

--- a/app/Utils/httpUtil.php
+++ b/app/Utils/httpUtil.php
@@ -12,10 +12,12 @@ final class FreshRSS_http_Util {
 		'169.254.0.0/16', // RFC3927
 		'0.0.0.0/8',      // RFC5735
 		'240.0.0.0/4',    // RFC1112
+		'100.64.0.0/10',  // RFC6598 (CGNAT / shared address space, e.g. Tailscale)
 		'::1/128',        // Loopback
 		'fc00::/7',       // Unique Local Address
 		'fe80::/10',      // Link Local Address
 		'::ffff:0:0/96',  // IPv4 translations
+		'64:ff9b::/96',   // RFC6052 (NAT64 well-known prefix; maps IPv4 incl. internal/metadata)
 		'::/128',         // Unspecified address
 	];
 	/** @var array<string, string[]> $resolve_ok */


### PR DESCRIPTION
Follow-up to the edge SSRF guard (ref: GHSA-hcv2-vrhw-mjq8), as @Alkarex suggested.

## Gap
`getCurlResolveInfo()` blocks private/reserved ranges via PHP `FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE` plus an explicit `PRIVATE_SUBNETS` list. Two internal-ish ranges are **not** covered by either, so an authenticated user can still SSRF to them:

- **CGNAT `100.64.0.0/10` (RFC6598)** — not in PHP's `NO_PRIV_RANGE` and not in `PRIVATE_SUBNETS`. This is the range **Tailscale** (and some corporate/ISP networks) use, so SSRF to peers on those networks remains possible.
- **NAT64 `64:ff9b::/96` (RFC6052)** — passes; on NAT64 networks `[64:ff9b::a9fe:a9fe]` maps to `169.254.169.254`, so cloud-metadata stays reachable via this form.

The standard ranges are correctly blocked (169.254, RFC1918, loopback, IPv4-mapped `::ffff:0:0/96`); only CGNAT + NAT64 slip through.

## Repro
```
php -r 'var_export(filter_var("100.64.0.1", FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE));'
// -> '100.64.0.1' (allowed); same for '64:ff9b::a9fe:a9fe'
```

## Fix
Add both ranges to `PRIVATE_SUBNETS` in `app/Utils/httpUtil.php` (2 lines). Verified with the project's CIDR check: `100.64.0.1` and `64:ff9b::a9fe:a9fe` are now blocked, while a public address (`1.1.1.1`) remains allowed.

Ref: GHSA-hcv2-vrhw-mjq8
