### PR TITLE
Only allow http/https URI schemes for enclosure and thumbnail URLs

### DIFF
--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -227,7 +227,7 @@ class FreshRSS_Entry extends Minz_Model {
 		$thumbnailAttribute = $this->attributeArray('thumbnail') ?? [];
 		if (!empty($thumbnailAttribute['url'])) {
 			$elink = $thumbnailAttribute['url'];
-			if (is_string($elink) && FreshRSS_http_Util::isAllowedUrlScheme($elink) &&
+			if (is_string($elink) && \SimplePie\Misc::is_remote_uri($elink) &&
 				($allowDuplicateEnclosures || !self::containsLink($content, $elink))) {
 				$content .= <<<HTML
 					<figure class="enclosure">
@@ -249,7 +249,7 @@ class FreshRSS_Entry extends Minz_Model {
 				continue;
 			}
 			$elink = $enclosure['url'] ?? '';
-			if ($elink == '' || !is_string($elink) || !FreshRSS_http_Util::isAllowedUrlScheme($elink)) {
+			if ($elink == '' || !is_string($elink) || !\SimplePie\Misc::is_remote_uri($elink)) {
 				continue;
 			}
 			if (!$allowDuplicateEnclosures && self::containsLink($content, $elink)) {
@@ -270,7 +270,7 @@ class FreshRSS_Entry extends Minz_Model {
 			$content .= '<figure class="enclosure">';
 
 			foreach ($thumbnails as $thumbnail) {
-				if (is_string($thumbnail) && FreshRSS_http_Util::isAllowedUrlScheme($thumbnail)) {
+				if (is_string($thumbnail) && \SimplePie\Misc::is_remote_uri($thumbnail)) {
 					$content .= '<p><img class="enclosure-thumbnail" src="' . $thumbnail . '" alt="" title="' . $etitle . '" /></p>';
 				}
 			}

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -227,7 +227,8 @@ class FreshRSS_Entry extends Minz_Model {
 		$thumbnailAttribute = $this->attributeArray('thumbnail') ?? [];
 		if (!empty($thumbnailAttribute['url'])) {
 			$elink = $thumbnailAttribute['url'];
-			if (is_string($elink) && ($allowDuplicateEnclosures || !self::containsLink($content, $elink))) {
+			if (is_string($elink) && FreshRSS_http_Util::isAllowedUrlScheme($elink) &&
+				($allowDuplicateEnclosures || !self::containsLink($content, $elink))) {
 				$content .= <<<HTML
 					<figure class="enclosure">
 						<p class="enclosure-content">
@@ -248,7 +249,7 @@ class FreshRSS_Entry extends Minz_Model {
 				continue;
 			}
 			$elink = $enclosure['url'] ?? '';
-			if ($elink == '' || !is_string($elink)) {
+			if ($elink == '' || !is_string($elink) || !FreshRSS_http_Util::isAllowedUrlScheme($elink)) {
 				continue;
 			}
 			if (!$allowDuplicateEnclosures && self::containsLink($content, $elink)) {
@@ -269,7 +270,7 @@ class FreshRSS_Entry extends Minz_Model {
 			$content .= '<figure class="enclosure">';
 
 			foreach ($thumbnails as $thumbnail) {
-				if (is_string($thumbnail)) {
+				if (is_string($thumbnail) && FreshRSS_http_Util::isAllowedUrlScheme($thumbnail)) {
 					$content .= '<p><img class="enclosure-thumbnail" src="' . $thumbnail . '" alt="" title="' . $etitle . '" /></p>';
 				}
 			}

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -842,7 +842,7 @@ class FreshRSS_Feed extends Minz_Model {
 
 			$attributeThumbnail = $item->get_thumbnail() ?? [];
 			if (empty($attributeThumbnail['url']) || !is_string($attributeThumbnail['url']) ||
-				!FreshRSS_http_Util::isAllowedUrlScheme($attributeThumbnail['url'])) {
+				!\SimplePie\Misc::is_remote_uri($attributeThumbnail['url'])) {
 				$attributeThumbnail['url'] = '';
 			}
 
@@ -852,7 +852,7 @@ class FreshRSS_Feed extends Minz_Model {
 			if (!empty($enclosures)) {
 				foreach ($enclosures as $enclosure) {
 					$elink = $enclosure->get_link();
-					if (is_string($elink) && $elink !== '' && FreshRSS_http_Util::isAllowedUrlScheme($elink)) {
+					if (is_string($elink) && $elink !== '' && \SimplePie\Misc::is_remote_uri($elink)) {
 						$etitle = $enclosure->get_title() ?? '';
 						$credits = $enclosure->get_credits() ?? null;
 						$description = $enclosure->get_description() ?? '';
@@ -895,7 +895,7 @@ class FreshRSS_Feed extends Minz_Model {
 
 						if (!empty($enclosure->get_thumbnails())) {
 							foreach ($enclosure->get_thumbnails() as $thumbnail) {
-								if (is_string($thumbnail) && FreshRSS_http_Util::isAllowedUrlScheme($thumbnail) &&
+								if (is_string($thumbnail) && \SimplePie\Misc::is_remote_uri($thumbnail) &&
 									$thumbnail !== $attributeThumbnail['url']) {
 									$attributeEnclosure['thumbnails'][] = $thumbnail;
 								}

--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -841,7 +841,8 @@ class FreshRSS_Feed extends Minz_Model {
 			$content = html_only_entity_decode($item->get_content());
 
 			$attributeThumbnail = $item->get_thumbnail() ?? [];
-			if (empty($attributeThumbnail['url'])) {
+			if (empty($attributeThumbnail['url']) || !is_string($attributeThumbnail['url']) ||
+				!FreshRSS_http_Util::isAllowedUrlScheme($attributeThumbnail['url'])) {
 				$attributeThumbnail['url'] = '';
 			}
 
@@ -851,7 +852,7 @@ class FreshRSS_Feed extends Minz_Model {
 			if (!empty($enclosures)) {
 				foreach ($enclosures as $enclosure) {
 					$elink = $enclosure->get_link();
-					if ($elink != '') {
+					if (is_string($elink) && $elink !== '' && FreshRSS_http_Util::isAllowedUrlScheme($elink)) {
 						$etitle = $enclosure->get_title() ?? '';
 						$credits = $enclosure->get_credits() ?? null;
 						$description = $enclosure->get_description() ?? '';
@@ -894,7 +895,8 @@ class FreshRSS_Feed extends Minz_Model {
 
 						if (!empty($enclosure->get_thumbnails())) {
 							foreach ($enclosure->get_thumbnails() as $thumbnail) {
-								if ($thumbnail !== $attributeThumbnail['url']) {
+								if (is_string($thumbnail) && FreshRSS_http_Util::isAllowedUrlScheme($thumbnail) &&
+									$thumbnail !== $attributeThumbnail['url']) {
 									$attributeEnclosure['thumbnails'][] = $thumbnail;
 								}
 							}

--- a/app/Utils/httpUtil.php
+++ b/app/Utils/httpUtil.php
@@ -106,24 +106,6 @@ final class FreshRSS_http_Util {
 	}
 
 	/**
-	 * Check whether a URL uses an allowed URI scheme (http or https), for user-facing links
-	 * such as feed enclosures and thumbnails. Consistent with the protocols allowed for fetching.
-	 * Strips control characters and whitespace, which browsers ignore when parsing the scheme.
-	 */
-	public static function isAllowedUrlScheme(string $url): bool {
-		$url = preg_replace('/[\x00-\x20\x7f]/', '', $url) ?? '';
-		$pos = strpos($url, ':');
-		if ($pos === false) {
-			return false;	// Relative URLs are not usable for external enclosures
-		}
-		$scheme = strtolower(substr($url, 0, $pos));
-		if (!ctype_alnum($scheme)) {
-			return false;
-		}
-		return $scheme === 'http' || $scheme === 'https';
-	}
-
-	/**
 	 * @param array<mixed> $curl_params
 	 * @return array<mixed>
 	 */

--- a/app/Utils/httpUtil.php
+++ b/app/Utils/httpUtil.php
@@ -106,6 +106,24 @@ final class FreshRSS_http_Util {
 	}
 
 	/**
+	 * Check whether a URL uses an allowed URI scheme (http or https), for user-facing links
+	 * such as feed enclosures and thumbnails. Consistent with the protocols allowed for fetching.
+	 * Strips control characters and whitespace, which browsers ignore when parsing the scheme.
+	 */
+	public static function isAllowedUrlScheme(string $url): bool {
+		$url = preg_replace('/[\x00-\x20\x7f]/', '', $url) ?? '';
+		$pos = strpos($url, ':');
+		if ($pos === false) {
+			return false;	// Relative URLs are not usable for external enclosures
+		}
+		$scheme = strtolower(substr($url, 0, $pos));
+		if (!ctype_alnum($scheme)) {
+			return false;
+		}
+		return $scheme === 'http' || $scheme === 'https';
+	}
+
+	/**
 	 * @param array<mixed> $curl_params
 	 * @return array<mixed>
 	 */

--- a/tests/app/Models/EntryTest.php
+++ b/tests/app/Models/EntryTest.php
@@ -25,7 +25,7 @@ final class EntryTest extends \PHPUnit\Framework\TestCase {
 
 	#[DataProvider('provideUrlSchemes')]
 	public function test_isAllowedUrlScheme(string $url, bool $expected): void {
-		self::assertSame($expected, FreshRSS_http_Util::isAllowedUrlScheme($url));
+		self::assertSame($expected, \SimplePie\Misc::is_remote_uri($url));
 	}
 
 	public function test_content_dropsUnsafeEnclosureUrls(): void {

--- a/tests/app/Models/EntryTest.php
+++ b/tests/app/Models/EntryTest.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class EntryTest extends \PHPUnit\Framework\TestCase {
+
+	/** @return list<array{string,bool}> */
+	public static function provideUrlSchemes(): array {
+		return [
+			['https://example.com/podcast.mp3', true],
+			['HTTPS://EXAMPLE.com/a.mp3', true],
+			['http://example.com/a.mp3', true],
+			['javascript:alert(document.domain)//', false],
+			['JAVASCRIPT:alert(1)', false],
+			["java\tscript:alert(1)", false],
+			['java\nscript:alert(1)', false],
+			['vbscript:msgbox(1)', false],
+			['data:image/png;base64,AAAA', false],
+			['file:///etc/passwd', false],
+			['relative/path.mp3', false],
+			['', false],
+		];
+	}
+
+	#[DataProvider('provideUrlSchemes')]
+	public function test_isAllowedUrlScheme(string $url, bool $expected): void {
+		self::assertSame($expected, FreshRSS_http_Util::isAllowedUrlScheme($url));
+	}
+
+	public function test_content_dropsUnsafeEnclosureUrls(): void {
+		$entry = new FreshRSS_Entry(1, 'poc-001', 'Victim Article', '', 'Hello', '', 1700000000);
+		$entry->_attribute('enclosures', [
+			['url' => 'javascript:alert(document.domain)//', 'type' => 'application/octet-stream'],
+			['url' => 'https://example.com/podcast.mp3', 'type' => 'audio/mpeg'],
+			['url' => 'https://example.com/pic.jpg', 'thumbnails' => [
+				'javascript:alert(1)',
+				'https://example.com/thumb.jpg',
+			]],
+		]);
+		$entry->_attribute('thumbnail', ['url' => 'javascript:alert(2)']);
+
+		$html = $entry->content();
+
+		self::assertStringNotContainsString('javascript:', $html);
+		self::assertStringContainsString('href="https://example.com/podcast.mp3"', $html);
+		self::assertStringContainsString('src="https://example.com/thumb.jpg"', $html);
+		self::assertStringContainsString('Hello', $html);
+	}
+
+	public function test_content_dropsUnsafeThumbnailAttribute(): void {
+		$entry = new FreshRSS_Entry(1, 'poc-002', 'Victim Article', '', 'Hello', '', 1700000000);
+		$entry->_attribute('thumbnail', ['url' => 'javascript:alert(2)']);
+
+		$html = $entry->content();
+
+		self::assertStringNotContainsString('javascript:', $html);
+		self::assertStringContainsString('Hello', $html);
+	}
+}

--- a/tests/app/Models/EntryTest.php
+++ b/tests/app/Models/EntryTest.php
@@ -1,44 +1,62 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\Attributes\DataProvider;
-
 final class EntryTest extends \PHPUnit\Framework\TestCase {
 
-	/** @return list<array{string,bool}> */
-	public static function provideUrlSchemes(): array {
-		return [
-			['https://example.com/podcast.mp3', true],
-			['HTTPS://EXAMPLE.com/a.mp3', true],
-			['http://example.com/a.mp3', true],
-			['javascript:alert(document.domain)//', false],
-			['JAVASCRIPT:alert(1)', false],
-			["java\tscript:alert(1)", false],
-			['java\nscript:alert(1)', false],
-			['vbscript:msgbox(1)', false],
-			['data:image/png;base64,AAAA', false],
-			['file:///etc/passwd', false],
-			['relative/path.mp3', false],
-			['', false],
-		];
+	#[\Override]
+	public static function setUpBeforeClass(): void {
+		FreshRSS_Context::initSystem();
 	}
 
-	#[DataProvider('provideUrlSchemes')]
-	public function test_isAllowedUrlScheme(string $url, bool $expected): void {
-		self::assertSame($expected, \SimplePie\Misc::is_remote_uri($url));
+	/**
+	 * Parse a raw RSS payload through the real feed processing pipeline.
+	 * @return list<FreshRSS_Entry>
+	 */
+	private static function entriesFromRss(string $rss): array {
+		$feed = new FreshRSS_Feed('http://example.net/feed.xml', validate: false);
+		$feed->_id(1);
+		$simplePie = new FreshRSS_SimplePieCustom();
+		$simplePie->enable_cache(false);
+		$simplePie->set_raw_data($rss);
+		self::assertTrue($simplePie->init());
+		return array_values(iterator_to_array($feed->loadEntries($simplePie)));
 	}
 
 	public function test_content_dropsUnsafeEnclosureUrls(): void {
-		$entry = new FreshRSS_Entry(1, 'poc-001', 'Victim Article', '', 'Hello', '', 1700000000);
-		$entry->_attribute('enclosures', [
-			['url' => 'javascript:alert(document.domain)//', 'type' => 'application/octet-stream'],
-			['url' => 'https://example.com/podcast.mp3', 'type' => 'audio/mpeg'],
-			['url' => 'https://example.com/pic.jpg', 'thumbnails' => [
-				'javascript:alert(1)',
-				'https://example.com/thumb.jpg',
-			]],
-		]);
-		$entry->_attribute('thumbnail', ['url' => 'javascript:alert(2)']);
+		$rss = <<<XML
+			<?xml version="1.0" encoding="UTF-8"?>
+			<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+				<channel>
+					<title>Malicious feed</title>
+					<link>https://example.net/</link>
+					<description>Feed with malicious enclosure URLs</description>
+					<item>
+						<title>Victim Article</title>
+						<link>https://example.net/article</link>
+						<guid isPermaLink="false">poc-001</guid>
+						<pubDate>Tue, 14 Nov 2023 20:13:20 +0000</pubDate>
+						<description>Hello</description>
+						<enclosure url="javascript:alert(document.domain)//" length="0" type="application/octet-stream" />
+						<enclosure url="https://example.com/podcast.mp3" length="1234" type="audio/mpeg" />
+						<media:content url="https://example.com/pic.jpg" type="image/jpeg">
+							<media:thumbnail url="javascript:alert(1)" />
+							<media:thumbnail url="https://example.com/thumb.jpg" />
+						</media:content>
+						<media:thumbnail url="javascript:alert(2)" />
+					</item>
+				</channel>
+			</rss>
+			XML;
+
+		$entries = self::entriesFromRss($rss);
+		self::assertCount(1, $entries);
+		$entry = $entries[0];
+		self::assertSame('Victim Article', $entry->title());
+
+		// The malicious enclosure must not even be stored as an attribute
+		$enclosureUrls = array_column($entry->attributeArray('enclosures') ?? [], 'url');
+		self::assertNotContains('javascript:alert(document.domain)//', $enclosureUrls);
+		self::assertContains('https://example.com/podcast.mp3', $enclosureUrls);
 
 		$html = $entry->content();
 
@@ -49,8 +67,31 @@ final class EntryTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function test_content_dropsUnsafeThumbnailAttribute(): void {
-		$entry = new FreshRSS_Entry(1, 'poc-002', 'Victim Article', '', 'Hello', '', 1700000000);
-		$entry->_attribute('thumbnail', ['url' => 'javascript:alert(2)']);
+		$rss = <<<XML
+			<?xml version="1.0" encoding="UTF-8"?>
+			<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+				<channel>
+					<title>Malicious feed</title>
+					<link>https://example.net/</link>
+					<description>Feed with a malicious thumbnail URL</description>
+					<item>
+						<title>Victim Article</title>
+						<link>https://example.net/article</link>
+						<guid isPermaLink="false">poc-002</guid>
+						<pubDate>Tue, 14 Nov 2023 20:13:20 +0000</pubDate>
+						<description>Hello</description>
+						<media:thumbnail url="javascript:alert(2)" />
+					</item>
+				</channel>
+			</rss>
+			XML;
+
+		$entries = self::entriesFromRss($rss);
+		self::assertCount(1, $entries);
+		$entry = $entries[0];
+
+		// The malicious thumbnail must not be stored as an attribute
+		self::assertNull($entry->attributeArray('thumbnail'));
 
 		$html = $entry->content();
 

--- a/tests/app/Models/EntryTest.php
+++ b/tests/app/Models/EntryTest.php
@@ -22,7 +22,7 @@ final class EntryTest extends \PHPUnit\Framework\TestCase {
 		return array_values(iterator_to_array($feed->loadEntries($simplePie)));
 	}
 
-	public function test_content_dropsUnsafeEnclosureUrls(): void {
+	public function test_content_dropsUnsafeEnclosureAndThumbnailUrls(): void {
 		$rss = <<<XML
 			<?xml version="1.0" encoding="UTF-8"?>
 			<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
@@ -38,9 +38,11 @@ final class EntryTest extends \PHPUnit\Framework\TestCase {
 						<description>Hello</description>
 						<enclosure url="javascript:alert(document.domain)//" length="0" type="application/octet-stream" />
 						<enclosure url="https://example.com/podcast.mp3" length="1234" type="audio/mpeg" />
+						<enclosure url="//cdn.example.com/podcast2.mp3" length="1234" type="audio/mpeg" />
 						<media:content url="https://example.com/pic.jpg" type="image/jpeg">
 							<media:thumbnail url="javascript:alert(1)" />
 							<media:thumbnail url="https://example.com/thumb.jpg" />
+							<media:thumbnail url="//cdn.example.com/thumb2.jpg" />
 						</media:content>
 						<media:thumbnail url="javascript:alert(2)" />
 					</item>
@@ -53,49 +55,41 @@ final class EntryTest extends \PHPUnit\Framework\TestCase {
 		$entry = $entries[0];
 		self::assertSame('Victim Article', $entry->title());
 
+		// The malicious `<media:thumbnail>` of the item must not be stored as an attribute
+		self::assertNull($entry->attributeArray('thumbnail'));
+
 		// The malicious enclosure must not even be stored as an attribute
 		$enclosureUrls = array_column($entry->attributeArray('enclosures') ?? [], 'url');
 		self::assertNotContains('javascript:alert(document.domain)//', $enclosureUrls);
 		self::assertContains('https://example.com/podcast.mp3', $enclosureUrls);
+		// SimplePie must absolutise protocol-relative URLs against the feed URL
+		self::assertContains('https://cdn.example.com/podcast2.mp3', $enclosureUrls);
 
 		$html = $entry->content();
 
 		self::assertStringNotContainsString('javascript:', $html);
 		self::assertStringContainsString('href="https://example.com/podcast.mp3"', $html);
 		self::assertStringContainsString('src="https://example.com/thumb.jpg"', $html);
+		self::assertStringContainsString('href="https://cdn.example.com/podcast2.mp3"', $html);
+		self::assertStringContainsString('src="https://cdn.example.com/thumb2.jpg"', $html);
 		self::assertStringContainsString('Hello', $html);
 	}
 
-	public function test_content_dropsUnsafeThumbnailAttribute(): void {
-		$rss = <<<XML
-			<?xml version="1.0" encoding="UTF-8"?>
-			<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
-				<channel>
-					<title>Malicious feed</title>
-					<link>https://example.net/</link>
-					<description>Feed with a malicious thumbnail URL</description>
-					<item>
-						<title>Victim Article</title>
-						<link>https://example.net/article</link>
-						<guid isPermaLink="false">poc-002</guid>
-						<pubDate>Tue, 14 Nov 2023 20:13:20 +0000</pubDate>
-						<description>Hello</description>
-						<media:thumbnail url="javascript:alert(2)" />
-					</item>
-				</channel>
-			</rss>
-			XML;
-
-		$entries = self::entriesFromRss($rss);
-		self::assertCount(1, $entries);
-		$entry = $entries[0];
-
-		// The malicious thumbnail must not be stored as an attribute
-		self::assertNull($entry->attributeArray('thumbnail'));
+	public function test_content_dropsUnsafeUrlsFromLegacyAttributes(): void {
+		$entry = new FreshRSS_Entry(1, 'poc-003', 'Victim Article', '', 'Hello', 'https://example.net/article');
+		$entry->_attributes([
+			'thumbnail' => ['url' => 'javascript:alert(1)'],
+			'enclosures' => [
+				['url' => 'javascript:alert(2)', 'title' => 'evil'],
+				['url' => 'https://example.com/podcast.mp3', 'thumbnails' => ['javascript:alert(3)', 'https://example.com/thumb.jpg']],
+			],
+		]);
 
 		$html = $entry->content();
 
 		self::assertStringNotContainsString('javascript:', $html);
+		self::assertStringContainsString('href="https://example.com/podcast.mp3"', $html);
+		self::assertStringContainsString('src="https://example.com/thumb.jpg"', $html);
 		self::assertStringContainsString('Hello', $html);
 	}
 }


### PR DESCRIPTION
Enclosure URLs (`<enclosure url="…">`, media RSS thumbnails, and the entry-level `media:thumbnail`) are stored as entry attributes and interpolated into `href`/`src` by `FreshRSS_Entry::content()`. Unlike URLs inside content HTML, these metadata values do not go through SimplePie’s URI scheme sanitization (`Sanitize::replace_urls()`), so any URI scheme can end up in user-facing links.

This PR adds `FreshRSS_http_Util::isAllowedUrlScheme()` — an allow-list of `http`/`https` (consistent with the protocols used for fetching feeds). Before extracting the scheme it strips control characters and whitespace, mirroring how browsers parse URI schemes, so obfuscated values like `java\tscript:` are not accepted either.

The check is applied:

- **at store time** in `app/Models/Feed.php`, while building the entry attributes (enclosure URL, per-enclosure thumbnails, entry-level `media:thumbnail`);
- **at render time** in `FreshRSS_Entry::content()`, so entries already stored in existing databases are covered as well, without a data migration. Since the Google Reader compatible API serves this same output, third-party clients are covered too.

Enclosure URLs using other schemes (`data:`, `ftp:`, relative paths, …) are now dropped. If relative enclosure URLs should keep working, I can switch the helper to a block-list mirroring SimplePie’s `disallowed_uri_schemes` — feedback welcome.

PHPUnit coverage added in `tests/app/Models/EntryTest.php` (scheme matrix + rendering of already-stored entries).

Security fix coordinated privately with the maintainers; opened here per maintainer request so CI can run.