### PR TITLE
Fix 'headers already sent' warning in extensionController

### DIFF
--- a/app/Controllers/extensionController.php
+++ b/app/Controllers/extensionController.php
@@ -362,8 +362,7 @@ class FreshRSS_extension_Controller extends FreshRSS_ActionController {
 		header("Content-Disposition: inline; filename='{$filename}'");
 		header('Referrer-Policy: same-origin');
 		if (file_exists(DATA_PATH . '/no-cache.txt') || !httpConditional($mtime, cacheSeconds: 604800, cachePrivacy: 2)) {
-			echo $extension->getFile($filename);
+			$this->view->content = $extension->getFile($filename);
 		}
-		exit;
 	}
 }

--- a/app/Controllers/extensionController.php
+++ b/app/Controllers/extensionController.php
@@ -364,5 +364,6 @@ class FreshRSS_extension_Controller extends FreshRSS_ActionController {
 		if (file_exists(DATA_PATH . '/no-cache.txt') || !httpConditional($mtime, cacheSeconds: 604800, cachePrivacy: 2)) {
 			echo $extension->getFile($filename);
 		}
+		exit;
 	}
 }

--- a/app/Controllers/extensionController.php
+++ b/app/Controllers/extensionController.php
@@ -362,7 +362,8 @@ class FreshRSS_extension_Controller extends FreshRSS_ActionController {
 		header("Content-Disposition: inline; filename='{$filename}'");
 		header('Referrer-Policy: same-origin');
 		if (file_exists(DATA_PATH . '/no-cache.txt') || !httpConditional($mtime, cacheSeconds: 604800, cachePrivacy: 2)) {
-			$this->view->content = $extension->getFile($filename);
+			$contents = $extension->getFile($filename);
+			$this->view->content = is_string($contents) ? $contents : '';
 		}
 	}
 }

--- a/app/views/extension/serve.phtml
+++ b/app/views/extension/serve.phtml
@@ -1,0 +1,4 @@
+<?php
+declare(strict_types=1);
+/** @var FreshRSS_View $this */
+echo $this->content;


### PR DESCRIPTION
Closes #9229

Changes proposed in this pull request:

This PR fixes a "Cannot modify header information - headers already sent" warning that occurs when serving extension files (like custom CSS) via `extensionController.php`.
It's done by rendering the extension file in the view instead of echoing it, so that it matches the order of operations:
* execute action -> declare csp header -> render view
instead of:
* execute action -> start output by printing the extension file's contents (!) -> declare csp header (output already started, prints warning) -> render view (which was empty before)

How to test the feature manually:

With this change:
1. Go to FreshRSS UserCSS extension config
2. Enable the UserCSS and set the CSS code in it.
3. Go to FreshRSS feeds page.
4. Hit the ctrl + F5 button and see no errors in the nginx log.

CSS file: [style.css](https://github.com/user-attachments/files/31338410/style.css)

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://freshrss.github.io/FreshRSS/en/developers/04_Pull_requests.html).
