### PR TITLE
Fix typo in alert error border color variable

### DIFF
--- a/p/themes/Dark/dark.css
+++ b/p/themes/Dark/dark.css
@@ -40,7 +40,7 @@
 	--alert-success-border-color: #484;
 	--alert-success-background-color: inherit;
 	--alert-error-font-color: #a44;
-	--alert-error-boder-color: #a44;
+	--alert-error-border-color: #a44;
 	--alert-error-background-color: inherit;
 
 	--box-shadow-color: #000a;

--- a/p/themes/Dark/dark.rtl.css
+++ b/p/themes/Dark/dark.rtl.css
@@ -40,7 +40,7 @@
 	--alert-success-border-color: #484;
 	--alert-success-background-color: inherit;
 	--alert-error-font-color: #a44;
-	--alert-error-boder-color: #a44;
+	--alert-error-border-color: #a44;
 	--alert-error-background-color: inherit;
 
 	--box-shadow-color: #000a;

--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -50,7 +50,7 @@
 	--alert-success-border-color: #cec;
 	--alert-error-background-color: #fdd;
 	--alert-error-font-color: #693a3a;
-	--alert-error-boder-color: #ecc;
+	--alert-error-border-color: #ecc;
 
 	--notification-good-background-color: #ffe;
 	--notification-good-border-color: #eeb;
@@ -558,7 +558,7 @@ button:hover .icon,
 .alert-error {
 	background-color: var(--alert-error-background-color);
 	color: var(--alert-error-font-color);
-	border: 1px solid var(--alert-error-boder-color);
+	border: 1px solid var(--alert-error-border-color);
 }
 
 .alert-error a {
@@ -1302,7 +1302,7 @@ button:hover .icon,
 		--alert-success-border-color: #cec;
 		--alert-error-background-color: #fdda;
 		--alert-error-font-color: #512b2b;
-		--alert-error-boder-color: #ecc;
+		--alert-error-border-color: #ecc;
 
 		--notification-good-background-color: #ffe;
 		--notification-good-border-color: #eeb;

--- a/p/themes/Origine/origine.rtl.css
+++ b/p/themes/Origine/origine.rtl.css
@@ -50,7 +50,7 @@
 	--alert-success-border-color: #cec;
 	--alert-error-background-color: #fdd;
 	--alert-error-font-color: #693a3a;
-	--alert-error-boder-color: #ecc;
+	--alert-error-border-color: #ecc;
 
 	--notification-good-background-color: #ffe;
 	--notification-good-border-color: #eeb;
@@ -558,7 +558,7 @@ button:hover .icon,
 .alert-error {
 	background-color: var(--alert-error-background-color);
 	color: var(--alert-error-font-color);
-	border: 1px solid var(--alert-error-boder-color);
+	border: 1px solid var(--alert-error-border-color);
 }
 
 .alert-error a {
@@ -1302,7 +1302,7 @@ button:hover .icon,
 		--alert-success-border-color: #cec;
 		--alert-error-background-color: #fdda;
 		--alert-error-font-color: #512b2b;
-		--alert-error-boder-color: #ecc;
+		--alert-error-border-color: #ecc;
 
 		--notification-good-background-color: #ffe;
 		--notification-good-border-color: #eeb;


### PR DESCRIPTION
Changes proposed in this pull request:

Fix typo in alert error border color variable.

How to test the feature manually:

1. Test an error alert message with the changed code.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://freshrss.github.io/FreshRSS/en/developers/04_Pull_requests.html).
