### PR TITLE
i18n(id): complete Indonesian translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ See also [the FreshRSS releases](https://github.com/FreshRSS/FreshRSS/releases).
 	* New `freshrss:entryStateChange` JavaScript event for extensions, dispatched when an article has finished being marked as read/unread [#8862](https://github.com/FreshRSS/FreshRSS/pull/9031)
 * I18n
 	* New Lithuanian (lietuvių) translation
+	* Complete Indonesian (Bahasa Indonesia) translation [#6349](https://github.com/FreshRSS/FreshRSS/issues/6349)
 	* Improve Hungarian [#8879](https://github.com/FreshRSS/FreshRSS/pull/8879)
 	* Improve Italian [#8880](https://github.com/FreshRSS/FreshRSS/pull/8880)
 	* Improve Persian [#8923](https://github.com/FreshRSS/FreshRSS/pull/8923)

--- a/README.fr.md
+++ b/README.fr.md
@@ -240,7 +240,7 @@ Voir le [dépôt dédié à ces extensions](https://github.com/FreshRSS/Extensio
 | Français (fr) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | עברית (he) | ￭￭￭￭･･････ 41% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhe+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Magyar (hu) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhu+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭･･ 88% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Italiano (it) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fit+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 日本語 (ja) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fja+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 한국어 (ko) | ￭￭￭￭￭￭￭￭･･ 80% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fko+%2F%28TODO%7CDIRTY%29%24%2F) |

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ See the [repository dedicated to those extensions](https://github.com/FreshRSS/E
 | Français (fr) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |
 | עברית (he) | ￭￭￭￭･･････ 41% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhe+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Magyar (hu) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fhu+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭･･ 88% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Bahasa Indonesia (id) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fid+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Italiano (it) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fit+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 日本語 (ja) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fja+%2F%28TODO%7CDIRTY%29%24%2F) |
 | 한국어 (ko) | ￭￭￭￭￭￭￭￭･･ 80% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fko+%2F%28TODO%7CDIRTY%29%24%2F) |

--- a/app/i18n/id/admin.php
+++ b/app/i18n/id/admin.php
@@ -16,7 +16,7 @@ return array(
 		'allow_anonymous_refresh' => 'Izinkan untuk memuat ulang artikel awanama',
 		'api_enabled' => 'Izinkan akses <abbr>API</abbr> <small>(Diperlukan untuk aplikasi seluler dan untuk membagikan pencarian pengguna)</small>',
 		'form' => 'Formulir Web (klasik, membutuhkan JavaScript)',
-		'http' => 'HTTP (tingkat lanjut: dikelola oleh peladen Web, OIDC, SSO, dll.)',
+		'http' => 'HTTP (tingkat lanjut: dikelola oleh server Web, OIDC, SSO, dll.)',
 		'none' => 'Tidak ada (berbahaya)',
 		'title' => 'Autentikasi',
 		'token' => 'Token autentikasi utama',
@@ -31,7 +31,7 @@ return array(
 		'empty_list' => 'Tidak ada ekstensi yang terpasang',
 		'empty_list_help' => 'Periksa log untuk menemukan alasan daftar ekstensi yang kosong.',
 		'enabled' => 'Diaktifkan',
-		'is_compatible' => 'Is compatible',	// TODO
+		'is_compatible' => 'Kompatibel',
 		'latest' => 'Terpasang',
 		'name' => 'Nama',
 		'no_configure_view' => 'Ekstensi ini tidak dapat dikonfigurasi.',
@@ -48,8 +48,8 @@ return array(
 		'_' => 'Statistik',
 		'all_feeds' => 'Semua umpan',
 		'category' => 'Kategori',
-		'date_published' => 'Publication date',	// TODO
-		'date_received' => 'Received date',	// TODO
+		'date_published' => 'Tanggal terbit',
+		'date_received' => 'Tanggal diterima',
 		'entry_count' => 'Jumlah entri',
 		'entry_per_category' => 'Entri per kategori',
 		'entry_per_day' => 'Entri per hari (30 hari terakhir)',
@@ -62,7 +62,7 @@ return array(
 		'idle' => 'Umpan Tak Terbarukan',
 		'main' => 'Statistik utama',
 		'main_stream' => 'Bagian utama',
-		'nb_unreads' => 'Number of unread articles',	// TODO
+		'nb_unreads' => 'Jumlah artikel belum dibaca',
 		'no_idle' => 'Tidak ada umpan tak terbarukan!',
 		'number_entries' => '%d artikel',
 		'overview' => 'Ringkasan',
@@ -74,30 +74,30 @@ return array(
 		'status_unread' => 'Belum Terbaca',
 		'title' => 'Statistik',
 		'top_feed' => 'Sepuluh umpan teratas',
-		'unread_dates' => 'Dates with most unread articles',	// TODO
+		'unread_dates' => 'Tanggal dengan artikel belum dibaca terbanyak',
 	),
 	'system' => array(
 		'_' => 'Konfigurasi Sistem',
-		'auto-update-url' => 'URL peladen untuk pembaruan otomatis',
+		'auto-update-url' => 'URL server untuk pembaruan otomatis',
 		'base-url' => array(
-			'_' => 'URL peladen',
+			'_' => 'URL server',
 			'recommendation' => 'Rekomendasi Otomatis: <kbd>%s</kbd>',
 		),
-		'closed_registration_message' => 'Message if registrations are closed',	// TODO
+		'closed_registration_message' => 'Pesan jika pendaftaran ditutup',
 		'cookie-duration' => array(
 			'help' => 'dalam detik',
 			'number' => 'Durasi untuk terus masuk',
 		),
-		'default_closed_registration_message' => 'This server does not accept new registrations at the moment.',	// TODO
+		'default_closed_registration_message' => 'Server ini tidak menerima pendaftaran baru untuk saat ini.',
 		'force_email_validation' => 'Paksa verifikasi alamat surel',
-		'instance-name' => 'Nama peladen',
+		'instance-name' => 'Nama server',
 		'internal-host-allowlist' => array(
-			'_' => 'Internal host allowlist',	// TODO
-			'help' => 'One entry per line:<ul><li>A <code>host:port</code>. For instance <code>127.0.0.1:8080</code> or <code>rss-bridge:80</code></li><li>A CIDR notation. For instance <code>0.0.0.0/0</code> to allow any IPv4, <code>::/0</code> to allow any IPv6</li><li>A <code>*</code> to allow any host (unsafe)</li></ul>',	// TODO
+			'_' => 'Daftar izin host internal',
+			'help' => 'Satu entri per baris:<ul><li>Sebuah <code>host:port</code>. Misalnya <code>127.0.0.1:8080</code> atau <code>rss-bridge:80</code></li><li>Notasi CIDR. Misalnya <code>0.0.0.0/0</code> untuk mengizinkan semua IPv4, <code>::/0</code> untuk mengizinkan semua IPv6</li><li>Sebuah <code>*</code> untuk mengizinkan semua host (tidak aman)</li></ul>',
 		),
 		'max-categories' => 'Jumlah kategori maksimal per pengguna',
 		'max-feeds' => 'Jumlah umpan maksimal per pengguna',
-		'override-by-env-var' => 'This setting is set by the environment variable <kbd>%s</kbd>.',	// TODO
+		'override-by-env-var' => 'Pengaturan ini ditetapkan oleh variabel lingkungan <kbd>%s</kbd>.',
 		'registration' => array(
 			'number' => 'Jumlah akun maksimal',
 			'select' => array(

--- a/app/i18n/id/api.php
+++ b/app/i18n/id/api.php
@@ -12,22 +12,22 @@
 
 return array(
 	'information' => array(
-		'address' => 'Your API address:',	// TODO
+		'address' => 'Alamat API Anda:',
 		'output' => array(
-			'encoding-support' => '⚠️ WARN: no <code>%2F</code> support, some clients might not work!',	// TODO
-			'invalid-configuration' => '⚠️ WARN: Probable invalid base URL in ./data/config.php',	// TODO
-			'pass' => '✔️ PASS',	// TODO
-			'unknown-error' => '❌ ',	// TODO
+			'encoding-support' => '⚠️ PERINGATAN: tidak ada dukungan <code>%2F</code>, beberapa klien mungkin tidak berfungsi!',
+			'invalid-configuration' => '⚠️ PERINGATAN: Kemungkinan URL dasar tidak valid di ./data/config.php',
+			'pass' => '✔️ BERHASIL',
+			'unknown-error' => '❌ ',	// IGNORE
 		),
 		'test' => array(
-			'fever' => 'Fever API configuration test:',	// TODO
-			'greader' => 'Google Reader API configuration test:',	// TODO
+			'fever' => 'Uji konfigurasi API Fever:',
+			'greader' => 'Uji konfigurasi API Google Reader:',
 		),
 		'title' => array(
-			'_' => 'FreshRSS API endpoints',	// TODO
-			'extension' => 'API for extensions',	// TODO
-			'fever' => 'Fever compatible API',	// TODO
-			'greader' => 'Google Reader compatible API',	// TODO
+			'_' => 'Endpoint API FreshRSS',
+			'extension' => 'API untuk ekstensi',
+			'fever' => 'API kompatibel Fever',
+			'greader' => 'API kompatibel Google Reader',
 		),
 	),
 );

--- a/app/i18n/id/conf.php
+++ b/app/i18n/id/conf.php
@@ -69,7 +69,7 @@ return array(
 			'help' => 'Hanya untuk tema yang kompatibel',
 			'no' => 'Tidak',
 		),
-		'display_enclosures' => 'Show enclosures',	// TODO
+		'display_enclosures' => 'Tampilkan lampiran media',
 		'headline' => array(
 			'articles_header_footer' => 'Artikel: Baris Atas/Bawah',
 		),
@@ -91,13 +91,13 @@ return array(
 		'show_nav_buttons' => 'Tampilkan tombol navigasi',
 		'show_title_unread' => 'Tampilkan jumlah artikel yang belum dibaca di judul',
 		'show_unread_count' => array(
-			'_' => 'Show unread counts in sidebar',	// TODO
-			'all' => 'For all categories and feeds',	// TODO
-			'important' => 'For important feeds only',	// TODO
-			'important_locked' => 'Important feeds always show their unread count.',	// TODO
-			'none' => 'Never',	// TODO
+			'_' => 'Tampilkan jumlah belum dibaca di bilah sisi',
+			'all' => 'Untuk semua kategori dan umpan',
+			'important' => 'Hanya untuk umpan penting',
+			'important_locked' => 'Umpan penting selalu menampilkan jumlah belum dibacanya.',
+			'none' => 'Tidak pernah',
 		),
-		'sidebar_hidden_by_default' => 'Hide sidebar by default',	// TODO
+		'sidebar_hidden_by_default' => 'Sembunyikan bilah sisi secara bawaan',
 		'theme' => array(
 			'_' => 'Tema',
 			'deprecated' => array(
@@ -150,22 +150,22 @@ return array(
 		'small' => 'Kecil',
 	),
 	'notification' => array(
-		'html5_enable_notif' => 'Enable notification',	// TODO
+		'html5_enable_notif' => 'Aktifkan notifikasi',
 	),
 	'notification_timeout' => array(
 		'bad' => array(
-			'label' => 'Show warning banner',	// TODO
-			'seconds' => 'seconds (at least 1)',	// TODO
+			'label' => 'Tampilkan spanduk peringatan',
+			'seconds' => 'detik (minimal 1)',
 		),
 		'good' => array(
-			'label' => 'Show acknowledgement banner',	// TODO
-			'seconds' => 'seconds (0 means not shown)',	// TODO
+			'label' => 'Tampilkan spanduk konfirmasi',
+			'seconds' => 'detik (0 berarti tidak ditampilkan)',
 		),
 	),
 	'privacy' => array(
 		'_' => 'Privasi',
 		'retrieve_extension_list' => 'Ambil daftar ekstensi',
-		'send_referrer_allowlist' => 'Sites allowed to see your server address (%s)',	// TODO
+		'send_referrer_allowlist' => 'Situs yang diizinkan melihat alamat server Anda (%s)',
 	),
 	'profile' => array(
 		'_' => 'Pengelolaan Profil',
@@ -177,24 +177,24 @@ return array(
 			'disabled' => 'Akses API dinonaktifkan.',
 			'documentation_link' => 'Lihat <a href="https://freshrss.github.io/FreshRSS/en/users/06_Mobile_access.html#access-via-mobile-app" target="_blank">dokumentasi dan daftar aplikasi yang diketahui</a>',
 			'help' => 'Lihat <a href="http://freshrss.github.io/FreshRSS/en/users/06_Mobile_access.html#access-via-mobile-app" target=_blank>dokumentasi</a>',
-			'security_warning' => 'Use HTTPS. The API password is transmitted in clear text and may appear in server logs if sent via GET.',	// TODO
+			'security_warning' => 'Gunakan HTTPS. Kata sandi API dikirim dalam teks polos dan dapat muncul di log server jika dikirim melalui GET.',
 		),
-		'change_password' => 'Change password',	// TODO
-		'confirm_new_password' => 'Confirm new password',	// TODO
-		'current_password' => 'Current password<br /><small>(for the Web-form login method)</small>',	// TODO
+		'change_password' => 'Ubah kata sandi',
+		'confirm_new_password' => 'Konfirmasi kata sandi baru',
+		'current_password' => 'Kata sandi saat ini<br /><small>(untuk metode masuk formulir Web)</small>',
 		'delete' => array(
 			'_' => 'Hapus akun',
 			'warn' => 'Akun Anda dan semua data terkait akan dihapus.',
 		),
 		'email' => 'Alamat surel',
-		'new_password' => 'New password',	// TODO
+		'new_password' => 'Kata sandi baru',
 		'password_api' => 'Sandi API<br /><small>(contoh: untuk aplikasi ponsel)</small>',
 		'password_format' => 'Minimal 7 karakter',
 		'title' => 'Profil',
 	),
 	'query' => array(
 		'_' => 'Pencarian Pengguna',
-		'create' => 'Create new user query',	// TODO
+		'create' => 'Buat kueri pengguna baru',
 		'deprecated' => 'Pencarian ini tidak valid lagi. Kategori atau umpan yang dirujuk telah dihapus.',
 		'description' => 'Deskripsi',
 		'filter' => array(
@@ -202,7 +202,7 @@ return array(
 			'categories' => 'Tampilkan berdasarkan kategori',
 			'feeds' => 'Tampilkan berdasarkan umpan',
 			'order' => 'Urutkan berdasarkan tanggal',
-			'publish_labels_instead_of_tags' => 'Replace <i>feed tags</i> by <i>user labels</i> in the shared RSS',	// TODO
+			'publish_labels_instead_of_tags' => 'Ganti <i>tag umpan</i> dengan <i>label pengguna</i> pada RSS yang dibagikan',
 			'search' => 'Ekspresi Pencarian',
 			'shareOpml' => 'Aktifkan berbagi melalui OPML dari kategori dan umpan terkait',
 			'shareRss' => 'Aktifkan berbagi melalui HTML &amp; RSS',
@@ -286,7 +286,7 @@ return array(
 			'upon_gone' => 'saat artikel hilang dari umpan situs aslinya',
 			'upon_reception' => 'saat menerima artikel',
 			'when' => 'Tandai artikel sebagai sudah dibaca…',
-			'when_same_guid_in_category' => 'if an identical GUID already exists in the top <i>n</i> newest articles of the category',	// TODO
+			'when_same_guid_in_category' => 'jika GUID yang identik sudah ada di <i>n</i> artikel terbaru teratas dalam kategori tersebut',
 			'when_same_title_in_category' => 'jika judul yang identik sudah ada di <i>n</i> artikel terbaru dalam kategori',
 			'when_same_title_in_feed' => 'jika judul yang identik sudah ada di <i>n</i> artikel terbaru dari umpan',
 		),
@@ -307,8 +307,8 @@ return array(
 			'when' => 'Tandai artikel sebagai favorit…',
 		),
 		'sticky_post' => 'Sematkan artikel ke bagian atas saat dibuka',
-		'sticky_sort' => 'Pertahankan urutan pengurutan manual saat menavigasi',	// DIRTY
-		'sticky_sort_help' => 'Menentukan apakah urutan pengurutan manual terakhir tetap aktif atau setiap kategori atau umpan selalu menggunakan pengaturan bawaan atau globalnya sendiri.',	// DIRTY
+		'sticky_sort' => 'Pertahankan urutan pengurutan manual saat menavigasi',
+		'sticky_sort_help' => 'Menentukan apakah urutan pengurutan manual terakhir tetap aktif atau setiap kategori atau umpan selalu menggunakan pengaturan bawaan atau globalnya sendiri.',
 		'title' => 'Membaca',
 		'view' => array(
 			'default' => 'Tampilan baku',
@@ -368,7 +368,7 @@ return array(
 		'skip_next_article' => 'Fokus berikutnya tanpa membuka',
 		'skip_previous_article' => 'Fokus sebelumnya tanpa membuka',
 		'title' => 'Pintasan',
-		'toggle_aside' => 'Toggle sidebar',	// TODO
+		'toggle_aside' => 'Alihkan bilah sisi',
 		'toggle_media' => 'Putar/jeda media',
 		'user_filter' => 'Akses pencarian pengguna',
 		'user_filter_help' => 'Jika hanya ada satu pencarian pengguna, maka itu akan digunakan. Jika tidak, pencarian dapat diakses dengan nomornya',

--- a/app/i18n/id/feedback.php
+++ b/app/i18n/id/feedback.php
@@ -57,16 +57,16 @@ return array(
 		'removed' => '%s dihapus',
 	),
 	'import_export' => array(
-		'export_no_zip_extension' => 'Ekstensi ZIP tidak tersedia di peladen Anda. Coba untuk mengekspor berkasnya satu per satu.',
+		'export_no_zip_extension' => 'Ekstensi ZIP tidak tersedia di server Anda. Coba untuk mengekspor berkasnya satu per satu.',
 		'feeds_imported' => 'Umpan Anda telah diimpor. Jika Anda sudah selesai mengimpor, Anda bisa mengklik tombol <i>Perbarui umpan</i>.',
 		'feeds_imported_with_errors' => 'Umpan Anda telah diimpor, tapi ada beberapa galat. Jika Anda sudah selesai mengimpor, Anda bisa mengklik tombol <i>Perbarui umpan</i>.',
 		'file_cannot_be_uploaded' => 'Berkas tidak dapt diunggah!',
-		'no_zip_extension' => 'Ekstensi ZIP tidak tersedia di peladen Anda.',
+		'no_zip_extension' => 'Ekstensi ZIP tidak tersedia di server Anda.',
 		'zip_error' => 'Galat terjadi ketika pemrosesan ZIP.',
 	),
 	'profile' => array(
 		'error' => 'Profil Anda tidak dapat diubah',
-		'passwords_dont_match' => 'Passwords don’t match',	// TODO
+		'passwords_dont_match' => 'Kata sandi tidak cocok',
 		'updated' => 'Profil Anda telah diubah',
 	),
 	'sub' => array(
@@ -81,7 +81,7 @@ return array(
 			'emptied' => 'Kategori telah dikosongkan',
 			'error' => 'Kategori tidak dapat diperbarui',
 			'name_exists' => 'Nama kategori sudah ada.',
-			'no_id' => 'You must specify the id of the category.',	// TODO
+			'no_id' => 'Anda harus menentukan id kategori.',
 			'no_name' => 'Nama kategori tidak boleh kosong.',
 			'not_delete_default' => 'Tidak dapat menghapus kategori baku!',
 			'not_exist' => 'Kategori ini tidak ada!',
@@ -130,10 +130,10 @@ return array(
 	'update' => array(
 		'can_apply' => 'Pembaruan FreshRSS tersedia: <strong>Versi %s</strong>.',
 		'error' => 'Galat terjadi dalam proses pembaruan: %s',
-		'file_is_nok' => 'Pembaruan FreshRSS tersedia (<strong>Versi %s</strong>), but check permissions on <em>%s</em> directory. HTTP server must have have write permission , dan periksa izin di direktori <em>%s</em>. Peladen HTTP harus memiliki izin menulis di direktori tersebut',
+		'file_is_nok' => 'Pembaruan FreshRSS tersedia (<strong>Versi %s</strong>), but check permissions on <em>%s</em> directory. HTTP server must have have write permission , dan periksa izin di direktori <em>%s</em>. Server HTTP harus memiliki izin menulis di direktori tersebut',
 		'finished' => 'Pembaruan selesai!',
 		'none' => 'Tidak ada pembaruan yang tersedia',
-		'server_not_found' => 'Peladen pembaruan tidak dapat ditemukan. [%s]',
+		'server_not_found' => 'Server pembaruan tidak dapat ditemukan. [%s]',
 	),
 	'user' => array(
 		'created' => array(

--- a/app/i18n/id/feedback.php
+++ b/app/i18n/id/feedback.php
@@ -130,7 +130,7 @@ return array(
 	'update' => array(
 		'can_apply' => 'Pembaruan FreshRSS tersedia: <strong>Versi %s</strong>.',
 		'error' => 'Galat terjadi dalam proses pembaruan: %s',
-		'file_is_nok' => 'Pembaruan FreshRSS tersedia (<strong>Versi %s</strong>), but check permissions on <em>%s</em> directory. HTTP server must have have write permission , dan periksa izin di direktori <em>%s</em>. Server HTTP harus memiliki izin menulis di direktori tersebut',
+		'file_is_nok' => 'Pembaruan FreshRSS tersedia (<strong>Versi %s</strong>), tetapi periksa izin pada direktori <em>%s</em>. Server HTTP harus memiliki izin menulis di direktori tersebut.',
 		'finished' => 'Pembaruan selesai!',
 		'none' => 'Tidak ada pembaruan yang tersedia',
 		'server_not_found' => 'Server pembaruan tidak dapat ditemukan. [%s]',

--- a/app/i18n/id/gen.php
+++ b/app/i18n/id/gen.php
@@ -27,7 +27,7 @@ return array(
 		'empty' => 'Kosongkan',
 		'enable' => 'Aktifkan',
 		'export' => 'Ekspor',
-		'filter' => 'Filter',	// TODO
+		'filter' => 'Saring',
 		'import' => 'Impor',
 		'load_default_shortcuts' => 'Muat pintasan baku',
 		'manage' => 'Kelola',
@@ -62,9 +62,9 @@ return array(
 			'format' => '<small>Paling tidak 7 karakter</small>',
 		),
 		'reauth' => array(
-			'header' => 'Reauthentication is required',	// TODO
-			'tip' => 'You won’t be asked to sign in again for <u>%d minutes</u>',	// TODO
-			'title' => 'Reauthentication',	// TODO
+			'header' => 'Autentikasi ulang diperlukan',
+			'tip' => 'Anda tidak akan diminta masuk lagi selama <u>%d menit</u>',
+			'title' => 'Autentikasi ulang',
 		),
 		'registration' => array(
 			'_' => 'Akun baru',
@@ -73,7 +73,7 @@ return array(
 		),
 		'username' => array(
 			'_' => 'Nama pengguna',
-			'format' => '<small>1-39 characters: letters, digits, and <code>. _ @ -</code></small>',	// TODO
+			'format' => '<small>1-39 karakter: huruf, angka, dan <code>. _ @ -</code></small>',
 		),
 	),
 	'date' => array(
@@ -165,13 +165,13 @@ return array(
 		'category_empty' => 'Kategori kosong',
 		'confirm_action' => 'Apakah Anda yakin ingin melakukan ini? Ini tidak dapat dibatalkan!',
 		'confirm_action_feed_cat' => 'Apakah Anda yakin ingin melakukan ini? Anda akan kehilangan favorit dan pencarian pengguna terkait. Ini tidak dapat dibatalkan.',
-		'confirm_exit_slider' => 'Are you sure you want to discard unsaved settings?',	// TODO
+		'confirm_exit_slider' => 'Apakah Anda yakin ingin membuang pengaturan yang belum disimpan?',
 		'feedback' => array(
 			'body_new_articles' => array(
-				0 => 'Ada %d artikel baru untuk dibaca di FreshRSS.',	// DIRTY
+				0 => 'Ada %d artikel baru untuk dibaca di FreshRSS.',
 			),
 			'body_unread_articles' => array(
-				0 => '(belum dibaca: %d)',	// DIRTY
+				0 => '(belum dibaca: %d)',
 			),
 			'request_failed' => 'Permintaan gagal, mungkin dikarenakan masalah koneksi internet.',
 			'title_new_articles' => 'FreshRSS: artikel baru!',
@@ -179,7 +179,7 @@ return array(
 		'labels_empty' => 'Tidak ada label',
 		'new_article' => 'Tidak ada artikel baru yang tersedia, klik untuk menyegarkan halaman.',
 		'should_be_activated' => 'JavaScript harus diaktifkan',
-		'unsafe_csp_header' => 'The CSP header in use is unsafe and FreshRSS may be vulnerable to XSS attacks. <a target="_blank" href="https://freshrss.github.io/FreshRSS/en/admins/10_ServerConfig.html#security">See documentation</a>',	// TODO
+		'unsafe_csp_header' => 'Header CSP yang digunakan tidak aman dan FreshRSS mungkin rentan terhadap serangan XSS. <a target="_blank" href="https://freshrss.github.io/FreshRSS/en/admins/10_ServerConfig.html#security">Lihat dokumentasi</a>',
 	),
 	'lang' => array(
 		'cs' => 'Čeština',	// IGNORE
@@ -197,7 +197,7 @@ return array(
 		'it' => 'Italiano',	// IGNORE
 		'ja' => '日本語',	// IGNORE
 		'ko' => '한국어',	// IGNORE
-		'lt' => 'Lietuvių',	// TODO
+		'lt' => 'Lietuvių',	// IGNORE
 		'lv' => 'Latviešu',	// IGNORE
 		'nl' => 'Nederlands',	// IGNORE
 		'oc' => 'Occitan',	// IGNORE
@@ -215,7 +215,7 @@ return array(
 		'about' => 'Tentang',
 		'account' => 'Akun',
 		'admin' => 'Administrasi',
-		'advanced_search' => 'Advanced Search',	// TODO
+		'advanced_search' => 'Pencarian Lanjutan',
 		'archiving' => 'Pengarsipan',
 		'authentication' => 'Autentikasi',
 		'check_install' => 'Pemeriksaan pemasangan',
@@ -249,32 +249,32 @@ return array(
 		'translated' => 'Progress',	// IGNORE
 	),
 	'search' => array(
-		'advanced_search_help' => 'This form helps construct search queries, but manual queries are even more powerful.',	// TODO
-		'authors' => 'Authors',	// TODO
-		'categories' => 'Categories',	// TODO
-		'content' => 'Content',	// TODO
-		'date_from' => 'From',	// TODO
-		'date_modified' => 'Server Modification Date',	// TODO
-		'date_past' => 'In the past',	// TODO
-		'date_published' => 'Publication Date',	// TODO
-		'date_range' => 'Date Range',	// TODO
-		'date_received' => 'Received Date',	// TODO
-		'date_to' => 'To',	// TODO
-		'date_user' => 'User Modification Date',	// TODO
-		'feeds' => 'Feeds',	// TODO
-		'free_text' => 'Free Text',	// TODO
-		'free_text_help' => 'Search both in title and content',	// TODO
-		'full_documentation' => 'View <a href="https://freshrss.github.io/FreshRSS/en/users/10_filter.html#with-the-search-field" target="_blank">full search documentation</a>',	// TODO
-		'labels' => 'My Labels',	// TODO
-		'multiple_help' => 'Select one or more (hold <kbd>Ctrl</kbd> or <kbd>Cmd</kbd>)',	// TODO
-		'sources' => 'Sources',	// TODO
-		'tags' => 'Article Tags',	// TODO
-		'text' => 'Text Search',	// TODO
-		'text_help' => 'Multiple lines are combined by a logical <i>or</i>. Also supports <a href="https://freshrss.github.io/FreshRSS/en/users/10_filter.html#regex" target="_blank">regular expressions</a>.',	// TODO
-		'text_placeholder' => 'Keyword',	// TODO
-		'title' => 'Title',	// TODO
-		'url' => 'URL',	// TODO
-		'user_queries' => 'User Queries',	// TODO
+		'advanced_search_help' => 'Formulir ini membantu menyusun kueri pencarian, tetapi kueri manual jauh lebih ampuh.',
+		'authors' => 'Penulis',
+		'categories' => 'Kategori',
+		'content' => 'Konten',
+		'date_from' => 'Dari',
+		'date_modified' => 'Tanggal Modifikasi Server',
+		'date_past' => 'Dalam kurun terakhir',
+		'date_published' => 'Tanggal Terbit',
+		'date_range' => 'Rentang Tanggal',
+		'date_received' => 'Tanggal Diterima',
+		'date_to' => 'Sampai',
+		'date_user' => 'Tanggal Modifikasi Pengguna',
+		'feeds' => 'Umpan',
+		'free_text' => 'Teks Bebas',
+		'free_text_help' => 'Cari di judul dan konten sekaligus',
+		'full_documentation' => 'Lihat <a href="https://freshrss.github.io/FreshRSS/en/users/10_filter.html#with-the-search-field" target="_blank">dokumentasi pencarian lengkap</a>',
+		'labels' => 'Label Saya',
+		'multiple_help' => 'Pilih satu atau beberapa (tahan <kbd>Ctrl</kbd> atau <kbd>Cmd</kbd>)',
+		'sources' => 'Sumber',
+		'tags' => 'Tag Artikel',
+		'text' => 'Pencarian Teks',
+		'text_help' => 'Beberapa baris digabungkan dengan <i>atau</i> logis. Juga mendukung <a href="https://freshrss.github.io/FreshRSS/en/users/10_filter.html#regex" target="_blank">ekspresi reguler</a>.',
+		'text_placeholder' => 'Kata kunci',
+		'title' => 'Judul',
+		'url' => 'URL',	// IGNORE
+		'user_queries' => 'Kueri Pengguna',
 	),
 	'share' => array(
 		'Known' => 'Situs berbasis Known',
@@ -296,7 +296,7 @@ return array(
 		'linkedin' => 'LinkedIn',	// IGNORE
 		'mastodon' => 'Mastodon',	// IGNORE
 		'movim' => 'Movim',	// IGNORE
-		'nextcloud-bookmarks' => 'Nextcloud Penanda',	// DIRTY
+		'nextcloud-bookmarks' => 'Nextcloud Bookmarks',	// IGNORE
 		'omnivore' => 'Omnivore',	// IGNORE
 		'pinboard' => 'Pinboard',	// IGNORE
 		'pinterest' => 'Pinterest',	// IGNORE

--- a/app/i18n/id/index.php
+++ b/app/i18n/id/index.php
@@ -17,9 +17,9 @@ return array(
 		'bug_reports' => array(
 			'environment_information' => array(
 				'_' => 'Informasi sistem',
-				'browser' => 'Peladen',
+				'browser' => 'Browser',	// IGNORE
 				'database' => 'Basis data',
-				'server_software' => 'Aplikasi peladen',
+				'server_software' => 'Aplikasi server',
 				'version_curl' => 'versi cURL',
 				'version_frss' => 'versi FreshRSS',
 				'version_php' => 'versi PHP',
@@ -37,13 +37,13 @@ return array(
 	'feed' => array(
 		'empty' => 'Tidak ada artikel untuk diperlihatkan.',
 		'published' => array(
-			'_' => 'Published',	// TODO
-			'future' => 'Published in the future',	// TODO
-			'today' => 'Published today',	// TODO
-			'yesterday' => 'Published yesterday',	// TODO
+			'_' => 'Diterbitkan',
+			'future' => 'Diterbitkan di masa mendatang',
+			'today' => 'Diterbitkan hari ini',
+			'yesterday' => 'Diterbitkan kemarin',
 		),
 		'received' => array(
-			'_' => 'Received',	// TODO
+			'_' => 'Diterima',
 			'today' => 'Diterima hari ini',
 			'yesterday' => 'Diterima kemarin',
 		),
@@ -52,9 +52,9 @@ return array(
 		'title_fav' => 'Favorit',
 		'title_global' => 'Tampilan Global',
 		'userModified' => array(
-			'_' => 'Modified by user',	// TODO
-			'today' => 'Modified by user today',	// TODO
-			'yesterday' => 'Modified by user yesterday',	// TODO
+			'_' => 'Diubah oleh pengguna',
+			'today' => 'Diubah oleh pengguna hari ini',
+			'yesterday' => 'Diubah oleh pengguna kemarin',
 		),
 	),
 	'log' => array(
@@ -85,37 +85,37 @@ return array(
 		'rss_view' => 'Umpan RSS',
 		'search_short' => 'Cari',
 		'sort' => array(
-			'asc' => 'Ascending',	// TODO
+			'asc' => 'Menaik',
 			'c' => array(
-				'name_asc' => 'Category, feed titles A→Z',	// TODO
-				'name_desc' => 'Category, feed titles Z→A',	// TODO
+				'name_asc' => 'Kategori, judul umpan A→Z',
+				'name_desc' => 'Kategori, judul umpan Z→A',
 			),
 			'date_asc' => 'Tanggal publikasi 1→9',
 			'date_desc' => 'Tanggal publikasi 9→1',
-			'desc' => 'Descending',	// TODO
+			'desc' => 'Menurun',
 			'f' => array(
-				'name_asc' => 'Feed title A→Z',	// TODO
-				'name_desc' => 'Feed title Z→A',	// TODO
+				'name_asc' => 'Judul umpan A→Z',
+				'name_desc' => 'Judul umpan Z→A',
 			),
 			'id_asc' => 'Yang baru diterima terakhir',
 			'id_desc' => 'Yang baru diterima paling awal',
-			'length_asc' => 'Content length 1→9',	// TODO
-			'length_desc' => 'Content length 9→1',	// TODO
+			'length_asc' => 'Panjang konten 1→9',
+			'length_desc' => 'Panjang konten 9→1',
 			'link_asc' => 'Tautan A→Z',
 			'link_desc' => 'Tautan Z→A',
 			'primary' => array(
-				'_' => 'Sorting criterion',	// TODO
-				'help' => 'Sorting by <em>received</em> date is recommended in most cases, for consistency and performance',	// TODO
+				'_' => 'Kriteria pengurutan',
+				'help' => 'Pengurutan berdasarkan tanggal <em>diterima</em> disarankan untuk sebagian besar kasus, demi konsistensi dan performa',
 			),
 			'rand' => 'Acak',
 			'secondary' => array(
-				'_' => 'Secondary sorting criterion',	// TODO
-				'help' => 'Only relevant when the primary sorting criterion is categories or feeds titles',	// TODO
+				'_' => 'Kriteria pengurutan sekunder',
+				'help' => 'Hanya relevan bila kriteria pengurutan utama adalah kategori atau judul umpan',
 			),
 			'title_asc' => 'Judul A→Z',
 			'title_desc' => 'Judul Z→A',
-			'user_modified_asc' => 'User modified 1→9',	// TODO
-			'user_modified_desc' => 'User modified 9→1',	// TODO
+			'user_modified_asc' => 'Diubah pengguna 1→9',
+			'user_modified_desc' => 'Diubah pengguna 9→1',
 		),
 		'starred' => 'Tampilkan yang difavoritkan',
 		'stats' => 'Statistik',

--- a/app/i18n/id/index.php
+++ b/app/i18n/id/index.php
@@ -85,14 +85,14 @@ return array(
 		'rss_view' => 'Umpan RSS',
 		'search_short' => 'Cari',
 		'sort' => array(
-			'asc' => 'Menaik',
+			'asc' => 'Naik',
 			'c' => array(
 				'name_asc' => 'Kategori, judul umpan A→Z',
 				'name_desc' => 'Kategori, judul umpan Z→A',
 			),
 			'date_asc' => 'Tanggal publikasi 1→9',
 			'date_desc' => 'Tanggal publikasi 9→1',
-			'desc' => 'Menurun',
+			'desc' => 'Turun',
 			'f' => array(
 				'name_asc' => 'Judul umpan A→Z',
 				'name_desc' => 'Judul umpan Z→A',

--- a/app/i18n/id/install.php
+++ b/app/i18n/id/install.php
@@ -35,7 +35,7 @@ return array(
 		'_' => 'Pemeriksaan',
 		'already_installed' => 'Kami mendeteksi bahwa FreshRSS sudah terpasang!',
 		'cache' => array(
-			'nok' => 'Periksa izin direktori <em>%1$s</em> untuk pengguna <em>%2$s</em>. Peladen HTTP harus memiliki izin menulis di direktori tersebut.',
+			'nok' => 'Periksa izin direktori <em>%1$s</em> untuk pengguna <em>%2$s</em>. Server HTTP harus memiliki izin menulis di direktori tersebut.',
 			'ok' => 'Izin untuk direktori tembolok sudah bagus.',
 		),
 		'ctype' => array(
@@ -47,32 +47,32 @@ return array(
 			'ok' => 'Anda memiliki pustaka cURL.',
 		),
 		'data' => array(
-			'nok' => 'Periksa izin direktori <em>%1$s</em> untuk pengguna <em>%2$s</em>. Peladen HTTP harus memiliki izin menulis di direktori tersebut.',
+			'nok' => 'Periksa izin direktori <em>%1$s</em> untuk pengguna <em>%2$s</em>. Server HTTP harus memiliki izin menulis di direktori tersebut.',
 			'ok' => 'Izin untuk direktori data sudah bagus.',
 		),
 		'database-connection' => array(
-			'nok' => 'Database connection error.',	// TODO
-			'ok' => 'Database connection is good.',	// TODO
+			'nok' => 'Kesalahan koneksi basis data.',
+			'ok' => 'Koneksi basis data sudah bagus.',
 		),
 		'database-table' => array(
-			'nok' => 'Database table "%s" is incomplete.',	// TODO
-			'ok' => 'Database table "%s" is good.',	// TODO
+			'nok' => 'Tabel basis data "%s" tidak lengkap.',
+			'ok' => 'Tabel basis data "%s" sudah bagus.',
 		),
 		'database-tables' => array(
-			'nok' => 'Some database tables are missing.',	// TODO
-			'ok' => 'All database tables exist.',	// TODO
+			'nok' => 'Beberapa tabel basis data tidak ditemukan.',
+			'ok' => 'Semua tabel basis data sudah ada.',
 		),
-		'database-title' => 'Database',	// TODO
+		'database-title' => 'Basis data',
 		'docroot' => array(
-			'nok' => 'Your web server document root does not seem to point to the <code>./p/</code> folder. Other folders such as <code>./data/</code> may be publicly accessible.',	// TODO
-			'ok' => 'Your web server document root correctly points to the <code>./p/</code> folder.',	// TODO
+			'nok' => 'Root dokumen server web Anda tampaknya tidak menunjuk ke folder <code>./p/</code>. Folder lain seperti <code>./data/</code> mungkin dapat diakses publik.',
+			'ok' => 'Root dokumen server web Anda sudah menunjuk dengan benar ke folder <code>./p/</code>.',
 		),
 		'dom' => array(
 			'nok' => 'Tidak dapat menemukan pustaka yang diperlukan untuk menelusuri DOM.',
 			'ok' => 'Anda memiliki pustaka yang diperlukan untuk menelusuri DOM.',
 		),
 		'favicons' => array(
-			'nok' => 'Periksa izin direktori <em>%1$s</em> untuk pengguna <em>%2$s</em>. Peladen HTTP harus memiliki izin menulis di direktori tersebut.',
+			'nok' => 'Periksa izin direktori <em>%1$s</em> untuk pengguna <em>%2$s</em>. Server HTTP harus memiliki izin menulis di direktori tersebut.',
 			'ok' => 'Izin untuk direktori favicon sudah bagus.',
 		),
 		'fileinfo' => array(
@@ -81,12 +81,12 @@ return array(
 		),
 		'files' => 'Pemasangan Berkas',
 		'gmp' => array(
-			'nok' => 'Cannot find the required GMP extension for 32-bit PHP (php-gmp package).',	// TODO
-			'ok' => 'You have the GMP extension required for 32-bit PHP.',	// TODO
+			'nok' => 'Tidak dapat menemukan ekstensi GMP yang diperlukan untuk PHP 32-bit (paket php-gmp).',
+			'ok' => 'Anda memiliki ekstensi GMP yang diperlukan untuk PHP 32-bit.',
 		),
 		'intl' => array(
-			'nok' => 'Cannot find the recommended library php-intl for internationalisation.',	// TODO
-			'ok' => 'You have the recommended library php-intl for internationalisation.',	// TODO
+			'nok' => 'Tidak dapat menemukan pustaka php-intl yang disarankan untuk internasionalisasi.',
+			'ok' => 'Anda memiliki pustaka php-intl yang disarankan untuk internasionalisasi.',
 		),
 		'json' => array(
 			'nok' => 'Tidak dapat menemukan pustaka yang direkomendasikan untuk membaca JSON.',
@@ -101,14 +101,14 @@ return array(
 			'ok' => 'Anda memiliki pustaka untuk ekspresi regular (regex) (PCRE).',
 		),
 		'pdo-mysql' => array(
-			'nok' => 'Cannot find the required PDO driver for MySQL/MariaDB.',	// TODO
+			'nok' => 'Tidak dapat menemukan driver PDO yang diperlukan untuk MySQL/MariaDB.',
 		),
 		'pdo-pgsql' => array(
-			'nok' => 'Cannot find the required PDO driver for PostgreSQL.',	// TODO
+			'nok' => 'Tidak dapat menemukan driver PDO yang diperlukan untuk PostgreSQL.',
 		),
 		'pdo-sqlite' => array(
-			'nok' => 'Cannot find the PDO driver for SQLite.',	// TODO
-			'ok' => 'You have the PDO driver for SQLite.',	// TODO
+			'nok' => 'Tidak dapat menemukan driver PDO untuk SQLite.',
+			'ok' => 'Anda memiliki driver PDO untuk SQLite.',
 		),
 		'pdo' => array(
 			'nok' => 'Tidak dapat menemukan PDO atau sejenisnya untuk basis data yang didukung (pdo_sqlite, pdo_pgsql, pdo_mysql).',
@@ -121,16 +121,16 @@ return array(
 		),
 		'reload' => 'Periksa kembali',
 		'tmp' => array(
-			'nok' => 'Periksa izin direktori <em>%1$s</em> untuk pengguna <em>%2$s</em>. Peladen HTTP harus memiliki izin menulis di direktori tersebut.',
+			'nok' => 'Periksa izin direktori <em>%1$s</em> untuk pengguna <em>%2$s</em>. Server HTTP harus memiliki izin menulis di direktori tersebut.',
 			'ok' => 'Izin pada direktori tmp sudah bagus.',
 		),
 		'tokens' => array(
-			'nok' => 'Periksa izin direktori <em>./data/tokens</em>. Peladen HTTP harus memiliki izin menulis di direktori tersebut.',
+			'nok' => 'Periksa izin direktori <em>./data/tokens</em>. Server HTTP harus memiliki izin menulis di direktori tersebut.',
 			'ok' => 'Izin pada direktori token sudah bagus.',
 		),
 		'unknown_process_username' => 'tidak diketahui',
 		'users' => array(
-			'nok' => 'Periksa izin direktori <em>%1$s</em> untuk pengguna <em>%2$s</em>. Peladen HTTP harus memiliki izin menulis di direktori tersebut.',
+			'nok' => 'Periksa izin direktori <em>%1$s</em> untuk pengguna <em>%2$s</em>. Server HTTP harus memiliki izin menulis di direktori tersebut.',
 			'ok' => 'Izin pada direktori pengguna sudah bagus.',
 		),
 		'xml' => array(
@@ -149,7 +149,7 @@ return array(
 	'congratulations' => 'Selamat datang!',
 	'default_user' => array(
 		'_' => 'Nama pengguna untuk pengguna baku',
-		'max_char' => '1-39 characters: letters, digits, and <code>. _ @ -</code>',	// TODO
+		'max_char' => '1-39 karakter: huruf, angka, dan <code>. _ @ -</code>',
 	),
 	'fix_errors_before' => 'Perbaiki galat sebelum melanjutkan.',
 	'javascript_is_better' => 'FreshRSS lebih baik dengan JavaScript diaktifkan',
@@ -164,7 +164,7 @@ return array(
 	'missing_applied_migrations' => 'Ada sesuatu yang salah, Anda harus membuat berkas kosong <em>%s</em> secara manual.',
 	'ok' => 'Proses pemasangan sukses.',
 	'session' => array(
-		'nok' => 'Sepertinya konfigurasi peladen webnya salah untuk kuki yang dibutuhkan untuk sesi PHP!',
+		'nok' => 'Sepertinya konfigurasi server webnya salah untuk kuki yang dibutuhkan untuk sesi PHP!',
 	),
 	'step' => 'langkah %d',
 	'steps' => 'Langkah-Langkah',

--- a/app/i18n/id/sub.php
+++ b/app/i18n/id/sub.php
@@ -29,7 +29,7 @@ return array(
 			'help' => 'Sediakan URL ke <a href="http://opml.org/" target="_blank">berkas OPML</a> untuk memasukkan umpan ke kategori ini secara dinamis',
 		),
 		'empty' => 'Kategori kosong',
-		'error' => 'This dynamic OPML category has encountered a problem. Check that the OPML URL is still reachable and that the maximum number of feeds per user has not been exceeded.',	// TODO
+		'error' => 'Kategori OPML dinamis ini mengalami masalah. Periksa apakah URL OPML masih dapat dijangkau dan jumlah maksimum umpan per pengguna belum terlampaui.',
 		'expand' => 'Kembangkan kategori',
 		'information' => 'Informasi',
 		'open' => 'Buka kategori',
@@ -40,7 +40,7 @@ return array(
 	),
 	'feed' => array(
 		'accept_cookies' => 'Terima kuki',
-		'accept_cookies_help' => 'Perbolehkan peladen umpan untuk mengirimkan kuki (hanya disimpan di memori selama durasi permintaan)',
+		'accept_cookies_help' => 'Perbolehkan server umpan untuk mengirimkan kuki (hanya disimpan di memori selama durasi permintaan)',
 		'add' => 'Tambah umpan',
 		'advanced' => 'Lebih lanjut',
 		'archiving' => 'Pengarsipan',
@@ -81,14 +81,14 @@ return array(
 		'filteractions' => array(
 			'_' => 'Tindakan penyaringan',
 			'help' => 'Tulis satu penyaringan pencarian per baris. Operator <a href="https://freshrss.github.io/FreshRSS/en/users/10_filter.html#with-the-search-field" target="_blank">lihat dokumentasi</a>.',
-			'view_filter' => 'Preview filters on existing articles (new window)',	// TODO
+			'view_filter' => 'Pratinjau filter pada artikel yang ada (jendela baru)',
 		),
-		'global_hint' => 'Use <a href="%s">the global view</a> to see how many articles in each feed are matching a state or a search expression',	// TODO
+		'global_hint' => 'Gunakan <a href="%s">tampilan global</a> untuk melihat berapa banyak artikel di setiap umpan yang cocok dengan suatu status atau ekspresi pencarian',
 		'http_headers' => 'Tajuk HTTP',
 		'http_headers_help' => 'Tajuk dipisahkan dengan baris baru dan nama dan nilai dari tajuk dipisahkan dengan titik dua (contoh: <kbd><code>Accept: application/atom+xml<br />Authorization: Bearer some-token</code></kbd>).',
 		'icon' => 'Ikon',
 		'information' => 'Informasi',
-		'keep_adding_feed' => 'Then add more feeds',	// TODO
+		'keep_adding_feed' => 'Lalu tambahkan umpan lainnya',
 		'keep_min' => 'Jumlah minimum artikel yang harus disimpan',
 		'kind' => array(
 			'_' => 'Jenis sumber umpan',
@@ -188,10 +188,10 @@ return array(
 			'rss' => 'RSS / Atom (baku)',
 			'xml_xpath' => 'XML + XPath',	// IGNORE
 		),
-		'last-entry-publication-date' => 'Last article published <time datetime="%1$s" title="%1$s">%2$s</time>.',	// TODO
-		'last-entry-received-date' => 'Last article received <time datetime="%1$s" title="%1$s">%2$s</time>.',	// TODO
-		'last-error-date' => 'Last erroneous update <time datetime="%1$s" title="%1$s">%2$s</time>.',	// TODO
-		'last-update' => 'Last successful update <time datetime="%1$s" title="%1$s">%2$s</time>.',	// TODO
+		'last-entry-publication-date' => 'Artikel terakhir diterbitkan <time datetime="%1$s" title="%1$s">%2$s</time>.',
+		'last-entry-received-date' => 'Artikel terakhir diterima <time datetime="%1$s" title="%1$s">%2$s</time>.',
+		'last-error-date' => 'Pembaruan gagal terakhir <time datetime="%1$s" title="%1$s">%2$s</time>.',
+		'last-update' => 'Pembaruan berhasil terakhir <time datetime="%1$s" title="%1$s">%2$s</time>.',
 		'maintenance' => array(
 			'clear_cache' => 'Bersihkan tembolok',
 			'clear_cache_help' => 'Bersihkan tembolok untuk umpan ini.',
@@ -218,7 +218,7 @@ return array(
 		'priority' => array(
 			'_' => 'Ketampakan',
 			'category' => 'Tampilkan hanya di kategorinya saja',
-			'feed' => 'Show in its feed',	// TODO
+			'feed' => 'Tampilkan di umpannya sendiri',
 			'hidden' => 'Jangan tampilkan',
 			'important' => 'Tampilkan di umpan penting',
 			'main_stream' => 'Tampilkan di bagian utama',
@@ -290,7 +290,7 @@ return array(
 			'idle' => 'Umpan tak terbarukan',
 			'main' => 'Statistik utama',
 			'repartition' => 'Pengkategorian artikel',
-			'unread_dates' => 'Unread dates',	// TODO
+			'unread_dates' => 'Tanggal belum dibaca',
 		),
 		'subscription_management' => 'Pengelolaan langganan',
 		'subscription_tools' => 'Alat langganan',

--- a/app/i18n/id/user.php
+++ b/app/i18n/id/user.php
@@ -20,7 +20,7 @@ return array(
 			'change_email' => 'Anda dapat mengubah alamat surel Anda <a href="%s">di halaman profil</a>.',
 			'email_sent_to' => 'Kami sudah mengirimkan Anda surel ke <strong>%s</strong>. Ikuti petunjuk di surel untuk memvalidasi alamat surel Anda.',
 			'feedback' => array(
-				'email_failed' => 'Kami tidak dapat mengirimi Anda surel dikarenakan kesalahan konfigurasi di peladen. ',
+				'email_failed' => 'Kami tidak dapat mengirimi Anda surel dikarenakan kesalahan konfigurasi di server. ',
 				'email_sent' => 'Surel sudah dikirim ke surel Anda.',
 				'error' => 'Validasi alamat surel Anda gagal.',
 				'ok' => 'Alamat surel ini sudah divalidasi.',


### PR DESCRIPTION
- Translate the 130 remaining `// TODO` entries in `app/i18n/id/` into Indonesian, taking Bahasa Indonesia from 88% to 100%. Covers `admin`, `api`, `conf`, `feedback`, `gen`, `index`, `install` and `sub`.
- Refresh the 5 `// DIRTY` entries so they match the current English meaning.
- Mark 5 entries `// IGNORE` where no natural Indonesian form exists, instead of leaving them silently identical to English: the `lt` language endonym, `gen.search.url`, the symbol-only API error marker, the `Nextcloud Bookmarks` product name, and the `Browser` field label.
- Replace `peladen` with `server` throughout, including in strings that predate this PR. `peladen` is the formal term but is unfamiliar to most Indonesian readers, and the language files were already inconsistent — `peladen` dominated `admin`/`install` while `server` dominated `conf`/`gen`.
- Fix a pre-existing mistranslation found during that sweep: the **Browser** field in the system information panel read `Peladen`, i.e. *server* — the wrong word entirely.
- Regenerate the translation progress tables in `README.md` and `README.fr.md`, and add a `CHANGELOG.md` entry.

Terminology follows the strings already shipped (`umpan`, `kategori`, `artikel`, `belum dibaca`, `tandai`, `pintasan`). Placeholders, inline markup and documentation links are preserved unchanged. Every edit was made through `cli/manipulate.translation.php` rather than by hand-editing the language files.

How to test the feature manually:

1. Set the interface language to Bahasa Indonesia under *Configuration → Display → Language*, then browse the main reading view: sorting menu, article dates (published / received / modified by user), search and advanced search. All labels and help text should render in Indonesian.
2. Open *Configuration → Display*, *Notifications*, *Profile* and *Shortcuts*, plus the subscription management screens (feed details, last-update timestamps, filter actions). Check that messages containing values — for example "Pembaruan berhasil terakhir <date>." and "Situs yang diizinkan melihat alamat server Anda (%s)" — render with the value in the right place and no leftover `%s`.
3. As an administrator, open *System information* (the **Browser** row should say `Browser`, not `Peladen`), *Statistics*, the *Internal host allowlist* help text (its `<code>` examples and `CIDR`/`IPv4`/`IPv6` terms must stay in English), and the API information page. Optionally run the installation wizard with Bahasa Indonesia selected to check the requirement-check messages.

Verification that does not need a browser:

```sh
./cli/check.translation.php -l id -r   # 100.0% complete
./cli/check.translation.php -l id -d   # no output
grep -rn '// TODO\|// DIRTY' app/i18n/id/*.php   # no output
```

Pull request checklist:
- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [x] documentation updated

Fixes [#6349](https://github.com/FreshRSS/FreshRSS/issues/6349).