### PR TITLE
Translate missing pt-BR strings

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -249,7 +249,7 @@ Voir le [dépôt dédié à ces extensions](https://github.com/FreshRSS/Extensio
 | Nederlands (nl) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fnl+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Occitan (oc) | ￭￭￭￭￭￭￭･･･ 73% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Foc+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Polski (pl) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpl+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Português (Brasil) (pt-BR) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-BR+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Português (Brasil) (pt-BR) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-BR+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Português (Portugal) (pt-PT) | ￭￭￭￭￭￭￭￭･･ 80% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-PT+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Русский (ru) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fru+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Slovenčina (sk) | ￭￭￭￭￭￭￭￭･･ 81% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fsk+%2F%28TODO%7CDIRTY%29%24%2F) |

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ See the [repository dedicated to those extensions](https://github.com/FreshRSS/E
 | Nederlands (nl) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fnl+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Occitan (oc) | ￭￭￭￭￭￭￭･･･ 73% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Foc+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Polski (pl) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpl+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Português (Brasil) (pt-BR) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-BR+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Português (Brasil) (pt-BR) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-BR+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Português (Portugal) (pt-PT) | ￭￭￭￭￭￭￭￭･･ 80% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fpt-PT+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Русский (ru) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fru+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Slovenčina (sk) | ￭￭￭￭￭￭￭￭･･ 81% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fsk+%2F%28TODO%7CDIRTY%29%24%2F) |

