### PR TITLE
Cut the Docker Hub description at a heading, not mid-sentence

### DIFF
--- a/.github/scripts/dockerhub-description.php
+++ b/.github/scripts/dockerhub-description.php
@@ -1,0 +1,122 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+/**
+ * Build the Docker Hub description from Docker/README.md.
+ *
+ * Docker Hub caps a repository's full description at 25,000 characters and
+ * peter-evans/dockerhub-description simply cuts at the limit, which lands
+ * mid-section and makes the documentation look unfinished (#9211).
+ *
+ * So cut it ourselves, at a heading rather than at a character, and say so
+ * with a link to the rest.
+ *
+ * Usage: php .github/scripts/dockerhub-description.php <in.md> <out.md>
+ */
+
+/**
+ * peter-evans/dockerhub-description truncates to 25,000 *bytes*, not
+ * characters (`utils.truncateToBytes`), so count bytes here too or a README
+ * with emoji in it would still be cut by the action.
+ */
+const DOCKER_HUB_LIMIT = 25000;
+
+const SOURCE_URL = 'https://github.com/FreshRSS/FreshRSS/blob/edge/Docker/README.md';
+
+/**
+ * Headings inside a fenced code block are shell comments, not headings, and
+ * this README is full of them.
+ */
+function isHeading(string $line, bool $insideFence): bool {
+	return !$insideFence && str_starts_with($line, '## ');
+}
+
+function isFence(string $line): bool {
+	return str_starts_with(ltrim($line), '```');
+}
+
+/** @return list<string> */
+function truncateAtHeading(string $markdown, int $budget): array {
+	$lines = explode("\n", $markdown);
+	$insideFence = false;
+	$kept = [];
+	$lastSafeCut = null;
+	$length = 0;
+
+	foreach ($lines as $line) {
+		if (isHeading($line, $insideFence) && $length <= $budget) {
+			// A heading we could stop just before, with everything so far fitting.
+			$lastSafeCut = count($kept);
+		}
+		if (isFence($line)) {
+			$insideFence = !$insideFence;
+		}
+		$kept[] = $line;
+		$length += strlen($line) + 1;
+	}
+
+	if ($lastSafeCut === null) {
+		// No heading fits; fall back to whole lines, which at least never cuts
+		// a word or a link in half.
+		$lastSafeCut = 0;
+		$length = 0;
+		foreach ($lines as $index => $line) {
+			$length += strlen($line) + 1;
+			if ($length > $budget) {
+				break;
+			}
+			$lastSafeCut = $index + 1;
+		}
+	}
+
+	return array_slice($kept, 0, $lastSafeCut);
+}
+
+function footer(): string {
+	return implode("\n", [
+		'',
+		'---',
+		'',
+		'📖 **This description is shortened to fit Docker Hub\'s 25,000-character limit.**',
+		'',
+		'[**Read the full documentation on GitHub →**](' . SOURCE_URL . ')',
+		'',
+	]);
+}
+
+$source = $argv[1] ?? 'Docker/README.md';
+$target = $argv[2] ?? null;
+if ($target === null) {
+	fwrite(STDERR, "Usage: dockerhub-description.php <in.md> <out.md>\n");
+	exit(1);
+}
+
+$markdown = file_get_contents($source);
+if ($markdown === false) {
+	fwrite(STDERR, "Cannot read $source\n");
+	exit(1);
+}
+
+$total = strlen($markdown);
+if ($total <= DOCKER_HUB_LIMIT) {
+	// Nothing to do; keep the description byte-identical to the README so this
+	// step disappears on its own if the README ever shrinks again.
+	file_put_contents($target, $markdown);
+	fwrite(STDERR, "Docker Hub description: $total bytes, under the limit, passed through unchanged.\n");
+	exit(0);
+}
+
+$foot = footer();
+$budget = DOCKER_HUB_LIMIT - strlen($foot);
+$kept = truncateAtHeading($markdown, $budget);
+$out = rtrim(implode("\n", $kept), "\n") . "\n" . $foot;
+
+$final = strlen($out);
+if ($final > DOCKER_HUB_LIMIT) {
+	fwrite(STDERR, "Truncation produced $final bytes, over the limit\n");
+	exit(1);
+}
+
+file_put_contents($target, $out);
+fwrite(STDERR, "Docker Hub description: $total bytes truncated to $final, cut at a heading.\n");

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -4,6 +4,8 @@ on:
   push:
     paths:
       - Docker/README.md
