### PR TITLE
fix(favicon): fetch YouTube channel avatars

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -443,8 +443,9 @@ class FreshRSS_Feed extends Minz_Model {
 		$feedIconUrl = $this->attributeString('feedIconUrl') ?? '';
 		$websiteUrl = $this->website(fallback: false);
 		if ($websiteUrl === '' || $websiteUrl === $this->url) {
-			// Get root URL from the feed URL
-			$websiteUrl = preg_replace('%^(https?://[^/]+).*$%i', '$1/', $this->url) ?? $this->url;
+			// YouTube feed URLs expose the channel ID but no channel avatar.
+			$websiteUrl = youtubeChannelPageUrl($this->url)
+				?? (preg_replace('%^(https?://[^/]+).*$%i', '$1/', $this->url) ?? $this->url);
 		}
 		$url = $feedIconUrl !== '' ? $feedIconUrl : $websiteUrl;
 

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -444,7 +444,7 @@ class FreshRSS_Feed extends Minz_Model {
 		$websiteUrl = $this->website(fallback: false);
 		if ($websiteUrl === '' || $websiteUrl === $this->url) {
 			// YouTube feed URLs expose the channel ID but no channel avatar.
-			$websiteUrl = youtubeChannelPageUrl($this->url)
+			$websiteUrl = youtubeChannelPageUrlFromFeed($this->url)
 				?? (preg_replace('%^(https?://[^/]+).*$%i', '$1/', $this->url) ?? $this->url);
 		}
 		$url = $feedIconUrl !== '' ? $feedIconUrl : $websiteUrl;

--- a/lib/favicons.php
+++ b/lib/favicons.php
@@ -25,7 +25,14 @@ function faviconCachePath(string $url): string {
 	return CACHE_PATH . '/' . sha1($url) . '.ico';
 }
 
-function youtubeChannelPageUrl(string $url): ?string {
+function isYoutubeUrl(string $url): bool {
+	return preg_match('#^https?://(?:www\.|m\.)?youtube\.com/#i', $url) === 1;
+}
+
+/**
+ * Returns a channel page URL when given YouTube's channel feed URL format.
+ */
+function youtubeChannelPageUrlFromFeed(string $url): ?string {
 	$url = FreshRSS_http_Util::checkUrl($url);
 	if (!is_string($url) || $url === '') {
 		return null;
@@ -39,16 +46,19 @@ function youtubeChannelPageUrl(string $url): ?string {
 	return FreshRSS_http_Util::checkUrl('https://www.youtube.com/channel/' . $match[1]) ?: null;
 }
 
-function searchYoutubeFavicon(string $url): string {
-	$url = youtubeChannelPageUrl($url) ?? (FreshRSS_http_Util::checkUrl($url) ?: '');
-	if ($url === '' || preg_match('#^https?://(?:www\.|m\.)?youtube\.com/#i', $url) !== 1) {
+/**
+ * Finds a YouTube channel avatar from the page's Open Graph image metadata.
+ */
+function searchYoutubeFavicon(string $pageUrl): string {
+	$pageUrl = youtubeChannelPageUrlFromFeed($pageUrl) ?? (FreshRSS_http_Util::checkUrl($pageUrl) ?: '');
+	if ($pageUrl === '' || !isYoutubeUrl($pageUrl)) {
 		return '';
 	}
 
-	$response = FreshRSS_http_Util::httpGet($url, CACHE_PATH . '/' . sha1($url) . '.html', 'html');
+	$response = FreshRSS_http_Util::httpGet($pageUrl, cachePath: CACHE_PATH . '/' . sha1($pageUrl) . '.html', type: 'html');
 	$html = $response['body'];
-	$effectiveUrl = $response['effective_url'] !== '' ? $response['effective_url'] : $url;
-	if ($response['fail'] || $html === '' || preg_match('#^https?://(?:www\.|m\.)?youtube\.com/#i', $effectiveUrl) !== 1) {
+	$effectiveUrl = $response['effective_url'] !== '' ? $response['effective_url'] : $pageUrl;
+	if ($response['fail'] || $html === '' || !isYoutubeUrl($effectiveUrl)) {
 		return '';
 	}
 

--- a/lib/favicons.php
+++ b/lib/favicons.php
@@ -25,6 +25,65 @@ function faviconCachePath(string $url): string {
 	return CACHE_PATH . '/' . sha1($url) . '.ico';
 }
 
+function youtubeChannelPageUrl(string $url): ?string {
+	$url = FreshRSS_http_Util::checkUrl($url);
+	if (!is_string($url) || $url === '') {
+		return null;
+	}
+
+	if (preg_match('#^https?://(?:www\.|m\.)?youtube\.com/feeds/videos\.xml#i', $url) !== 1
+		|| preg_match('/[?&]channel_id=([A-Za-z0-9_-]+)/', $url, $match) !== 1) {
+		return null;
+	}
+
+	return FreshRSS_http_Util::checkUrl('https://www.youtube.com/channel/' . $match[1]) ?: null;
+}
+
+function searchYoutubeFavicon(string $url): string {
+	$url = youtubeChannelPageUrl($url) ?? (FreshRSS_http_Util::checkUrl($url) ?: '');
+	if ($url === '' || preg_match('#^https?://(?:www\.|m\.)?youtube\.com/#i', $url) !== 1) {
+		return '';
+	}
+
+	$response = FreshRSS_http_Util::httpGet($url, CACHE_PATH . '/' . sha1($url) . '.html', 'html');
+	$html = $response['body'];
+	$effectiveUrl = $response['effective_url'] !== '' ? $response['effective_url'] : $url;
+	if ($response['fail'] || $html === '' || preg_match('#^https?://(?:www\.|m\.)?youtube\.com/#i', $effectiveUrl) !== 1) {
+		return '';
+	}
+
+	$match = [];
+	$found = preg_match('/<meta[^>]*property=["\']og:image["\'][^>]*content=["\']([^"\']+)/i', $html, $match) === 1
+		|| preg_match('/<meta[^>]*content=["\']([^"\']+)["\'][^>]*property=["\']og:image["\']/i', $html, $match) === 1;
+	if (!$found) {
+		return '';
+	}
+
+	$imageUrl = html_entity_decode(trim($match[1]), ENT_QUOTES);
+	try {
+		$iri = \SimplePie\IRI::absolutize($effectiveUrl, $imageUrl);
+		if ($iri === false) {
+			return '';
+		}
+		$absoluteImageUrl = $iri->get_iri();
+		if (!is_string($absoluteImageUrl)) {
+			return '';
+		}
+		$imageUrl = $absoluteImageUrl;
+	} catch (Throwable) {
+		return '';
+	}
+	$imageUrl = FreshRSS_http_Util::checkUrl($imageUrl, fixScheme: false);
+	if (!is_string($imageUrl) || $imageUrl === '') {
+		return '';
+	}
+
+	$favicon = FreshRSS_http_Util::httpGet($imageUrl, faviconCachePath($imageUrl), 'ico', curl_options: [
+		CURLOPT_REFERER => $effectiveUrl,
+	])['body'];
+	return isImgMime($favicon) ? $favicon : '';
+}
+
 function searchFavicon(string $url): string {
 	$url = trim($url);
 	if ($url === '') {
@@ -105,7 +164,10 @@ function download_favicon(string $url, string $dest): bool {
 	if (!is_string($url) || $url === '') {
 		return @copy(DEFAULT_FAVICON, $dest);
 	}
-	$favicon = searchFavicon($url);
+	$favicon = searchYoutubeFavicon($url);
+	if ($favicon === '') {
+		$favicon = searchFavicon($url);
+	}
 	if ($favicon == '') {
 		$rootUrl = preg_replace('%^(https?://[^/]+).*$%i', '$1/', $url) ?? $url;
 		if ($rootUrl != $url) {

--- a/lib/favicons.php
+++ b/lib/favicons.php
@@ -60,19 +60,15 @@ function searchYoutubeFavicon(string $url): string {
 	}
 
 	$imageUrl = html_entity_decode(trim($match[1]), ENT_QUOTES);
-	try {
-		$iri = \SimplePie\IRI::absolutize($effectiveUrl, $imageUrl);
-		if ($iri === false) {
-			return '';
-		}
-		$absoluteImageUrl = $iri->get_iri();
-		if (!is_string($absoluteImageUrl)) {
-			return '';
-		}
-		$imageUrl = $absoluteImageUrl;
-	} catch (Throwable) {
+	$iri = \SimplePie\IRI::absolutize($effectiveUrl, $imageUrl);
+	if ($iri === false) {
 		return '';
 	}
+	$absoluteImageUrl = $iri->get_iri();
+	if (!is_string($absoluteImageUrl)) {
+		return '';
+	}
+	$imageUrl = $absoluteImageUrl;
 	$imageUrl = FreshRSS_http_Util::checkUrl($imageUrl, fixScheme: false);
 	if (!is_string($imageUrl) || $imageUrl === '') {
 		return '';


### PR DESCRIPTION
## Summary

- Resolve YouTube channel feed URLs to their channel pages when preparing favicons.
- Fetch the channel avatar from YouTube's `og:image` metadata before falling back to the existing favicon discovery logic.
- Preserve the existing behaviour for user-selected icons and non-YouTube feeds.

## Root cause

YouTube channel feeds expose a `channel_id` in the feed URL, but the feed URL itself does not expose the channel avatar. The existing favicon flow reduced that URL to the YouTube root favicon, so channel icons were not fetched.

## Validation

- `git diff --check`
- PHP/Composer lint and test commands were unavailable in the local environment because PHP and Composer are not installed.

<img width="903" height="459" alt="image" src="https://github.com/user-attachments/assets/8461ff24-6589-4b80-83e2-86dd045a8641" />

