### PR TITLE
Fix path disclosure in cache error message

### DIFF
--- a/app/Utils/httpUtil.php
+++ b/app/Utils/httpUtil.php
@@ -738,7 +738,7 @@ final class FreshRSS_http_Util {
 		}
 
 		if ($cachePath !== null && file_put_contents($cachePath, $body) === false) {
-			Minz_Log::warning("Error saving cache $cachePath for $url");
+			Minz_Log::warning("Error saving cache for $url");
 		}
 
 		return ['body' => is_string($body) ? $body : '', 'effective_url' => $c_effective_url, 'redirect_count' => $redirs,


### PR DESCRIPTION
I mentioned it here before: https://github.com/FreshRSS/FreshRSS/security/advisories/GHSA-6c8h-w3j5-j293#advisory-comment-138339 (though it was maybe not needed)

There is no reason to print the full path of the FreshRSS directory to the user or the logged in admin. (file_put_contents will probably output a more useful message anyway in PHP error log)

Introduced in https://github.com/FreshRSS/FreshRSS/pull/4220


