### PR TITLE
Config + increase default values for search max length and depth

### DIFF
--- a/app/Models/BooleanSearch.php
+++ b/app/Models/BooleanSearch.php
@@ -6,9 +6,6 @@ declare(strict_types=1);
  */
 class FreshRSS_BooleanSearch implements \Stringable {
 
-	private const MAX_SEARCH_LENGTH = 4096;
-	private const MAX_PARENTHESES_DEPTH = 32;
-
 	private string $raw_input = '';
 	/** @var list<FreshRSS_BooleanSearch|FreshRSS_Search> */
 	private array $searches = [];
@@ -36,7 +33,7 @@ class FreshRSS_BooleanSearch implements \Stringable {
 		$this->raw_input = $input;
 
 		if ($level === 0) {
-			if (strlen($input) > self::MAX_SEARCH_LENGTH) {
+			if (strlen($input) > MAX_SEARCH_LENGTH) {
 				throw new Minz_BadRequestException('Search is too long!');
 			}
 			$input = self::escapeLiterals($input);
@@ -231,7 +228,7 @@ class FreshRSS_BooleanSearch implements \Stringable {
 	 * @throws Minz_BadRequestException if the search is too long or if the parentheses are nested too deeply
 	 */
 	public static function consistentOrParentheses(string $input): string {
-		if (strlen($input) > self::MAX_SEARCH_LENGTH) {
+		if (strlen($input) > MAX_SEARCH_LENGTH) {
 			throw new Minz_BadRequestException('Search is too long!');
 		}
 		if (!preg_match('/(?<!\\\\)\\(/', $input)) {
@@ -259,7 +256,7 @@ class FreshRSS_BooleanSearch implements \Stringable {
 						}
 						$c = '';
 					}
-					if ($parenthesesCount >= self::MAX_PARENTHESES_DEPTH) {	// @phpstan-ignore greaterOrEqual.alwaysFalse
+					if ($parenthesesCount >= MAX_SEARCH_PARENTHESES_DEPTH) {	// @phpstan-ignore greaterOrEqual.alwaysFalse
 						throw new Minz_BadRequestException('Search has too deeply nested parentheses!');
 					}
 					$parenthesesCount++;

--- a/app/Models/BooleanSearch.php
+++ b/app/Models/BooleanSearch.php
@@ -33,7 +33,7 @@ class FreshRSS_BooleanSearch implements \Stringable {
 		$this->raw_input = $input;
 
 		if ($level === 0) {
-			if (strlen($input) > MAX_SEARCH_LENGTH) {
+			if (strlen($input) > FreshRSS_Context::systemConf()->limits['max_search_length']) {
 				throw new Minz_BadRequestException('Search is too long!');
 			}
 			$input = self::escapeLiterals($input);
@@ -228,7 +228,7 @@ class FreshRSS_BooleanSearch implements \Stringable {
 	 * @throws Minz_BadRequestException if the search is too long or if the parentheses are nested too deeply
 	 */
 	public static function consistentOrParentheses(string $input): string {
-		if (strlen($input) > MAX_SEARCH_LENGTH) {
+		if (strlen($input) > FreshRSS_Context::systemConf()->limits['max_search_length']) {
 			throw new Minz_BadRequestException('Search is too long!');
 		}
 		if (!preg_match('/(?<!\\\\)\\(/', $input)) {
@@ -256,7 +256,7 @@ class FreshRSS_BooleanSearch implements \Stringable {
 						}
 						$c = '';
 					}
-					if ($parenthesesCount >= MAX_SEARCH_PARENTHESES_DEPTH) {	// @phpstan-ignore greaterOrEqual.alwaysFalse
+					if ($parenthesesCount >= FreshRSS_Context::systemConf()->limits['max_search_parentheses_depth']) {
 						throw new Minz_BadRequestException('Search has too deeply nested parentheses!');
 					}
 					$parenthesesCount++;

--- a/config.default.php
+++ b/config.default.php
@@ -152,6 +152,11 @@ return [
 		# Limits for regex, useful to limit regex during user searches
 		'regex_backtrack_limit' => 10000,
 		'regex_recursion_limit' => 100,
+
+		# Max length of a Boolean search query, in bytes
+		'max_search_length' => 16384,
+		# Max depth of parentheses nesting in a Boolean search query
+		'max_search_parentheses_depth' => 32,
 	],
 
 	# Options used by cURL when making HTTP requests, e.g. when the SimplePie library retrieves feeds.

--- a/constants.php
+++ b/constants.php
@@ -59,10 +59,6 @@ defined('MAX_LOG_SIZE') or define('MAX_LOG_SIZE', 1048576);
 // Amount of characters of text shown if feed has no title
 defined('MAX_CHARS_EMPTY_FEED_TITLE') or define('MAX_CHARS_EMPTY_FEED_TITLE', 75);
 
-// Limits for searches
-defined('MAX_SEARCH_LENGTH') or define('MAX_SEARCH_LENGTH', 16384);
-defined('MAX_SEARCH_PARENTHESES_DEPTH') or define('MAX_SEARCH_PARENTHESES_DEPTH', 32);
-
 //This directory must be writable
 $dataPath = getenv('DATA_PATH');
 if (is_string($dataPath) && $dataPath !== '') {

--- a/constants.php
+++ b/constants.php
@@ -59,6 +59,10 @@ defined('MAX_LOG_SIZE') or define('MAX_LOG_SIZE', 1048576);
 // Amount of characters of text shown if feed has no title
 defined('MAX_CHARS_EMPTY_FEED_TITLE') or define('MAX_CHARS_EMPTY_FEED_TITLE', 75);
 
+// Limits for searches
+defined('MAX_SEARCH_LENGTH') or define('MAX_SEARCH_LENGTH', 16384);
+defined('MAX_SEARCH_PARENTHESES_DEPTH') or define('MAX_SEARCH_PARENTHESES_DEPTH', 32);
+
 //This directory must be writable
 $dataPath = getenv('DATA_PATH');
 if (is_string($dataPath) && $dataPath !== '') {

--- a/tests/app/Models/BooleanSearchTest.php
+++ b/tests/app/Models/BooleanSearchTest.php
@@ -31,10 +31,17 @@ final class BooleanSearchTest extends \PHPUnit\Framework\TestCase {
 		self::assertSame($expectedValues, $values);
 	}
 
+	public function test_constructor_acceptsSearchesAtTheLimits(): void {
+		$input = str_repeat('a', MAX_SEARCH_LENGTH);
+		self::assertSame($input, (string)new FreshRSS_BooleanSearch($input));
+		$input = str_repeat('(', MAX_SEARCH_PARENTHESES_DEPTH) . 'ab' . str_repeat(')', MAX_SEARCH_PARENTHESES_DEPTH);
+		self::assertSame('ab', (string)new FreshRSS_BooleanSearch($input));
+	}
+
 	/** @return list<list{string}> */
 	public static function provideTooLongOrTooDeepSearches(): array {
-		$tooLong = str_repeat('ab ', 1400);	// Long enough to exceed the maximum search length
-		$tooDeep = str_repeat('(', 40) . 'ab' . str_repeat(')', 40);	// Deeper than the maximum parentheses depth
+		$tooLong = str_repeat('a', MAX_SEARCH_LENGTH + 1);
+		$tooDeep = str_repeat('(', MAX_SEARCH_PARENTHESES_DEPTH + 1) . 'ab' . str_repeat(')', MAX_SEARCH_PARENTHESES_DEPTH + 1);
 		return [
 			[$tooLong],
 			[$tooDeep],
@@ -44,7 +51,6 @@ final class BooleanSearchTest extends \PHPUnit\Framework\TestCase {
 	#[DataProvider('provideTooLongOrTooDeepSearches')]
 	public function test_constructor_rejectsTooLongOrTooDeepSearches(string $input): void {
 		self::expectException(Minz_BadRequestException::class);
-		// Tests run at the default PHP memory limit; a brute-force 1400-deep search would consume too much memory
 		new FreshRSS_BooleanSearch($input);
 	}
 }

--- a/tests/app/Models/BooleanSearchTest.php
+++ b/tests/app/Models/BooleanSearchTest.php
@@ -5,6 +5,13 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 final class BooleanSearchTest extends \PHPUnit\Framework\TestCase {
 
+	public function __construct(string $name) {
+		parent::__construct($name);
+		if (!FreshRSS_Context::hasSystemConf()) {
+			FreshRSS_Context::initSystem();
+		}
+	}
+
 	/**
 	 * `FreshRSS_BooleanSearch::prepend()` is used to restrict an existing search with an extra condition,
 	 * such as the maximum publication date of the “mark as read → articles older than one day/week” action.
@@ -32,16 +39,18 @@ final class BooleanSearchTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function test_constructor_acceptsSearchesAtTheLimits(): void {
-		$input = str_repeat('a', MAX_SEARCH_LENGTH);
+		$input = str_repeat('a', FreshRSS_Context::systemConf()->limits['max_search_length']);
 		self::assertSame($input, (string)new FreshRSS_BooleanSearch($input));
-		$input = str_repeat('(', MAX_SEARCH_PARENTHESES_DEPTH) . 'ab' . str_repeat(')', MAX_SEARCH_PARENTHESES_DEPTH);
+		$input = str_repeat('(', FreshRSS_Context::systemConf()->limits['max_search_parentheses_depth']) . 'ab' .
+			str_repeat(')', FreshRSS_Context::systemConf()->limits['max_search_parentheses_depth']);
 		self::assertSame('ab', (string)new FreshRSS_BooleanSearch($input));
 	}
 
 	/** @return list<list{string}> */
 	public static function provideTooLongOrTooDeepSearches(): array {
-		$tooLong = str_repeat('a', MAX_SEARCH_LENGTH + 1);
-		$tooDeep = str_repeat('(', MAX_SEARCH_PARENTHESES_DEPTH + 1) . 'ab' . str_repeat(')', MAX_SEARCH_PARENTHESES_DEPTH + 1);
+		$tooLong = str_repeat('a', FreshRSS_Context::systemConf()->limits['max_search_length'] + 1);
+		$tooDeep = str_repeat('(', FreshRSS_Context::systemConf()->limits['max_search_parentheses_depth'] + 1) . 'ab' .
+			str_repeat(')', FreshRSS_Context::systemConf()->limits['max_search_parentheses_depth'] + 1);
 		return [
 			[$tooLong],
 			[$tooDeep],

--- a/tests/app/Models/EntryTest.php
+++ b/tests/app/Models/EntryTest.php
@@ -3,9 +3,11 @@ declare(strict_types=1);
 
 final class EntryTest extends \PHPUnit\Framework\TestCase {
 
-	#[\Override]
-	public static function setUpBeforeClass(): void {
-		FreshRSS_Context::initSystem();
+	public function __construct(string $name) {
+		parent::__construct($name);
+		if (!FreshRSS_Context::hasSystemConf()) {
+			FreshRSS_Context::initSystem();
+		}
 	}
 
 	/**

--- a/tests/app/Models/SearchTest.php
+++ b/tests/app/Models/SearchTest.php
@@ -7,6 +7,13 @@ require_once LIB_PATH . '/lib_date.php';
 
 final class SearchTest extends \PHPUnit\Framework\TestCase {
 
+	public function __construct(string $name) {
+		parent::__construct($name);
+		if (!FreshRSS_Context::hasSystemConf()) {
+			FreshRSS_Context::initSystem();
+		}
+	}
+
 	#[DataProvider('provideEmptyInput')]
 	public static function test__construct_whenInputIsEmpty_getsOnlyNullValues(string $input): void {
 		$search = new FreshRSS_Search($input);

--- a/tests/app/Models/SimplePieCustomTest.php
+++ b/tests/app/Models/SimplePieCustomTest.php
@@ -9,9 +9,11 @@ use PHPUnit\Framework\Attributes\DataProvider;
  */
 final class SimplePieCustomTest extends \PHPUnit\Framework\TestCase {
 
-	#[\Override]
-	public static function setUpBeforeClass(): void {
-		FreshRSS_Context::initSystem();
+	public function __construct(string $name) {
+		parent::__construct($name);
+		if (!FreshRSS_Context::hasSystemConf()) {
+			FreshRSS_Context::initSystem();
+		}
 	}
 
 	public static function test_sanitizeHTML_whenEmptyString_returnsEmptyString(): void {

--- a/tests/app/Models/UserQueryTest.php
+++ b/tests/app/Models/UserQueryTest.php
@@ -8,6 +8,13 @@ use PHPUnit\Framework\TestCase;
  */
 class UserQueryTest extends TestCase {
 
+	public function __construct(string $name) {
+		parent::__construct($name);
+		if (!FreshRSS_Context::hasSystemConf()) {
+			FreshRSS_Context::initSystem();
+		}
+	}
+
 	public static function test__construct_whenAllQuery_storesAllParameters(): void {
 		$query = ['get' => 'a'];
 		$user_query = new FreshRSS_UserQuery($query, [], []);


### PR DESCRIPTION
Fix https://github.com/FreshRSS/FreshRSS/discussions/9279
Follow-up of https://github.com/FreshRSS/FreshRSS/pull/9277

Values can be overridden in `data/config.php`, or in `./data/config.custom.php` before the install process
