### PR TITLE
Strip feed URL credentials from anonymous query.php output

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -1273,7 +1273,7 @@ class FreshRSS_Entry extends Minz_Model {
 			if ($mode === 'compat') {
 				$item['origin']['title'] = escapeToUnicodeAlternative($feed->name(), true);
 			} elseif ($mode === 'freshrss') {
-				$item['origin']['feedUrl'] = htmlspecialchars_decode($feed->url());
+				$item['origin']['feedUrl'] = htmlspecialchars_decode($feed->url(includeCredentials: false));
 			}
 			if ($feed->priority() >= FreshRSS_Feed::PRIORITY_MAIN_STREAM) {
 				$item['categories'][] = 'user/-/state/org.freshrss/main';


### PR DESCRIPTION
The public query-sharing endpoint `p/api/query.php` emits `origin.feedUrl` with the
full stored feed URL — including any `user:pass@` credentials — for `f=json` and
`f=greader`. An anonymous recipient of a "Share by RSS" link can therefore read the
credentials of the owner's private feeds.

This strips the `user:pass@` credentials from `feedUrl` on the public serialization
path (`mode === 'freshrss'`), matching what the logging and OPML export paths already do.

Note: `SimplePie\Misc::url_remove_credentials()` only removes `user:pass@` userinfo, not
secrets passed as query parameters (e.g. `?apikey=…`), which would still appear in
`feedUrl`. Since `mode === 'freshrss'` is used only by this anonymous share export (the
authenticated GReader API uses `compat`, which omits `feedUrl` entirely), if you'd like
to close that case too, `feedUrl` could instead be dropped on this path. Happy to adjust.

Reported privately in GHSA-rpmm-h4hx-5p6p.
