### PR TITLE
Add 0xdeadrelay to CREDITS.md

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -8,6 +8,7 @@ People are sorted by name so please keep this order.
 
 ---
 
+* [0xdeadrelay](https://github.com/0xdeadrelay): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:0xdeadrelay)
 * [312k](https://github.com/312k): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:312k)
 * [4xfu](https://github.com/4xfu): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:4xfu)
 * [aarnej](https://github.com/aarnej): [contributions](https://github.com/FreshRSS/FreshRSS/pulls?q=is:pr+author:aarnej)


### PR DESCRIPTION
Following the merge of #9195, adding a credit line as requested by @Alkarex in https://github.com/FreshRSS/FreshRSS/pull/9195#issuecomment-0xdeadrelay.

Placed at the top as "0xdeadrelay" sorts before "312k".