--- a/app/i18n/pt-BR/admin.php
+++ b/app/i18n/pt-BR/admin.php
@@ -20,7 +20,7 @@ return array(
 		'none' => 'Nenhum (Perigoso)',
 		'title' => 'Autenticação',
 		'token' => 'Token de autenticação principal',
-		'token_help' => 'Permite acesso a todos as saídas RSS do usuário bem como atualização dos feeds sem autenticação:',
+		'token_help' => 'Permite acesso a todas as saídas RSS do usuário, bem como a atualização dos feeds sem autenticação:',
 		'type' => 'Método de autenticação',
 	),
 	'extensions' => array(
@@ -53,9 +53,9 @@ return array(
 		'entry_count' => 'Contagem de entrada',
 		'entry_per_category' => 'Entradas por categoria',
 		'entry_per_day' => 'Entradas por dia (últimos 30 dias)',
-		'entry_per_day_of_week' => 'Por dia da semana(média: %.2f mensagens)',
+		'entry_per_day_of_week' => 'Por dia da semana (média: %.2f mensagens)',
 		'entry_per_hour' => 'Por hora (média: %.2f mensagens)',
-		'entry_per_month' => 'Por mês(média: %.2f mensagens)',
+		'entry_per_month' => 'Por mês (média: %.2f mensagens)',
 		'entry_repartition' => 'Repartição de entradas',
 		'feed' => 'Feed',	// IGNORE
 		'feed_per_category' => 'Feeds por categoria',
@@ -73,7 +73,7 @@ return array(
 		'status_total' => 'Total',	// IGNORE
 		'status_unread' => 'Não lidos',
 		'title' => 'Estatísticas',
-		'top_feed' => 'Top10 Feeds',
+		'top_feed' => 'Top 10 Feeds',
 		'unread_dates' => 'Datas com mais artigos não lidos',
 	),
 	'system' => array(
@@ -86,18 +86,18 @@ return array(
 		'closed_registration_message' => 'Mensagem caso as inscrições estejam encerradas',
 		'cookie-duration' => array(
 			'help' => 'em segundos',
-			'number' => 'Manter seção ativa durante',
+			'number' => 'Manter sessão ativa durante',
 		),
 		'default_closed_registration_message' => 'Este servidor não aceita novas inscrições no momento.',
 		'force_email_validation' => 'Força verificação do endereço de email',
 		'instance-name' => 'Nome da instância',
 		'internal-host-allowlist' => array(
-			'_' => 'Internal host allowlist',	// TODO
-			'help' => 'One entry per line:<ul><li>A <code>host:port</code>. For instance <code>127.0.0.1:8080</code> or <code>rss-bridge:80</code></li><li>A CIDR notation. For instance <code>0.0.0.0/0</code> to allow any IPv4, <code>::/0</code> to allow any IPv6</li><li>A <code>*</code> to allow any host (unsafe)</li></ul>',	// TODO
+			'_' => 'Lista de permissões de hosts internos',
+			'help' => 'Uma entrada por linha:<ul><li>Um <code>host:porta</code>. Por exemplo, <code>127.0.0.1:8080</code> ou <code>rss-bridge:80</code></li><li>Uma notação CIDR. Por exemplo, <code>0.0.0.0/0</code> para permitir qualquer IPv4 e <code>::/0</code> para permitir qualquer IPv6</li><li>Um <code>*</code> para permitir qualquer host (não seguro)</li></ul>',
 		),
 		'max-categories' => 'Limite de categorias por usuário',
 		'max-feeds' => 'Limite de Feeds por usuário',
-		'override-by-env-var' => 'This setting is set by the environment variable <kbd>%s</kbd>.',	// TODO
+		'override-by-env-var' => 'Esta configuração é definida pela variável de ambiente <kbd>%s</kbd>.',
 		'registration' => array(
 			'number' => 'Máximo número de contas',
 			'select' => array(

--- a/app/i18n/pt-BR/conf.php
+++ b/app/i18n/pt-BR/conf.php
@@ -69,7 +69,7 @@ return array(
 			'help' => 'Somente para temas compatíveis',
 			'no' => 'Não',
 		),
-		'display_enclosures' => 'Show enclosures',	// TODO
+		'display_enclosures' => 'Mostrar anexos',
 		'headline' => array(
 			'articles_header_footer' => 'Artigos: cabeçalho/rodapé',
 		),
@@ -91,11 +91,11 @@ return array(
 		'show_nav_buttons' => 'Mostrar botões de navegação',
 		'show_title_unread' => 'Mostrar o número de artigos não lidos no título',
 		'show_unread_count' => array(
-			'_' => 'Show unread counts in sidebar',	// TODO
-			'all' => 'For all categories and feeds',	// TODO
-			'important' => 'For important feeds only',	// TODO
-			'important_locked' => 'Important feeds always show their unread count.',	// TODO
-			'none' => 'Never',	// TODO
+			'_' => 'Mostrar contagem de não lidos na barra lateral',
+			'all' => 'Para todas as categorias e feeds',
+			'important' => 'Apenas para feeds importantes',
+			'important_locked' => 'Feeds importantes sempre mostram sua contagem de não lidos.',
+			'none' => 'Nunca',
 		),
 		'sidebar_hidden_by_default' => 'Ocultar barra lateral por padrão',
 		'theme' => array(
@@ -177,7 +177,7 @@ return array(
 			'disabled' => 'O acesso à API está desativado.',
 			'documentation_link' => 'Veja a <a href="https://freshrss.github.io/FreshRSS/en/users/06_Mobile_access.html#access-via-mobile-app" target="_blank">documentação e lista de aplicativos conhecidos</a>',
 			'help' => 'Veja a <a href="https://freshrss.github.io/FreshRSS/en/users/06_Mobile_access.html#access-via-mobile-app" target=_blank>documentação</a>',
-			'security_warning' => 'Use HTTPS. The API password is transmitted in clear text and may appear in server logs if sent via GET.',	// TODO
+			'security_warning' => 'Use HTTPS. A senha da API é transmitida em texto simples e pode aparecer nos logs do servidor se enviada via GET.',
 		),
 		'change_password' => 'Alterar senha',
 		'confirm_new_password' => 'Confirmar nova senha',
@@ -201,8 +201,8 @@ return array(
 			'_' => 'Filtro aplicado:',
 			'categories' => 'Exibir por categoria',
 			'feeds' => 'Exibir por feed',
-			'include_article_tags_label' => 'Include article tags from feeds',	// TODO
-			'include_user_labels_label' => 'Include user labels, with prefix:',	// TODO
+			'include_article_tags_label' => 'Incluir tags dos artigos dos feeds',
+			'include_user_labels_label' => 'Incluir rótulos do usuário, com prefixo:',
 			'order' => 'Ordenar por data',
 			'search' => 'Expressão',
 			'shareOpml' => 'Habilita o compartilhamento por OPML de categorias e feeds correspondentes',

--- a/app/i18n/pt-BR/gen.php
+++ b/app/i18n/pt-BR/gen.php
@@ -73,7 +73,7 @@ return array(
 		),
 		'username' => array(
 			'_' => 'Usuário',
-			'format' => '<small>1-39 characters: letters, digits, and <code>. _ @ -</code></small>',	// TODO
+			'format' => '<small>De 1 a 39 caracteres: letras, números e <code>. _ @ -</code></small>',
 		),
 	),
 	'date' => array(
@@ -205,7 +205,7 @@ return array(
 		'it' => 'Italiano',	// IGNORE
 		'ja' => '日本語',	// IGNORE
 		'ko' => '한국어',	// IGNORE
-		'lt' => 'Lietuvių',	// TODO
+		'lt' => 'Lietuvių',	// IGNORE
 		'lv' => 'Latviešu',	// IGNORE
 		'nl' => 'Nederlands',	// IGNORE
 		'oc' => 'Occitan',	// IGNORE

--- a/app/i18n/pt-BR/install.php
+++ b/app/i18n/pt-BR/install.php
@@ -64,8 +64,8 @@ return array(
 		),
 		'database-title' => 'Banco de Dados',
 		'docroot' => array(
-			'nok' => 'Your web server document root does not seem to point to the <code>./p/</code> folder. Other folders such as <code>./data/</code> may be publicly accessible.',	// TODO
-			'ok' => 'Your web server document root correctly points to the <code>./p/</code> folder.',	// TODO
+			'nok' => 'A raiz de documentos do seu servidor web não parece apontar para a pasta <code>./p/</code>. Outras pastas, como <code>./data/</code>, podem estar acessíveis publicamente.',
+			'ok' => 'A raiz de documentos do seu servidor web aponta corretamente para a pasta <code>./p/</code>.',
 		),
 		'dom' => array(
 			'nok' => 'Não foi possível encontrar uma biblioteca necessária para navegar pelo DOM (php-xml).',
@@ -81,8 +81,8 @@ return array(
 		),
 		'files' => 'Instalação de arquivos',
 		'gmp' => array(
-			'nok' => 'Cannot find the required GMP extension for 32-bit PHP (php-gmp package).',	// TODO
-			'ok' => 'You have the GMP extension required for 32-bit PHP.',	// TODO
+			'nok' => 'Não foi possível encontrar a extensão GMP necessária para o PHP de 32 bits (pacote php-gmp).',
+			'ok' => 'Você tem a extensão GMP necessária para o PHP de 32 bits.',
 		),
 		'intl' => array(
 			'nok' => 'Não foi possível encontrar a biblioteca recomendada php-intl para internacionalização.',
@@ -149,7 +149,7 @@ return array(
 	'congratulations' => 'Parabéns!',
 	'default_user' => array(
 		'_' => 'Usuário do usuário padrão',
-		'max_char' => '1-39 characters: letters, digits, and <code>. _ @ -</code>',	// TODO
+		'max_char' => 'De 1 a 39 caracteres: letras, números e <code>. _ @ -</code>',
 	),
 	'fix_errors_before' => 'Por favor solucione os erros antes de ir para o próximo passo.',
 	'javascript_is_better' => 'O FreshRSS é mais agradável com o JavaScript ativo',

--- a/app/i18n/pt-BR/sub.php
+++ b/app/i18n/pt-BR/sub.php
@@ -83,7 +83,7 @@ return array(
 			'help' => 'Escreva um filtro de pesquisa por linha. Operadores <a href="https://freshrss.github.io/FreshRSS/en/users/10_filter.html#with-the-search-field" target="_blank">consulte a documentação</a>.',
 			'view_filter' => 'Visualizar filtros em artigos existentes (nova janela)',
 		),
-		'global_hint' => 'Use <a href="%s">the global view</a> to see how many articles in each feed are matching a state or a search expression',	// TODO
+		'global_hint' => 'Use a <a href="%s">visão global</a> para ver quantos artigos em cada feed correspondem a um estado ou a uma expressão de busca',
 		'http_headers' => 'Cabeçalhos HTTP',
 		'http_headers_help' => 'Os cabeçalhos são separados por uma nova linha, e o nome e o valor de um cabeçalho são separados por dois pontos (ex: <kbd><code>Accept: application/atom+xml<br />Authorization: Bearer some-token</code></kbd>).',
 		'icon' => 'Ícone',


### PR DESCRIPTION
Changes proposed in this pull request:

- Translate missing pt-BR strings
- Remove resolved TODO markers
- Improve Brazilian Portuguese localization consistency

How to test the feature manually:

1. Set the interface language to Brazilian Portuguese (pt-BR)
2. Navigate through the application
3. Verify that the translated strings are displayed correctly

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

No functional changes were made.