### PR TITLE
SimplePie: Harden cache deserialization calls

### DIFF
--- a/app/Models/Feed.php
+++ b/app/Models/Feed.php
@@ -1302,6 +1302,7 @@ class FreshRSS_Feed extends Minz_Model {
 		$filename = $simplePie->get_cache_filename($url);
 		switch ($this->kind) {
 			case FreshRSS_Feed::KIND_HTML_XPATH:
+			case FreshRSS_Feed::KIND_HTML_XPATH_JSON_DOTNOTATION:
 				return CACHE_PATH . '/' . $filename . '.html';
 			case FreshRSS_Feed::KIND_XML_XPATH:
 				return CACHE_PATH . '/' . $filename . '.xml';
@@ -1311,8 +1312,9 @@ class FreshRSS_Feed extends Minz_Model {
 				return CACHE_PATH . '/' . $filename . '.json';
 			case FreshRSS_Feed::KIND_RSS:
 			case FreshRSS_Feed::KIND_RSS_FORCED:
-			default:
 				return CACHE_PATH . '/' . $filename . '.spc';
+			default:
+				return CACHE_PATH . '/' . $filename . '.raw';
 		}
 	}
 

--- a/lib/composer.json
+++ b/lib/composer.json
@@ -18,7 +18,7 @@
 		"marienfressinaud/lib_opml": "dev-main#f0e850b6394af90b898daf0e65fcc7363457b844",
 		"phpgt/cssxpath": "v1.5.0",
 		"phpmailer/phpmailer": "7.1.1",
-		"simplepie/simplepie": "dev-freshrss#0b0908c4c05462a781e029119c8bf3f98e9b8b80"
+		"simplepie/simplepie": "dev-freshrss#ec17fd8af7dc4dc60895b0542d551ea6895e1dbb"
 	},
 	"config": {
 		"sort-packages": true,

--- a/lib/simplepie/simplepie/src/Cache/File.php
+++ b/lib/simplepie/simplepie/src/Cache/File.php
@@ -85,7 +85,10 @@ class File implements Base
     public function load()
     {
         if (file_exists($this->name) && is_readable($this->name)) {
-            return unserialize((string) file_get_contents($this->name));
+            $deserialized = unserialize((string) file_get_contents($this->name), ['allowed_classes' => false]);
+            if (is_array($deserialized)) {
+                return $deserialized;
+            }
         }
         return false;
     }


### PR DESCRIPTION
To reduce impact if a maliciously provided cache file is somehow loaded, e.g. from a manipulated backup or some kind of external arbitrary file write vulnerability.