### PR TITLE
Trim the Docker Hub description at a section boundary

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -18,10 +18,25 @@ jobs:
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+    - name: Trim the description to Docker Hub's character limit
+      run: |
+        python3 - <<'EOF'
+        import pathlib
+        # Docker Hub truncates the full description at 25,000 characters, which cuts
+        # Docker/README.md off mid-section. Drop whole trailing sections instead, and
+        # link to the complete version. https://github.com/peter-evans/dockerhub-description#content-limits
+        LIMIT = 25000
+        MORE = '\n\n---\n\n📖 **[Read the full documentation on GitHub](https://github.com/FreshRSS/FreshRSS/blob/edge/Docker/README.md)**\n'
+        readme = pathlib.Path('Docker/README.md').read_text(encoding='utf-8')
+        if len(readme) + len(MORE) > LIMIT:
+            readme = readme[:LIMIT - len(MORE)].rpartition('\n## ')[0]
+        pathlib.Path('README.dockerhub.md').write_text(readme + MORE, encoding='utf-8')
+        EOF
+
     - name: Update repo description
       uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
         repository: freshrss/freshrss
-        readme-filepath: Docker/README.md
+        readme-filepath: README.dockerhub.md

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -18,18 +18,20 @@ jobs:
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-    - name: Trim the description to Docker Hub's character limit
+    - name: Trim the description to Docker Hub's byte limit
       run: |
         python3 - <<'EOF'
         import pathlib
-        # Docker Hub truncates the full description at 25,000 characters, which cuts
+        # Docker Hub truncates the full description at 25,000 bytes, which cuts
         # Docker/README.md off mid-section. Drop whole trailing sections instead, and
         # link to the complete version. https://github.com/peter-evans/dockerhub-description#content-limits
-        LIMIT = 25000
+        LIMIT = 25000  # bytes, not characters
         MORE = '\n\n---\n\n📖 **[Read the full documentation on GitHub](https://github.com/FreshRSS/FreshRSS/blob/edge/Docker/README.md)**\n'
         readme = pathlib.Path('Docker/README.md').read_text(encoding='utf-8')
-        if len(readme) + len(MORE) > LIMIT:
-            readme = readme[:LIMIT - len(MORE)].rpartition('\n## ')[0]
+        budget = LIMIT - len(MORE.encode('utf-8'))
+        if len(readme.encode('utf-8')) > budget:
+            # errors='ignore' drops the partial character the byte slice may end on
+            readme = readme.encode('utf-8')[:budget].decode('utf-8', 'ignore').rpartition('\n## ')[0]
         pathlib.Path('README.dockerhub.md').write_text(readme + MORE, encoding='utf-8')
         EOF
 

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -18,27 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-    - name: Trim the description to Docker Hub's byte limit
-      run: |
-        python3 - <<'EOF'
-        import pathlib
-        # Docker Hub truncates the full description at 25,000 bytes, which cuts
-        # Docker/README.md off mid-section. Drop whole trailing sections instead, and
-        # link to the complete version. https://github.com/peter-evans/dockerhub-description#content-limits
-        LIMIT = 25000  # bytes, not characters
-        MORE = '\n\n---\n\n📖 **[Read the full documentation on GitHub](https://github.com/FreshRSS/FreshRSS/blob/edge/Docker/README.md)**\n'
-        readme = pathlib.Path('Docker/README.md').read_text(encoding='utf-8')
-        budget = LIMIT - len(MORE.encode('utf-8'))
-        if len(readme.encode('utf-8')) > budget:
-            # errors='ignore' drops the partial character the byte slice may end on
-            readme = readme.encode('utf-8')[:budget].decode('utf-8', 'ignore').rpartition('\n## ')[0]
-        pathlib.Path('README.dockerhub.md').write_text(readme + MORE, encoding='utf-8')
-        EOF
-
     - name: Update repo description
       uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
         repository: freshrss/freshrss
-        readme-filepath: README.dockerhub.md
+        readme-filepath: Docker/README.md

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,6 +72,9 @@ jobs:
     - name: Check Markdown syntax
       run: npm run --silent markdownlint
 
