### PR TITLE
Improve aside keyboard navigation

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -612,7 +612,7 @@ function next_unread_entry(skipping) {
 	toggleContent(new_active, old_active, skipping);
 }
 
-function prev_feed(jump_to_unread) {
+function prev_feed() {
 	let found = false;
 	let adjacent = null;
 	const feeds = document.querySelectorAll('#aside_feed .feed');
@@ -628,10 +628,7 @@ function prev_feed(jump_to_unread) {
 		if (getComputedStyle(feed).display === 'none') {
 			continue;
 		}
-		if (jump_to_unread && feed.dataset.unread != 0) {
-			delayedClick(feed.querySelector('a.item-title'));
-			return;
-		} else if (adjacent === null) {
+		if (adjacent === null) {
 			adjacent = feed;
 		}
 	}
@@ -1295,7 +1292,7 @@ function init_shortcuts() {
 			if (ev.altKey) {
 				prev_category();
 			} else if (ev.shiftKey) {
-				prev_feed(false);
+				prev_feed();
 			} else {
 				prev_entry(false);
 			}

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -323,9 +323,7 @@ function send_mark_queue_tick(callback) {
 const delayedFunction = send_mark_queue_tick;
 
 function delayedClick(a) {
-	if (a) {
-		delayedFunction(function () { a.click(); });
-	}
+	delayedFunction(function () { a.click(); });
 }
 
 function mark_read(div, only_not_read, asBatch) {

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -714,6 +714,10 @@ function last_feed() {
 function prev_category() {
 	const active_cat = document.querySelector('#aside_feed .category.active');
 	if (active_cat) {
+		if (active_cat.querySelector('.feed.active')) {
+			delayedClick(active_cat.querySelector('a.tree-folder-title'));
+			return;
+		}
 		let cat = active_cat;
 		do cat = cat.previousElementSibling;
 		while (cat && getComputedStyle(cat).display === 'none');

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -748,12 +748,12 @@ function next_unread_category() {
 }
 
 function first_category() {
-	const a = document.querySelector('#aside_feed .category:not([data-unread="0"]) a.tree-folder-title');
+	const a = document.querySelector('#aside_feed .category a.tree-folder-title');
 	delayedClick(a);
 }
 
 function last_category() {
-	const links = document.querySelectorAll('#aside_feed .category:not([data-unread="0"]) a.tree-folder-title');
+	const links = document.querySelectorAll('#aside_feed .category a.tree-folder-title');
 	if (links && links.length > 0) {
 		delayedClick(links[links.length - 1]);
 	}

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -638,6 +638,7 @@ function prev_feed(jump_to_unread) {
 	if (found && adjacent) {
 		delayedClick(adjacent.querySelector('a.item-title'));
 	} else {
+		// if the current active item is a category, goes to the last feed of the category above
 		last_feed();
 	}
 }
@@ -668,20 +669,41 @@ function next_feed(jump_to_unread) {
 	if (found && adjacent) {
 		delayedClick(adjacent.querySelector('a.item-title'));
 	} else {
-		first_feed();
+		// if the current active feed is the last of the entire feed list, doesn't do anything
+		first_feed(jump_to_unread);
 	}
 }
 
-function first_feed() {
-	const a = document.querySelector('#aside_feed .category.active .feed:not([data-unread="0"]) a.item-title');
-	delayedClick(a);
+function first_feed(jump_to_unread, skip_if_last = true) {
+	let link;
+	if (jump_to_unread) {
+		link = document.querySelector('#aside_feed .category.active .feed:not([data-unread="0"]) > a.item-title');
+	} else {
+		link = document.querySelector('#aside_feed .category.active .feed > a.item-title');
+	}
+	const feed = link.parentElement;
+	const categoryItems = feed.parentElement;
+	if (skip_if_last && categoryItems.querySelector('.feed.active') === categoryItems.lastElementChild) {
+		return;
+	}
+	delayedClick(link);
 }
 
 function last_feed() {
-	const links = document.querySelectorAll('#aside_feed .category.active .feed:not([data-unread="0"]) a.item-title');
-	if (links && links.length > 0) {
-		delayedClick(links[links.length - 1]);
+	const links = document.querySelectorAll('#aside_feed .category.active .feed > a.item-title');
+	if (!(links && links.length > 0)) {
+		return;
 	}
+	const link = links[links.length - 1];
+	const feed = link.parentElement;
+	if (feed.classList.contains('active')) {
+		const category = feed.closest('.category').previousElementSibling;
+		if (category) {
+			delayedClick(category);
+		}
+		return;
+	}
+	delayedClick(link);
 }
 
 function prev_category() {
@@ -720,6 +742,8 @@ function next_unread_category() {
 		while (cat && cat.getAttribute('data-unread') <= 0);
 		if (cat) {
 			delayedClick(cat.querySelector('a.tree-folder-title'));
+		} else if (active_cat.nextElementSibling) {
+			delayedClick(active_cat.nextElementSibling.querySelector('a.tree-folder-title'));
 		}
 	} else {
 		first_category();
@@ -1293,7 +1317,7 @@ function init_shortcuts() {
 			if (ev.altKey) {
 				first_category();
 			} else if (ev.shiftKey) {
-				first_feed();
+				first_feed(false, false);
 			} else {
 				const old_active = document.querySelector('.flux.current');
 				const first = document.querySelector('.flux');

--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -672,27 +672,28 @@ function next_feed(jump_to_unread) {
 }
 
 function first_feed(jump_to_unread, skip_if_last = true) {
-	let link;
+	let feed;
 	if (jump_to_unread) {
-		link = document.querySelector('#aside_feed .category.active .feed:not([data-unread="0"]) > a.item-title');
+		feed = document.querySelector('#aside_feed .category.active .feed:not([data-unread="0"])');
 	} else {
-		link = document.querySelector('#aside_feed .category.active .feed > a.item-title');
+		feed = document.querySelector('#aside_feed .category.active .feed');
 	}
-	const feed = link.parentElement;
+	while (getComputedStyle(feed).display === 'none') {
+		feed = feed.nextElementSibling;
+		if (!feed) {
+			return;
+		}
+	}
 	const categoryItems = feed.parentElement;
 	if (skip_if_last && categoryItems.querySelector('.feed.active') === categoryItems.lastElementChild) {
 		return;
 	}
+	const link = feed.querySelector('a.item-title');
 	delayedClick(link);
 }
 
 function last_feed() {
-	const links = document.querySelectorAll('#aside_feed .category.active .feed > a.item-title');
-	if (!(links && links.length > 0)) {
-		return;
-	}
-	const link = links[links.length - 1];
-	const feed = link.parentElement;
+	let feed = document.querySelector('#aside_feed .category.active .feed:last-child');
 	if (feed.classList.contains('active')) {
 		const category = feed.closest('.category').previousElementSibling;
 		if (category) {
@@ -700,6 +701,13 @@ function last_feed() {
 		}
 		return;
 	}
+	while (getComputedStyle(feed).display === 'none') {
+		feed = feed.previousElementSibling;
+		if (!feed) {
+			return;
+		}
+	}
+	const link = feed.querySelector('a.item-title');
 	delayedClick(link);
 }
 
@@ -748,15 +756,20 @@ function next_unread_category() {
 }
 
 function first_category() {
+	// goes to main stream which is always visible
 	const a = document.querySelector('#aside_feed .category a.tree-folder-title');
 	delayedClick(a);
 }
 
 function last_category() {
-	const links = document.querySelectorAll('#aside_feed .category a.tree-folder-title');
-	if (links && links.length > 0) {
-		delayedClick(links[links.length - 1]);
+	let category = document.querySelector('#sidebar > :nth-last-child(2)');
+	while (getComputedStyle(category).display === 'none') {
+		category = category.previousElementSibling;
+		if (!category) {
+			return;
+		}
 	}
+	delayedClick(category.querySelector('a.tree-folder-title'));
 }
 
 function collapse_entry() {


### PR DESCRIPTION
### Feature changes

* It's now possible to jump from categories to feeds (press shift+j when focused on a category)
   * Similarly, it's possible to jump from a feed to the current category by using alt+k
* If the very first feed is focused and the user presses shift+k, there is no jump to the last unread feed in that category anymore, instead nothing happens.
   * Same if the very last is focused and the user presses shift+j (no jump to the first unread feed in that category)
* Alt+home/end (first/last category) now jumps regardless if the first/last category is read or unread
   * In addition, shift+home/end does not jump between unread feeds anymore, now it jumps between the first visible feed in the category and the last visible feed in the category 
* Alt+h (jump to next unread category) now fall backs to the same behavior as alt+j (jump to next category) if there are no more unread categories after

### Minor code changes

* Removed dead code in `prev_feed`
* `delayedClick(null)` will now throw an error