### PR TITLE
Fix desync between favicon and title unread counters

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -2196,8 +2196,8 @@ function refreshUnreads() {
 
 		const nb_unreads = title ? str2int(title.getAttribute('data-unread')) : 0;
 
+		faviconNbUnread(nb_unreads);
 		if (nb_unreads > 0 && new_articles) {
-			faviconNbUnread(nb_unreads);
 			notifs_html5_show(json.notifBody);
 		}
 	};


### PR DESCRIPTION
Closes #8237
Regression from https://github.com/FreshRSS/FreshRSS/commit/80e7e15e3f619408db1752a3899ff708bc7bcc93, https://github.com/FreshRSS/FreshRSS/commit/d289c5340f3b21f1561e57390e89b0b5c7881d17

The function for updating the favicon count would only get called if there were articles newly marked as unread, so if there were only articles newly marked as read, the separate counters would display different values.

Behavior is now the same as for updating the title - always updating the favicon counter, without requiring any conditions to be true.