### PR TITLE
Pin the docker publish actions and scope two workflow tokens

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,13 +40,13 @@ jobs:
             #  type=semver,pattern={{major}}.{{minor}}-alpine
     steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Get FreshRSS version
       run: |
@@ -56,7 +56,7 @@ jobs:
 
     - name: Add metadata to Docker images
       id: meta
-      uses: docker/metadata-action@v6
+      uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
       with:
         flavor: ${{ matrix.flavor }}
         images: |
@@ -69,21 +69,21 @@ jobs:
 
     - name: Login to Docker Hub
       if: github.repository_owner == 'FreshRSS'
-      uses: docker/login-action@v4
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Login to GitHub Container Registry
       if: github.repository_owner == 'FreshRSS'
-      uses: docker/login-action@v4
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push Docker images
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         context: . # Switching from git context to path context, needed for .dockerignore to be applied. See: https://github.com/docker/build-push-action#git-context
         file: ${{ matrix.file }}

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -8,6 +8,9 @@ on:
       - edge
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   dockerhub-description:
     if: github.repository_owner == 'FreshRSS'

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository_owner == 'FreshRSS'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Update repo description
       uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b
         with:
@@ -38,13 +38,13 @@ jobs:
           cache-version: 1 # Increment this number if you need to re-download cached gems
           working-directory: docs
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Build with Jekyll
         run: |
           cd docs
           bundle exec jekyll build --destination ../_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
 
   # Deployment job
   deploy:
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ edge ]
 
+permissions:
+  contents: read
+
 jobs:
 
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Git checkout source code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Composer tests
 
@@ -29,7 +29,7 @@ jobs:
 
     - name: Use Composer cache
       id: composer-cache
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
@@ -55,7 +55,7 @@ jobs:
     # NPM tests
 
     - name: Uses Node.js
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         # https://nodejs.org/en/about/previous-releases
         node-version: lts/*
@@ -79,7 +79,7 @@ jobs:
 
     - name: Use shell cache
       id: shell-cache
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: bin
         key: ${{ runner.os }}-bin-shfmt@v3.8.0-hadolint@v2.12.0-typos@v1.29.9


### PR DESCRIPTION
Changes proposed in this pull request:

- Pin every action in the four workflows to a full commit, with the version kept as a trailing comment. setup-ruby and dockerhub-description were already pinned this way here, this extends the same practice to the docker and pages actions. Versions stay exactly where they were.
- Declare a read only token on the tests and dockerhub-description workflows, matching what docker-publish and the pages workflow already declare. Neither writes through the GitHub token, the Docker Hub description update authenticates with its own credentials.

Why: the docker-publish workflow logs into Docker Hub and pushes the official images, and a version tag is a movable pointer, whoever controls an action repository can point it at different code after review. That is how the tj-actions/changed-files incident (CVE-2025-30066) leaked CI secrets at scale. A full commit cannot be retargeted, and dependabot keeps bumping commit pins the same way it bumps tags today. One heads-up: if the org ever restricts allowed actions with tag patterns like `owner/action@v4`, those stop matching commit refs and workflows fail at startup, the fix is `owner/action@*` in that setting.

How to test the feature manually:

1. For any pinned line, open the action's releases page and check the commit behind the tag named in the trailing comment matches the pinned SHA.
2. Parse the four workflow files (yamllint or actionlint), no structural change beyond the refs and the two permissions blocks.
3. Watch the checks on this PR, the tests workflow runs exactly as before.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard) *(workflow-only change, not applicable)*
- [ ] documentation updated *(not applicable)*

Found and fixed by [Plumber](https://github.com/getplumber/plumber)'s analysis, reviewed and submitted by me.