### PR TITLE
i18n(es): complete Spanish translations

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -234,7 +234,7 @@ Voir le [dépôt dédié à ces extensions](https://github.com/FreshRSS/Extensio
 | Ελληνικά (el) | ￭￭￭￭￭￭￭･･･ 75% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fel+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (en) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Español (es) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Español (es) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
 | فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Suomi (fi) | ￭￭￭￭￭￭￭￭￭･ 91% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffi+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Français (fr) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribuer](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ See the [repository dedicated to those extensions](https://github.com/FreshRSS/E
 | Ελληνικά (el) | ￭￭￭￭￭￭￭･･･ 75% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fel+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (en) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen+%2F%28TODO%7CDIRTY%29%24%2F) |
 | English (United States) (en-US) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fen-US+%2F%28TODO%7CDIRTY%29%24%2F) |
-| Español (es) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
+| Español (es) | ￭￭￭￭￭￭￭￭￭￭ 100% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Fes+%2F%28TODO%7CDIRTY%29%24%2F) |
 | فارسی (fa) | ￭￭￭￭￭￭￭￭￭･ 98% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffa+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Suomi (fi) | ￭￭￭￭￭￭￭￭￭･ 91% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffi+%2F%28TODO%7CDIRTY%29%24%2F) |
 | Français (fr) | ￭￭￭￭￭￭￭￭￭･ 99% | [contribute](https://github.com/search?q=repo%3AFreshRSS%2FFreshRSS+path%3Aapp%2Fi18n%2Ffr+%2F%28TODO%7CDIRTY%29%24%2F) |

--- a/app/i18n/es/admin.php
+++ b/app/i18n/es/admin.php
@@ -92,12 +92,12 @@ return array(
 		'force_email_validation' => 'Forzar la validación de direcciones de correo electrónico',
 		'instance-name' => 'Nombre de la fuente',
 		'internal-host-allowlist' => array(
-			'_' => 'Internal host allowlist',	// TODO
-			'help' => 'One entry per line:<ul><li>A <code>host:port</code>. For instance <code>127.0.0.1:8080</code> or <code>rss-bridge:80</code></li><li>A CIDR notation. For instance <code>0.0.0.0/0</code> to allow any IPv4, <code>::/0</code> to allow any IPv6</li><li>A <code>*</code> to allow any host (unsafe)</li></ul>',	// TODO
+			'_' => 'Lista de permitidos de hosts internos',
+			'help' => 'Una entrada por línea:<ul><li>Un <code>host:puerto</code>. Por ejemplo <code>127.0.0.1:8080</code> o <code>rss-bridge:80</code></li><li>Una notación CIDR. Por ejemplo <code>0.0.0.0/0</code> para permitir cualquier IPv4, <code>::/0</code> para permitir cualquier IPv6</li><li>Un <code>*</code> para permitir cualquier host (inseguro)</li></ul>',
 		),
 		'max-categories' => 'Límite de categorías por usuario',
 		'max-feeds' => 'Límite de fuentes por usuario',
-		'override-by-env-var' => 'This setting is set by the environment variable <kbd>%s</kbd>.',	// TODO
+		'override-by-env-var' => 'Esta configuración está definida por la variable de entorno <kbd>%s</kbd>.',
 		'registration' => array(
 			'number' => 'Número máximo de cuentas',
 			'select' => array(

--- a/app/i18n/es/conf.php
+++ b/app/i18n/es/conf.php
@@ -69,7 +69,7 @@ return array(
 			'help' => 'Solo para temas compatibles',
 			'no' => 'No',	// IGNORE
 		),
-		'display_enclosures' => 'Show enclosures',	// TODO
+		'display_enclosures' => 'Mostrar adjuntos',
 		'headline' => array(
 			'articles_header_footer' => 'Artículos: encabezado/pie de página',
 		),
@@ -201,8 +201,8 @@ return array(
 			'_' => 'Filtro aplicado:',
 			'categories' => 'Mostrar por categoría',
 			'feeds' => 'Mostrar por fuente',
-			'include_article_tags_label' => 'Include article tags from feeds',	// TODO
-			'include_user_labels_label' => 'Include user labels, with prefix:',	// TODO
+			'include_article_tags_label' => 'Incluir etiquetas de artículos de los feeds',
+			'include_user_labels_label' => 'Incluir etiquetas del usuario, con el prefijo:',
 			'order' => 'Ordenar por fecha',
 			'search' => 'Expresión',
 			'shareOpml' => 'Permitir que OPML comparta las categorías y fuentes correspondientes',
@@ -308,8 +308,8 @@ return array(
 			'when' => 'Marca un artículo como favorito…',
 		),
 		'sticky_post' => 'Fijar el artículo a la parte superior al abrirlo',
-		'sticky_sort' => 'Mantener el orden de clasificación manual durante la navegación',	// DIRTY
-		'sticky_sort_help' => 'Determina si se mantiene activo el último orden de clasificación manual o si cada categoría o fuente usa siempre su propia configuración predeterminada o global.',	// DIRTY
+		'sticky_sort' => 'Mantener el orden de clasificación personalizado durante la navegación',
+		'sticky_sort_help' => 'Determina si el último orden de clasificación personalizado permanece activo o si cada categoría o feed utiliza siempre su propia configuración predeterminada o global.',
 		'title' => 'Lectura',
 		'view' => array(
 			'default' => 'Vista por defecto',

--- a/app/i18n/es/gen.php
+++ b/app/i18n/es/gen.php
@@ -73,7 +73,7 @@ return array(
 		),
 		'username' => array(
 			'_' => 'Nombre de usuario',
-			'format' => '<small>1-39 characters: letters, digits, and <code>. _ @ -</code></small>',	// TODO
+			'format' => '<small>1-39 caracteres: letras, dígitos y <code>. _ @ -</code></small>',
 		),
 	),
 	'date' => array(
@@ -174,12 +174,12 @@ return array(
 		'confirm_exit_slider' => '¿Estás seguro de que quieres descartar los cambios no guardados?',
 		'feedback' => array(
 			'body_new_articles' => array(
-				0 => 'Hay %d artículo nuevo para leer en FreshRSS.',	// DIRTY
-				1 => 'Hay %d nuevos artículos para leer en FreshRSS.',	// DIRTY
+				0 => 'Hay %d artículo nuevo para leer en FreshRSS.',
+				1 => 'Hay %d artículos nuevos para leer en FreshRSS.',
 			),
 			'body_unread_articles' => array(
-				0 => '(No leídos: %d)',	// DIRTY
-				1 => '(No leídos: %d)',	// DIRTY
+				0 => '(sin leer: %d)',
+				1 => '(sin leer: %d)',
 			),
 			'request_failed' => 'La petición ha fallado. Puede ser debido a problemas de conexión a internet.',
 			'title_new_articles' => 'FreshRSS: ¡nuevos artículos!',
@@ -205,7 +205,7 @@ return array(
 		'it' => 'Italiano',	// IGNORE
 		'ja' => '日本語',	// IGNORE
 		'ko' => '한국어',	// IGNORE
-		'lt' => 'Lietuvių',	// TODO
+		'lt' => 'Lietuvių',	// IGNORE
 		'lv' => 'Latviešu',	// IGNORE
 		'nl' => 'Nederlands',	// IGNORE
 		'oc' => 'Occitan',	// IGNORE
@@ -304,7 +304,7 @@ return array(
 		'linkedin' => 'LinkedIn',	// IGNORE
 		'mastodon' => 'Mastodon',	// IGNORE
 		'movim' => 'Movim',	// IGNORE
-		'nextcloud-bookmarks' => 'Nextcloud Marcadores',	// DIRTY
+		'nextcloud-bookmarks' => 'Marcadores de Nextcloud',
 		'omnivore' => 'Omnivore',	// IGNORE
 		'pinboard' => 'Pinboard',	// IGNORE
 		'pinterest' => 'Pinterest',	// IGNORE

--- a/app/i18n/es/install.php
+++ b/app/i18n/es/install.php
@@ -64,8 +64,8 @@ return array(
 		),
 		'database-title' => 'Base de datos',
 		'docroot' => array(
-			'nok' => 'Your web server document root does not seem to point to the <code>./p/</code> folder. Other folders such as <code>./data/</code> may be publicly accessible.',	// TODO
-			'ok' => 'Your web server document root correctly points to the <code>./p/</code> folder.',	// TODO
+			'nok' => 'La raíz de documentos de su servidor web no parece apuntar a la carpeta <code>./p/</code>. Otras carpetas como <code>./data/</code> podrían ser accesibles públicamente.',
+			'ok' => 'La raíz de documentos de su servidor web apunta correctamente a la carpeta <code>./p/</code>.',
 		),
 		'dom' => array(
 			'nok' => 'No se ha podido localizar la librería necesaria para explorar la DOM.',
@@ -81,8 +81,8 @@ return array(
 		),
 		'files' => 'Instalación de Archivos',
 		'gmp' => array(
-			'nok' => 'Cannot find the required GMP extension for 32-bit PHP (php-gmp package).',	// TODO
-			'ok' => 'You have the GMP extension required for 32-bit PHP.',	// TODO
+			'nok' => 'No se puede encontrar la extensión GMP requerida para PHP de 32 bits (paquete php-gmp).',
+			'ok' => 'Tiene la extensión GMP requerida para PHP de 32 bits.',
 		),
 		'intl' => array(
 			'nok' => 'No se ha podido localizar la librería recomendada php-intl para internacionalización.',
@@ -149,7 +149,7 @@ return array(
 	'congratulations' => '¡Enhorabuena!',
 	'default_user' => array(
 		'_' => 'Nombre de usuario para el usuario por defecto',
-		'max_char' => '1-39 characters: letters, digits, and <code>. _ @ -</code>',	// TODO
+		'max_char' => '1-39 caracteres: letras, dígitos y <code>. _ @ -</code>',
 	),
 	'fix_errors_before' => 'Por favor, soluciona los errores detectados antes de proceder con el siguiente paso.',
 	'javascript_is_better' => 'FreshRSS funciona mejor con JavaScript activado',

--- a/app/i18n/es/sub.php
+++ b/app/i18n/es/sub.php
@@ -83,7 +83,7 @@ return array(
 			'help' => 'Escribir un filtro de búsqueda por línea. Ver <a href="https://freshrss.github.io/FreshRSS/en/users/10_filter.html#with-the-search-field" target="_blank">documentación de operadores de búsqueda</a>.',
 			'view_filter' => 'Vista previa de filtros en artículos existentes (nueva ventana)',
 		),
-		'global_hint' => 'Use <a href="%s">the global view</a> to see how many articles in each feed are matching a state or a search expression',	// TODO
+		'global_hint' => 'Utilice <a href="%s">la vista global</a> para ver cuántos artículos de cada fuente coinciden con un estado o una expresión de búsqueda',
 		'http_headers' => 'Cabeceras HTTP',
 		'http_headers_help' => 'Las cabeceras son separadas por un salto de línea, y el nombre y valor de una cabecera son separadas por dos puntos (e.g: <kbd><code>Accept: application/atom+xml<br />Authorization: Bearer some-token</code></kbd>).',
 		'icon' => 'Icono',


### PR DESCRIPTION
### Changes proposed in this pull request:

- Reviewed all remaining Spanish translations marked as TODO or DIRTY
- Updated translations against the current English source
- Removed obsolete TODO, DIRTY, and IGNORE markers after verification
- Brought Spanish translation completion to 100%

How to test the feature manually:

1. Select Spanish (Español) as the interface language
2. Navigate through the affected pages and menus
3. Verify that all translated strings are displayed correctly
4. Run `php cli/check.translation.php --display-report` and confirm Spanish is 100.0% complete

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated