### PR TITLE
Gate greader/json share formats behind Share by OPML

### DIFF
--- a/app/Models/UserQuery.php
+++ b/app/Models/UserQuery.php
@@ -347,7 +347,7 @@ class FreshRSS_UserQuery {
 	}
 
 	public function sharedUrlGreader(bool $xmlEscaped = true): string {
-		if ($this->shareRss && $this->token !== '') {
+		if ($this->shareOpml && $this->token !== '') {
 			return $this->sharedUrl($xmlEscaped) . ($xmlEscaped ? '&amp;' : '&') . 'f=greader';
 		}
 		return '';

--- a/app/views/helpers/configure/query.phtml
+++ b/app/views/helpers/configure/query.phtml
@@ -48,7 +48,6 @@
 						<?php if ($this->query->sharedUrlRss() !== ''): ?>
 						<ul>
 							<li><a href="<?= $this->query->sharedUrlHtml() ?>"><?= _i('link') ?> <?= _t('conf.query.share.html') ?></a></li>
-							<li><a href="<?= $this->query->sharedUrlGreader() ?>"><?= _i('link') ?> <?= _t('conf.query.share.greader') ?></a></li>
 							<li><a href="<?= $this->query->sharedUrlRss() ?>"><?= _i('link') ?> <?= _t('conf.query.share.rss') ?></a></li>
 						</ul>
 					</div>
@@ -75,6 +74,7 @@
 						<?php if ($this->query->sharedUrlOpml() !== ''): ?>
 						<ul>
 							<li><a href="<?= $this->query->sharedUrlOpml() ?>"><?= _i('link') ?> <?= _t('conf.query.share.opml') ?></a></li>
+							<li><a href="<?= $this->query->sharedUrlGreader() ?>"><?= _i('link') ?> <?= _t('conf.query.share.greader') ?></a></li>
 						</ul>
 						<?php endif; ?>
 					</div>

--- a/p/api/query.php
+++ b/p/api/query.php
@@ -75,14 +75,14 @@ foreach (FreshRSS_Context::userConf()->queries as $raw_query) {
 	if (!empty($raw_query['token']) && hash_equals($raw_query['token'], $token)) {
 		switch ($format) {
 			case 'atom':
-			case 'greader':
 			case 'html':
-			case 'json':
 			case 'rss':
 				if (empty($raw_query['shareRss'])) {
 					continue 2;
 				}
 				break;
+			case 'greader':
+			case 'json':
 			case 'opml':
 				if (empty($raw_query['shareOpml'])) {
 					continue 2;


### PR DESCRIPTION
Follow-up to #9246, per @Alkarex's suggestion on GHSA-rpmm-h4hx-5p6p.

The greader and json share formats expose origin.feedUrl (the feed's subscription URL). Sharing feed URLs is what the "Share by OPML" option explicitly means, whereas "Share by RSS" is meant to share article content. This moves greader and json in p/api/query.php from the shareRss gate to the shareOpml gate, so feed URLs are only served when the owner opted into OPML sharing.

Note: moved json alongside greader too, since both emit feedUrl (same toGReader path).