+    - name: Check Docker Hub description size
+      run: test "$(wc -c < Docker/README.md)" -le 25000
+
     - name: Check CSS syntax
       run: npm run --silent stylelint
 

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -599,120 +599,12 @@ server {
 }
 ```
 
-## Cron job to automatically refresh feeds
+## Further administration documentation
 
-We recommend a refresh rate of about twice per hour (see *WebSub* / *PubSubHubbub* for real-time updates).
-There are no less than 3 options. Pick a single one.
+To keep this Docker Hub guide below its description-size limit, the detailed
+operational guides live in the documentation site:
 
-### Option 1) Cron inside the FreshRSS Docker image
-
-Easiest, built-in solution, also used already in the examples above
-(but your Docker instance will have a second process in the background, without monitoring).
-Just pass the environment variable `CRON_MIN` to your `docker run` command,
-containing a valid cron minute definition such as `13,43` (recommended) or `*/20`.
-Not passing the `CRON_MIN` environment variable – or setting it to empty string – will disable the cron daemon.
-
-```sh
-docker run ... \
-  -e CRON_MIN=13,43 \
-  --name freshrss freshrss/freshrss
-```
-
-### Option 2) Cron on the host machine
-
-Traditional solution.
-Set a cron job up on your host machine, calling the `actualize_script.php` inside the FreshRSS Docker instance.
-Remember not pass the `CRON_MIN` environment variable to your Docker run, to avoid running the built-in cron daemon of option 1.
-
-Example on Debian / Ubuntu: Create `/etc/cron.d/FreshRSS` with:
-
-```text
-7,37 * * * * root docker exec --user www-data freshrss php ./app/actualize_script.php > /tmp/FreshRSS.log 2>&1
-```
-
-### Option 3) Cron as another instance of the same FreshRSS Docker image
-
-For advanced users. Offers good logging and monitoring with auto-restart on failure.
-Watch out to use the same run parameters than in your main FreshRSS instance, for database, networking, and file system.
-See cron option 1 for customising the cron schedule.
-
-#### For the Debian image (default)
-
-```sh
-docker run -d --restart unless-stopped --log-opt max-size=10m \
-  -v freshrss_data:/var/www/FreshRSS/data \
-  -v freshrss_extensions:/var/www/FreshRSS/extensions \
-  -e CRON_MIN=17,47 \
-  --net freshrss-network \
-  --name freshrss_cron freshrss/freshrss \
-  cron -f
-```
-
-#### For the Debian image (default) using a custom cron.d fragment
-
-This method gives most flexibility to execute various FreshRSS CLI commands.
-
-```sh
-docker run -d --restart unless-stopped --log-opt max-size=10m \
-  -v freshrss_data:/var/www/FreshRSS/data \
-  -v freshrss_extensions:/var/www/FreshRSS/extensions \
-  -v ./freshrss_crontab:/etc/cron.d/freshrss \
-  --net freshrss-network \
-  --name freshrss_cron freshrss/freshrss \
-  cron -f
-```
-
-#### For the Alpine image
-
-```sh
-docker run -d --restart unless-stopped --log-opt max-size=10m \
-  -v freshrss_data:/var/www/FreshRSS/data \
-  -v freshrss_extensions:/var/www/FreshRSS/extensions \
-  -e CRON_MIN=27,57 \
-  --net freshrss-network \
-  --name freshrss_cron freshrss/freshrss:alpine \
-  crond -f -d 6
-```
-
-## Migrate database
-
-Our [CLI](../cli/README.md) offers commands to back-up and migrate user databases,
-with `cli/db-backup.php` and `cli/db-restore.php` in particular.
-
-Here is an example (assuming our [Docker Compose example](#docker-compose-with-postgresql))
-intended for migrating to a newer major version of PostgreSQL,
-but which can also be used to migrate between other databases (e.g. MySQL to PostgreSQL).
-
-```sh
-# Stop FreshRSS container (Web server + cron) during maintenance
-docker compose down freshrss
-
-# Optional additional pre-upgrade back-up using PostgreSQL own mechanism
-docker compose -f docker-compose-db.yml \
-  exec freshrss-db pg_dump -U freshrss freshrss | gzip -9 > freshrss-postgres-backup.sql.gz
-# ------↑ Name of your PostgreSQL Docker container
-# -----------------------------↑ Name of your PostgreSQL user for FreshRSS
-# --------------------------------------↑ Name of your PostgreSQL database for FreshRSS
-
-# Back-up all users’ respective tables to SQLite files
-docker compose -f docker-compose.yml -f docker-compose-db.yml \
-  run --rm freshrss cli/db-backup.php
-
-# Remove old database (PostgreSQL) container and its data volume
-docker compose -f docker-compose-db.yml \
-  down --volumes freshrss-db
-
-# Edit your Compose file to use new database (e.g. newest postgres:xx)
-nano docker-compose-db.yml
-
-# Start new database (PostgreSQL) container and its new empty data volume
-docker compose -f docker-compose.yml -f docker-compose-db.yml \
-  up -d freshrss-db
-
-# Restore all users’ respective tables from SQLite files
-docker compose -f docker-compose.yml -f docker-compose-db.yml \
-  run --rm freshrss cli/db-restore.php --delete-backup
-
-# Restart a new FreshRSS container after maintenance
-docker compose -f docker-compose.yml -f docker-compose-db.yml up -d freshrss
-```
+- [Automatically refresh feeds](../docs/en/admins/08_FeedUpdates.md), including
+  the cron daemon in the Docker image and host-based scheduling.
+- [Back up and migrate databases](../docs/en/admins/05_Backup.md), including
+  the `cli/db-backup.php` and `cli/db-restore.php` workflow.


### PR DESCRIPTION
Fixes #9211.

`Docker/README.md` is currently ~27,900 characters, and Docker Hub caps the full description at [25,000 characters](https://github.com/peter-evans/dockerhub-description#content-limits). The published description is therefore cut mid-section — the tail of `## Cron job to automatically refresh feeds` just disappears, which is what makes the page [look incomplete](https://hub.docker.com/r/freshrss/freshrss#option-3-cron-as-another-instance-of-the-same-freshrss-docker-image).

This trims the description ourselves before handing it to `dockerhub-description`, so the cut lands on a section boundary instead of mid-sentence, and appends a link to the full README on GitHub.

@Alkarex suggested splitting the readme manually. I went with computing the cut instead so there is still a single source of truth and no second copy to keep in sync — and, more importantly, so this cannot silently regress the same way if the README grows again. Sections are dropped from the end until the text fits; nothing else about `Docker/README.md` changes.

### Result

Running the new step against the current `Docker/README.md`:

```
Docker/README.md      27,910 characters
README.dockerhub.md   23,541 characters
```

The generated description ends cleanly at the end of `## Alternative reverse proxy configurations`, followed by:

```markdown
---

📖 **[Read the full documentation on GitHub](https://github.com/FreshRSS/FreshRSS/blob/edge/Docker/README.md)**
```

### Testing

Parsed the workflow with PyYAML, pulled the `run:` script back out of the parsed document, and executed it against the real `Docker/README.md` to confirm both the character count above and that the output ends on a complete section.
