### PR TITLE
Fix spam of empty log messages

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -1104,7 +1104,10 @@ class FreshRSS_Entry extends Minz_Model {
 					}
 				} catch (Exception $e) {
 					// rien à faire, on garde l’ancien contenu(requête a échoué)
-					Minz_Log::warning($e->getMessage());
+					$message = $e->getMessage();
+					if ($message !== '') {
+						Minz_Log::warning($message);
+					}
 				}
 			}
 		} elseif (trim($feed->attributeString('path_entries_filter') ?? '') !== '') {

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -1058,7 +1058,8 @@ class FreshRSS_Entry extends Minz_Model {
 
 			return trim($html);
 		} else {
-			throw new Minz_Exception();
+			Minz_Log::warning('Empty response body when fetching article content for ' . $url);
+			return '';
 		}
 	}
 

--- a/lib/Minz/Log.php
+++ b/lib/Minz/Log.php
@@ -35,6 +35,11 @@ class Minz_Log {
 	 * @throws Minz_PermissionDeniedException
 	 */
 	public static function record(string $information, int $level, ?string $file_name = null): void {
+		// Prevent spam of empty log messages
+		if (trim($information) === '') {
+			return;
+		}
+
 		$env = getenv('FRESHRSS_ENV');
 		$log_level = '';
 		try {


### PR DESCRIPTION
Fix spam of empty log messages

When fetching full article content fails with an exception that has
an empty message, the catch block in Entry::loadCompleteContent()
logs an empty warning message, causing log spam.

Fix:
1. In Entry.php: Only log the exception message if it's not empty
2. In Minz_Log.php: Add early return for empty/whitespace messages
   to prevent any empty log entries at the framework level

Fixes #9222