+      - .github/scripts/dockerhub-description.php
+      - .github/workflows/dockerhub-description.yml
     branches:
       - edge
   workflow_dispatch:
@@ -18,10 +20,16 @@ jobs:
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+    # Docker Hub caps the description at 25,000 characters and the action below
+    # cuts at exactly that, mid-section (#9211). Cut at a heading instead, and
+    # link to the rest.
+    - name: Build the Docker Hub description
+      run: php .github/scripts/dockerhub-description.php Docker/README.md "$RUNNER_TEMP/dockerhub-description.md"
+
     - name: Update repo description
       uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
         repository: freshrss/freshrss
-        readme-filepath: Docker/README.md
+        readme-filepath: ${{ runner.temp }}/dockerhub-description.md


### PR DESCRIPTION
Fixes #9211.

Takes @Alkarex's suggestion of splitting the readme, but has the workflow do the splitting so nobody has to remember to keep two files in step.

## What was happening

`peter-evans/dockerhub-description` cuts at exactly the limit — `utils.truncateToBytes(readmeContent, 25000)` in its `readme-helper.ts`. `Docker/README.md` is **28,050 bytes**, so the published page stops inside *"Option 3: cron as another instance of the same FreshRSS Docker image"*, exactly where the issue points.

## What this does

`.github/scripts/dockerhub-description.php` builds the description, and the workflow feeds that to the action instead of the README:

```yaml
- name: Build the Docker Hub description
  run: php .github/scripts/dockerhub-description.php Docker/README.md "$RUNNER_TEMP/dockerhub-description.md"
```

It cuts **before the last top-level heading that still fits**, then appends:

```markdown
---

📖 **This description is shortened to fit Docker Hub's 25,000-byte limit.**

[**Read the full documentation on GitHub →**](https://github.com/FreshRSS/FreshRSS/blob/edge/Docker/README.md)
```

Three details that are not obvious and are the reason this is a script rather than a `head -c`:

- **Fenced code blocks are tracked.** `Docker/README.md` is full of shell comments starting with `#`, and `grep '^## '` finds two of them. Cutting at one would end the description inside an unterminated code block. The fence state is carried through the scan, so a `##` line inside a fence is not a heading.
- **The budget is bytes, not characters,** because that is what the action measures. On this README the two differ by 48, and the gap grows with every emoji added.
- **Under the limit it copies the file through unchanged and appends no footer.** So if the README ever shrinks below 25,000 bytes the description goes back to being exactly the README, with no "shortened" notice that is no longer true, and nobody has to remember to remove this step.

The workflow's `paths:` filter now also covers the script and the workflow itself, so a change to the truncation actually republishes the description.

## Verified locally

Run against the real `Docker/README.md` with PHP 8.3:

```
$ php .github/scripts/dockerhub-description.php Docker/README.md out.md
Docker Hub description: 28050 bytes truncated to 23732, cut at a heading.
```

| check | result |
| --- | --- |
| output size | 23,732 bytes — under 25,000 |
| where it ends | after a complete fenced code block, at the end of *Docker Compose* |
| code fences in output | 52 — balanced |
| sections dropped | 2 of 15 (*Cron job to automatically refresh feeds*, *Migrate database*), 4,520 bytes, now behind the link |
| `phpcs --standard=phpcs.xml` on the new file | clean |

The action's own path resolution was checked rather than assumed: `getReadmeContent` calls `fs.promises.readFile(readmeFilepath)` directly, so the absolute `$RUNNER_TEMP` path is read as given, and `enableUrlCompletion` is off by default so nothing rewrites the absolute link in the footer.

## Not verified

The workflow itself only runs on `FreshRSS/FreshRSS` pushes to `edge` (`if: github.repository_owner == 'FreshRSS'`), so I could not watch it publish. What I could run is the part that does the work — the script — against the actual file.

Happy to change the wording of the footer, or to cut at `###` rather than `##` if you would rather keep more of the README.
