### PR TITLE
Added the missing semicolons to the grid-area manage-labels and the manage-share

### DIFF
--- a/p/themes/base-theme/frss.css
+++ b/p/themes/base-theme/frss.css
@@ -2639,11 +2639,11 @@ html.slider-active {
 	}
 
 	.flux .flux_header.has-thumbnail.has-summary li.labels {
-		grid-area: manage-labels
+		grid-area: manage-labels;
 	}
 
 	.flux .flux_header.has-thumbnail.has-summary li.share {
-		grid-area: manage-share
+		grid-area: manage-share;
 	}
 
 	#overlay .close {

--- a/p/themes/base-theme/frss.rtl.css
+++ b/p/themes/base-theme/frss.rtl.css
@@ -2639,11 +2639,11 @@ html.slider-active {
 	}
 
 	.flux .flux_header.has-thumbnail.has-summary li.labels {
-		grid-area: manage-labels
+		grid-area: manage-labels;
 	}
 
 	.flux .flux_header.has-thumbnail.has-summary li.share {
-		grid-area: manage-share
+		grid-area: manage-share;
 	}
 
 	#overlay .close {


### PR DESCRIPTION
Changes proposed in this pull request:

- It added 4 missing semicolons to the base-theme frss.css files.

How to test the feature manually:

1. Open the FreshRSS with this fixes.

Pull request checklist:

- [x] clear commit messages
- [x] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://freshrss.github.io/FreshRSS/en/developers/04_Pull_requests.html).
