### PR TITLE
Fix documentation of TRUSTED_PROXY syntax and document limitations.

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -352,7 +352,7 @@ services:
 
       # Optional parameter, remove for automatic settings, set to 0 to disable,
       # or (if you use a proxy) to a space-separated list of trusted IP ranges
-      # compatible with https://httpd.apache.org/docs/current/mod/mod_remoteip.html#remoteipinternalproxy
+      # in CIDR notation. Write `/32` or `/128` explicitly to allowlist a single IPv4 or v6 address.
       # This impacts which IP address is logged (X-Forwarded-For or REMOTE_ADDR).
       # This also impacts external authentication methods;
       # see https://freshrss.github.io/FreshRSS/en/admins/09_AccessControl.html

--- a/docs/en/admins/09_AccessControl.md
+++ b/docs/en/admins/09_AccessControl.md
@@ -62,7 +62,8 @@ To enable this feature, you need to add the IP range (in CIDR notation) of your 
 To allow only one IPv4, you can use a `/32` like this: `trusted_sources => [ '192.168.1.10/32' ]`.
 Likewise to allow only one IPv6, you can use a `/128` like this: `trusted_sources => [ '::1/128' ]`.
 
-You may alternatively pass a `TRUSTED_PROXY` environment variable in a format compatible with [Apache’s `mod_remoteip` `RemoteIPInternalProxy`](https://httpd.apache.org/docs/current/mod/mod_remoteip.html#remoteipinternalproxy).
+You may alternatively pass a `TRUSTED_PROXY` environment variable, which is a space-separated list of CIDR notations like this: `192.168.1.10/32 ::1/128`.
+Unlike [Apache’s `mod_remoteip` `RemoteIPInternalProxy`](https://httpd.apache.org/docs/current/mod/mod_remoteip.html#remoteipinternalproxy) syntax, domain names or a single IP missing a `/32` or `/128` suffix is not supported and will silently cause requests to be rejected as unauthorized.
 
 > ☠️ WARNING: FreshRSS will trust any IP configured in the `trusted_sources` option, if your proxy isn’t properly secured, an attacker could simply attach this header and get admin access.
 


### PR DESCRIPTION
Closes #9210

Changes proposed in this pull request:

- Updated documentation on `TRUSTED_PROXY` syntax.
- No code or behavior changes.

How to test the feature manually:

I've manually tried domain names. Then IPs without `/`. Either way, requests got rejected on my server. Then I looked at the code, as described in #9210 investigation steps, and concluded that they are WAI (working as _implemented_ , not sure if _intended_ ). I don't particularly like the existing behavior (failures with no debuggable warnings or logs) but I try to document it as-is without judgement.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard) -- did not write for docs
- [x] documentation updated

[Additional information can be found in the documentation](https://freshrss.github.io/FreshRSS/en/developers/04_Pull_requests.html).
